### PR TITLE
ci: enforce `make schema-ddl` when migrations or DDL scripts change

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -33,6 +33,7 @@ jobs:
       phoenix_evals: ${{ steps.filter.outputs.phoenix_evals }}
       phoenix_otel: ${{ steps.filter.outputs.phoenix_otel }}
       migrations: ${{ steps.filter.outputs.migrations }}
+      ddl: ${{ steps.filter.outputs.ddl }}
       uv_lock: ${{ steps.filter.outputs.uv_lock }}
       json_canonicalization_schema: ${{ steps.filter.outputs.json_canonicalization_schema }}
     steps:
@@ -67,6 +68,9 @@ jobs:
               - "tox.ini"
             migrations:
               - "src/phoenix/db/migrations/versions/**"
+            ddl:
+              - "src/phoenix/db/migrations/**"
+              - "scripts/ddl/**"
             json_canonicalization_schema:
               - "src/phoenix/vendor/json_canonicalization_scheme/**/*.py"
             uv_lock:
@@ -82,6 +86,7 @@ jobs:
           PHOENIX_EVALS: ${{ steps.filter.outputs.phoenix_evals }}
           PHOENIX_OTEL: ${{ steps.filter.outputs.phoenix_otel }}
           MIGRATIONS: ${{ steps.filter.outputs.migrations }}
+          DDL: ${{ steps.filter.outputs.ddl }}
           UV_LOCK: ${{ steps.filter.outputs.uv_lock }}
           JSON_CANONICALIZATION_SCHEMA: ${{ steps.filter.outputs.json_canonicalization_schema }}
         run: |
@@ -93,6 +98,7 @@ jobs:
           echo "phoenix_evals: $PHOENIX_EVALS"
           echo "phoenix_otel: $PHOENIX_OTEL"
           echo "migrations: $MIGRATIONS"
+          echo "ddl: $DDL"
           echo "uv_lock: $UV_LOCK"
           echo "json_canonicalization_schema: $JSON_CANONICALIZATION_SCHEMA"
 
@@ -314,6 +320,36 @@ jobs:
           version: "0.11.12"
       - name: Build OpenAPI schema
         run: make schema-openapi
+      - run: git diff --exit-code
+
+  build-ddl-schema:
+    name: Build DDL Schema
+    needs: changes
+    if: ${{ needs.changes.outputs.ddl == 'true' }}
+    strategy:
+      matrix:
+        py: ["3.14"]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.py }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Set up `uv`
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.12"
+      - name: Create virtual environment
+        # `make schema-ddl` installs its dependencies with `uv pip install`,
+        # which requires an existing environment.
+        run: uv venv
+      - name: Compile DDL schema
+        run: make schema-ddl
       - run: git diff --exit-code
 
   codegen-prompts:
@@ -666,6 +702,7 @@ jobs:
       - clean-jupyter-notebooks
       - build-graphql-schema
       - build-openapi-schema
+      - build-ddl-schema
       - codegen-prompts
       - check-lockfile
       - type-check


### PR DESCRIPTION
## Summary

- Add a `build-ddl-schema` CI job that runs `make schema-ddl` and fails on `git diff`, matching the existing OpenAPI/GraphQL codegen checks.
- Trigger the job when migration files or `scripts/ddl/**` change, via a dedicated `ddl` path filter (broader than the existing `migrations` filter so generator-only edits are covered without running the full migration matrix).
- Wire the job into `ci-required`; skipped on unrelated PRs.

## Test plan

- [ ] Confirm `build-ddl-schema` runs and passes on this PR (touches the workflow only; job should skip).
- [ ] On a migration PR, confirm the job runs, regenerates `scripts/ddl/postgresql_schema.sql`, and fails if the committed snapshot is stale.
- [ ] Confirm a `scripts/ddl/**`-only change triggers the job without running `test-migrations`.