### PR TITLE
fix(db): reflect JSONB back as JSONB on SQLite

### DIFF
--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -35,7 +35,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.dialects.sqlite.base import SQLiteCompiler
+from sqlalchemy.dialects.sqlite.base import SQLiteCompiler, SQLiteDialect
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -202,6 +202,11 @@ class JSONB(JSON):
 def _(*args: Any, **kwargs: Any) -> str:
     # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
     return "JSONB"
+
+
+# Without this, reflection maps "JSONB" to NUMERIC, and Alembic batch_alter_table
+# rebuilds SQLite tables from reflection -- silently redeclaring JSON columns.
+SQLiteDialect.ischema_names["JSONB"] = JSONB
 
 
 JSON_ = (

--- a/tests/integration/db_migrations/test_data_migration_4ded9e43755f_create_project_sessions_table.py
+++ b/tests/integration/db_migrations/test_data_migration_4ded9e43755f_create_project_sessions_table.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timedelta, timezone
 from itertools import cycle
 from secrets import token_bytes, token_hex, token_urlsafe
@@ -171,13 +170,7 @@ async def test_data_migration_for_project_sessions(
                     "parent_id": row["parent_id"],
                     "start_time": row["start_time"],
                     "end_time": row["end_time"],
-                    "session_id": str(
-                        (
-                            json.loads(row["attributes"])  # type: ignore[unused-ignore]
-                            if _engine.dialect.name == "sqlite"
-                            else row["attributes"]
-                        )["session"]["id"]
-                    ),  # type: ignore[dict-item, unused-ignore]
+                    "session_id": str(row["attributes"]["session"]["id"]),
                 },
             ),
             axis=1,

--- a/tests/unit/db/test_models.py
+++ b/tests/unit/db/test_models.py
@@ -8,6 +8,8 @@ import pytest
 import sqlalchemy as sa
 from deepdiff.diff import DeepDiff
 from sqlalchemy import select
+from sqlalchemy.dialects import postgresql as postgresql_dialect
+from sqlalchemy.dialects import sqlite as sqlite_dialect
 from sqlalchemy.orm import selectinload
 
 from phoenix.db import models
@@ -1807,3 +1809,39 @@ class TestExperimentJobPolymorphism:
             assert isinstance(eval_config, models.ExperimentEvalOnlyConfig)
             assert not isinstance(eval_config, models.ExperimentPromptTask)
             assert eval_config.type == "EVAL_ONLY"
+
+
+class TestJSONBReflection:
+    def test_sqlite_reflects_jsonb_as_jsonb(self) -> None:
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            conn.exec_driver_sql("CREATE TABLE t (doc JSONB NOT NULL)")
+            conn.commit()
+        metadata = sa.MetaData()
+        metadata.reflect(bind=engine)
+        reflected = metadata.tables["t"].columns["doc"].type
+        assert isinstance(reflected, models.JSONB)
+        assert reflected.compile(sqlite_dialect.dialect()) == "JSONB"
+
+    @pytest.mark.parametrize(
+        "dialect,expected",
+        [
+            (sqlite_dialect.dialect(), "JSONB"),
+            (postgresql_dialect.dialect(), "JSONB"),  # type: ignore[no-untyped-call]
+        ],
+        ids=["sqlite", "postgresql"],
+    )
+    def test_json_columns_compile_to_jsonb_on_both_backends(
+        self, dialect: Any, expected: str
+    ) -> None:
+        for table_name, column_name in [
+            ("datasets", "metadata"),
+            ("dataset_versions", "metadata"),
+            ("experiments", "metadata"),
+            ("span_annotations", "metadata"),
+            ("spans", "attributes"),
+            ("experiment_runs", "output"),
+        ]:
+            column = models.Base.metadata.tables[table_name].columns[column_name]
+            actual = column.type.compile(dialect)
+            assert actual == expected, f"{table_name}.{column_name} -> {actual}"


### PR DESCRIPTION
## What this fixes

`@compiles(JSONB, "sqlite")` renders the type, but nothing reads it back. `ischema_names` is the registry SQLite reflection consults, and a name missing from it reflects as `NUMERIC` — the affinity SQLite assigns to any type it does not recognise.

That silently rewrote the schema. Alembic cannot `ALTER COLUMN` on SQLite, so it rebuilds a table from a reflection of itself, which means every `batch_alter_table` touching a table with a JSON column recreated it as `metadata NUMERIC`. **Nine columns across the shipped schema** were affected — `datasets`, `dataset_versions`, `experiments` and `span_annotations` among them — and a fresh migration still reproduced it.

## What does not change

Behaviour. Both spellings take `NUMERIC` affinity, so SQLite coerces numeric-looking JSON scalars either way and its JSON functions accept the result.

What changes is what the schema *says*. The declared type is what anything reflecting the database reports, and `NUMERIC` gives no hint the column holds JSON.

Existing databases keep the old spelling. Repairing them would mean rebuilding tables to change a string that changes no behaviour.

## Review notes

Three files. `src/phoenix/db/models.py` is the fix; the rest is coverage.

One test change is worth a look. `test_data_migration_4ded9e43755f_create_project_sessions_table.py` had a dialect conditional that called `json.loads` on SQLite and read the value directly on PostgreSQL — that conditional existed *because* of this bug. With reflection fixed, both dialects hand back a decoded object, so the branch is gone along with its two `type: ignore` comments.

## Verification

- `tests/unit/db/test_models.py` asserts the round trip: a `JSONB` column reflects back as `JSONB` rather than `NUMERIC`.
- The migration test above passes on both backends (`CI_TEST_DB_BACKEND=sqlite` and `postgresql`).
