### PR TITLE
chore(deps): bump uv to 0.11.31 to match Dependabot

### DIFF
--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
 
       - name: Install PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/cost-sync.yml
+++ b/.github/workflows/cost-sync.yml
@@ -23,7 +23,7 @@ jobs:
       
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Sync model cost manifest with LiteLLM

--- a/.github/workflows/harbor-evals.yml
+++ b/.github/workflows/harbor-evals.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      UV_VERSION: "0.11.12"
+      UV_VERSION: "0.11.31"
       HARBOR_ENV: daytona
       # Two attempts, gated on the mean: a one-off agent slip passes while a
       # consistent regression still fails.

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
           python-version: "3.14"
 
       - name: Run Helm chart tests

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -94,7 +94,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Install dependencies
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
         run: uv sync --extra container

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -110,7 +110,7 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Build distribution
         run: rm -rf dist && uv build
       - name: Verify bundled UI assets in wheel
@@ -219,7 +219,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uv build
         if: steps.check.outputs.needed == 'true'
         working-directory: ${{ matrix.path }}
@@ -441,7 +441,7 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
-          version: "0.11.12"
+          version: "0.11.31"
           enable-cache: false
       - name: Stamp dev version
         env:
@@ -513,7 +513,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.11.12"
+          version: "0.11.31"
           enable-cache: false
       - name: Stamp dev version
         if: steps.check.outputs.needed == 'true'

--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Check Phoenix connectivity

--- a/.github/workflows/pxi-online-evals.yml
+++ b/.github/workflows/pxi-online-evals.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --frozen

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -39,7 +39,7 @@ jobs:
             verify_latest: false
     env:
       PYTHON_VERSION: "3.12"
-      UV_VERSION: "0.11.12"
+      UV_VERSION: "0.11.31"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PHOENIX_HOST: "127.0.0.1"
       PHOENIX_PORT: "6606"

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -117,7 +117,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals:
@@ -141,7 +141,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
@@ -164,7 +164,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   test-json-canonicalization-schema:
@@ -200,7 +200,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Install make (Windows)
         if: runner.os == 'Windows'
         run: choco install make --no-progress -y
@@ -234,7 +234,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Clean Jupyter notebooks
         run: make clean-notebooks
       - run: git diff --exit-code
@@ -260,7 +260,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Build GraphQL schema
         run: make schema-graphql
       - run: git diff --exit-code
@@ -286,7 +286,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Run doctests
         run: make doctest
 
@@ -311,7 +311,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Build OpenAPI schema
         run: make schema-openapi
       - run: git diff --exit-code
@@ -337,7 +337,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Compile Prompts
         run: make codegen-prompts
       - name: Check for changes
@@ -365,7 +365,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Check lockfile is up to date
         run: uv lock --check
 
@@ -389,7 +389,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Run formatter and linter
         run: |
           make format-python
@@ -426,7 +426,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Type check all Python code
@@ -465,7 +465,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql'
         # The floor version from the PGDG repository, not whatever the
@@ -539,7 +539,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 16
@@ -578,7 +578,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Install arize-phoenix and database dependencies
         run: |
           uv pip install --system -qU 'arize-phoenix[pg]'
@@ -651,7 +651,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Run canary tests for ${{ matrix.pkg }}
         run: uvx tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
 

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql' && runner.os == 'Linux'
         # Floor version from PGDG; see the note in python-CI.yml. The macOS
@@ -164,7 +164,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
@@ -193,7 +193,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals-non-linux:
@@ -219,7 +219,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel-non-linux:
@@ -245,7 +245,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   slack-notification:

--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
           enable-cache: false
 
       - name: Update lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pnpm install
 RUN pnpm run build
 
 # The second stage builds the backend.
-FROM ghcr.io/astral-sh/uv:0.11.12-python3.13-trixie-slim AS backend-builder
+FROM ghcr.io/astral-sh/uv:0.11.31-python3.13-trixie-slim AS backend-builder
 WORKDIR /phoenix
 COPY ./src /phoenix/src
 COPY ./pyproject.toml /phoenix/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,7 +424,7 @@ line-ending = "native"
 script_location = "src/phoenix/db/migrations"  # enables `uv run alembic <command>`
 
 [tool.uv]
-required-version = "==0.11.12"  # When updating this version, also update the `backend-builder` image in the Dockerfile
+required-version = "==0.11.31"  # When updating this version, also update the `backend-builder` image in the Dockerfile
 exclude-newer = "3 days"
 # Exempt our own workspace packages from the `exclude-newer` window so freshly
 # published versions are immediately resolvable.

--- a/scripts/docker/devops/Dockerfile
+++ b/scripts/docker/devops/Dockerfile
@@ -23,7 +23,7 @@ FROM python:${PYTHON_VERSION}-slim-bullseye AS backend-builder
 WORKDIR /phoenix
 
 # Install uv - pin version to match pyproject.toml [tool.uv] required-version
-RUN pip install uv==0.11.12
+RUN pip install uv==0.11.31
 
 # Copy dependency files first for better layer caching
 COPY ./pyproject.toml ./uv.lock ./LICENSE ./IP_NOTICE ./README.md ./


### PR DESCRIPTION
## Summary

Bumps the pinned `uv` CLI version across the repo from `0.11.12` to `0.11.31` to match the version supported by Dependabot (see [dependabot-core's `uv/Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile)).

This PR was generated automatically by [`.github/workflows/check-dependabot-uv-version.yml`](.github/workflows/check-dependabot-uv-version.yml).

## Changes

- `pyproject.toml`: `[tool.uv] required-version`
- `Dockerfile`: `ghcr.io/astral-sh/uv` base image tag
- `scripts/docker/devops/Dockerfile`: `pip install uv==...`
- `.github/workflows/*.yml|*.yaml`: `astral-sh/setup-uv` `version:` inputs and `UV_VERSION` env vars

## Note

`uv lock` could not be run to regenerate `uv.lock` in this environment because the sandboxed shell was non-functional (all `Bash` invocations failed at the `bwrap` sandbox layer, even for trivial commands like `echo`). The lockfile has **not** been regenerated against uv `0.11.31` — please run `uv lock` before merging.
