### PR TITLE
fix(agents): prevent history mutations during active turns

### DIFF
--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -117,6 +117,7 @@ function AgentSessionsContent({
               title
               ...EditAgentSessionTitleDialog_session
               isTemporary: isEphemeral
+              isActive
               createdAt
               updatedAt
             }
@@ -132,6 +133,9 @@ function AgentSessionsContent({
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
   const chatStatusBySessionId = useAgentContext(
     (state) => state.chatStatusBySessionId
+  );
+  const isBusyElsewhereBySessionId = useAgentContext(
+    (state) => state.isBusyElsewhereBySessionId
   );
   const setActiveSession = useAgentContext((state) => state.setActiveSession);
   const clearSessionEphemeralState = useAgentContext(
@@ -167,10 +171,16 @@ function AgentSessionsContent({
         isTemporary: node.isTemporary,
         createdAt: Date.parse(node.createdAt as string),
         isDeleteDisabled:
+          node.isActive ||
+          isBusyElsewhereBySessionId[node.id] === true ||
           chatStatusBySessionId[node.id] === "submitted" ||
           chatStatusBySessionId[node.id] === "streaming",
       })),
-    [chatStatusBySessionId, data.agentSessions.edges]
+    [
+      chatStatusBySessionId,
+      data.agentSessions.edges,
+      isBusyElsewhereBySessionId,
+    ]
   );
 
   // On first open with no selection, resume the most recent conversation, or

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -658,14 +658,14 @@ export function ChatView({
   const hasChatSettled = status === "ready" || status === "error";
 
   const onRewindRequest = useMemo<MessageRewindRequest | undefined>(() => {
-    if (!hasChatSettled || !rewindToMessage) {
+    if (!hasChatSettled || isBusyElsewhere || !rewindToMessage) {
       return undefined;
     }
     return (request) => {
       setHistoryActionError(null);
       setRewindRequest(request);
     };
-  }, [hasChatSettled, rewindToMessage]);
+  }, [hasChatSettled, isBusyElsewhere, rewindToMessage]);
 
   const handleConfirmRewind = async () => {
     if (!rewindRequest) {

--- a/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bceb1d1bfd99b2569314bc38ce1df637>>
+ * @generated SignedSource<<b1bc6aa6a162c6b032930585f696ed6f>>
  * @lightSyntaxTransform
  */
 
@@ -127,6 +127,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isActive",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "createdAt",
                     "storageKey": null
                   },
@@ -197,16 +204,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b1c4d74d9e472d684ccaa359d9620207",
+    "cacheID": "af9de1f161b1c40702d400eb8d0b7ad4",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourcePaginationQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        isActive\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f139691753745b6b9ab58de36be057c4";
+(node as any).hash = "aacd6105eb0a2c04b2918acfb824a9c1";
 
 export default node;

--- a/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9f152b21fde87ba5fdcf244ff1f1ddab>>
+ * @generated SignedSource<<db27a07453bd83c8c0d55c82abe20a8b>>
  * @lightSyntaxTransform
  */
 
@@ -114,6 +114,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isActive",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "createdAt",
                     "storageKey": null
                   },
@@ -184,12 +191,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "347819b47fc2e5e986e683ee91fb07fe",
+    "cacheID": "23ed66a5cc93ad300e5ba670db20cf77",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourceQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        isActive\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<05f2cb9ce0229829d34661fd8e7bb974>>
+ * @generated SignedSource<<37b6cbf7e5ee1dd2f99a53b7f6f9d799>>
  * @lightSyntaxTransform
  */
 
@@ -15,6 +15,7 @@ export type AgentSessionsResource_sessions$data = {
       readonly node: {
         readonly createdAt: string;
         readonly id: string;
+        readonly isActive: boolean;
         readonly isTemporary: boolean;
         readonly title: string;
         readonly updatedAt: string;
@@ -127,6 +128,13 @@ return {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "isActive",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "createdAt",
                   "storageKey": null
                 },
@@ -191,6 +199,6 @@ return {
 };
 })();
 
-(node as any).hash = "f139691753745b6b9ab58de36be057c4";
+(node as any).hash = "aacd6105eb0a2c04b2918acfb824a9c1";
 
 export default node;

--- a/app/src/components/agent/__generated__/EditAgentSessionTitleDialogMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/EditAgentSessionTitleDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a5c5ad4252569a83583adbdc9f42049b>>
+ * @generated SignedSource<<e559909eb69526db05f5d5d1bed1234d>>
  * @lightSyntaxTransform
  */
 
@@ -227,6 +227,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "isActive",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "createdAt",
                             "storageKey": null
                           },
@@ -303,12 +310,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "72442aa6f2edb2fca4b151eaf5b5d915",
+    "cacheID": "d696e5e5ea5cae97501b165bb762d0c8",
     "id": null,
     "metadata": {},
     "name": "EditAgentSessionTitleDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation EditAgentSessionTitleDialogMutation(\n  $input: UpdateAgentSessionTitleInput!\n) {\n  updateAgentSessionTitle(input: $input) {\n    agentSession {\n      ...EditAgentSessionTitleDialog_session\n      id\n    }\n    query {\n      ...SettingsAgentSessionsCard_sessions_3dfUwN\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3dfUwN on Query {\n  agentSessions(first: 20, viewerOnly: false) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "mutation EditAgentSessionTitleDialogMutation(\n  $input: UpdateAgentSessionTitleInput!\n) {\n  updateAgentSessionTitle(input: $input) {\n    agentSession {\n      ...EditAgentSessionTitleDialog_session\n      id\n    }\n    query {\n      ...SettingsAgentSessionsCard_sessions_3dfUwN\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3dfUwN on Query {\n  agentSessions(first: 20, viewerOnly: false) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        isActive\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -1,10 +1,10 @@
-import { act, type ReactNode } from "react";
+import { act, type ReactNode, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
-import { AgentProvider } from "@phoenix/contexts/AgentContext";
+import { AgentProvider, useAgentStore } from "@phoenix/contexts/AgentContext";
 import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 
 import { ChatView } from "../Chat";
@@ -79,6 +79,14 @@ const messages = [
 
 const unansweredUserMessages = [messages[0]!] as AgentUIMessage[];
 
+function SessionBusyElsewhere({ sessionId }: { sessionId: string }) {
+  const store = useAgentStore();
+  useEffect(() => {
+    store.getState().setSessionBusyElsewhere(sessionId, true);
+  }, [sessionId, store]);
+  return null;
+}
+
 function renderChatView(
   root: Root,
   {
@@ -98,6 +106,7 @@ function renderChatView(
     clearOperationError,
     rewindToMessage,
     forkFromMessage,
+    isBusyElsewhere = false,
   }: {
     sessionId?: string;
     autoFocusInput?: boolean;
@@ -115,6 +124,7 @@ function renderChatView(
     clearOperationError?: () => void;
     rewindToMessage?: (messageId: string) => Promise<string | null>;
     forkFromMessage?: (messageId: string) => Promise<void>;
+    isBusyElsewhere?: boolean;
   } = {}
 ) {
   act(() => {
@@ -154,6 +164,9 @@ function renderChatView(
               ? { isDraftSessionTemporary }
               : {})}
           >
+            {isBusyElsewhere ? (
+              <SessionBusyElsewhere sessionId={sessionId} />
+            ) : null}
             <ChatView
               key={chatKey ?? sessionId ?? "no-session"}
               sessionId={sessionId}
@@ -689,6 +702,21 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("Retry");
     expect(container.textContent).toContain("Edit message");
     expect(container.textContent).toContain("Branch before message");
+  });
+
+  it("hides rewind and branch actions while the session is busy elsewhere", () => {
+    renderChatView(root, {
+      chatMessages: unansweredUserMessages,
+      status: "ready",
+      rewindToMessage: vi.fn(),
+      forkFromMessage: vi.fn(),
+      isBusyElsewhere: true,
+    });
+
+    expect(container.textContent).toContain("Session in use elsewhere");
+    expect(container.textContent).not.toContain("Retry");
+    expect(container.textContent).not.toContain("Edit message");
+    expect(container.textContent).not.toContain("Branch before message");
   });
 
   it("retries an interrupted user message without duplicating it", async () => {

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -203,6 +203,7 @@ export function useAgentChat({
     sessionId,
     isDraft,
     chatInstance,
+    isBusyElsewhere,
     pendingElicitation,
     createChatForSession,
     setMessages,

--- a/app/src/components/agent/useAgentSessionHistory.ts
+++ b/app/src/components/agent/useAgentSessionHistory.ts
@@ -80,6 +80,7 @@ export function useAgentSessionHistory({
   sessionId,
   isDraft,
   chatInstance,
+  isBusyElsewhere,
   pendingElicitation,
   createChatForSession,
   setMessages,
@@ -88,6 +89,7 @@ export function useAgentSessionHistory({
   sessionId: string | null;
   isDraft: boolean;
   chatInstance: Chat<AgentUIMessage> | null;
+  isBusyElsewhere: boolean;
   pendingElicitation: PendingElicitation | null;
   /** Builds the runtime chat for a branch's new session Relay ID. */
   createChatForSession: (
@@ -160,6 +162,7 @@ export function useAgentSessionHistory({
         isDraft ||
         !sessionId ||
         !chatInstance ||
+        isBusyElsewhere ||
         isRequestActive(chatInstance.status)
       ) {
         return Promise.resolve(null);
@@ -199,6 +202,7 @@ export function useAgentSessionHistory({
       clearDroppedToolState,
       clearError,
       commitTruncateAgentSession,
+      isBusyElsewhere,
       isDraft,
       sessionId,
       setMessages,
@@ -211,7 +215,13 @@ export function useAgentSessionHistory({
   // runtime chat from the returned transcript and activates it.
   const forkFromMessage = useCallback(
     (messageId: string): Promise<void> => {
-      if (isDraft || !sessionId || !chatInstance) {
+      if (
+        isDraft ||
+        !sessionId ||
+        !chatInstance ||
+        isBusyElsewhere ||
+        isRequestActive(chatInstance.status)
+      ) {
         return Promise.resolve();
       }
       clearError();
@@ -263,6 +273,7 @@ export function useAgentSessionHistory({
       clearError,
       commitBranchAgentSession,
       createChatForSession,
+      isBusyElsewhere,
       isDraft,
       runtime,
       sessionId,

--- a/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
+++ b/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
@@ -64,10 +64,12 @@ export function SettingsAgentSessionActionMenu({
   sessionId,
   sessionTitle,
   session,
+  isActive,
 }: {
   sessionId: string;
   sessionTitle: string;
   session: EditAgentSessionTitleDialog_session$key;
+  isActive: boolean;
 }) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -78,12 +80,18 @@ export function SettingsAgentSessionActionMenu({
   const chatStatus = useAgentContext(
     (state) => state.chatStatusBySessionId[sessionId]
   );
+  const isBusyElsewhere = useAgentContext(
+    (state) => state.isBusyElsewhereBySessionId[sessionId] ?? false
+  );
   const setActiveSession = useAgentContext((state) => state.setActiveSession);
   const clearSessionEphemeralState = useAgentContext(
     (state) => state.clearSessionEphemeralState
   );
   const isDeleteDisabled =
-    chatStatus === "submitted" || chatStatus === "streaming";
+    isActive ||
+    isBusyElsewhere ||
+    chatStatus === "submitted" ||
+    chatStatus === "streaming";
   const connectionIds = [
     ConnectionHandler.getConnectionID(
       "client:root",

--- a/app/src/pages/settings/SettingsAgentSessionsCard.tsx
+++ b/app/src/pages/settings/SettingsAgentSessionsCard.tsx
@@ -91,6 +91,7 @@ export function SettingsAgentSessionsCard({
                 profilePictureUrl
               }
               firstInput
+              isActive
               createdAt
               updatedAt
             }
@@ -160,6 +161,7 @@ export function SettingsAgentSessionsCard({
                           sessionId={node.id}
                           sessionTitle={node.title}
                           session={node}
+                          isActive={node.isActive}
                         />
                       </Flex>
                     ) : null}

--- a/app/src/pages/settings/__generated__/SettingsAgentSessionsCardPaginationQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentSessionsCardPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dfcd972ad2148fb895d3ed19c8d09ce7>>
+ * @generated SignedSource<<6bdabc1bdfcde76dbc58f31d4f94917e>>
  * @lightSyntaxTransform
  */
 
@@ -154,6 +154,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isActive",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "createdAt",
                     "storageKey": null
                   },
@@ -224,16 +231,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fe0158fc790fda0cfba9cf7d113029e0",
+    "cacheID": "c6a9b41183c04089af8ba071a948c800",
     "id": null,
     "metadata": {},
     "name": "SettingsAgentSessionsCardPaginationQuery",
     "operationKind": "query",
-    "text": "query SettingsAgentSessionsCardPaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...SettingsAgentSessionsCard_sessions_2HEEH6\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after, viewerOnly: false) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SettingsAgentSessionsCardPaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...SettingsAgentSessionsCard_sessions_2HEEH6\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after, viewerOnly: false) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        isActive\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "70dfcc80abc2e6a267ffbfe41bc13c37";
+(node as any).hash = "f5c49fb2bf880303f39692c618e18c1b";
 
 export default node;

--- a/app/src/pages/settings/__generated__/SettingsAgentSessionsCard_sessions.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentSessionsCard_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e87261ab3f28da49d29f0ac54492aeda>>
+ * @generated SignedSource<<5eef1d8806c7b8733f05da9a3f733716>>
  * @lightSyntaxTransform
  */
 
@@ -16,6 +16,7 @@ export type SettingsAgentSessionsCard_sessions$data = {
         readonly createdAt: string;
         readonly firstInput: string | null;
         readonly id: string;
+        readonly isActive: boolean;
         readonly title: string;
         readonly updatedAt: string;
         readonly user: {
@@ -156,6 +157,13 @@ return {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "isActive",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "createdAt",
                   "storageKey": null
                 },
@@ -220,6 +228,6 @@ return {
 };
 })();
 
-(node as any).hash = "70dfcc80abc2e6a267ffbfe41bc13c37";
+(node as any).hash = "f5c49fb2bf880303f39692c618e18c1b";
 
 export default node;

--- a/app/src/pages/settings/__generated__/settingsAgentsPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsAgentsPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b8e5218c9ea809ee428339fed96ec09a>>
+ * @generated SignedSource<<f61860bc51ce64ca83d574a562c78e15>>
  * @lightSyntaxTransform
  */
 
@@ -141,6 +141,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isActive",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "createdAt",
                     "storageKey": null
                   },
@@ -211,12 +218,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5767a3de2d7583dfccbcf81d7395002d",
+    "cacheID": "33f25376ee037543e1658674734291ff",
     "id": null,
     "metadata": {},
     "name": "settingsAgentsPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsAgentsPageLoaderQuery(\n  $first: Int!\n) {\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first, viewerOnly: false) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsAgentsPageLoaderQuery(\n  $first: Int!\n) {\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first, viewerOnly: false) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        isActive\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -1,5 +1,6 @@
 """Mutations for persisted assistant chat sessions."""
 
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import strawberry
@@ -24,7 +25,8 @@ from phoenix.server.api.auth import (
     IsNotViewer,
 )
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest, NotFound
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
+from phoenix.server.api.helpers.agent_sessions import is_turn_active
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.AgentSession import AgentSession, to_gql_agent_session
 from phoenix.server.api.types.node import from_global_id_with_expected_type
@@ -160,6 +162,7 @@ class AgentSessionMutationMixin:
                 agent_session_rowid=agent_session_rowid,
                 for_update=True,
             )
+            _ensure_agent_session_is_idle(agent_session)
             target = (
                 await session.execute(
                     select(
@@ -213,7 +216,9 @@ class AgentSessionMutationMixin:
                 session,
                 info=info,
                 agent_session_rowid=agent_session_rowid,
+                for_update=True,
             )
+            _ensure_agent_session_is_idle(source_session)
             message_prefix = await _load_session_message_prefix(
                 session,
                 agent_session_rowid=source_session.id,
@@ -295,22 +300,29 @@ class AgentSessionMutationMixin:
             )
         except ValueError as exc:
             raise BadRequest(str(exc)) from exc
-        lookup_stmt = select(models.AgentSession.id).where(
-            models.AgentSession.id == agent_session_rowid
-        )
-        if (owner_filter := get_agent_session_owner_filter(info.context)) is not None:
-            lookup_stmt = lookup_stmt.where(owner_filter)
         async with info.context.db() as session:
-            agent_session_id = await session.scalar(lookup_stmt)
-            if agent_session_id is not None:
-                await session.execute(
-                    delete(models.AgentSession).where(models.AgentSession.id == agent_session_id)
-                )
-        if agent_session_id is None:
-            raise NotFound(f"No agent session found for ID '{input.id}'")
+            agent_session = await _load_owned_agent_session(
+                session,
+                info=info,
+                agent_session_rowid=agent_session_rowid,
+                for_update=True,
+            )
+            _ensure_agent_session_is_idle(agent_session)
+            agent_session_id = agent_session.id
+            await session.execute(
+                delete(models.AgentSession).where(models.AgentSession.id == agent_session_id)
+            )
         return DeleteAgentSessionMutationPayload(
             deleted_agent_session_id=GlobalID(AgentSession.__name__, str(agent_session_id)),
             query=Query(),
+        )
+
+
+def _ensure_agent_session_is_idle(agent_session: models.AgentSession) -> None:
+    if is_turn_active(agent_session.heartbeat_at, now=datetime.now(timezone.utc)):
+        raise Conflict(
+            "This session is busy. "
+            "Wait for the current operation to finish before modifying the conversation."
         )
 
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1585,12 +1585,10 @@ async def _persist_agent_session_turn(
             title=title or "",
         )
         if updated_agent_session_rowid is None:
-            logger.error(
-                "Agent session %r no longer exists; discarding %d generated message(s). ",
-                str(GlobalID("AgentSession", str(agent_session_rowid))),
-                len(new_messages),
+            raise RuntimeError(
+                f"Agent session {GlobalID('AgentSession', str(agent_session_rowid))!s} "
+                "no longer exists"
             )
-            return
         if new_messages[0].role == "assistant":
             # Client-tool continuations replace the persisted assistant message.
             await _update_trailing_assistant_message(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -59,6 +59,7 @@ from phoenix.server.api.routers.agents import (
     _emit_turn_root_span,
     _get_span_context,
     _merge_messages,
+    _persist_agent_session_turn,
     _persist_db_traces,
     _resolve_turn_trace_ids,
     _synthesize_client_tool_spans,
@@ -2523,6 +2524,26 @@ async def test_chat_is_rejected_with_storage_guidance_when_writes_are_already_lo
 
     assert response.status_code == 507
     assert insufficient_storage_message() in response.text
+
+
+async def test_persisting_a_turn_for_a_deleted_session_fails(
+    db: DbSessionFactory,
+) -> None:
+    agent_session_id = await _create_agent_session_row(db, title="Already titled")
+    agent_session_rowid = int(GlobalID.from_id(agent_session_id).node_id)
+    async with db() as session:
+        agent_session = await session.get(models.AgentSession, agent_session_rowid)
+        assert agent_session is not None
+        await session.delete(agent_session)
+
+    with pytest.raises(RuntimeError, match="no longer exists"):
+        await _persist_agent_session_turn(
+            db,
+            agent_session_rowid=agent_session_rowid,
+            user_id=None,
+            new_messages=[PhoenixUIMessage.model_validate(_user_message("discarded"))],
+            bashkit_snapshot=None,
+        )
 
 
 async def test_transcript_write_failure_is_reported_as_an_unsaved_turn(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -14,7 +14,7 @@ from phoenix.db.types.data_stream_protocol import (
     TextUIPart,
 )
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
-from phoenix.server.api.helpers.agent_sessions import get_otel_session_id
+from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, get_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
@@ -151,6 +151,7 @@ async def _seed_session_with_transcript(
     title: str = "",
     is_ephemeral: bool = False,
     updated_at: datetime | None = None,
+    heartbeat_at: datetime | None = None,
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
@@ -158,6 +159,7 @@ async def _seed_session_with_transcript(
             title=title,
             project_name="assistant_agent",
             is_ephemeral=is_ephemeral,
+            heartbeat_at=heartbeat_at,
         )
         if updated_at is not None:
             agent_session.created_at = agent_session.updated_at = updated_at
@@ -171,6 +173,71 @@ async def _seed_session_with_transcript(
             for message in _transcript_messages()
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message_id"),
+    [
+        (_TRUNCATE_MUTATION, _message_uuid("user-2")),
+        (_BRANCH_MUTATION, _message_uuid("assistant-1")),
+        (_DELETE_MUTATION, None),
+    ],
+    ids=("truncate", "branch", "delete"),
+)
+async def test_session_history_mutations_reject_an_active_turn(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+    mutation: str,
+    message_id: str | None,
+) -> None:
+    agent_session_id = await _seed_session_with_transcript(
+        db,
+        heartbeat_at=datetime.now(timezone.utc),
+    )
+    variables = {"id": agent_session_id}
+    if message_id is not None:
+        variables["messageId"] = message_id
+
+    response = await gql_client.execute(query=mutation, variables=variables)
+
+    assert response.errors
+    assert response.errors[0].message == (
+        "This session is busy. "
+        "Wait for the current operation to finish before modifying the conversation."
+    )
+    async with db() as session:
+        assert await session.scalar(select(func.count()).select_from(models.AgentSession)) == 1
+        assert await session.scalar(
+            select(func.count()).select_from(models.AgentSessionMessage)
+        ) == len(_transcript_messages())
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message_id"),
+    [
+        (_TRUNCATE_MUTATION, _message_uuid("user-2")),
+        (_BRANCH_MUTATION, _message_uuid("assistant-1")),
+        (_DELETE_MUTATION, None),
+    ],
+    ids=("truncate", "branch", "delete"),
+)
+async def test_session_history_mutations_accept_a_stale_turn_lock(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+    mutation: str,
+    message_id: str | None,
+) -> None:
+    agent_session_id = await _seed_session_with_transcript(
+        db,
+        heartbeat_at=datetime.now(timezone.utc) - TURN_LOCK_STALENESS - timedelta(seconds=1),
+    )
+    variables = {"id": agent_session_id}
+    if message_id is not None:
+        variables["messageId"] = message_id
+
+    response = await gql_client.execute(query=mutation, variables=variables)
+
+    assert not response.errors
 
 
 async def test_truncate_agent_session_at_a_user_message_removes_it_and_later_turns(


### PR DESCRIPTION
## Summary

- reject truncate, branch, and delete mutations while an agent session is active
- disable related frontend actions for local and remotely active turns
- fail turn persistence when its session has been removed instead of acknowledging a discarded transcript

Closes #14949

## Verification

- backend mutation and persistence tests
- frontend chat tests, lint, typecheck, and Relay generation
- browser verification against localhost for local activity, busy-elsewhere state, and direct GraphQL mutation rejection
