### PR TITLE
fix: add empty state for column selector

### DIFF
--- a/app/src/components/core/content/VisuallyHidden.tsx
+++ b/app/src/components/core/content/VisuallyHidden.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import type { ReactNode } from "react";
+import type { AriaRole, ReactNode } from "react";
 
 const visuallyHiddenCSS = css`
   border: 0;
@@ -14,9 +14,19 @@ const visuallyHiddenCSS = css`
 /**
  * Component for only displaying content to screen readers.
  */
-export const VisuallyHidden = ({ children }: { children: ReactNode }) => {
+export const VisuallyHidden = ({
+  children,
+  role,
+}: {
+  children: ReactNode;
+  /**
+   * Role for the hidden span, e.g. `"status"` to make it a polite live region
+   * that announces updates without showing them.
+   */
+  role?: AriaRole;
+}) => {
   return (
-    <span className="visually-hidden" css={visuallyHiddenCSS}>
+    <span className="visually-hidden" css={visuallyHiddenCSS} role={role}>
       {children}
     </span>
   );

--- a/app/src/components/table/columnSelector/ColumnSelector.tsx
+++ b/app/src/components/table/columnSelector/ColumnSelector.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from "react";
 import {
   Button,
   Checkbox,
+  CompactEmptyState,
   DebouncedSearch,
   DialogTrigger,
   Icon,
@@ -205,42 +206,54 @@ export function ColumnSelectorMenu({
         />
       </MenuHeader>
       <div css={columnSelectorBodyCSS}>
-        <ColumnOrderingProvider
-          columnOrder={orderedColumns.map((column) => column.id)}
-          onColumnOrderChange={setDraftColumnOrder}
-          onColumnOrderCommit={(columnOrder) => {
-            setDraftColumnOrder(null);
-            // A canceled or round-trip drag commits the order it started
-            // with; skip the parent update so consumers don't persist and
-            // re-render for an unchanged order.
-            const hasOrderChanged = columnOrder.some(
-              (columnId, index) => columns[index]?.id !== columnId
-            );
-            if (hasOrderChanged) {
-              onColumnOrderChange?.(columnOrder);
-            }
-          }}
-        >
-          <ul css={columnListCSS}>
-            {filteredColumns.map((column, index) => (
-              <SortableColumnRow
-                key={column.id}
-                column={column}
-                // When filtered, reordering is disabled and the index within
-                // the full order is not needed
-                index={index}
-                isVisible={isColumnVisible(columnVisibility, column.id)}
-                isReorderingDisabled={!isReorderingEnabled}
-                onVisibilityChange={(isSelected) =>
-                  onColumnVisibilityChange({
-                    ...columnVisibility,
-                    [column.id]: isSelected,
-                  })
-                }
-              />
-            ))}
-          </ul>
-        </ColumnOrderingProvider>
+        {filteredColumns.length === 0 ? (
+          // Without this the list renders as an empty <ul> and the popover
+          // collapses to just the search header, reading as a broken menu.
+          // The search input is not inside an Autocomplete, so the filtered
+          // state has to be passed explicitly rather than auto-detected.
+          <CompactEmptyState
+            icon={<Icon svg={<Icons.Column />} />}
+            description="No columns"
+            isFiltered={searchQuery.trim().length > 0}
+          />
+        ) : (
+          <ColumnOrderingProvider
+            columnOrder={orderedColumns.map((column) => column.id)}
+            onColumnOrderChange={setDraftColumnOrder}
+            onColumnOrderCommit={(columnOrder) => {
+              setDraftColumnOrder(null);
+              // A canceled or round-trip drag commits the order it started
+              // with; skip the parent update so consumers don't persist and
+              // re-render for an unchanged order.
+              const hasOrderChanged = columnOrder.some(
+                (columnId, index) => columns[index]?.id !== columnId
+              );
+              if (hasOrderChanged) {
+                onColumnOrderChange?.(columnOrder);
+              }
+            }}
+          >
+            <ul css={columnListCSS}>
+              {filteredColumns.map((column, index) => (
+                <SortableColumnRow
+                  key={column.id}
+                  column={column}
+                  // When filtered, reordering is disabled and the index within
+                  // the full order is not needed
+                  index={index}
+                  isVisible={isColumnVisible(columnVisibility, column.id)}
+                  isReorderingDisabled={!isReorderingEnabled}
+                  onVisibilityChange={(isSelected) =>
+                    onColumnVisibilityChange({
+                      ...columnVisibility,
+                      [column.id]: isSelected,
+                    })
+                  }
+                />
+              ))}
+            </ul>
+          </ColumnOrderingProvider>
+        )}
         {children}
       </div>
     </div>

--- a/app/src/components/table/columnSelector/ColumnSelector.tsx
+++ b/app/src/components/table/columnSelector/ColumnSelector.tsx
@@ -14,6 +14,7 @@ import {
   Icons,
   MenuHeader,
   Popover,
+  VisuallyHidden,
 } from "@phoenix/components";
 import { dndDragFeedbackCSS, dndRowHandleCSS } from "@phoenix/components/dnd";
 
@@ -179,15 +180,19 @@ export function ColumnSelectorMenu({
         : orderColumns({ columns, columnOrder: draftColumnOrder }),
     [columns, draftColumnOrder]
   );
+  const trimmedQuery = searchQuery.trim();
+  // Drives both the filtering below and the empty state's "no matches" vs
+  // "no columns at all" wording, so the two can't disagree.
+  const isFiltering = trimmedQuery.length > 0;
   const filteredColumns = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) {
+    if (!isFiltering) {
       return orderedColumns;
     }
+    const query = trimmedQuery.toLowerCase();
     return orderedColumns.filter((column) =>
       column.label.toLowerCase().includes(query)
     );
-  }, [orderedColumns, searchQuery]);
+  }, [orderedColumns, isFiltering, trimmedQuery]);
 
   // Reordering a filtered list is ambiguous, so it is only enabled when the
   // full list is shown
@@ -206,6 +211,18 @@ export function ColumnSelectorMenu({
         />
       </MenuHeader>
       <div css={columnSelectorBodyCSS}>
+        {/* The search field is a plain input, not an Autocomplete, so React
+            Aria announces nothing as the list narrows. This region is mounted
+            for the life of the menu (live regions added at the same time as
+            their content announce unreliably) and stays silent until the user
+            actually searches. */}
+        <VisuallyHidden role="status">
+          {isFiltering
+            ? `${filteredColumns.length} ${
+                filteredColumns.length === 1 ? "column" : "columns"
+              } found`
+            : ""}
+        </VisuallyHidden>
         {filteredColumns.length === 0 ? (
           // Without this the list renders as an empty <ul> and the popover
           // collapses to just the search header, reading as a broken menu.
@@ -214,7 +231,7 @@ export function ColumnSelectorMenu({
           <CompactEmptyState
             icon={<Icon svg={<Icons.Column />} />}
             description="No columns"
-            isFiltered={searchQuery.trim().length > 0}
+            isFiltered={isFiltering}
           />
         ) : (
           <ColumnOrderingProvider

--- a/app/src/components/table/columnSelector/__tests__/ColumnSelector.test.tsx
+++ b/app/src/components/table/columnSelector/__tests__/ColumnSelector.test.tsx
@@ -1,0 +1,86 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ColumnSelectorMenu } from "../ColumnSelector";
+
+const columns = [
+  { id: "name", label: "Name" },
+  { id: "latency", label: "Latency" },
+  { id: "tokens", label: "Total Tokens" },
+];
+
+/**
+ * Types into the search field the way React sees it: the native value setter
+ * bypasses React's own value tracking, so the subsequent `input` event is not
+ * swallowed as a no-op change.
+ */
+function typeIntoSearch(container: HTMLElement, value: string) {
+  const input = container.querySelector("input") as HTMLInputElement;
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value"
+  )!.set!;
+  act(() => {
+    setValue.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("ColumnSelectorMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderMenu() {
+    act(() => {
+      root.render(
+        <ColumnSelectorMenu
+          columns={columns}
+          columnVisibility={{}}
+          onColumnVisibilityChange={() => {}}
+        />
+      );
+    });
+  }
+
+  it("renders a row per column when there is no search query", () => {
+    renderMenu();
+    expect(container.querySelectorAll("li")).toHaveLength(columns.length);
+  });
+
+  it("shows an empty state instead of a blank list when the search matches nothing", async () => {
+    renderMenu();
+    typeIntoSearch(container, "zzzznotacolumn");
+    // The search is debounced, so the filter has not been applied yet
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+    expect(container.textContent).toContain("No results");
+  });
+
+  it("filters to the matching columns", async () => {
+    renderMenu();
+    typeIntoSearch(container, "tokens");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    const rows = container.querySelectorAll("li");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("Total Tokens");
+  });
+});

--- a/app/src/components/table/columnSelector/__tests__/ColumnSelector.test.tsx
+++ b/app/src/components/table/columnSelector/__tests__/ColumnSelector.test.tsx
@@ -1,38 +1,30 @@
 import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { userEvent } from "storybook/test";
 
+import type { ColumnSelectorColumn } from "../ColumnSelector";
 import { ColumnSelectorMenu } from "../ColumnSelector";
 
-const columns = [
+const columns: ColumnSelectorColumn[] = [
   { id: "name", label: "Name" },
   { id: "latency", label: "Latency" },
   { id: "tokens", label: "Total Tokens" },
 ];
 
-/**
- * Types into the search field the way React sees it: the native value setter
- * bypasses React's own value tracking, so the subsequent `input` event is not
- * swallowed as a no-op change.
- */
-function typeIntoSearch(container: HTMLElement, value: string) {
-  const input = container.querySelector("input") as HTMLInputElement;
-  const setValue = Object.getOwnPropertyDescriptor(
-    HTMLInputElement.prototype,
-    "value"
-  )!.set!;
-  act(() => {
-    setValue.call(input, value);
-    input.dispatchEvent(new Event("input", { bubbles: true }));
-  });
-}
+/** Matches `DebouncedSearch`'s default `debounceMs`. */
+const DEBOUNCE_MS = 200;
 
 describe("ColumnSelectorMenu", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(() => {
-    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    vi.useFakeTimers();
+    // Without this, `user.type` awaits real timers that the fake clock never
+    // advances, and every interaction hangs until the test times out.
+    user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -41,17 +33,28 @@ describe("ColumnSelectorMenu", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
   });
 
-  function renderMenu() {
+  function renderMenu(menuColumns = columns) {
     act(() => {
       root.render(
         <ColumnSelectorMenu
-          columns={columns}
+          columns={menuColumns}
           columnVisibility={{}}
           onColumnVisibilityChange={() => {}}
         />
       );
+    });
+  }
+
+  /** Types into the search field and lets the debounced change land. */
+  async function search(query: string) {
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    await user.type(input!, query);
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS);
     });
   }
 
@@ -60,27 +63,39 @@ describe("ColumnSelectorMenu", () => {
     expect(container.querySelectorAll("li")).toHaveLength(columns.length);
   });
 
+  it("filters to the matching columns", async () => {
+    renderMenu();
+    await search("tokens");
+
+    const rows = container.querySelectorAll("li");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("Total Tokens");
+  });
+
   it("shows an empty state instead of a blank list when the search matches nothing", async () => {
     renderMenu();
-    typeIntoSearch(container, "zzzznotacolumn");
-    // The search is debounced, so the filter has not been applied yet
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    });
+    await search("zzzznotacolumn");
 
     expect(container.querySelectorAll("li")).toHaveLength(0);
     expect(container.textContent).toContain("No results");
   });
 
-  it("filters to the matching columns", async () => {
-    renderMenu();
-    typeIntoSearch(container, "tokens");
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    });
+  it("distinguishes having no columns at all from a search that matched none", () => {
+    renderMenu([]);
 
-    const rows = container.querySelectorAll("li");
-    expect(rows).toHaveLength(1);
-    expect(rows[0].textContent).toContain("Total Tokens");
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+    expect(container.textContent).toContain("No columns");
+    expect(container.textContent).not.toContain("No results");
+  });
+
+  it("announces the result count only once a search is active", async () => {
+    renderMenu();
+    const status = container.querySelector("[role='status']");
+    expect(status).not.toBeNull();
+    // Silent until the user searches, so opening the menu announces nothing
+    expect(status!.textContent).toBe("");
+
+    await search("tokens");
+    expect(status!.textContent).toBe("1 column found");
   });
 });


### PR DESCRIPTION
resolves #14943 

The empty state for **Column Selector** dropdown is added.
<img width="480" height="367" alt="image" src="https://github.com/user-attachments/assets/58a018c0-b2f6-46b2-8e27-6800e731c53a" />

I have created test cases to verify [here](https://claude.ai/code/artifact/26c2dd02-c121-456d-8e55-187c6861a57d?via=auto_preview) with a skill I use to test affected areas

