### PR TITLE
docs: update user interview cal.com link to arize team

### DIFF
--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -10,7 +10,7 @@ GitHub
 </Card>
 
 <Info>
-**We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize-devrel/user-interview).
+**We want to hear from you!** The DevRel team wants to hear from the Phoenix community. If you're building with Phoenix and want to tell us what's working, what's painful, or what you wish existed, [grab 25 minutes with us](https://cal.com/team/arize/user-interview).
 </Info>
 
 <ReleaseUpdate label="07.28.2026" href="/docs/phoenix/release-notes/07-2026/07-28-2026-experiment-charts-span-downloads-and-root-span-filters" title="Experiment Charts, Span Downloads, and Root-Span Filters">


### PR DESCRIPTION
## Summary

The user interview booking link in the release notes pointed at the old `arize-devrel` cal.com team. Updated it to `arize`.

- `https://cal.com/team/arize-devrel/user-interview` → `https://cal.com/team/arize/user-interview`

This was the only occurrence of the old link in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)