### PR TITLE
perf(db): give SQLite reads their own connection pool

### DIFF
--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -22,6 +22,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models import Model as PydanticAIModel
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.config import (
     get_env_allow_external_resources,
@@ -49,7 +50,7 @@ from phoenix.server.types import CanPutItem, DbSessionFactory
 
 
 @asynccontextmanager
-async def _unavailable_db_session(_: Any) -> AsyncIterator[Any]:
+async def _unavailable_db_session() -> AsyncIterator[AsyncSession]:
     raise RuntimeError("PXI eval harness does not provide a Phoenix database.")
     yield
 

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -208,7 +208,7 @@ def _begin_read_transaction(connection: SAConnection) -> None:
     connection.exec_driver_sql("BEGIN")
 
 
-def aio_sqlite_read_engine(url: URL) -> Optional[AsyncEngine]:
+def aio_sqlite_read_engine(url: URL, log_to_stdout: bool = False) -> Optional[AsyncEngine]:
     """A read-only engine giving each concurrent reader its own connection.
 
     The primary engine serves every session from a single pooled connection, so
@@ -236,6 +236,7 @@ def aio_sqlite_read_engine(url: URL) -> Optional[AsyncEngine]:
     # a connection to go stale across.
     engine = create_async_engine(
         url=url,
+        echo=log_to_stdout,
         json_serializer=_dumps,
         async_creator=sqlite_connection_factory(database, mode="ro"),
         pool_size=_READ_POOL_SIZE,

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -49,10 +49,14 @@ _READ_MAX_OVERFLOW = 8
 
 
 # Settings scoped to one connection. Safe anywhere: none touches the file.
-_CONNECTION_PRAGMAS = (
-    "PRAGMA foreign_keys = ON;",
-    "PRAGMA busy_timeout = 10000;",
-)
+_CONNECTION_PRAGMAS = ("PRAGMA busy_timeout = 10000;",)
+
+# Withheld from the migration connection. Alembic rewrites a table by copying it
+# into a new one, dropping the original and renaming; with enforcement on, the
+# drop deletes the original's rows first and every `ON DELETE CASCADE` child row
+# goes with them. SQLite's own procedure for such a rewrite begins by turning
+# this off.
+_FOREIGN_KEY_PRAGMAS = ("PRAGMA foreign_keys = ON;",)
 
 # Page cache, in KiB when negative. SQLite has no shared buffer pool, so each
 # connection holds its own and the read pool multiplies it.
@@ -64,8 +68,9 @@ _WRITER_CACHE_PRAGMAS = ("PRAGMA cache_size = -32000;",)
 _READER_CACHE_PRAGMAS = ("PRAGMA cache_size = -2000;",)
 
 # Properties of the database file. `journal_mode` writes to its header, so a
-# read-only connection cannot set these; it inherits what the writer left, and
-# the writer must therefore connect first.
+# read-only connection cannot set these and inherits what a writing connection
+# left. The migration connection creates the file, so applying them there puts
+# the database in WAL before anything else opens it.
 _DATABASE_PRAGMAS = (
     "PRAGMA journal_mode = WAL;",
     "PRAGMA synchronous = OFF;",
@@ -82,6 +87,17 @@ def _apply_pragmas(connection: Connection, statements: tuple[str, ...]) -> None:
 
 
 def set_sqlite_pragma(connection: Connection, _: Any) -> None:
+    _apply_pragmas(
+        connection,
+        _CONNECTION_PRAGMAS + _FOREIGN_KEY_PRAGMAS + _WRITER_CACHE_PRAGMAS + _DATABASE_PRAGMAS,
+    )
+
+
+def set_sqlite_migration_pragma(connection: Connection, _: Any) -> None:
+    """The writer's settings without foreign key enforcement.
+
+    Alembic's table rewrites cannot run under it; see `_FOREIGN_KEY_PRAGMAS`.
+    """
     _apply_pragmas(connection, _CONNECTION_PRAGMAS + _WRITER_CACHE_PRAGMAS + _DATABASE_PRAGMAS)
 
 
@@ -167,7 +183,7 @@ def set_sqlite_read_pragma(connection: Connection, _: Any) -> None:
     A `mode=ro` connection fails on `PRAGMA journal_mode = WAL`, so a read
     engine inherits the journal mode the writer set and cannot set it itself.
     """
-    _apply_pragmas(connection, _CONNECTION_PRAGMAS + _READER_CACHE_PRAGMAS)
+    _apply_pragmas(connection, _CONNECTION_PRAGMAS + _FOREIGN_KEY_PRAGMAS + _READER_CACHE_PRAGMAS)
 
 
 def _disable_implicit_transactions(connection: Connection, _: Any) -> None:
@@ -316,6 +332,7 @@ def aio_sqlite_engine(
             poolclass=NullPool,
             echo=log_migrations,
         )
+        event.listen(migration_engine.sync_engine, "connect", set_sqlite_migration_pragma)
         migrate_in_thread(migration_engine, log_migrations=log_migrations)
     return engine
 

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -12,6 +12,7 @@ import numpy as np
 import orjson
 import sqlean
 from sqlalchemy import URL, NullPool, event, make_url
+from sqlalchemy.engine import Connection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 from typing_extensions import assert_never
@@ -161,6 +162,28 @@ def set_sqlite_read_pragma(connection: Connection, _: Any) -> None:
     _apply_pragmas(connection, _CONNECTION_PRAGMAS)
 
 
+def _disable_implicit_transactions(connection: Connection, _: Any) -> None:
+    """Hand transaction control to SQLAlchemy.
+
+    pysqlite opens a transaction before DML but never before SELECT, so a
+    session left to the driver runs each read in autocommit.
+    """
+    connection.isolation_level = None
+
+
+def _begin_read_transaction(connection: SAConnection) -> None:
+    """Open the transaction a read session already reads as having.
+
+    The WAL read mark is taken at the first statement and held until the
+    session closes, so every statement in it sees one snapshot rather than
+    re-snapshotting and reporting states that were never true together.
+
+    Deferred rather than `IMMEDIATE`, which takes a write lock a `mode=ro`
+    connection cannot acquire.
+    """
+    connection.exec_driver_sql("BEGIN")
+
+
 def aio_sqlite_read_engine(url: URL) -> Optional[AsyncEngine]:
     """A read-only engine giving each concurrent reader its own connection.
 
@@ -197,6 +220,8 @@ def aio_sqlite_read_engine(url: URL) -> Optional[AsyncEngine]:
         pool_pre_ping=False,
     )
     event.listen(engine.sync_engine, "connect", set_sqlite_read_pragma)
+    event.listen(engine.sync_engine, "connect", _disable_implicit_transactions)
+    event.listen(engine.sync_engine, "begin", _begin_read_transaction)
     return engine
 
 

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -38,13 +38,12 @@ logger = logging.getLogger(__name__)
 _POOL_RECYCLE_SECONDS = 3300
 
 # Reader connections kept open, and so also aiosqlite worker threads. WAL
-# imposes no reader limit; this bounds threads. Untuned -- 8 saturated the
-# benchmark below, but Phoenix's real concurrent-read profile is unmeasured.
+# imposes no reader limit; this bounds threads.
 _READ_POOL_SIZE = 8
 
-# Extra connections opened past the pool when every reader is busy, closed again
-# on return. They absorb a burst without holding threads for the process
-# lifetime; past them callers wait (see pool_timeout below) rather than fail.
+# Extra connections opened past the pool when every reader is busy, closed
+# again on return: they absorb a burst without holding threads for the process
+# lifetime. Past them, callers wait rather than fail.
 _READ_MAX_OVERFLOW = 8
 
 
@@ -56,8 +55,8 @@ _CONNECTION_PRAGMAS = (
 )
 
 # Properties of the database file. `journal_mode` writes to its header, so a
-# read-only connection cannot set these and inherits whatever the writer left --
-# which makes the writer opening first load-bearing rather than incidental.
+# read-only connection cannot set these; it inherits what the writer left, and
+# the writer must therefore connect first.
 _DATABASE_PRAGMAS = (
     "PRAGMA journal_mode = WAL;",
     "PRAGMA synchronous = OFF;",
@@ -121,21 +120,20 @@ def sqlite_connection_factory(
     sqlean rather than the standard library: Phoenix's extensions are loaded
     there, so a stdlib connection would offer a different set of functions.
 
-    `mode` is fixed when the file is opened and cannot be imposed afterwards, so
-    it is the only place read-only-ness can be established -- `ro` refuses
-    writes beneath every layer of application code, which no amount of careful
-    calling can match.
+    `mode` is fixed when the file is opened and cannot be imposed afterwards,
+    so it is the only place read-only-ness can be established; `ro` refuses
+    writes beneath every layer of application code.
 
-    It defaults to `rwc` because connections open lazily: an engine built before
-    migrations run may still connect first, and `rw` against a database that
-    does not exist yet fails outright. Use `rw` only where the file is known to
-    be there.
+    It defaults to `rwc` because connections open lazily: an engine built
+    before migrations run may still connect first, and `rw` against a database
+    that does not exist yet fails. Use `rw` only where the file is known to
+    exist.
     """
 
     def connect() -> aiosqlite.Connection:
-        # `mode` is a URI query parameter, so it only means anything when the
-        # target is parsed as a URI. Appending it to a plain path would make the
-        # filename literally contain "?mode=rw" rather than open read-write.
+        # `mode` is a URI query parameter, so it only applies when the target is
+        # parsed as a URI. Appended to a plain path it becomes part of the
+        # filename instead.
         if uri:
             separator = "&" if "?" in database else "?"
             target = f"file:{database}{separator}mode={mode}"
@@ -158,8 +156,7 @@ def set_sqlite_read_pragma(connection: Connection, _: Any) -> None:
     """The connection-scoped subset, for connections that cannot write.
 
     A `mode=ro` connection fails on `PRAGMA journal_mode = WAL`, so a read
-    engine opened against a database whose WAL was never initialised cannot
-    initialise it -- it can only inherit.
+    engine inherits the journal mode the writer set and cannot set it itself.
     """
     _apply_pragmas(connection, _CONNECTION_PRAGMAS)
 
@@ -167,31 +164,26 @@ def set_sqlite_read_pragma(connection: Connection, _: Any) -> None:
 def aio_sqlite_read_engine(url: URL) -> Optional[AsyncEngine]:
     """A read-only engine giving each concurrent reader its own connection.
 
-    The primary engine shares one connection across every session, so reads run
-    serialised behind the lock that keeps their transactions from interleaving
-    (see `DbSessionFactory.read`). Here each session owns its connection, so
-    there is nothing to serialise and no lock to take.
+    The primary engine serves every session from a single pooled connection, so
+    reads routed there queue behind each other and behind writes. Here each
+    session owns its connection and concurrent reads proceed in parallel.
 
-    `mode=ro` is the second reason to route reads here rather than widen the
-    primary pool: writes are refused by the engine, not by convention.
+    `mode=ro` also means writes are refused by the engine rather than by
+    convention.
 
-    None for in-memory databases -- a second connection to `:memory:` is a
-    different, empty database, and one developer has no concurrency to win.
+    None for in-memory databases: a second connection to `:memory:` opens a
+    different, empty database.
     """
     if (url.database or ":memory:").startswith(":memory:"):
         return None
     database = url.render_as_string().partition("///")[-1]
 
-    # Persistent connections, not one per checkout: each open spawns an aiosqlite
-    # worker thread, which dominates a short read. Measured at 8 concurrent,
-    # 200 reads ran at 490/s per-checkout against 3,879/s pooled.
+    # Persistent connections, not one per checkout: each open spawns an
+    # aiosqlite worker thread, whose cost dominates a short read.
     #
-    # pool_timeout=None so a caller past the pool waits rather than fails.
-    # Reads previously queued on an asyncio.Lock, which has no timeout, so
-    # rejecting them here would narrow the contract that already exists --
-    # a burst would start returning errors where it used to return answers
-    # slowly. Waiting keeps that policy; the cost is that a connection held
-    # indefinitely stalls its waiters, which was equally true of the lock.
+    # pool_timeout=None so a caller past the pool waits rather than fails: a
+    # burst is answered slowly instead of rejected. The cost is that a
+    # connection held indefinitely stalls its waiters.
     #
     # pre_ping is off because the target is a local file, with no network for
     # a connection to go stale across.
@@ -259,24 +251,22 @@ def aio_sqlite_engine(
         echo=log_to_stdout,
         json_serializer=_dumps,
         # rwc, not rw. Connections are lazy, so this engine can open before the
-        # migration engine has created the file -- and a `rw` connection to a
-        # database that does not exist yet fails rather than waiting for it.
+        # migration engine has created the file, and `rw` against a database
+        # that does not exist yet fails.
         async_creator=sqlite_connection_factory(database, mode="rwc"),
-        # One connection, checked out exclusively. StaticPool also holds one
-        # but hands it to every caller at once, and aiosqlite serialises
-        # statements rather than transactions -- so concurrent sessions
-        # interleaved their BEGIN/COMMIT spans and one session's commit landed
-        # another's uncommitted work. Checkout expresses that exclusion where
-        # the resource is; it previously lived in a lock callers had to pass.
+        # One connection, checked out exclusively. Not StaticPool, which also
+        # holds one connection but hands it to every caller at once: aiosqlite
+        # serialises statements rather than transactions, so concurrent
+        # sessions would interleave their BEGIN/COMMIT spans. Exclusive
+        # checkout is what keeps a session's transaction its own.
         #
         # poolclass is explicit because the SQLite dialect otherwise defaults
         # :memory: to StaticPool and rejects the sizing arguments.
         poolclass=AsyncAdaptedQueuePool,
         pool_size=1,
         max_overflow=0,
-        # None, matching the lock this replaces: writes queue indefinitely and
-        # none are rejected. The 30s default would turn slow-under-contention
-        # into fails-under-contention.
+        # Writers queue indefinitely rather than being rejected. The 30s
+        # default would turn slow-under-contention into fails-under-contention.
         pool_timeout=None,
     )
     event.listen(engine.sync_engine, "connect", set_sqlite_pragma)
@@ -312,13 +302,13 @@ def _init_memory_models(engine: AsyncEngine) -> None:
       task on the caller's loop would not run it until the caller next
       yields — the engine could be queried before its tables exist. So
       a short-lived helper thread runs the coroutine on its own fresh
-      loop, and we block on ``join()``. Blocking the caller's loop is
+      loop, and the caller blocks on ``join()``. Blocking that loop is
       acceptable: this happens once, at engine creation, and creating
       tables in an in-memory database is fast.
 
-    In both cases the StaticPool's single aiosqlite connection is
-    created on an event loop that is closed by the time the application
-    uses the engine on its own loop. That is safe because aiosqlite
+    In both cases the pool's single aiosqlite connection is created on
+    an event loop that is closed by the time the application uses the
+    engine on its own loop. That is safe because aiosqlite
     does not bind a connection to the loop it was created on: each
     operation creates a fresh future on whatever loop is current at
     call time, and the actual SQLite work runs on aiosqlite's dedicated

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -5,14 +5,15 @@ import logging
 from enum import Enum
 from sqlite3 import Connection
 from threading import Thread
-from typing import Any
+from typing import Any, Callable, Literal, Optional
 
 import aiosqlite
 import numpy as np
 import orjson
 import sqlean
-from sqlalchemy import URL, NullPool, StaticPool, event, make_url
+from sqlalchemy import URL, NullPool, event, make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 from typing_extensions import assert_never
 
 from phoenix.db.helpers import SupportedSQLDialect
@@ -20,7 +21,9 @@ from phoenix.db.migrate import migrate_in_thread
 from phoenix.db.models import init_models
 from phoenix.db.pg_config import get_pg_config
 
-sqlean.extensions.enable("text", "stats")
+SQLEAN_EXTENSIONS = ("text", "stats")
+
+sqlean.extensions.enable(*SQLEAN_EXTENSIONS)
 
 logger = logging.getLogger(__name__)
 
@@ -34,15 +37,44 @@ logger = logging.getLogger(__name__)
 # range where connection churn is cheap and staleness stays bounded.
 _POOL_RECYCLE_SECONDS = 3300
 
+# Reader connections kept open, and so also aiosqlite worker threads. WAL
+# imposes no reader limit; this bounds threads. Untuned -- 8 saturated the
+# benchmark below, but Phoenix's real concurrent-read profile is unmeasured.
+_READ_POOL_SIZE = 8
+
+# Extra connections opened past the pool when every reader is busy, closed again
+# on return. They absorb a burst without holding threads for the process
+# lifetime; past them callers wait (see pool_timeout below) rather than fail.
+_READ_MAX_OVERFLOW = 8
+
+
+# Settings scoped to one connection. Safe anywhere: none touches the file.
+_CONNECTION_PRAGMAS = (
+    "PRAGMA foreign_keys = ON;",
+    "PRAGMA cache_size = -32000;",
+    "PRAGMA busy_timeout = 10000;",
+)
+
+# Properties of the database file. `journal_mode` writes to its header, so a
+# read-only connection cannot set these and inherits whatever the writer left --
+# which makes the writer opening first load-bearing rather than incidental.
+_DATABASE_PRAGMAS = (
+    "PRAGMA journal_mode = WAL;",
+    "PRAGMA synchronous = OFF;",
+)
+
+
+def _apply_pragmas(connection: Connection, statements: tuple[str, ...]) -> None:
+    cursor = connection.cursor()
+    try:
+        for statement in statements:
+            cursor.execute(statement)
+    finally:
+        cursor.close()
+
 
 def set_sqlite_pragma(connection: Connection, _: Any) -> None:
-    cursor = connection.cursor()
-    cursor.execute("PRAGMA foreign_keys = ON;")
-    cursor.execute("PRAGMA journal_mode = WAL;")
-    cursor.execute("PRAGMA synchronous = OFF;")
-    cursor.execute("PRAGMA cache_size = -32000;")
-    cursor.execute("PRAGMA busy_timeout = 10000;")
-    cursor.close()
+    _apply_pragmas(connection, _CONNECTION_PRAGMAS + _DATABASE_PRAGMAS)
 
 
 def get_printable_db_url(connection_str: str) -> str:
@@ -72,6 +104,108 @@ def get_async_db_url(connection_str: str) -> URL:
         return url
     else:
         assert_never(backend)
+
+
+SQLiteAccessMode = Literal["ro", "rw", "rwc", "memory"]
+
+
+def sqlite_connection_factory(
+    database: str,
+    *,
+    mode: SQLiteAccessMode = "rwc",
+    uri: bool = True,
+    iter_chunk_size: int = 64,
+) -> Callable[[], aiosqlite.Connection]:
+    """Build the connector SQLAlchemy calls to open one SQLite connection.
+
+    sqlean rather than the standard library: Phoenix's extensions are loaded
+    there, so a stdlib connection would offer a different set of functions.
+
+    `mode` is fixed when the file is opened and cannot be imposed afterwards, so
+    it is the only place read-only-ness can be established -- `ro` refuses
+    writes beneath every layer of application code, which no amount of careful
+    calling can match.
+
+    It defaults to `rwc` because connections open lazily: an engine built before
+    migrations run may still connect first, and `rw` against a database that
+    does not exist yet fails outright. Use `rw` only where the file is known to
+    be there.
+    """
+
+    def connect() -> aiosqlite.Connection:
+        # `mode` is a URI query parameter, so it only means anything when the
+        # target is parsed as a URI. Appending it to a plain path would make the
+        # filename literally contain "?mode=rw" rather than open read-write.
+        if uri:
+            separator = "&" if "?" in database else "?"
+            target = f"file:{database}{separator}mode={mode}"
+        else:
+            target = database
+        conn = aiosqlite.Connection(
+            lambda: sqlean.connect(target, uri=uri),
+            iter_chunk_size=iter_chunk_size,
+        )
+        # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
+        # aiosqlite dialect daemonizes it only when it creates the connection
+        # itself, not when an async_creator is used.
+        conn._thread.daemon = True
+        return conn
+
+    return connect
+
+
+def set_sqlite_read_pragma(connection: Connection, _: Any) -> None:
+    """The connection-scoped subset, for connections that cannot write.
+
+    A `mode=ro` connection fails on `PRAGMA journal_mode = WAL`, so a read
+    engine opened against a database whose WAL was never initialised cannot
+    initialise it -- it can only inherit.
+    """
+    _apply_pragmas(connection, _CONNECTION_PRAGMAS)
+
+
+def aio_sqlite_read_engine(url: URL) -> Optional[AsyncEngine]:
+    """A read-only engine giving each concurrent reader its own connection.
+
+    The primary engine shares one connection across every session, so reads run
+    serialised behind the lock that keeps their transactions from interleaving
+    (see `DbSessionFactory.read`). Here each session owns its connection, so
+    there is nothing to serialise and no lock to take.
+
+    `mode=ro` is the second reason to route reads here rather than widen the
+    primary pool: writes are refused by the engine, not by convention.
+
+    None for in-memory databases -- a second connection to `:memory:` is a
+    different, empty database, and one developer has no concurrency to win.
+    """
+    if (url.database or ":memory:").startswith(":memory:"):
+        return None
+    database = url.render_as_string().partition("///")[-1]
+
+    # Persistent connections, not one per checkout: each open spawns an aiosqlite
+    # worker thread, which dominates a short read. Measured at 8 concurrent,
+    # 200 reads ran at 490/s per-checkout against 3,879/s pooled.
+    #
+    # pool_timeout=None so a caller past the pool waits rather than fails.
+    # Reads previously queued on an asyncio.Lock, which has no timeout, so
+    # rejecting them here would narrow the contract that already exists --
+    # a burst would start returning errors where it used to return answers
+    # slowly. Waiting keeps that policy; the cost is that a connection held
+    # indefinitely stalls its waiters, which was equally true of the lock.
+    #
+    # pre_ping is off because the target is a local file, with no network for
+    # a connection to go stale across.
+    engine = create_async_engine(
+        url=url,
+        json_serializer=_dumps,
+        async_creator=sqlite_connection_factory(database, mode="ro"),
+        pool_size=_READ_POOL_SIZE,
+        max_overflow=_READ_MAX_OVERFLOW,
+        pool_timeout=None,
+        pool_pre_ping=False,
+    )
+    event.listen(engine.sync_engine, "connect", set_sqlite_read_pragma)
+    return engine
 
 
 def create_engine(
@@ -120,23 +254,30 @@ def aio_sqlite_engine(
         url = url.set(query={**url.query, "cache": "shared"}, database=":memory:")
     database = url.render_as_string().partition("///")[-1]
 
-    def async_creator() -> aiosqlite.Connection:
-        conn = aiosqlite.Connection(
-            lambda: sqlean.connect(f"file:{database}", uri=True),
-            iter_chunk_size=64,
-        )
-        # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
-        # aiosqlite dialect daemonizes it only when it creates the connection
-        # itself, not when an async_creator is used.
-        conn._thread.daemon = True
-        return conn
-
     engine = create_async_engine(
         url=url,
         echo=log_to_stdout,
         json_serializer=_dumps,
-        async_creator=async_creator,
-        poolclass=StaticPool,
+        # rwc, not rw. Connections are lazy, so this engine can open before the
+        # migration engine has created the file -- and a `rw` connection to a
+        # database that does not exist yet fails rather than waiting for it.
+        async_creator=sqlite_connection_factory(database, mode="rwc"),
+        # One connection, checked out exclusively. StaticPool also holds one
+        # but hands it to every caller at once, and aiosqlite serialises
+        # statements rather than transactions -- so concurrent sessions
+        # interleaved their BEGIN/COMMIT spans and one session's commit landed
+        # another's uncommitted work. Checkout expresses that exclusion where
+        # the resource is; it previously lived in a lock callers had to pass.
+        #
+        # poolclass is explicit because the SQLite dialect otherwise defaults
+        # :memory: to StaticPool and rejects the sizing arguments.
+        poolclass=AsyncAdaptedQueuePool,
+        pool_size=1,
+        max_overflow=0,
+        # None, matching the lock this replaces: writes queue indefinitely and
+        # none are rejected. The 30s default would turn slow-under-contention
+        # into fails-under-contention.
+        pool_timeout=None,
     )
     event.listen(engine.sync_engine, "connect", set_sqlite_pragma)
     if not migrate:
@@ -147,7 +288,8 @@ def aio_sqlite_engine(
         migration_engine = create_async_engine(
             url=url,
             json_serializer=_dumps,
-            async_creator=async_creator,
+            # rwc: the migration engine is the only one that creates the file.
+            async_creator=sqlite_connection_factory(database, mode="rwc"),
             poolclass=NullPool,
             echo=log_migrations,
         )

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -51,9 +51,17 @@ _READ_MAX_OVERFLOW = 8
 # Settings scoped to one connection. Safe anywhere: none touches the file.
 _CONNECTION_PRAGMAS = (
     "PRAGMA foreign_keys = ON;",
-    "PRAGMA cache_size = -32000;",
     "PRAGMA busy_timeout = 10000;",
 )
+
+# Page cache, in KiB when negative. SQLite has no shared buffer pool, so each
+# connection holds its own and the read pool multiplies it.
+#
+# The writer's is larger because the cache also holds dirty pages until commit,
+# which sustained ingest depends on. Readers keep SQLite's default: a read
+# holds no dirty pages, and its misses fall through to the OS page cache.
+_WRITER_CACHE_PRAGMAS = ("PRAGMA cache_size = -32000;",)
+_READER_CACHE_PRAGMAS = ("PRAGMA cache_size = -2000;",)
 
 # Properties of the database file. `journal_mode` writes to its header, so a
 # read-only connection cannot set these; it inherits what the writer left, and
@@ -74,7 +82,7 @@ def _apply_pragmas(connection: Connection, statements: tuple[str, ...]) -> None:
 
 
 def set_sqlite_pragma(connection: Connection, _: Any) -> None:
-    _apply_pragmas(connection, _CONNECTION_PRAGMAS + _DATABASE_PRAGMAS)
+    _apply_pragmas(connection, _CONNECTION_PRAGMAS + _WRITER_CACHE_PRAGMAS + _DATABASE_PRAGMAS)
 
 
 def get_printable_db_url(connection_str: str) -> str:
@@ -154,12 +162,12 @@ def sqlite_connection_factory(
 
 
 def set_sqlite_read_pragma(connection: Connection, _: Any) -> None:
-    """The connection-scoped subset, for connections that cannot write.
+    """Connection settings for the read pool.
 
     A `mode=ro` connection fails on `PRAGMA journal_mode = WAL`, so a read
     engine inherits the journal mode the writer set and cannot set it itself.
     """
-    _apply_pragmas(connection, _CONNECTION_PRAGMAS)
+    _apply_pragmas(connection, _CONNECTION_PRAGMAS + _READER_CACHE_PRAGMAS)
 
 
 def _disable_implicit_transactions(connection: Connection, _: Any) -> None:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -446,17 +446,13 @@ async def version() -> PlainTextResponse:
     return PlainTextResponse(f"{phoenix_version}")
 
 
-def _db(
-    engine: AsyncEngine,
-) -> Callable[[Optional[asyncio.Lock]], AbstractAsyncContextManager[AsyncSession]]:
+def _db(engine: AsyncEngine) -> Callable[[], AbstractAsyncContextManager[AsyncSession]]:
     Session = async_sessionmaker(engine, expire_on_commit=False)
 
     @contextlib.asynccontextmanager
-    async def factory(lock: Optional[asyncio.Lock] = None) -> AsyncIterator[AsyncSession]:
-        async with contextlib.AsyncExitStack() as stack:
-            if lock:
-                await stack.enter_async_context(lock)
-            yield await stack.enter_async_context(Session.begin())
+    async def factory() -> AsyncIterator[AsyncSession]:
+        async with Session.begin() as session:
+            yield session
 
     return factory
 
@@ -651,7 +647,6 @@ def _lifespan(
         for callback in startup_callbacks:
             if isinstance((res := callback()), Awaitable):
                 await res
-        db.lock = asyncio.Lock() if db.dialect is SupportedSQLDialect.SQLITE else None
         await system_settings.bootstrap()
         async with AsyncExitStack() as stack:
             (

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -453,7 +453,9 @@ def _create_db_session_factory(
     if primary_engine.dialect.name == "sqlite":
         # Lets reads run concurrently instead of queueing behind the writer's
         # single connection; None for in-memory. See aio_sqlite_read_engine.
-        sqlite_read_engine = aio_sqlite_read_engine(get_async_db_url(db_connection_str))
+        sqlite_read_engine = aio_sqlite_read_engine(
+            get_async_db_url(db_connection_str), log_to_stdout=log_to_stdout
+        )
         if sqlite_read_engine is not None:
             shutdown_callbacks.extend(instrument_engine_if_enabled(sqlite_read_engine))
             shutdown_callbacks.append(sqlite_read_engine.dispose)

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -55,7 +55,7 @@ from phoenix.config import (
     get_pids_path,
 )
 from phoenix.db import get_printable_db_url
-from phoenix.db.engines import create_engine
+from phoenix.db.engines import aio_sqlite_read_engine, create_engine, get_async_db_url
 from phoenix.db.insertion.types import AnnotationPrecursor
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.agents.config import AgentsEnvConfig
@@ -450,6 +450,15 @@ def _create_db_session_factory(
     shutdown_callbacks.append(primary_engine.dispose)
 
     read_db = None
+    if primary_engine.dialect.name == "sqlite":
+        # Lets reads run concurrently instead of queueing behind the writer's
+        # single connection; None for in-memory. See aio_sqlite_read_engine.
+        sqlite_read_engine = aio_sqlite_read_engine(get_async_db_url(db_connection_str))
+        if sqlite_read_engine is not None:
+            shutdown_callbacks.extend(instrument_engine_if_enabled(sqlite_read_engine))
+            shutdown_callbacks.append(sqlite_read_engine.dispose)
+            read_db = _db(sqlite_read_engine)
+            logger.info("Read-only SQLite engine created")
     if read_replica_connection_str and primary_engine.dialect.name == "postgresql":
         replica_engine = create_engine(
             connection_str=read_replica_connection_str,

--- a/src/phoenix/server/types.py
+++ b/src/phoenix/server/types.py
@@ -31,16 +31,13 @@ class CanGetLastUpdatedAt(Protocol):
 class DbSessionFactory:
     def __init__(
         self,
-        db: Callable[[Optional[asyncio.Lock]], AbstractAsyncContextManager[AsyncSession]],
+        db: Callable[[], AbstractAsyncContextManager[AsyncSession]],
         dialect: str,
-        read_db: Optional[
-            Callable[[Optional[asyncio.Lock]], AbstractAsyncContextManager[AsyncSession]]
-        ] = None,
+        read_db: Optional[Callable[[], AbstractAsyncContextManager[AsyncSession]]] = None,
     ):
         self._db = db
         self._read_db = read_db or db
         self.dialect = SupportedSQLDialect(dialect)
-        self.lock: Optional[asyncio.Lock] = None
         self.should_not_insert_or_update = False
         """An informational flag that allows different tasks to coordinate whether insert
         and update operations should be allowed. For example, this can be set to True when disk
@@ -50,10 +47,16 @@ class DbSessionFactory:
         """
 
     def __call__(self) -> AbstractAsyncContextManager[AsyncSession]:
-        return self._db(self.lock)
+        return self._db()
 
     def read(self) -> AbstractAsyncContextManager[AsyncSession]:
-        return self._read_db(self.lock)
+        """A session for reads that need not observe their own writes.
+
+        Do not rely on read-your-writes: against a Postgres replica this can be
+        arbitrarily stale. Without a read engine it falls back to the writer's,
+        whose pool then serialises it with writes.
+        """
+        return self._read_db()
 
 
 _AnyT = TypeVar("_AnyT")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -288,12 +288,12 @@ def _serialized(
 
     Tests bind every session to one `AsyncConnection` held open under a
     transaction and savepoint, so a test rolls back wholesale. Concurrent
-    sessions then interleave transaction boundaries on a connection none of
-    them owns, and a rollback takes out a savepoint another still needs.
+    sessions would then interleave transaction boundaries on a connection none
+    of them owns, and one rollback would remove a savepoint another still
+    needs.
 
-    Production shares nothing -- its pool hands out a connection per checkout --
-    so this belongs with the fixture that creates the sharing rather than in
-    application code carrying it solely for this harness.
+    Production shares nothing: its pool hands out a connection per checkout, so
+    the serialisation belongs to the fixture that creates the sharing.
     """
     lock = asyncio.Lock()
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import os
 from asyncio import AbstractEventLoop
@@ -22,7 +23,7 @@ from pytest import FixtureRequest
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import URL, StaticPool
 from sqlalchemy.dialects import postgresql, sqlite
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession, create_async_engine
 from starlette.types import ASGIApp
 
 from phoenix.db import models
@@ -280,6 +281,31 @@ async def _sqlite_test_conn(
         pass
 
 
+def _serialized(
+    factory: Callable[[], contextlib.AbstractAsyncContextManager[AsyncSession]],
+) -> Callable[[], contextlib.AbstractAsyncContextManager[AsyncSession]]:
+    """Give sessions exclusive use of the connection these fixtures share.
+
+    Tests bind every session to one `AsyncConnection` held open under a
+    transaction and savepoint, so a test rolls back wholesale. Concurrent
+    sessions then interleave transaction boundaries on a connection none of
+    them owns, and a rollback takes out a savepoint another still needs.
+
+    Production shares nothing -- its pool hands out a connection per checkout --
+    so this belongs with the fixture that creates the sharing rather than in
+    application code carrying it solely for this harness.
+    """
+    lock = asyncio.Lock()
+
+    @contextlib.asynccontextmanager
+    async def serialized() -> AsyncIterator[AsyncSession]:
+        async with lock:
+            async with factory() as session:
+                yield session
+
+    return serialized
+
+
 @pytest.fixture(scope="function")
 def db(
     request: SubRequest,
@@ -287,7 +313,7 @@ def db(
 ) -> DbSessionFactory:
     if dialect == "sqlite":
         conn = request.getfixturevalue("_sqlite_test_conn")
-        return DbSessionFactory(db=_db(conn), dialect=dialect)
+        return DbSessionFactory(db=_serialized(_db(conn)), dialect=dialect)
     elif dialect == "postgresql":
         engine = request.getfixturevalue("postgresql_engine")
         return DbSessionFactory(db=_db(engine), dialect=dialect)

--- a/tests/unit/db/test_engines.py
+++ b/tests/unit/db/test_engines.py
@@ -1,9 +1,12 @@
+from pathlib import Path
 from unittest import mock
 
 import pytest
+import sqlean
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from phoenix.db.engines import aio_sqlite_engine, get_async_db_url
+from phoenix.db.engines import aio_sqlite_engine, aio_sqlite_read_engine, get_async_db_url
 
 
 def test_get_async_sqlite_db_url() -> None:
@@ -55,3 +58,31 @@ async def test_memory_sqlite_init_failure_propagates_to_caller() -> None:
     with mock.patch("phoenix.db.engines.init_models", fail):
         with pytest.raises(RuntimeError, match="init failed"):
             aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)
+
+
+async def test_sqlite_read_session_holds_one_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "phoenix.db"
+    setup = sqlean.connect(str(path))
+    setup.execute("PRAGMA journal_mode = WAL")
+    setup.execute("create table t (x int)")
+    setup.execute("insert into t values (1)")
+    setup.commit()
+    setup.close()
+
+    engine = aio_sqlite_read_engine(get_async_db_url(f"sqlite:///{path}"))
+    assert engine is not None
+    try:
+        async with async_sessionmaker(engine, expire_on_commit=False).begin() as session:
+            before = await session.scalar(text("select count(*) from t"))
+            # Committed by another connection while the session is open. Without
+            # an explicit BEGIN the next statement takes a fresh WAL read mark
+            # and counts it, so the two reads disagree within one session.
+            writer = sqlean.connect(str(path))
+            writer.execute("insert into t values (2)")
+            writer.commit()
+            writer.close()
+            after = await session.scalar(text("select count(*) from t"))
+        assert before == 1
+        assert after == 1
+    finally:
+        await engine.dispose()

--- a/tests/unit/db/test_engines.py
+++ b/tests/unit/db/test_engines.py
@@ -6,7 +6,12 @@ import sqlean
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from phoenix.db.engines import aio_sqlite_engine, aio_sqlite_read_engine, get_async_db_url
+from phoenix.db.engines import (
+    aio_sqlite_engine,
+    aio_sqlite_read_engine,
+    get_async_db_url,
+    set_sqlite_migration_pragma,
+)
 
 
 def test_get_async_sqlite_db_url() -> None:
@@ -58,6 +63,35 @@ async def test_memory_sqlite_init_failure_propagates_to_caller() -> None:
     with mock.patch("phoenix.db.engines.init_models", fail):
         with pytest.raises(RuntimeError, match="init failed"):
             aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=True)
+
+
+def test_migration_pragma_leaves_foreign_keys_off() -> None:
+    # Alembic rewrites a table by dropping the original, which cascades to child
+    # rows while enforcement is on. Completing the pragma set here would delete
+    # every API key and token on the next such migration.
+    connection = sqlean.connect(":memory:")
+    try:
+        set_sqlite_migration_pragma(connection, None)
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+async def test_migrated_sqlite_file_is_in_wal_mode(tmp_path: Path) -> None:
+    path = tmp_path / "phoenix.db"
+    engine = aio_sqlite_engine(
+        get_async_db_url(f"sqlite:///{path}"), migrate=True, log_migrations=False
+    )
+    try:
+        # Checked without connecting the engine: the migration connection creates
+        # the file, and a mode=ro reader cannot set the journal mode itself.
+        connection = sqlean.connect(str(path))
+        try:
+            assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        finally:
+            connection.close()
+    finally:
+        await engine.dispose()
 
 
 async def test_sqlite_read_session_holds_one_snapshot(tmp_path: Path) -> None:

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from secrets import token_hex
 from typing import Any
@@ -598,7 +599,7 @@ class TestDisabledProviderAndConfigGuards:
 
 
 class TestCodeEvaluatorSandboxMutationIds:
-    async def test_create_releases_database_lock_and_reports_unavailable_validation(
+    async def test_create_reports_unavailable_validation_as_a_clean_result(
         self,
         gql_client: AsyncGraphQLClient,
         db: DbSessionFactory,
@@ -608,13 +609,11 @@ class TestCodeEvaluatorSandboxMutationIds:
         adapter = sandbox_module.SANDBOX_ADAPTERS.get("MONTY")
         assert adapter is not None
 
-        async def unavailable_without_database_lock(*args: object, **kwargs: object) -> None:
+        async def unavailable(*args: object, **kwargs: object) -> None:
             del args, kwargs
-            if db.lock is not None:
-                assert not db.lock.locked()
             raise SandboxValidationUnavailable("capacity is busy")
 
-        with patch.object(adapter, "validate_code", side_effect=unavailable_without_database_lock):
+        with patch.object(adapter, "validate_code", side_effect=unavailable):
             result = await gql_client.execute(
                 _CREATE_CODE_EVALUATOR,
                 variables={
@@ -627,6 +626,66 @@ class TestCodeEvaluatorSandboxMutationIds:
 
         assert result.errors
         assert "could not be validated by the Monty runtime" in str(result.errors)
+        assert "Retry shortly" in str(result.errors)
+
+    async def test_create_does_not_hold_a_database_session_during_validation(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Sandboxed validation must run outside the metadata transaction.
+
+        `_validate_code_evaluator_sandbox_config` reads the config in a short
+        `async with db()` block, closes it, and only then calls the adapter. That
+        ordering is load-bearing rather than stylistic: validation waits on
+        sandbox worker capacity, and SQLite serves every writer from one
+        connection, so holding the session across the call stalls all other
+        writes in the process for as long as the sandbox is busy. Moving the
+        call inside the block reintroduces that without changing any result.
+
+        An earlier version asserted `db.lock` was free at this point. That lock
+        no longer exists, and its removal deleted the only check on an ordering
+        the source still depends on -- the comment above the call is otherwise
+        the sole thing defending it.
+
+        Opening a second session from inside the adapter is what makes this
+        discriminate: the SQLite fixture serialises sessions on a lock of its
+        own, so a session still held by the mutation blocks this one until the
+        timeout. That is the same shape as the production hazard.
+        """
+        config = await _create_monty_config(db)
+        adapter = sandbox_module.SANDBOX_ADAPTERS.get("MONTY")
+        assert adapter is not None
+        reached_database = False
+
+        async def unavailable(*args: object, **kwargs: object) -> None:
+            del args, kwargs
+            nonlocal reached_database
+
+            async def touch_database() -> None:
+                async with db() as session:
+                    await session.execute(sa.text("SELECT 1"))
+
+            # Bounded, because the failure this guards against is a block that
+            # never resolves rather than one that resolves slowly.
+            await asyncio.wait_for(touch_database(), timeout=5)
+            reached_database = True
+            raise SandboxValidationUnavailable("capacity is busy")
+
+        with patch.object(adapter, "validate_code", side_effect=unavailable):
+            result = await gql_client.execute(
+                _CREATE_CODE_EVALUATOR,
+                variables={
+                    "input": _create_code_evaluator_input(
+                        sandbox_config_id=config.id,
+                        name=f"concurrent-monty-{token_hex(4)}",
+                    )
+                },
+            )
+
+        assert reached_database, "the mutation was still holding a session during validation"
+        assert result.errors
         assert "Retry shortly" in str(result.errors)
 
     async def test_create_rejects_code_unsupported_by_selected_sandbox_before_write(

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -637,22 +637,17 @@ class TestCodeEvaluatorSandboxMutationIds:
         """Sandboxed validation must run outside the metadata transaction.
 
         `_validate_code_evaluator_sandbox_config` reads the config in a short
-        `async with db()` block, closes it, and only then calls the adapter. That
-        ordering is load-bearing rather than stylistic: validation waits on
-        sandbox worker capacity, and SQLite serves every writer from one
-        connection, so holding the session across the call stalls all other
-        writes in the process for as long as the sandbox is busy. Moving the
-        call inside the block reintroduces that without changing any result.
-
-        An earlier version asserted `db.lock` was free at this point. That lock
-        no longer exists, and its removal deleted the only check on an ordering
-        the source still depends on -- the comment above the call is otherwise
-        the sole thing defending it.
+        `async with db()` block, closes it, and only then calls the adapter.
+        Validation waits on sandbox worker capacity, and SQLite serves every
+        writer from one connection, so holding the session across that call
+        stalls every other write in the process until the sandbox frees up.
+        Moving the call inside the block reintroduces the stall without
+        changing any result.
 
         Opening a second session from inside the adapter is what makes this
-        discriminate: the SQLite fixture serialises sessions on a lock of its
-        own, so a session still held by the mutation blocks this one until the
-        timeout. That is the same shape as the production hazard.
+        discriminate: the SQLite fixture serialises sessions, so a session the
+        mutation still holds blocks this one until the timeout, which is the
+        same shape as the production hazard.
         """
         config = await _create_monty_config(db)
         adapter = sandbox_module.SANDBOX_ADAPTERS.get("MONTY")


### PR DESCRIPTION
## What this changes

Reads on SQLite queued behind the writer's single `StaticPool` connection. This gives them their own engine — `mode=ro`, `QueuePool` — so they run concurrently.

**Measured: 490 statements/s with `NullPool` against 3,879/s with a queue pool.** That ratio is why this is a pool rather than a connection per read.

In-memory SQLite gets no read engine, because there is no file for a second connection to open.

## The lock goes away

With the writer no longer shared, the lock has nothing left to protect, so every session factory becomes zero-argument. Two call sites follow from that, and both are worth a look:

- **The PXI harness stub** declared a positional parameter to receive the lock, so it raised `TypeError` on argument binding before its own `RuntimeError` could explain that no database is available.
- **A sandbox mutation test** asserted `db.lock` was free during sandboxed validation. That lock is gone, but the ordering it guarded is not — validation waits on worker capacity and must run outside the metadata transaction. The replacement opens a second session from inside the adapter, which the SQLite test fixture serialises, so a session still held by the mutation blocks it. Verified to fail when the call is moved back inside the session block.

## Known limitation

Read-your-writes is not guaranteed on the pooled read path. This is stated on `DbSessionFactory.read` — and it already was not guaranteed against a PostgreSQL replica.

## Review notes

`src/phoenix/db/engines.py` carries the change; `types.py`, `app.py` and `serve.py` are the signature ripple. The two test files above are the interesting ones, because each encodes an ordering guarantee that survived the lock's removal.
