### PR TITLE
fix: tracer leak and cost tracking guards

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -10,12 +10,18 @@ from collections.abc import (
     Iterable,
     Sequence,
 )
-from contextlib import AbstractContextManager, aclosing, nullcontext
+from contextlib import (
+    AbstractAsyncContextManager,
+    AbstractContextManager,
+    aclosing,
+    nullcontext,
+)
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Literal, TypeVar
 
+import anyio
 from fastapi import APIRouter, Depends, HTTPException
 from openinference.instrumentation import using_metadata, using_session, using_user
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
@@ -136,6 +142,10 @@ from phoenix.tracers import (
 )
 
 _PHOENIX_PROVIDER_METADATA_KEY = "phoenix"
+
+# Bound on the shielded trace write in `_persist_agent_traces`, matching
+# the experiment runner's shielded DB writes.
+_TRACE_PERSIST_TIMEOUT_SECONDS = 5
 
 _PXI_INSTRUMENTATION_SCOPE = InstrumentationScope("phoenix.server.pxi")
 
@@ -831,29 +841,42 @@ async def _persist_db_traces_and_emit_event(
         event_queue.put(SpanInsertEvent(project_ids))
 
 
-async def _flush_and_persist_agent_traces(
+def _tracer_scope(tracer: Tracer | None) -> AbstractAsyncContextManager[object]:
+    """Bound a tracer's lifetime, or do nothing when trace recording is off.
+
+    Leaving the block releases the tracer, so teardown depends on no statement
+    inside it running. It is also what drains the remote exporter, on a worker
+    thread and necessarily after everything in the block — so a hung collector
+    cannot delay the local write, and there is no flush left to order by hand.
+    """
+    return nullcontext() if tracer is None else tracer
+
+
+async def _persist_agent_traces(
     *,
     tracer: Tracer,
     request: Request,
     project_name: str,
-    ingest_traces: bool,
 ) -> None:
-    """Flush an agent turn's tracer, persist what it captured, and tear it down.
+    """Persist what an agent turn's tracer captured.
 
-    Every caller runs this from a ``finally``, which is what makes the guarding
-    here load-bearing on two counts. An exception raised in a ``finally``
-    replaces the one already in flight, so an unguarded failure here would
-    discard the real error — an endpoint raising ``HTTPException(502)`` would
-    answer 500 with none of its detail. And it would skip the ``shutdown()``
-    below, stranding the provider's export thread and holding onto every
-    buffered span for the life of the process.
+    Callers run this from a ``finally``, so it never raises: an exception here
+    would replace the one already in flight, and a turn whose traces cannot be
+    written still produced its answer. Failures are logged instead.
 
-    Recording telemetry is bookkeeping either way: a turn whose traces cannot be
-    written still produced its answer, so a failure is logged rather than raised.
+    Teardown is not done here — the ``with`` block owning the tracer releases
+    it, so nothing this function does can skip it.
+
+    Both phases are shielded because the usual failure is a client
+    disconnecting, which cancels this scope: unshielded, the first suspending
+    ``await`` raises ``CancelledError`` straight through ``except Exception``
+    and the traces are lost. ``_persist_run`` shields the same way.
     """
     try:
-        tracer.tracer_provider.force_flush()
-        if ingest_traces:
+        # Bounded as well as shielded, so a stalled database cannot pile up
+        # handlers on a burst of disconnects. Expiry is a `TimeoutError`, so it
+        # logs like any other write failure.
+        with anyio.fail_after(_TRACE_PERSIST_TIMEOUT_SECONDS, shield=True):
             project_id = await _ensure_project_exists(request.app.state.db, project_name)
             db_traces = tracer.get_db_traces(project_id=project_id)
             await _persist_db_traces_and_emit_event(
@@ -863,8 +886,6 @@ async def _flush_and_persist_agent_traces(
             )
     except Exception:
         logger.exception("Failed to persist agent traces for project %r", project_name)
-    finally:
-        tracer.tracer_provider.shutdown()
 
 
 async def _refresh_cumulative_span_counts(
@@ -1297,33 +1318,33 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             )
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
-            try:
-                with detached_otel_context(), using_session(session_id=session_id):
-                    raw_stream = adapter.run_stream(deps=None, on_complete=_on_complete)
-                    assert _is_async_generator(raw_stream)
-                    async with aclosing(raw_stream) as stream:
-                        async for chunk in stream:
-                            if isinstance(chunk, ToolInputAvailableChunk):
-                                chunk.provider_metadata = _get_updated_provider_metadata(
-                                    provider_metadata=chunk.provider_metadata or {},
-                                    tool_name=chunk.tool_name,
-                                    emitted_at=datetime.now(timezone.utc),
-                                )
-                            yield chunk
-            except Exception as exc:
-                # Surface the failure to the client as an error chunk (e.g. a
-                # rejected API key) instead of letting the connection close
-                # silently, which leaves the agent appearing to hang.
-                logger.exception("Server agent chat stream failed for session %s", session_id)
-                yield build_stream_error_chunk(exc)
-            finally:
-                if tracer is not None:
-                    await _flush_and_persist_agent_traces(
-                        tracer=tracer,
-                        request=request,
-                        project_name=project_name,
-                        ingest_traces=ingest_traces,
-                    )
+            async with _tracer_scope(tracer):
+                try:
+                    with detached_otel_context(), using_session(session_id=session_id):
+                        raw_stream = adapter.run_stream(deps=None, on_complete=_on_complete)
+                        assert _is_async_generator(raw_stream)
+                        async with aclosing(raw_stream) as stream:
+                            async for chunk in stream:
+                                if isinstance(chunk, ToolInputAvailableChunk):
+                                    chunk.provider_metadata = _get_updated_provider_metadata(
+                                        provider_metadata=chunk.provider_metadata or {},
+                                        tool_name=chunk.tool_name,
+                                        emitted_at=datetime.now(timezone.utc),
+                                    )
+                                yield chunk
+                except Exception as exc:
+                    # Surface the failure to the client as an error chunk (e.g. a
+                    # rejected API key) instead of letting the connection close
+                    # silently, which leaves the agent appearing to hang.
+                    logger.exception("Server agent chat stream failed for session %s", session_id)
+                    yield build_stream_error_chunk(exc)
+                finally:
+                    if tracer is not None and ingest_traces:
+                        await _persist_agent_traces(
+                            tracer=tracer,
+                            request=request,
+                            project_name=project_name,
+                        )
 
         return adapter.streaming_response(_stream_with_session())
 
@@ -1548,108 +1569,112 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
             stream_error: BaseException | None = None
-            try:
-                if tracer is not None and body.turn_trace_context is not None:
-                    _synthesize_client_tool_spans(
-                        tracer=tracer,
-                        turn_ids=turn_ids,
-                        messages=body.messages,
-                        received_at=request_received_at,
-                        session_id=session_id,
-                    )
-                with (
-                    detached_otel_context(parent_context),
-                    using_session(session_id=session_id),
-                    _maybe_using_user(attach_user_id, phoenix_user_email),
-                ):
-                    raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
-                    assert _is_async_generator(raw_stream)
-
-                    async def _agent_message_chunks() -> AsyncIterator[BaseChunk]:
-                        # Forced skills are streamed as their own `load_skill` steps so
-                        # the browser transcript matches what the model received. They
-                        # are emitted once, right after the stream's opening `start`
-                        # message chunk and before the model's own output.
-                        forced_skills_streamed = not forced_skills
-                        async with aclosing(raw_stream) as stream:
-                            async for agent_message_chunk in stream:
-                                if isinstance(agent_message_chunk, ToolInputAvailableChunk):
-                                    agent_message_chunk.provider_metadata = (
-                                        _get_updated_provider_metadata(
-                                            provider_metadata=agent_message_chunk.provider_metadata
-                                            or {},
-                                            tool_name=agent_message_chunk.tool_name,
-                                            emitted_at=datetime.now(timezone.utc),
-                                        )
-                                    )
-                                yield agent_message_chunk
-                                if not forced_skills_streamed and isinstance(
-                                    agent_message_chunk,
-                                    StartChunk,
-                                ):
-                                    forced_skill_message_chunks = (
-                                        iter_requested_skill_response_chunks(
-                                            skills=forced_skills,
-                                            load_skill_template=agent_prompts.load_skill,
-                                        )
-                                    )
-                                    for forced_skill_message_chunk in forced_skill_message_chunks:
-                                        if isinstance(
-                                            forced_skill_message_chunk, ToolInputAvailableChunk
-                                        ):
-                                            provider_metadata = _get_updated_provider_metadata(
-                                                provider_metadata=forced_skill_message_chunk.provider_metadata
-                                                or {},
-                                                tool_name=forced_skill_message_chunk.tool_name,
-                                                emitted_at=datetime.now(timezone.utc),
-                                            )
-                                            forced_skill_message_chunk.provider_metadata = (
-                                                provider_metadata
-                                            )
-                                        yield forced_skill_message_chunk
-                                    forced_skills_streamed = True
-
-                    async for message_chunk in _interleave_agent_and_subagent_message_chunks(
-                        agent_message_chunks=_agent_message_chunks(),
-                        subagent_message_chunks=subagent_message_chunks,
-                        final_tool_outputs_by_tool_call_id=final_tool_outputs_by_tool_call_id,
-                    ):
-                        yield message_chunk
-            except Exception as exc:
-                # Surface the failure to the client as an error chunk (e.g. a
-                # rejected API key) instead of letting the connection close
-                # silently, which leaves the agent appearing to hang.
-                stream_error = exc
-                logger.exception("Agent chat stream failed for session %s", session_id)
-                yield build_stream_error_chunk(exc)
-            except BaseException as exc:
-                # Cancellation and other non-``Exception`` failures propagate so
-                # client disconnects are not misreported as agent errors.
-                stream_error = exc
-                raise
-            finally:
-                if tracer is not None:
-                    if turn_is_terminal or stream_error is not None:
-                        _emit_turn_root_span(
+            async with _tracer_scope(tracer):
+                try:
+                    if tracer is not None and body.turn_trace_context is not None:
+                        _synthesize_client_tool_spans(
                             tracer=tracer,
                             turn_ids=turn_ids,
+                            messages=body.messages,
+                            received_at=request_received_at,
                             session_id=session_id,
-                            input_text=_get_last_user_text(body.messages),
-                            output_text=turn_final_output_text,
-                            error_message=(
-                                None
-                                if stream_error is None
-                                else (str(stream_error) or type(stream_error).__name__)
-                            ),
-                            end_time=datetime.now(timezone.utc),
-                            user_email=phoenix_user_email if attach_user_id else None,
                         )
-                    await _flush_and_persist_agent_traces(
-                        tracer=tracer,
-                        request=request,
-                        project_name=project_name,
-                        ingest_traces=ingest_traces,
-                    )
+                    with (
+                        detached_otel_context(parent_context),
+                        using_session(session_id=session_id),
+                        _maybe_using_user(attach_user_id, phoenix_user_email),
+                    ):
+                        raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
+                        assert _is_async_generator(raw_stream)
+
+                        async def _agent_message_chunks() -> AsyncIterator[BaseChunk]:
+                            # Forced skills are streamed as their own `load_skill` steps so
+                            # the browser transcript matches what the model received. They
+                            # are emitted once, right after the stream's opening `start`
+                            # message chunk and before the model's own output.
+                            forced_skills_streamed = not forced_skills
+                            async with aclosing(raw_stream) as stream:
+                                async for agent_message_chunk in stream:
+                                    if isinstance(agent_message_chunk, ToolInputAvailableChunk):
+                                        agent_message_chunk.provider_metadata = (
+                                            _get_updated_provider_metadata(
+                                                provider_metadata=(
+                                                    agent_message_chunk.provider_metadata or {}
+                                                ),
+                                                tool_name=agent_message_chunk.tool_name,
+                                                emitted_at=datetime.now(timezone.utc),
+                                            )
+                                        )
+                                    yield agent_message_chunk
+                                    if not forced_skills_streamed and isinstance(
+                                        agent_message_chunk,
+                                        StartChunk,
+                                    ):
+                                        forced_skill_message_chunks = (
+                                            iter_requested_skill_response_chunks(
+                                                skills=forced_skills,
+                                                load_skill_template=agent_prompts.load_skill,
+                                            )
+                                        )
+                                        for (
+                                            forced_skill_message_chunk
+                                        ) in forced_skill_message_chunks:
+                                            if isinstance(
+                                                forced_skill_message_chunk, ToolInputAvailableChunk
+                                            ):
+                                                provider_metadata = _get_updated_provider_metadata(
+                                                    provider_metadata=forced_skill_message_chunk.provider_metadata
+                                                    or {},
+                                                    tool_name=forced_skill_message_chunk.tool_name,
+                                                    emitted_at=datetime.now(timezone.utc),
+                                                )
+                                                forced_skill_message_chunk.provider_metadata = (
+                                                    provider_metadata
+                                                )
+                                            yield forced_skill_message_chunk
+                                        forced_skills_streamed = True
+
+                        async for message_chunk in _interleave_agent_and_subagent_message_chunks(
+                            agent_message_chunks=_agent_message_chunks(),
+                            subagent_message_chunks=subagent_message_chunks,
+                            final_tool_outputs_by_tool_call_id=final_tool_outputs_by_tool_call_id,
+                        ):
+                            yield message_chunk
+                except Exception as exc:
+                    # Surface the failure to the client as an error chunk (e.g. a
+                    # rejected API key) instead of letting the connection close
+                    # silently, which leaves the agent appearing to hang.
+                    stream_error = exc
+                    logger.exception("Agent chat stream failed for session %s", session_id)
+                    yield build_stream_error_chunk(exc)
+                except BaseException as exc:
+                    # Cancellation and other non-``Exception`` failures propagate so
+                    # client disconnects are not misreported as agent errors.
+                    stream_error = exc
+                    raise
+                finally:
+                    if tracer is not None:
+                        if turn_is_terminal or stream_error is not None:
+                            _emit_turn_root_span(
+                                tracer=tracer,
+                                turn_ids=turn_ids,
+                                session_id=session_id,
+                                input_text=_get_last_user_text(body.messages),
+                                output_text=turn_final_output_text,
+                                error_message=(
+                                    None
+                                    if stream_error is None
+                                    else (str(stream_error) or type(stream_error).__name__)
+                                ),
+                                end_time=datetime.now(timezone.utc),
+                                user_email=phoenix_user_email if attach_user_id else None,
+                            )
+                        if ingest_traces:
+                            await _persist_agent_traces(
+                                tracer=tracer,
+                                request=request,
+                                project_name=project_name,
+                            )
 
         return adapter.streaming_response(_stream_with_session())
 
@@ -1687,42 +1712,42 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         )
         tracer_provider = tracer.tracer_provider if tracer is not None else None
 
-        try:
-            async with request.app.state.db() as session:
-                model = await build_model(
-                    body.model,
-                    session=session,
-                    decrypt=request.app.state.decrypt,
-                    tracer_provider=tracer_provider,
-                )
-                user = request.user if "user" in request.scope else None
-                phoenix_user = user if isinstance(user, PhoenixUser) else None
-                phoenix_user_email = await _load_phoenix_user_email(
-                    session=session,
-                    phoenix_user=phoenix_user,
-                )
-        except AgentError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+        async with _tracer_scope(tracer):
+            try:
+                async with request.app.state.db() as session:
+                    model = await build_model(
+                        body.model,
+                        session=session,
+                        decrypt=request.app.state.decrypt,
+                        tracer_provider=tracer_provider,
+                    )
+                    user = request.user if "user" in request.scope else None
+                    phoenix_user = user if isinstance(user, PhoenixUser) else None
+                    phoenix_user_email = await _load_phoenix_user_email(
+                        session=session,
+                        phoenix_user=phoenix_user,
+                    )
+            except AgentError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
-        history = VercelAIAdapter.load_messages(body.messages)
-        parent_context = extract_otel_context(dict(request.headers))
-        try:
-            with (
-                detached_otel_context(parent_context),
-                using_metadata({"session_id": session_id}),
-                _maybe_using_user(attach_user_id, phoenix_user_email),
-            ):
-                result = await summarize_messages(messages=history, model=model)
-        except SummarizationError as exc:
-            raise HTTPException(status_code=502, detail=str(exc)) from exc
-        finally:
-            if tracer is not None:
-                await _flush_and_persist_agent_traces(
-                    tracer=tracer,
-                    request=request,
-                    project_name=project_name,
-                    ingest_traces=ingest_traces,
-                )
-        return _SummarizeResponse(summary=result.summary.strip())
+            history = VercelAIAdapter.load_messages(body.messages)
+            parent_context = extract_otel_context(dict(request.headers))
+            try:
+                with (
+                    detached_otel_context(parent_context),
+                    using_metadata({"session_id": session_id}),
+                    _maybe_using_user(attach_user_id, phoenix_user_email),
+                ):
+                    result = await summarize_messages(messages=history, model=model)
+            except SummarizationError as exc:
+                raise HTTPException(status_code=502, detail=str(exc)) from exc
+            finally:
+                if tracer is not None and ingest_traces:
+                    await _persist_agent_traces(
+                        tracer=tracer,
+                        request=request,
+                        project_name=project_name,
+                    )
+            return _SummarizeResponse(summary=result.summary.strip())
 
     return router

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -143,8 +143,11 @@ from phoenix.tracers import (
 
 _PHOENIX_PROVIDER_METADATA_KEY = "phoenix"
 
-# Bound on the shielded trace write in `_persist_agent_traces`, matching
-# the experiment runner's shielded DB writes.
+# Arbitrary in the seconds range; nothing downstream derives it. On SQLite every
+# session serializes on one process-wide `asyncio.Lock` that waits indefinitely,
+# so the bound is what keeps a disconnected turn's bookkeeping out of the way of
+# live requests. It therefore fires under load, not only on a broken database,
+# and no larger value avoids that.
 _TRACE_PERSIST_TIMEOUT_SECONDS = 5
 
 _PXI_INSTRUMENTATION_SCOPE = InstrumentationScope("phoenix.server.pxi")
@@ -844,10 +847,10 @@ async def _persist_db_traces_and_emit_event(
 def _tracer_scope(tracer: Tracer | None) -> AbstractAsyncContextManager[object]:
     """Bound a tracer's lifetime, or do nothing when trace recording is off.
 
-    Leaving the block releases the tracer, so teardown depends on no statement
-    inside it running. It is also what drains the remote exporter, on a worker
-    thread and necessarily after everything in the block — so a hung collector
-    cannot delay the local write, and there is no flush left to order by hand.
+    Leaving the block releases the tracer, so the release does not depend on
+    any statement inside the block running. The release is also what drains the
+    remote exporter. It runs on a worker thread, after everything in the block,
+    so a hung collector cannot delay the local write.
     """
     return nullcontext() if tracer is None else tracer
 
@@ -864,17 +867,17 @@ async def _persist_agent_traces(
     would replace the one already in flight, and a turn whose traces cannot be
     written still produced its answer. Failures are logged instead.
 
-    Teardown is not done here — the ``with`` block owning the tracer releases
-    it, so nothing this function does can skip it.
+    Releasing the tracer belongs to the ``with`` block that owns it, so nothing
+    this function does can skip teardown.
 
-    Both phases are shielded because the usual failure is a client
-    disconnecting, which cancels this scope: unshielded, the first suspending
-    ``await`` raises ``CancelledError`` straight through ``except Exception``
-    and the traces are lost. ``_persist_run`` shields the same way.
+    The project lookup and the write are shielded: a client disconnect cancels
+    this scope, and unshielded the first suspending ``await`` would raise
+    ``CancelledError`` straight through ``except Exception``, losing the
+    traces.
     """
     try:
-        # Bounded as well as shielded, so a stalled database cannot pile up
-        # handlers on a burst of disconnects. Expiry is a `TimeoutError`, so it
+        # Bounded as well as shielded, so a slow database cannot pile up
+        # handlers on a burst of disconnects. Expiry raises `TimeoutError` and
         # logs like any other write failure.
         with anyio.fail_after(_TRACE_PERSIST_TIMEOUT_SECONDS, shield=True):
             project_id = await _ensure_project_exists(request.app.state.db, project_name)

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -129,10 +129,10 @@ from phoenix.server.api.types.SandboxConfig import (
     get_sandbox_backend_info,
 )
 from phoenix.server.bearer_auth import PhoenixUser, is_authenticated
-from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
+from phoenix.server.dml_event import SpanInsertEvent
 from phoenix.server.sandbox import SecretsContext
 from phoenix.server.sandbox.types import SandboxRuntimeContext
-from phoenix.server.types import CanPutItem, DbSessionFactory
+from phoenix.server.types import DbSessionFactory
 from phoenix.tracers import (
     Tracer,
     build_synthetic_readable_span,
@@ -830,20 +830,6 @@ async def _persist_db_traces(
     return project_ids
 
 
-async def _persist_db_traces_and_emit_event(
-    *,
-    db: DbSessionFactory,
-    event_queue: CanPutItem[DmlEvent],
-    db_traces: list[models.Trace],
-) -> None:
-    if not db_traces:
-        return
-    async with db() as session:
-        project_ids = await _persist_db_traces(session=session, db_traces=db_traces)
-    if project_ids:
-        event_queue.put(SpanInsertEvent(project_ids))
-
-
 def _tracer_scope(tracer: Tracer | None) -> AbstractAsyncContextManager[object]:
     """Bound a tracer's lifetime, or do nothing when trace recording is off.
 
@@ -876,17 +862,21 @@ async def _persist_agent_traces(
     traces.
     """
     try:
+        db: DbSessionFactory = request.app.state.db
         # Bounded as well as shielded, so a slow database cannot pile up
         # handlers on a burst of disconnects. Expiry raises `TimeoutError` and
         # logs like any other write failure.
         with anyio.fail_after(_TRACE_PERSIST_TIMEOUT_SECONDS, shield=True):
-            project_id = await _ensure_project_exists(request.app.state.db, project_name)
-            db_traces = tracer.get_db_traces(project_id=project_id)
-            await _persist_db_traces_and_emit_event(
-                db=request.app.state.db,
-                event_queue=request.state.event_queue,
-                db_traces=db_traces,
-            )
+            async with db() as session:
+                project_id = await _ensure_project_exists(session, project_name)
+                db_traces = tracer.get_db_traces(project_id=project_id)
+                project_ids = (
+                    await _persist_db_traces(session=session, db_traces=db_traces)
+                    if db_traces
+                    else ()
+                )
+            if project_ids:
+                request.state.event_queue.put(SpanInsertEvent(project_ids))
     except Exception:
         logger.exception("Failed to persist agent traces for project %r", project_name)
 
@@ -1093,21 +1083,31 @@ async def _interleave_agent_and_subagent_message_chunks(
             await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
 
 
-async def _ensure_project_exists(db: DbSessionFactory, project_name: str) -> int:
-    """Resolve project_id by name, creating the project row if missing."""
-    async with db() as session:
-        await session.execute(
-            insert_on_conflict(
-                {"name": project_name},
-                table=models.Project,
-                dialect=db.dialect,
-                unique_by=("name",),
-                on_conflict=OnConflict.DO_NOTHING,
-            )
-        )
-        project_id = await session.scalar(select(models.Project.id).filter_by(name=project_name))
-        assert project_id is not None
+async def _ensure_project_exists(session: AsyncSession, project_name: str) -> int:
+    """Resolve project_id by name, creating the project row if missing.
+
+    Read first, so the steady-state path is one statement and does not write.
+    The insert cannot carry the read: ``ON CONFLICT DO NOTHING`` returns no row
+    when the conflict fires, which is every call after the project's first.
+    """
+    by_name = select(models.Project.id).filter_by(name=project_name)
+    if (project_id := await session.scalar(by_name)) is not None:
         return project_id
+    dialect = SupportedSQLDialect(session.bind.dialect.name)
+    project_id = await session.scalar(
+        insert_on_conflict(
+            {"name": project_name},
+            table=models.Project,
+            dialect=dialect,
+            unique_by=("name",),
+            on_conflict=OnConflict.DO_NOTHING,
+        ).returning(models.Project.id)
+    )
+    if project_id is None:
+        # A concurrent caller won the insert, so the statement returned no row.
+        project_id = await session.scalar(by_name)
+    assert project_id is not None
+    return project_id
 
 
 async def _upsert_project_sessions(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -831,6 +831,42 @@ async def _persist_db_traces_and_emit_event(
         event_queue.put(SpanInsertEvent(project_ids))
 
 
+async def _flush_and_persist_agent_traces(
+    *,
+    tracer: Tracer,
+    request: Request,
+    project_name: str,
+    ingest_traces: bool,
+) -> None:
+    """Flush an agent turn's tracer, persist what it captured, and tear it down.
+
+    Every caller runs this from a ``finally``, which is what makes the guarding
+    here load-bearing on two counts. An exception raised in a ``finally``
+    replaces the one already in flight, so an unguarded failure here would
+    discard the real error — an endpoint raising ``HTTPException(502)`` would
+    answer 500 with none of its detail. And it would skip the ``shutdown()``
+    below, stranding the provider's export thread and holding onto every
+    buffered span for the life of the process.
+
+    Recording telemetry is bookkeeping either way: a turn whose traces cannot be
+    written still produced its answer, so a failure is logged rather than raised.
+    """
+    try:
+        tracer.tracer_provider.force_flush()
+        if ingest_traces:
+            project_id = await _ensure_project_exists(request.app.state.db, project_name)
+            db_traces = tracer.get_db_traces(project_id=project_id)
+            await _persist_db_traces_and_emit_event(
+                db=request.app.state.db,
+                event_queue=request.state.event_queue,
+                db_traces=db_traces,
+            )
+    except Exception:
+        logger.exception("Failed to persist agent traces for project %r", project_name)
+    finally:
+        tracer.tracer_provider.shutdown()
+
+
 async def _refresh_cumulative_span_counts(
     *,
     session: AsyncSession,
@@ -1282,18 +1318,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 yield build_stream_error_chunk(exc)
             finally:
                 if tracer is not None:
-                    tracer.tracer_provider.force_flush()
-                    if ingest_traces:
-                        project_id = await _ensure_project_exists(
-                            request.app.state.db, project_name
-                        )
-                        db_traces = tracer.get_db_traces(project_id=project_id)
-                        await _persist_db_traces_and_emit_event(
-                            db=request.app.state.db,
-                            event_queue=request.state.event_queue,
-                            db_traces=db_traces,
-                        )
-                    tracer.tracer_provider.shutdown()
+                    await _flush_and_persist_agent_traces(
+                        tracer=tracer,
+                        request=request,
+                        project_name=project_name,
+                        ingest_traces=ingest_traces,
+                    )
 
         return adapter.streaming_response(_stream_with_session())
 
@@ -1614,18 +1644,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             end_time=datetime.now(timezone.utc),
                             user_email=phoenix_user_email if attach_user_id else None,
                         )
-                    tracer.tracer_provider.force_flush()
-                    if ingest_traces:
-                        project_id = await _ensure_project_exists(
-                            request.app.state.db, project_name
-                        )
-                        db_traces = tracer.get_db_traces(project_id=project_id)
-                        await _persist_db_traces_and_emit_event(
-                            db=request.app.state.db,
-                            event_queue=request.state.event_queue,
-                            db_traces=db_traces,
-                        )
-                    tracer.tracer_provider.shutdown()
+                    await _flush_and_persist_agent_traces(
+                        tracer=tracer,
+                        request=request,
+                        project_name=project_name,
+                        ingest_traces=ingest_traces,
+                    )
 
         return adapter.streaming_response(_stream_with_session())
 
@@ -1693,16 +1717,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
         finally:
             if tracer is not None:
-                tracer.tracer_provider.force_flush()
-                if ingest_traces:
-                    project_id = await _ensure_project_exists(request.app.state.db, project_name)
-                    db_traces = tracer.get_db_traces(project_id=project_id)
-                    await _persist_db_traces_and_emit_event(
-                        db=request.app.state.db,
-                        event_queue=request.state.event_queue,
-                        db_traces=db_traces,
-                    )
-                tracer.tracer_provider.shutdown()
+                await _flush_and_persist_agent_traces(
+                    tracer=tracer,
+                    request=request,
+                    project_name=project_name,
+                    ingest_traces=ingest_traces,
+                )
         return _SummarizeResponse(summary=result.summary.strip())
 
     return router

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -84,53 +84,53 @@ async def _stream_single_chat_completion(
     span_cost_calculator: SpanCostCalculator,
     otel_context: OtelContext,
 ) -> ChatStream:
-    tracer = Tracer(span_cost_calculator=span_cost_calculator)
-    try:
-        messages = prompt_chat_template_to_playground_messages(
-            input.prompt_version.template.to_orm()
-        )
-        if template_options := input.template:
-            messages = formatted_messages(
-                messages=messages,
-                template_format=template_options.format,
-                template_variables=cast(Mapping[str, Any], template_options.variables),
+    async with Tracer(span_cost_calculator=span_cost_calculator) as tracer:
+        try:
+            messages = prompt_chat_template_to_playground_messages(
+                input.prompt_version.template.to_orm()
             )
-        invocation_parameters = input.prompt_version.invocation_parameters.to_orm()
-        tools = input.prompt_version.tools.to_orm() if input.prompt_version.tools else None
-        response_format = (
-            input.prompt_version.response_format.to_orm()
-            if input.prompt_version.response_format
-            else None
-        )
+            if template_options := input.template:
+                messages = formatted_messages(
+                    messages=messages,
+                    template_format=template_options.format,
+                    template_variables=cast(Mapping[str, Any], template_options.variables),
+                )
+            invocation_parameters = input.prompt_version.invocation_parameters.to_orm()
+            tools = input.prompt_version.tools.to_orm() if input.prompt_version.tools else None
+            response_format = (
+                input.prompt_version.response_format.to_orm()
+                if input.prompt_version.response_format
+                else None
+            )
 
-        async for chunk in llm_client.chat_completion_create(
-            messages=messages,
-            tools=tools,
-            response_format=response_format,
-            invocation_parameters=invocation_parameters,
-            tracer=tracer,
-            otel_context=otel_context,
-            stream_model_output=input.stream_model_output,
-        ):
-            chunk.repetition_number = repetition_number
-            yield chunk
-    except Exception as error:
-        yield ChatCompletionSubscriptionError(
-            message=str(error),
-            repetition_number=repetition_number,
-        )
+            async for chunk in llm_client.chat_completion_create(
+                messages=messages,
+                tools=tools,
+                response_format=response_format,
+                invocation_parameters=invocation_parameters,
+                tracer=tracer,
+                otel_context=otel_context,
+                stream_model_output=input.stream_model_output,
+            ):
+                chunk.repetition_number = repetition_number
+                yield chunk
+        except Exception as error:
+            yield ChatCompletionSubscriptionError(
+                message=str(error),
+                repetition_number=repetition_number,
+            )
 
-    db_traces = tracer.get_db_traces(project_id=project_id)
-    async with db() as session:
-        session.add_all(db_traces)
-        await session.flush()
-    if db_traces and db_traces[0].spans:
-        db_span = db_traces[0].spans[0]
-        yield ChatCompletionSubscriptionResult(
-            span=Span(id=db_span.id, db_record=db_span),
-            repetition_number=repetition_number,
-        )
-        on_span_insertion()
+        db_traces = tracer.get_db_traces(project_id=project_id)
+        async with db() as session:
+            session.add_all(db_traces)
+            await session.flush()
+        if db_traces and db_traces[0].spans:
+            db_span = db_traces[0].spans[0]
+            yield ChatCompletionSubscriptionResult(
+                span=Span(id=db_span.id, db_record=db_span),
+                repetition_number=repetition_number,
+            )
+            on_span_insertion()
 
 
 async def _cleanup_chat_completion_resources(

--- a/src/phoenix/server/cost_tracking/token_cost_calculator.py
+++ b/src/phoenix/server/cost_tracking/token_cost_calculator.py
@@ -34,7 +34,15 @@ class ThresholdBasedTokenCostCalculator(TokenCostCalculator):
         attributes: Mapping[str, Any],
         tokens: float,
     ) -> float:
-        if not (v := get_attribute_value(attributes, self.key)):
+        v = get_attribute_value(attributes, self.key)
+        # `v` is whatever the span carried: OTLP preserves the type the client
+        # sent, so a token count can arrive as a string or a list. Comparing one
+        # of those against the threshold raises, which costs the span its entire
+        # cost record — the callers that ingest spans swallow the error and move
+        # on. Anything not numeric bills at the base rate, matching how
+        # `get_aggregated_tokens` reads the same attributes. `bool` is excluded
+        # because it is an `int` subclass and never a token count.
+        if not isinstance(v, (int, float)) or isinstance(v, bool) or not v:
             return tokens * self.base_rate
         if v > self.threshold:
             return tokens * self.new_rate

--- a/src/phoenix/server/cost_tracking/token_cost_calculator.py
+++ b/src/phoenix/server/cost_tracking/token_cost_calculator.py
@@ -35,13 +35,12 @@ class ThresholdBasedTokenCostCalculator(TokenCostCalculator):
         tokens: float,
     ) -> float:
         v = get_attribute_value(attributes, self.key)
-        # `v` is whatever the span carried: OTLP preserves the type the client
-        # sent, so a token count can arrive as a string or a list. Comparing one
-        # of those against the threshold raises, which costs the span its entire
-        # cost record — the callers that ingest spans swallow the error and move
-        # on. Anything not numeric bills at the base rate, matching how
-        # `get_aggregated_tokens` reads the same attributes. `bool` is excluded
-        # because it is an `int` subclass and never a token count.
+        # OTLP preserves the type the client sent, so this attribute can be a
+        # string or a list. Comparing one against the threshold raises, and span
+        # ingestion catches per span, so the span forfeits its whole cost record.
+        # Non-numeric values bill at the base rate, as `get_aggregated_tokens`
+        # does for the same attributes. `bool` is an `int` subclass, never a
+        # token count.
         if not isinstance(v, (int, float)) or isinstance(v, bool) or not v:
             return tokens * self.base_rate
         if v > self.threshold:

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -527,7 +527,6 @@ class TaskWorkItem(WorkItem):
     async def execute(self) -> None:
         """Execute the task, write to DB, and report results."""
         logger.debug(f"TaskWorkItem {self.debug_identifier} starting execution")
-        tracer = self._tracer_factory()
         example_id = GlobalID(
             DatasetExample.__name__,
             str(self._dataset_example_revision.dataset_example_id),
@@ -571,6 +570,10 @@ class TaskWorkItem(WorkItem):
             await self._running_experiment.on_failure(self, error)
             return
 
+        # Built here rather than at the top of the method so the `finally` below
+        # spans its whole lifetime — the branch above returns without ever
+        # tracing anything.
+        tracer = self._tracer_factory()
         try:
             logger.debug(
                 f"TaskWorkItem {self.debug_identifier}: "
@@ -712,6 +715,12 @@ class TaskWorkItem(WorkItem):
 
             logger.debug(f"TaskWorkItem {self.debug_identifier} completed successfully")
             await self._running_experiment.on_task_success(self, db_run)
+
+        finally:
+            # The tracer is scoped to this one work item and holds every span it
+            # captured — full message histories included — so release it here
+            # rather than waiting on a collection cycle.
+            tracer.shutdown()
 
     def _is_rate_limit_error(self, e: Exception) -> bool:
         """Check if exception is a rate limit error using client's provider-specific logic."""
@@ -983,6 +992,10 @@ class EvalWorkItem(WorkItem):
                     f"wrote {len(annotations)} annotation(s)"
                 )
                 await self._running_experiment.on_eval_success(self)
+
+        finally:
+            # See the matching teardown in TaskWorkItem.execute.
+            tracer.shutdown()
 
     async def _persist_eval_results(
         self,

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -570,157 +570,157 @@ class TaskWorkItem(WorkItem):
             await self._running_experiment.on_failure(self, error)
             return
 
-        # Built here rather than at the top of the method so the `finally` below
-        # spans its whole lifetime — the branch above returns without ever
-        # tracing anything.
-        tracer = self._tracer_factory()
-        try:
-            logger.debug(
-                f"TaskWorkItem {self.debug_identifier}: "
-                f"starting streaming (timeout={self._timeout}s)"
-            )
-            with anyio.fail_after(self._timeout):
-                async for chunk in self._llm_client.chat_completion_create(
-                    messages=messages,
-                    tools=self._prompt_task.tools,
-                    response_format=self._prompt_task.response_format,
-                    invocation_parameters=self._prompt_task.invocation_parameters,
-                    tracer=tracer,
-                    otel_context=OtelContext(),
-                    stream_model_output=self._prompt_task.stream_model_output,
-                ):
-                    chunk.dataset_example_id = example_id
-                    chunk.repetition_number = self._repetition_number
-                    self._running_experiment._broadcast(chunk)
-
-        except TimeoutError:
-            logger.warning(f"TaskWorkItem {self.debug_identifier} timed out")
-            await self._running_experiment.on_timeout(self)
-
-        except anyio.get_cancelled_exc_class():
-            logger.debug(f"TaskWorkItem {self.debug_identifier} cancelled")
-            raise
-
-        except Exception as e:
-            err_type = type(e).__name__
-            if self._is_rate_limit_error(e):
-                logger.debug(f"TaskWorkItem {self.debug_identifier} hit rate limit ({err_type})")
-                await self._running_experiment.on_rate_limit(self)
-            elif self._is_transient_error(e):
-                logger.warning(
-                    f"TaskWorkItem {self.debug_identifier} transient error ({err_type}): {e}"
+        async with self._tracer_factory() as tracer:
+            try:
+                logger.debug(
+                    f"TaskWorkItem {self.debug_identifier}: "
+                    f"starting streaming (timeout={self._timeout}s)"
                 )
-                await self._running_experiment.on_transient_error(self, e)
+                with anyio.fail_after(self._timeout):
+                    async for chunk in self._llm_client.chat_completion_create(
+                        messages=messages,
+                        tools=self._prompt_task.tools,
+                        response_format=self._prompt_task.response_format,
+                        invocation_parameters=self._prompt_task.invocation_parameters,
+                        tracer=tracer,
+                        otel_context=OtelContext(),
+                        stream_model_output=self._prompt_task.stream_model_output,
+                    ):
+                        chunk.dataset_example_id = example_id
+                        chunk.repetition_number = self._repetition_number
+                        self._running_experiment._broadcast(chunk)
+
+            except TimeoutError:
+                logger.warning(f"TaskWorkItem {self.debug_identifier} timed out")
+                await self._running_experiment.on_timeout(self)
+
+            except anyio.get_cancelled_exc_class():
+                logger.debug(f"TaskWorkItem {self.debug_identifier} cancelled")
+                raise
+
+            except Exception as e:
+                err_type = type(e).__name__
+                if self._is_rate_limit_error(e):
+                    logger.debug(
+                        f"TaskWorkItem {self.debug_identifier} hit rate limit ({err_type})"
+                    )
+                    await self._running_experiment.on_rate_limit(self)
+                elif self._is_transient_error(e):
+                    logger.warning(
+                        f"TaskWorkItem {self.debug_identifier} transient error ({err_type}): {e}"
+                    )
+                    await self._running_experiment.on_transient_error(self, e)
+                else:
+                    logger.exception(
+                        f"TaskWorkItem {self.debug_identifier} failed ({err_type}): {e}"
+                    )
+                    error_end_time = datetime.now(timezone.utc)
+                    task_db_traces = tracer.get_db_traces(project_id=self._project_id)
+                    task_db_trace = task_db_traces[0] if task_db_traces else None
+                    db_run = models.ExperimentRun(
+                        experiment_id=self._experiment.id,
+                        dataset_example_id=revision.dataset_example_id,
+                        trace_id=task_db_trace.trace_id if task_db_trace is not None else None,
+                        output={},
+                        repetition_number=self._repetition_number,
+                        start_time=format_start_time,
+                        end_time=error_end_time,
+                        error=str(e),
+                    )
+                    try:
+                        db_run = await self._persist_run(
+                            db_run,
+                            db_traces=task_db_traces if task_db_trace is not None else None,
+                        )
+                    except Exception as persist_err:
+                        logger.warning(
+                            f"TaskWorkItem {self.debug_identifier}: "
+                            f"failed to persist error run to DB",
+                            exc_info=True,
+                        )
+                        await self._running_experiment.on_failure(self, persist_err)
+                        return
+
+                    error_db_span = (
+                        task_db_trace.spans[0]
+                        if task_db_trace is not None and task_db_trace.spans
+                        else None
+                    )
+                    self._running_experiment._broadcast(
+                        ChatCompletionSubscriptionError(
+                            message=str(e),
+                            dataset_example_id=example_id,
+                            repetition_number=self._repetition_number,
+                            span=(
+                                Span(id=error_db_span.id, db_record=error_db_span)
+                                if error_db_span is not None
+                                else None
+                            ),
+                            experiment_run=ExperimentRun(id=db_run.id, db_record=db_run),
+                        )
+                    )
+                    await self._running_experiment.on_failure(self, e)
+
             else:
-                logger.exception(f"TaskWorkItem {self.debug_identifier} failed ({err_type}): {e}")
-                error_end_time = datetime.now(timezone.utc)
+                logger.debug(
+                    f"TaskWorkItem {self.debug_identifier}: stream finished, building traces"
+                )
                 task_db_traces = tracer.get_db_traces(project_id=self._project_id)
                 task_db_trace = task_db_traces[0] if task_db_traces else None
-                db_run = models.ExperimentRun(
-                    experiment_id=self._experiment.id,
-                    dataset_example_id=revision.dataset_example_id,
-                    trace_id=task_db_trace.trace_id if task_db_trace is not None else None,
-                    output={},
-                    repetition_number=self._repetition_number,
-                    start_time=format_start_time,
-                    end_time=error_end_time,
-                    error=str(e),
+                db_span = (
+                    task_db_trace.spans[0]
+                    if task_db_trace is not None and task_db_trace.spans
+                    else None
                 )
+                if db_span is not None and task_db_trace is not None:
+                    db_run = get_db_experiment_run(
+                        db_span,
+                        task_db_trace,
+                        experiment_id=self._experiment.id,
+                        example_id=self._dataset_example_revision.dataset_example_id,
+                        repetition_number=self._repetition_number,
+                    )
+                else:
+                    logger.warning(
+                        f"TaskWorkItem {self.debug_identifier}: no trace recorded "
+                        "(stream may have completed without emitting spans)"
+                    )
+                    db_run = models.ExperimentRun(
+                        experiment_id=self._experiment.id,
+                        dataset_example_id=revision.dataset_example_id,
+                        trace_id=None,
+                        output={},
+                        repetition_number=self._repetition_number,
+                        start_time=format_start_time,
+                        end_time=datetime.now(timezone.utc),
+                        error=None,
+                        trace=None,
+                    )
                 try:
                     db_run = await self._persist_run(
-                        db_run,
-                        db_traces=task_db_traces if task_db_trace is not None else None,
+                        db_run, db_traces=task_db_traces if task_db_trace is not None else None
                     )
                 except Exception as persist_err:
                     logger.warning(
-                        f"TaskWorkItem {self.debug_identifier}: failed to persist error run to DB",
+                        f"TaskWorkItem {self.debug_identifier}: failed to persist run to DB",
                         exc_info=True,
                     )
                     await self._running_experiment.on_failure(self, persist_err)
                     return
 
-                error_db_span = (
-                    task_db_trace.spans[0]
-                    if task_db_trace is not None and task_db_trace.spans
-                    else None
-                )
                 self._running_experiment._broadcast(
-                    ChatCompletionSubscriptionError(
-                        message=str(e),
-                        dataset_example_id=example_id,
-                        repetition_number=self._repetition_number,
+                    ChatCompletionSubscriptionResult(
                         span=(
-                            Span(id=error_db_span.id, db_record=error_db_span)
-                            if error_db_span is not None
-                            else None
+                            Span(id=db_span.id, db_record=db_span) if db_span is not None else None
                         ),
                         experiment_run=ExperimentRun(id=db_run.id, db_record=db_run),
+                        dataset_example_id=example_id,
+                        repetition_number=self._repetition_number,
                     )
                 )
-                await self._running_experiment.on_failure(self, e)
 
-        else:
-            logger.debug(f"TaskWorkItem {self.debug_identifier}: stream finished, building traces")
-            task_db_traces = tracer.get_db_traces(project_id=self._project_id)
-            task_db_trace = task_db_traces[0] if task_db_traces else None
-            db_span = (
-                task_db_trace.spans[0]
-                if task_db_trace is not None and task_db_trace.spans
-                else None
-            )
-            if db_span is not None and task_db_trace is not None:
-                db_run = get_db_experiment_run(
-                    db_span,
-                    task_db_trace,
-                    experiment_id=self._experiment.id,
-                    example_id=self._dataset_example_revision.dataset_example_id,
-                    repetition_number=self._repetition_number,
-                )
-            else:
-                logger.warning(
-                    f"TaskWorkItem {self.debug_identifier}: no trace recorded "
-                    "(stream may have completed without emitting spans)"
-                )
-                db_run = models.ExperimentRun(
-                    experiment_id=self._experiment.id,
-                    dataset_example_id=revision.dataset_example_id,
-                    trace_id=None,
-                    output={},
-                    repetition_number=self._repetition_number,
-                    start_time=format_start_time,
-                    end_time=datetime.now(timezone.utc),
-                    error=None,
-                    trace=None,
-                )
-            try:
-                db_run = await self._persist_run(
-                    db_run, db_traces=task_db_traces if task_db_trace is not None else None
-                )
-            except Exception as persist_err:
-                logger.warning(
-                    f"TaskWorkItem {self.debug_identifier}: failed to persist run to DB",
-                    exc_info=True,
-                )
-                await self._running_experiment.on_failure(self, persist_err)
-                return
-
-            self._running_experiment._broadcast(
-                ChatCompletionSubscriptionResult(
-                    span=(Span(id=db_span.id, db_record=db_span) if db_span is not None else None),
-                    experiment_run=ExperimentRun(id=db_run.id, db_record=db_run),
-                    dataset_example_id=example_id,
-                    repetition_number=self._repetition_number,
-                )
-            )
-
-            logger.debug(f"TaskWorkItem {self.debug_identifier} completed successfully")
-            await self._running_experiment.on_task_success(self, db_run)
-
-        finally:
-            # The tracer is scoped to this one work item and holds every span it
-            # captured — full message histories included — so release it here
-            # rather than waiting on a collection cycle.
-            tracer.shutdown()
+                logger.debug(f"TaskWorkItem {self.debug_identifier} completed successfully")
+                await self._running_experiment.on_task_success(self, db_run)
 
     def _is_rate_limit_error(self, e: Exception) -> bool:
         """Check if exception is a rate limit error using client's provider-specific logic."""
@@ -830,172 +830,176 @@ class EvalWorkItem(WorkItem):
     async def execute(self) -> None:
         """Execute the evaluation, write to DB, and report results."""
         logger.debug(f"EvalWorkItem {self.debug_identifier}: starting (timeout={self._timeout}s)")
-        tracer = self._tracer_factory()
-        try:
-            with anyio.fail_after(self._timeout):
-                context_dict: dict[str, Any] = {
-                    "input": self._dataset_example_revision.input,
-                    "reference": self._dataset_example_revision.output,
-                    "output": self._experiment_run.output.get("task_output"),
-                    "metadata": self._dataset_example_revision.metadata_,
-                }
-                eval_results = await self._evaluator.evaluate(
-                    context=context_dict,
-                    input_mapping=self._input_mapping,
-                    name=self._output_configs[0].name,
-                    output_configs=self._output_configs,
-                    tracer=tracer,
-                )
-                logger.debug(
-                    f"EvalWorkItem {self.debug_identifier}: evaluator returned "
-                    f"{len(eval_results)} result(s)"
-                )
-                db_traces: list[models.Trace] = list(
-                    tracer.get_db_traces(project_id=self._project_id)
-                )
-                annotations: list[models.ExperimentRunAnnotation] = []
-                seen_names: set[str] = set()
-                for result in eval_results:
-                    annotation = evaluation_result_to_model(
-                        result,
-                        experiment_run_id=self._experiment_run.id,
+        async with self._tracer_factory() as tracer:
+            try:
+                with anyio.fail_after(self._timeout):
+                    context_dict: dict[str, Any] = {
+                        "input": self._dataset_example_revision.input,
+                        "reference": self._dataset_example_revision.output,
+                        "output": self._experiment_run.output.get("task_output"),
+                        "metadata": self._dataset_example_revision.metadata_,
+                    }
+                    eval_results = await self._evaluator.evaluate(
+                        context=context_dict,
+                        input_mapping=self._input_mapping,
+                        name=self._output_configs[0].name,
+                        output_configs=self._output_configs,
+                        tracer=tracer,
                     )
-                    if annotation.name not in seen_names:
-                        seen_names.add(annotation.name)
-                        annotations.append(annotation)
-
-        except TimeoutError:
-            logger.warning(f"EvalWorkItem {self.debug_identifier} timed out")
-            await self._running_experiment.on_timeout(self)
-
-        except anyio.get_cancelled_exc_class():
-            # Must re-raise so _run_and_release sees cancellation instead of
-            # misclassifying it as a transient/permanent error via the
-            # generic Exception handler below.
-            logger.debug(f"EvalWorkItem {self.debug_identifier} cancelled")
-            raise
-
-        except Exception as e:
-            err_type = type(e).__name__
-            if isinstance(e, MontyBusy):
-                logger.warning(
-                    f"EvalWorkItem {self.debug_identifier} sandbox capacity busy ({err_type}): {e}"
-                )
-                await self._running_experiment.on_capacity_error(self, e)
-            elif self._is_rate_limit_error(e):
-                logger.debug(f"EvalWorkItem {self.debug_identifier} hit rate limit ({err_type})")
-                await self._running_experiment.on_rate_limit(self)
-            elif self._is_transient_error(e):
-                logger.warning(
-                    f"EvalWorkItem {self.debug_identifier} transient error ({err_type}): {e}"
-                )
-                await self._running_experiment.on_transient_error(self, e)
-            else:
-                logger.exception(f"EvalWorkItem {self.debug_identifier} failed ({err_type}): {e}")
-                error_end_time = datetime.now(timezone.utc)
-                annotator_kind = "LLM" if isinstance(self._evaluator, LLMEvaluator) else "CODE"
-                error_annotations: list[models.ExperimentRunAnnotation] = []
-                for config in self._output_configs:
-                    error_annotations.append(
-                        models.ExperimentRunAnnotation(
+                    logger.debug(
+                        f"EvalWorkItem {self.debug_identifier}: evaluator returned "
+                        f"{len(eval_results)} result(s)"
+                    )
+                    db_traces: list[models.Trace] = list(
+                        tracer.get_db_traces(project_id=self._project_id)
+                    )
+                    annotations: list[models.ExperimentRunAnnotation] = []
+                    seen_names: set[str] = set()
+                    for result in eval_results:
+                        annotation = evaluation_result_to_model(
+                            result,
                             experiment_run_id=self._experiment_run.id,
-                            name=config.name,
-                            annotator_kind=annotator_kind,
-                            label=None,
-                            score=None,
-                            explanation=None,
-                            trace_id=None,
-                            error=str(e),
-                            metadata_={},
-                            start_time=error_end_time,
-                            end_time=error_end_time,
                         )
+                        if annotation.name not in seen_names:
+                            seen_names.add(annotation.name)
+                            annotations.append(annotation)
+
+            except TimeoutError:
+                logger.warning(f"EvalWorkItem {self.debug_identifier} timed out")
+                await self._running_experiment.on_timeout(self)
+
+            except anyio.get_cancelled_exc_class():
+                # Must re-raise so _run_and_release sees cancellation instead of
+                # misclassifying it as a transient/permanent error via the
+                # generic Exception handler below.
+                logger.debug(f"EvalWorkItem {self.debug_identifier} cancelled")
+                raise
+
+            except Exception as e:
+                err_type = type(e).__name__
+                if isinstance(e, MontyBusy):
+                    logger.warning(
+                        f"EvalWorkItem {self.debug_identifier} "
+                        f"sandbox capacity busy ({err_type}): {e}"
                     )
-                error_db_traces = list(tracer.get_db_traces(project_id=self._project_id))
+                    await self._running_experiment.on_capacity_error(self, e)
+                elif self._is_rate_limit_error(e):
+                    logger.debug(
+                        f"EvalWorkItem {self.debug_identifier} hit rate limit ({err_type})"
+                    )
+                    await self._running_experiment.on_rate_limit(self)
+                elif self._is_transient_error(e):
+                    logger.warning(
+                        f"EvalWorkItem {self.debug_identifier} transient error ({err_type}): {e}"
+                    )
+                    await self._running_experiment.on_transient_error(self, e)
+                else:
+                    logger.exception(
+                        f"EvalWorkItem {self.debug_identifier} failed ({err_type}): {e}"
+                    )
+                    error_end_time = datetime.now(timezone.utc)
+                    annotator_kind = "LLM" if isinstance(self._evaluator, LLMEvaluator) else "CODE"
+                    error_annotations: list[models.ExperimentRunAnnotation] = []
+                    for config in self._output_configs:
+                        error_annotations.append(
+                            models.ExperimentRunAnnotation(
+                                experiment_run_id=self._experiment_run.id,
+                                name=config.name,
+                                annotator_kind=annotator_kind,
+                                label=None,
+                                score=None,
+                                explanation=None,
+                                trace_id=None,
+                                error=str(e),
+                                metadata_={},
+                                start_time=error_end_time,
+                                end_time=error_end_time,
+                            )
+                        )
+                    error_db_traces = list(tracer.get_db_traces(project_id=self._project_id))
+                    try:
+                        await self._persist_eval_results(error_annotations, error_db_traces)
+                    except Exception as persist_err:
+                        logger.warning(
+                            f"EvalWorkItem {self.debug_identifier}: "
+                            f"failed to persist error results to DB",
+                            exc_info=True,
+                        )
+                        await self._running_experiment.on_failure(self, persist_err)
+                        return
+
+                    example_id = GlobalID(
+                        DatasetExample.__name__,
+                        str(self._dataset_example_revision.dataset_example_id),
+                    )
+                    for annotation in error_annotations:
+                        self._running_experiment._broadcast(
+                            EvaluationChunk(
+                                evaluator_name=annotation.name,
+                                experiment_run_evaluation=None,
+                                dataset_example_id=example_id,
+                                repetition_number=self._experiment_run.repetition_number,
+                                trace=None,
+                                error=annotation.error,
+                            )
+                        )
+                    await self._running_experiment.on_failure(self, e)
+
+            else:
                 try:
-                    await self._persist_eval_results(error_annotations, error_db_traces)
+                    await self._persist_eval_results(annotations, db_traces)
                 except Exception as persist_err:
                     logger.warning(
                         f"EvalWorkItem {self.debug_identifier}: "
-                        f"failed to persist error results to DB",
+                        f"failed to persist eval results to DB",
                         exc_info=True,
                     )
                     await self._running_experiment.on_failure(self, persist_err)
                     return
 
+                # Broadcast results to UI
                 example_id = GlobalID(
                     DatasetExample.__name__,
                     str(self._dataset_example_revision.dataset_example_id),
                 )
-                for annotation in error_annotations:
+                traces_by_trace_id = {t.trace_id: t for t in db_traces}
+                for annotation in annotations:
+                    eval_db_trace = (
+                        traces_by_trace_id.get(annotation.trace_id) if annotation.trace_id else None
+                    )
                     self._running_experiment._broadcast(
                         EvaluationChunk(
                             evaluator_name=annotation.name,
-                            experiment_run_evaluation=None,
+                            experiment_run_evaluation=(
+                                ExperimentRunAnnotation(id=annotation.id, db_record=annotation)
+                                if not annotation.error
+                                else None
+                            ),
                             dataset_example_id=example_id,
                             repetition_number=self._experiment_run.repetition_number,
-                            trace=None,
+                            trace=(
+                                Trace(id=eval_db_trace.id, db_record=eval_db_trace)
+                                if eval_db_trace
+                                else None
+                            ),
                             error=annotation.error,
                         )
                     )
-                await self._running_experiment.on_failure(self, e)
 
-        else:
-            try:
-                await self._persist_eval_results(annotations, db_traces)
-            except Exception as persist_err:
-                logger.warning(
-                    f"EvalWorkItem {self.debug_identifier}: failed to persist eval results to DB",
-                    exc_info=True,
-                )
-                await self._running_experiment.on_failure(self, persist_err)
-                return
-
-            # Broadcast results to UI
-            example_id = GlobalID(
-                DatasetExample.__name__,
-                str(self._dataset_example_revision.dataset_example_id),
-            )
-            traces_by_trace_id = {t.trace_id: t for t in db_traces}
-            for annotation in annotations:
-                eval_db_trace = (
-                    traces_by_trace_id.get(annotation.trace_id) if annotation.trace_id else None
-                )
-                self._running_experiment._broadcast(
-                    EvaluationChunk(
-                        evaluator_name=annotation.name,
-                        experiment_run_evaluation=(
-                            ExperimentRunAnnotation(id=annotation.id, db_record=annotation)
-                            if not annotation.error
-                            else None
-                        ),
-                        dataset_example_id=example_id,
-                        repetition_number=self._experiment_run.repetition_number,
-                        trace=(
-                            Trace(id=eval_db_trace.id, db_record=eval_db_trace)
-                            if eval_db_trace
-                            else None
-                        ),
-                        error=annotation.error,
+                # Check for evaluation error - treat as permanent failure for circuit breaker
+                error_result = next((r for r in eval_results if r.get("error") is not None), None)
+                if error_result is not None:
+                    error_exc = error_result.get("error_exc") or Exception(error_result["error"])
+                    logger.debug(
+                        f"EvalWorkItem {self.debug_identifier} returned error: {error_exc}"
                     )
-                )
-
-            # Check for evaluation error - treat as permanent failure for circuit breaker
-            error_result = next((r for r in eval_results if r.get("error") is not None), None)
-            if error_result is not None:
-                error_exc = error_result.get("error_exc") or Exception(error_result["error"])
-                logger.debug(f"EvalWorkItem {self.debug_identifier} returned error: {error_exc}")
-                await self._running_experiment.on_failure(self, error_exc)
-            else:
-                logger.debug(
-                    f"EvalWorkItem {self.debug_identifier}: success, "
-                    f"wrote {len(annotations)} annotation(s)"
-                )
-                await self._running_experiment.on_eval_success(self)
-
-        finally:
-            # See the matching teardown in TaskWorkItem.execute.
-            tracer.shutdown()
+                    await self._running_experiment.on_failure(self, error_exc)
+                else:
+                    logger.debug(
+                        f"EvalWorkItem {self.debug_identifier}: success, "
+                        f"wrote {len(annotations)} annotation(s)"
+                    )
+                    await self._running_experiment.on_eval_success(self)
 
     async def _persist_eval_results(
         self,

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -153,7 +153,17 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
         # chat conversations can record the full message history on each LLM
         # span without attribute eviction.
         span_limits = SpanLimits(max_span_attributes=100_000)
-        provider = TracerProvider(resource=resource, span_limits=span_limits)
+        # `shutdown_on_exit` (the SDK default) registers `atexit.register(provider.shutdown)`,
+        # which stores a bound method and so keeps the provider — and through it every
+        # buffered span, message histories included — reachable for the life of the process.
+        # That is meant for a single process-wide provider, but these are request-scoped:
+        # one per agent turn and one per experiment work item. Opt out, and let each owner
+        # shut its provider down when it is done with it.
+        provider = TracerProvider(
+            resource=resource,
+            span_limits=span_limits,
+            shutdown_on_exit=False,
+        )
         self._self_resource = resource
         simple_processor = SimpleSpanProcessor(self._self_exporter)
         self._self_span_processors: list[SpanProcessor] = [simple_processor]

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -111,17 +111,15 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     """
     An in-memory tracer that captures spans and builds database models.
 
-    Because cumulative counts are computed based on the spans in the buffer,
-    ensure that traces are not split across multiple calls to get_db_traces.
-    It's recommended to use a separate tracer for distinct operations.
+    Scoped to one operation, and single-use: ``__enter__`` rejects a second
+    entry. Cumulative counts are computed from the spans in the buffer, so a
+    tracer spanning two operations computes them across both.
 
-    A tracer is scoped to one operation and owns everything it captured, so use
-    it as a context manager: leaving the block stops the provider's processors
-    and releases the buffered spans. Build the trace models before leaving.
-
-    Use ``async with`` from async code. With a remote exporter attached the
-    release drains the batch queue, and ``async with`` moves that off the event
-    loop.
+    Use it as a context manager. Leaving the block stops the provider's
+    processors and releases the buffered spans, so build the trace models
+    first. Use ``async with`` from async code: with a remote exporter attached
+    the release drains the batch queue, which ``async with`` moves off the
+    event loop.
 
     Example usage:
         async with Tracer(span_cost_calculator=span_cost_calculator) as tracer:
@@ -162,11 +160,9 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
         # span without attribute eviction.
         span_limits = SpanLimits(max_span_attributes=100_000)
         # `shutdown_on_exit` (the SDK default) registers `atexit.register(provider.shutdown)`,
-        # which stores a bound method and so keeps the provider — and through it every
-        # buffered span, message histories included — reachable for the life of the process.
-        # That is meant for a single process-wide provider, but these are request-scoped:
-        # one per agent turn, one per experiment work item, one per playground stream.
-        # Opt out, and let each owner scope its tracer with `with`.
+        # which stores a bound method and so keeps the provider — and every span it
+        # buffered, message histories included — reachable for the life of the process.
+        # These providers are request-scoped; the owner's `with` block releases them.
         provider = TracerProvider(
             resource=resource,
             span_limits=span_limits,
@@ -310,12 +306,10 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     def __enter__(self) -> "Tracer":
         """Claim the tracer for one block. A second claim is an error.
 
-        Reuse fails quietly otherwise, which is the worst way for it to fail:
-        the first release stops the batch processor but not
-        ``SimpleSpanProcessor``, so spans recorded afterwards reach the local
-        buffer while remote export refuses them, and the two disagree with
-        nothing raised. The flag is never cleared, so this rejects reuse after
-        the block as well as re-entry inside it.
+        Unguarded reuse diverges silently: after a release the batch processor
+        refuses spans but ``SimpleSpanProcessor`` does not, so the local buffer
+        and the remote exporter disagree. The flag is never cleared, so reuse
+        after the block is rejected as well as re-entry inside it.
         """
         if self._self_entered:
             raise RuntimeError(
@@ -328,26 +322,19 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     def __exit__(self, *exc_info: object) -> None:
         """Stop the provider's processors, then release the captured spans.
 
-        The order matters. ``shutdown()`` runs the processors' shutdown hooks,
-        and with a remote exporter attached it also drains the batch queue — for
-        as long as the collector takes. ``SimpleSpanProcessor`` keeps filling the
-        buffer throughout, so clearing first would leave behind whatever ended
-        during the drain. Neither call is sufficient alone: ``shutdown()``
-        reaches ``_BufferedSpanExporter.shutdown()``, which returns without
-        touching the buffer.
+        Shutdown precedes the clear because it drains the batch queue, and
+        ``SimpleSpanProcessor`` keeps filling the buffer until it returns. Both
+        are needed: ``shutdown()`` reaches ``_BufferedSpanExporter.shutdown()``,
+        which leaves the buffer alone.
 
-        This does not seal the tracer. Only the batch processor refuses spans
-        afterwards; ``SimpleSpanProcessor.on_end`` has no shutdown check in SDK
-        1.43.0, so a span ending after this returns still lands in the buffer
-        unread. Nothing enforces a bound on that — the tracer is meant to go out
-        of scope with its block. Call ``get_db_traces`` before leaving.
+        Neither seals the tracer. ``SimpleSpanProcessor.on_end`` has no shutdown
+        check in SDK 1.43.0, so a span ending later still lands in the buffer
+        unread. Call ``get_db_traces`` before leaving the block.
 
-        A teardown failure is logged rather than raised, so that it cannot
-        replace the error — or the cancellation — the block is already
-        unwinding.
+        Teardown failures are logged rather than raised: the block is often
+        already unwinding an agent error or a cancellation.
 
-        Prefer ``async with`` in async code: with a remote exporter attached
-        this blocks for a whole OTLP round-trip.
+        Prefer ``async with`` in async code; this blocks on an OTLP round-trip.
         """
         try:
             self.shutdown()
@@ -359,30 +346,22 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
         return self.__enter__()
 
     async def __aexit__(self, *exc_info: object) -> None:
-        """Release, on a worker thread when the release can block.
+        """Release on a worker thread, shielded.
 
-        With a remote exporter attached and anything left in the batch queue,
-        the release drains it — a full OTLP round-trip. On the event loop that
-        would stall every other request on the worker, hence the thread.
+        With a remote exporter attached the release drains the batch queue — an
+        OTLP round-trip, which on the event loop would stall every other request
+        on the worker. ``BatchProcessor.shutdown`` bounds it near 30 seconds and
+        drops what it could not send by then.
 
-        ``BatchProcessor.shutdown`` joins its worker for up to 30 seconds, which
-        waits out an export already in flight. Past that it abandons what is
-        still queued and calls the exporter's ``shutdown()``; for the OTLP HTTP
-        exporter that closes the session and sets the flag its retry loop polls,
-        so a retrying export gives up at its next checkpoint. A hung collector
-        therefore delays the caller rather than hanging it, at the cost of the
-        spans it had not sent.
+        The shield covers the anyio scope cancellation Starlette delivers on
+        client disconnect, which is the usual way an agent turn ends early;
+        unshielded, the ``await`` raises before the release runs and the tracer
+        is never torn down. A native ``asyncio.Task.cancel`` arriving while this
+        is queued for a thread-pool token still skips it — no owner combines a
+        remote exporter with native cancellation.
 
-        Shielded because the usual way an agent turn ends early is the client
-        disconnecting, which cancels this scope: an unshielded ``await`` here
-        raises before the release runs, and the tracer is never torn down at
-        all. The shield covers anyio scope cancellation, which is what Starlette
-        delivers. A native ``asyncio.Task.cancel`` arriving while this is queued
-        for a thread-pool token still skips the release — no current owner
-        combines a remote exporter with native cancellation.
-
-        There is nothing to drain without a remote exporter, so that case skips
-        the thread rather than paying for a hop it cannot use.
+        Without a remote exporter there is nothing to drain, so that path stays
+        inline.
         """
         if self._self_remote_exporter is None:
             self.__exit__()

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -111,15 +111,15 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     """
     An in-memory tracer that captures spans and builds database models.
 
-    Scoped to one operation, and single-use: ``__enter__`` rejects a second
-    entry. Cumulative counts are computed from the spans in the buffer, so a
-    tracer spanning two operations computes them across both.
+    Single-use, and scoped to one operation: ``__enter__`` rejects a second
+    entry. Cumulative counts are derived from the spans held in the buffer, so
+    a tracer shared across two operations computes them across both.
 
     Use it as a context manager. Leaving the block stops the provider's
     processors and releases the buffered spans, so build the trace models
-    first. Use ``async with`` from async code: with a remote exporter attached
-    the release drains the batch queue, which ``async with`` moves off the
-    event loop.
+    inside the block. From async code use ``async with``: when a remote
+    exporter is attached the release drains the batch queue, and ``async with``
+    moves that drain off the event loop.
 
     Example usage:
         async with Tracer(span_cost_calculator=span_cost_calculator) as tracer:
@@ -159,10 +159,10 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
         # chat conversations can record the full message history on each LLM
         # span without attribute eviction.
         span_limits = SpanLimits(max_span_attributes=100_000)
-        # `shutdown_on_exit` (the SDK default) registers `atexit.register(provider.shutdown)`,
-        # which stores a bound method and so keeps the provider — and every span it
-        # buffered, message histories included — reachable for the life of the process.
-        # These providers are request-scoped; the owner's `with` block releases them.
+        # A provider is built per request and released by the owner's `with`
+        # block. `shutdown_on_exit` (the SDK default) would register
+        # `atexit.register(provider.shutdown)`, whose bound method keeps the
+        # provider and the spans it buffered reachable for the life of the process.
         provider = TracerProvider(
             resource=resource,
             span_limits=span_limits,
@@ -304,12 +304,13 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
         self._self_provider.shutdown()
 
     def __enter__(self) -> "Tracer":
-        """Claim the tracer for one block. A second claim is an error.
+        """Claim the tracer for one block. A second claim raises.
 
-        Unguarded reuse diverges silently: after a release the batch processor
-        refuses spans but ``SimpleSpanProcessor`` does not, so the local buffer
-        and the remote exporter disagree. The flag is never cleared, so reuse
-        after the block is rejected as well as re-entry inside it.
+        The flag is never cleared, so reuse after the block is rejected as well
+        as re-entry inside it. Either would leave the local buffer and the
+        remote exporter holding different spans: once the tracer is released
+        the batch processor refuses new spans, while ``SimpleSpanProcessor``
+        keeps accepting them.
         """
         if self._self_entered:
             raise RuntimeError(
@@ -322,19 +323,19 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     def __exit__(self, *exc_info: object) -> None:
         """Stop the provider's processors, then release the captured spans.
 
-        Shutdown precedes the clear because it drains the batch queue, and
-        ``SimpleSpanProcessor`` keeps filling the buffer until it returns. Both
-        are needed: ``shutdown()`` reaches ``_BufferedSpanExporter.shutdown()``,
-        which leaves the buffer alone.
+        Both steps are needed: ``shutdown()`` reaches
+        ``_BufferedSpanExporter.shutdown()``, which leaves the buffer alone.
+        Shutdown runs first because it drains the batch queue, and
+        ``SimpleSpanProcessor`` keeps filling the buffer until that returns.
 
-        Neither seals the tracer. ``SimpleSpanProcessor.on_end`` has no shutdown
-        check in SDK 1.43.0, so a span ending later still lands in the buffer
-        unread. Call ``get_db_traces`` before leaving the block.
+        Neither step seals the tracer. ``SimpleSpanProcessor.on_end`` has no
+        shutdown check in SDK 1.43.0, so a span ending afterwards still lands
+        in the buffer unread. Call ``get_db_traces`` before leaving the block.
 
-        Teardown failures are logged rather than raised: the block is often
-        already unwinding an agent error or a cancellation.
+        Teardown failures are logged rather than raised, since the block is
+        often already unwinding an agent error or a cancellation.
 
-        Prefer ``async with`` in async code; this blocks on an OTLP round-trip.
+        This blocks on an OTLP round-trip; prefer ``async with`` in async code.
         """
         try:
             self.shutdown()
@@ -348,20 +349,19 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     async def __aexit__(self, *exc_info: object) -> None:
         """Release on a worker thread, shielded.
 
-        With a remote exporter attached the release drains the batch queue — an
-        OTLP round-trip, which on the event loop would stall every other request
-        on the worker. ``BatchProcessor.shutdown`` bounds it near 30 seconds and
-        drops what it could not send by then.
+        With a remote exporter attached the release drains the batch queue,
+        which is an OTLP round-trip. Run on the event loop it would stall every
+        other request on the worker. ``BatchProcessor.shutdown`` bounds it near
+        30 seconds and drops whatever it could not send by then.
 
         The shield covers the anyio scope cancellation Starlette delivers on
-        client disconnect, which is the usual way an agent turn ends early;
-        unshielded, the ``await`` raises before the release runs and the tracer
-        is never torn down. A native ``asyncio.Task.cancel`` arriving while this
-        is queued for a thread-pool token still skips it — no owner combines a
-        remote exporter with native cancellation.
+        client disconnect; unshielded, the ``await`` raises before the release
+        runs. A native ``asyncio.Task.cancel`` arriving while this waits for a
+        thread-pool token still skips the release. That case is unreachable
+        while no owner combines a remote exporter with native cancellation.
 
-        Without a remote exporter there is nothing to drain, so that path stays
-        inline.
+        Without a remote exporter there is nothing to drain, so that path
+        releases inline.
         """
         if self._self_remote_exporter is None:
             self.__exit__()

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from threading import Lock
 from typing import Callable, Optional, Sequence
 
+import anyio
 import wrapt
 from openinference.semconv.resource import ResourceAttributes
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
@@ -114,20 +115,27 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
     ensure that traces are not split across multiple calls to get_db_traces.
     It's recommended to use a separate tracer for distinct operations.
 
+    A tracer is scoped to one operation and owns everything it captured, so use
+    it as a context manager: leaving the block stops the provider's processors
+    and releases the buffered spans. Build the trace models before leaving.
+
+    Use ``async with`` from async code. With a remote exporter attached the
+    release drains the batch queue, and ``async with`` moves that off the event
+    loop.
+
     Example usage:
-        tracer = Tracer(span_cost_calculator=span_cost_calculator)
+        async with Tracer(span_cost_calculator=span_cost_calculator) as tracer:
+            with tracer.start_as_current_span("operation") as span:
+                span.set_attribute("key", "value")
+                with tracer.start_as_current_span("child-operation") as child:
+                    pass
 
-        with tracer.start_as_current_span("operation") as span:
-            span.set_attribute("key", "value")
-            with tracer.start_as_current_span("child-operation") as child:
-                pass
+            # Build trace models and persist to database
 
-        # Build trace models and persist to database
-
-        db_traces = tracer.get_db_traces(project_id=123)
-        async with db_session() as session:
-            session.add_all(db_traces)
-            await session.flush()
+            db_traces = tracer.get_db_traces(project_id=123)
+            async with db_session() as session:
+                session.add_all(db_traces)
+                await session.flush()
 
         # Access spans, span_costs, and span cost details via SQLAlchemy relationships
         db_spans = db_traces[0].spans
@@ -157,8 +165,8 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
         # which stores a bound method and so keeps the provider — and through it every
         # buffered span, message histories included — reachable for the life of the process.
         # That is meant for a single process-wide provider, but these are request-scoped:
-        # one per agent turn and one per experiment work item. Opt out, and let each owner
-        # shut its provider down when it is done with it.
+        # one per agent turn, one per experiment work item, one per playground stream.
+        # Opt out, and let each owner scope its tracer with `with`.
         provider = TracerProvider(
             resource=resource,
             span_limits=span_limits,
@@ -181,6 +189,7 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
             provider.add_span_processor(remote_processor)
 
         self._self_provider = provider
+        self._self_entered = False
         tracer = provider.get_tracer(__name__)
         super().__init__(tracer)
 
@@ -297,6 +306,89 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
 
     def shutdown(self) -> None:
         self._self_provider.shutdown()
+
+    def __enter__(self) -> "Tracer":
+        """Claim the tracer for one block. A second claim is an error.
+
+        Reuse fails quietly otherwise, which is the worst way for it to fail:
+        the first release stops the batch processor but not
+        ``SimpleSpanProcessor``, so spans recorded afterwards reach the local
+        buffer while remote export refuses them, and the two disagree with
+        nothing raised. The flag is never cleared, so this rejects reuse after
+        the block as well as re-entry inside it.
+        """
+        if self._self_entered:
+            raise RuntimeError(
+                "This Tracer has already been entered. A tracer is scoped to one "
+                "operation — build a new one rather than reusing this."
+            )
+        self._self_entered = True
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Stop the provider's processors, then release the captured spans.
+
+        The order matters. ``shutdown()`` runs the processors' shutdown hooks,
+        and with a remote exporter attached it also drains the batch queue — for
+        as long as the collector takes. ``SimpleSpanProcessor`` keeps filling the
+        buffer throughout, so clearing first would leave behind whatever ended
+        during the drain. Neither call is sufficient alone: ``shutdown()``
+        reaches ``_BufferedSpanExporter.shutdown()``, which returns without
+        touching the buffer.
+
+        This does not seal the tracer. Only the batch processor refuses spans
+        afterwards; ``SimpleSpanProcessor.on_end`` has no shutdown check in SDK
+        1.43.0, so a span ending after this returns still lands in the buffer
+        unread. Nothing enforces a bound on that — the tracer is meant to go out
+        of scope with its block. Call ``get_db_traces`` before leaving.
+
+        A teardown failure is logged rather than raised, so that it cannot
+        replace the error — or the cancellation — the block is already
+        unwinding.
+
+        Prefer ``async with`` in async code: with a remote exporter attached
+        this blocks for a whole OTLP round-trip.
+        """
+        try:
+            self.shutdown()
+        except Exception:
+            logger.exception("Failed to shut down the tracer provider")
+        self.clear()
+
+    async def __aenter__(self) -> "Tracer":
+        return self.__enter__()
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Release, on a worker thread when the release can block.
+
+        With a remote exporter attached and anything left in the batch queue,
+        the release drains it — a full OTLP round-trip. On the event loop that
+        would stall every other request on the worker, hence the thread.
+
+        ``BatchProcessor.shutdown`` joins its worker for up to 30 seconds, which
+        waits out an export already in flight. Past that it abandons what is
+        still queued and calls the exporter's ``shutdown()``; for the OTLP HTTP
+        exporter that closes the session and sets the flag its retry loop polls,
+        so a retrying export gives up at its next checkpoint. A hung collector
+        therefore delays the caller rather than hanging it, at the cost of the
+        spans it had not sent.
+
+        Shielded because the usual way an agent turn ends early is the client
+        disconnecting, which cancels this scope: an unshielded ``await`` here
+        raises before the release runs, and the tracer is never torn down at
+        all. The shield covers anyio scope cancellation, which is what Starlette
+        delivers. A native ``asyncio.Task.cancel`` arriving while this is queued
+        for a thread-pool token still skips the release — no current owner
+        combines a remote exporter with native cancellation.
+
+        There is nothing to drain without a remote exporter, so that case skips
+        the thread rather than paying for a hop it cannot use.
+        """
+        if self._self_remote_exporter is None:
+            self.__exit__()
+            return
+        with anyio.CancelScope(shield=True):
+            await anyio.to_thread.run_sync(self.__exit__)
 
 
 def build_synthetic_readable_span(

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -34,13 +34,13 @@ from phoenix.server.api.routers import agents as agents_module
 from phoenix.server.api.routers.agents import (
     TurnTraceContext,
     _build_message_metadata_chunk,
+    _ensure_project_exists,
     _get_current_context_usage,
     _interleave_agent_and_subagent_message_chunks,
     _load_phoenix_user_email,
     _load_sandbox_availability,
     _maybe_using_user,
     _persist_agent_traces,
-    _persist_db_traces_and_emit_event,
     _SubagentMessageChunksClosed,
     _tracer_scope,
 )
@@ -57,7 +57,11 @@ class _EventQueue:
         self.events.append(item)
 
 
-class TestPersistDbTracesAndEmitEvent:
+class TestPersistAgentTracesAgainstTheDatabase:
+    """The whole write in one transaction: project upsert, traces, spans, and
+    the project-session roll-up, with the insert event emitted after commit.
+    """
+
     @staticmethod
     def _trace(
         *,
@@ -112,6 +116,8 @@ class TestPersistDbTracesAndEmitEvent:
             project_id = project.id
 
         start_time = datetime(2026, 6, 29, 15, 0, tzinfo=timezone.utc)
+        # The project already exists, so `_ensure_project_exists` resolves this
+        # id rather than creating one, and the prebuilt traces line up with it.
         db_traces = [
             self._trace(
                 project_id=project_id,
@@ -129,13 +135,19 @@ class TestPersistDbTracesAndEmitEvent:
             ),
         ]
         event_queue = _EventQueue()
+        tracer = MagicMock()
+        tracer.get_db_traces.return_value = db_traces
+        request = MagicMock()
+        request.app.state.db = db
+        request.state.event_queue = event_queue
 
-        await _persist_db_traces_and_emit_event(
-            db=db,
-            event_queue=event_queue,
-            db_traces=db_traces,
+        await _persist_agent_traces(
+            tracer=tracer,
+            request=request,
+            project_name="pxi-dev-test",
         )
 
+        assert tracer.get_db_traces.call_args.kwargs == {"project_id": project_id}
         assert event_queue.events == [SpanInsertEvent((project_id,))]
         async with db.read() as session:
             trace_count = await session.scalar(
@@ -148,6 +160,33 @@ class TestPersistDbTracesAndEmitEvent:
             assert project_session is not None
             assert project_session.start_time == start_time
             assert project_session.end_time == start_time + timedelta(seconds=3)
+
+
+class TestEnsureProjectExists:
+    """Read first, insert only when missing. The insert cannot carry the read:
+    `ON CONFLICT DO NOTHING` returns no row once the project exists, so the
+    creating call is the only one whose `RETURNING` yields an id.
+    """
+
+    async def test_creates_the_project_when_it_is_missing(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            project_id = await _ensure_project_exists(session, "brand-new")
+        async with db.read() as session:
+            name = await session.scalar(
+                select(models.Project.name).where(models.Project.id == project_id)
+            )
+        assert name == "brand-new"
+
+    async def test_resolves_an_existing_project_to_the_same_id(self, db: DbSessionFactory) -> None:
+        async with db() as session:
+            created = await _ensure_project_exists(session, "reused")
+            resolved = await _ensure_project_exists(session, "reused")
+        assert resolved == created
+        async with db.read() as session:
+            count = await session.scalar(
+                select(func.count(models.Project.id)).where(models.Project.name == "reused")
+            )
+        assert count == 1
 
 
 class TestTracerScope:
@@ -266,30 +305,31 @@ class TestPersistAgentTraces:
         turn produced its answer.
         """
         persisted: list[object] = []
+        db_traces = [MagicMock()]
+        tracer = MagicMock()
+        tracer.get_db_traces.return_value = db_traces
 
-        async def _ensure(db: object, name: str) -> int:
+        async def _ensure(session: object, name: str) -> int:
             await anyio.lowlevel.checkpoint()
             return 1
 
-        async def _persist(*, db: object, event_queue: object, db_traces: object) -> None:
+        async def _persist(*, session: object, db_traces: object) -> tuple[int, ...]:
             await anyio.lowlevel.checkpoint()
             persisted.append(db_traces)
+            return ()
 
         with (
             patch("phoenix.server.api.routers.agents._ensure_project_exists", new=_ensure),
-            patch(
-                "phoenix.server.api.routers.agents._persist_db_traces_and_emit_event",
-                new=_persist,
-            ),
+            patch("phoenix.server.api.routers.agents._persist_db_traces", new=_persist),
         ):
             with anyio.CancelScope() as scope:
                 scope.cancel()
                 await _persist_agent_traces(
-                    tracer=self._tracer(),
+                    tracer=tracer,
                     request=MagicMock(),
                     project_name="p",
                 )
-        assert persisted == [[]]
+        assert persisted == [db_traces]
 
     async def test_a_stalled_database_cannot_hold_the_handler_open(self) -> None:
         """The shield is bounded, so a burst of disconnects against a stalled
@@ -303,7 +343,7 @@ class TestPersistAgentTraces:
         failing.
         """
 
-        async def _hang(db: object, name: str) -> int:
+        async def _hang(session: object, name: str) -> int:
             await anyio.sleep(5)
             raise AssertionError("unreachable")
 

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -161,15 +161,14 @@ class TestTracerScope:
 
 
 class TestEveryAgentEndpointScopesItsTracer:
-    """The agents router is the heaviest `Tracer` owner — one per turn, holding
-    every span with its full message history — and it is the only owner with no
-    runtime lifecycle test. Each endpoint needs app state, authentication, a
-    built model and a constructed agent before it reaches the tracer, so none is
-    reachable from a unit test.
+    """The agents router is the heaviest `Tracer` owner: one per turn, holding
+    every span with its full message history. Each endpoint needs app state,
+    authentication, a built model and a constructed agent before it reaches the
+    tracer, so none is reachable from a unit test.
 
-    Guard the release structurally instead. Without this, deleting an
-    `async with` is invisible: replacing all three with `_tracer_scope(None)`
-    leaves this suite entirely green while no tracer is ever released.
+    These assertions read the source instead, checking that every endpoint that
+    builds a tracer also scopes it. Nothing else in this suite would notice an
+    `async with` going missing.
     """
 
     ENDPOINTS = ("run_server_agent", "chat", "summarize_endpoint")
@@ -261,10 +260,10 @@ class TestPersistAgentTraces:
                 )
 
     async def test_a_disconnected_client_does_not_lose_the_write(self) -> None:
-        """The commonest failure: the client goes away mid-turn and cancels the
-        scope this runs in. Unshielded, the first suspending `await` raises
-        `CancelledError` before the database is reached and the turn's traces
-        are lost even though the turn produced its answer.
+        """A client going away mid-turn cancels the scope this runs in.
+        Unshielded, the first suspending `await` raises `CancelledError` before
+        the database is reached, and the turn's traces are lost even though the
+        turn produced its answer.
         """
         persisted: list[object] = []
 
@@ -298,9 +297,10 @@ class TestPersistAgentTraces:
 
         The assertion is on elapsed time rather than an enclosing deadline. The
         bound lives inside the shield that protects the write from a client
-        disconnect, and that shield swallows an outer cancellation too — so an
-        enclosing `fail_after` can never fire, and dropping the bound would make
-        this test slow instead of making it fail.
+        disconnect, and that shield swallows an outer cancellation as well, so
+        an enclosing `fail_after` can never fire. Without the elapsed-time
+        assertion, dropping the bound would make this test slow rather than
+        failing.
         """
 
         async def _hang(db: object, name: str) -> int:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import ast
 import asyncio
+import logging
+import time
 from collections.abc import AsyncIterator
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
+import pytest
 from jinja2 import Template
 from opentelemetry.trace import (
     SpanContext,
@@ -24,6 +30,7 @@ from phoenix.server.agents.prompts import AgentPrompts
 from phoenix.server.agents.types import (
     SandboxAvailability,
 )
+from phoenix.server.api.routers import agents as agents_module
 from phoenix.server.api.routers.agents import (
     TurnTraceContext,
     _build_message_metadata_chunk,
@@ -32,8 +39,10 @@ from phoenix.server.api.routers.agents import (
     _load_phoenix_user_email,
     _load_sandbox_availability,
     _maybe_using_user,
+    _persist_agent_traces,
     _persist_db_traces_and_emit_event,
     _SubagentMessageChunksClosed,
+    _tracer_scope,
 )
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
@@ -139,6 +148,180 @@ class TestPersistDbTracesAndEmitEvent:
             assert project_session is not None
             assert project_session.start_time == start_time
             assert project_session.end_time == start_time + timedelta(seconds=3)
+
+
+class TestTracerScope:
+    def test_returns_the_tracer_so_the_block_releases_it(self) -> None:
+        tracer = MagicMock()
+        assert _tracer_scope(tracer) is tracer
+
+    async def test_is_a_no_op_when_trace_recording_is_off(self) -> None:
+        async with _tracer_scope(None):
+            pass
+
+
+class TestEveryAgentEndpointScopesItsTracer:
+    """The agents router is the heaviest `Tracer` owner — one per turn, holding
+    every span with its full message history — and it is the only owner with no
+    runtime lifecycle test. Each endpoint needs app state, authentication, a
+    built model and a constructed agent before it reaches the tracer, so none is
+    reachable from a unit test.
+
+    Guard the release structurally instead. Without this, deleting an
+    `async with` is invisible: replacing all three with `_tracer_scope(None)`
+    leaves this suite entirely green while no tracer is ever released.
+    """
+
+    ENDPOINTS = ("run_server_agent", "chat", "summarize_endpoint")
+
+    @staticmethod
+    def _functions() -> dict[str, ast.AsyncFunctionDef]:
+        source = Path(agents_module.__file__).read_text(encoding="utf-8")
+        return {
+            node.name: node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.AsyncFunctionDef)
+        }
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_the_endpoint_builds_a_tracer(self, endpoint: str) -> None:
+        function = self._functions()[endpoint]
+        built = [
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "Tracer"
+        ]
+        assert built, f"{endpoint} no longer builds a Tracer; this guard is now testing nothing"
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_the_endpoint_scopes_that_tracer(self, endpoint: str) -> None:
+        function = self._functions()[endpoint]
+        scoped = [
+            item.context_expr
+            for node in ast.walk(function)
+            if isinstance(node, ast.AsyncWith)
+            for item in node.items
+            if isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Name)
+            and item.context_expr.func.id == "_tracer_scope"
+        ]
+        assert scoped, f"{endpoint} never enters a tracer scope, so its tracer is never released"
+        for call in scoped:
+            assert [argument.id for argument in call.args if isinstance(argument, ast.Name)] == [
+                "tracer"
+            ], (
+                f"{endpoint} scopes something other than its own `tracer`, "
+                f"so the tracer it built is never released"
+            )
+
+
+class TestPersistAgentTraces:
+    """Teardown and the remote drain both belong to the `async with` that owns
+    the tracer, so what is left to protect here is that a bookkeeping failure
+    never replaces the exception already in flight — every caller runs this
+    from a `finally`.
+    """
+
+    @staticmethod
+    def _tracer() -> MagicMock:
+        tracer = MagicMock()
+        tracer.get_db_traces.return_value = []
+        return tracer
+
+    async def test_persistence_failure_is_logged_not_raised(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with patch(
+            "phoenix.server.api.routers.agents._ensure_project_exists",
+            new=AsyncMock(side_effect=RuntimeError("db is down")),
+        ):
+            with caplog.at_level(logging.ERROR, logger="phoenix.server.api.routers.agents"):
+                await _persist_agent_traces(
+                    tracer=self._tracer(),
+                    request=MagicMock(),
+                    project_name="p",
+                )
+        assert "Failed to persist agent traces" in caplog.text
+
+    async def test_cancellation_propagates(self) -> None:
+        """The guard must not swallow a `CancelledError` raised by the write
+        itself. Shielding covers cancellation delivered from outside; it does
+        not, and should not, turn this into a success.
+        """
+        with patch(
+            "phoenix.server.api.routers.agents._ensure_project_exists",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _persist_agent_traces(
+                    tracer=self._tracer(),
+                    request=MagicMock(),
+                    project_name="p",
+                )
+
+    async def test_a_disconnected_client_does_not_lose_the_write(self) -> None:
+        """The commonest failure: the client goes away mid-turn and cancels the
+        scope this runs in. Unshielded, the first suspending `await` raises
+        `CancelledError` before the database is reached and the turn's traces
+        are lost even though the turn produced its answer.
+        """
+        persisted: list[object] = []
+
+        async def _ensure(db: object, name: str) -> int:
+            await anyio.lowlevel.checkpoint()
+            return 1
+
+        async def _persist(*, db: object, event_queue: object, db_traces: object) -> None:
+            await anyio.lowlevel.checkpoint()
+            persisted.append(db_traces)
+
+        with (
+            patch("phoenix.server.api.routers.agents._ensure_project_exists", new=_ensure),
+            patch(
+                "phoenix.server.api.routers.agents._persist_db_traces_and_emit_event",
+                new=_persist,
+            ),
+        ):
+            with anyio.CancelScope() as scope:
+                scope.cancel()
+                await _persist_agent_traces(
+                    tracer=self._tracer(),
+                    request=MagicMock(),
+                    project_name="p",
+                )
+        assert persisted == [[]]
+
+    async def test_a_stalled_database_cannot_hold_the_handler_open(self) -> None:
+        """The shield is bounded, so a burst of disconnects against a stalled
+        database cannot pile up handlers. Expiry logs like any write failure.
+
+        The assertion is on elapsed time rather than an enclosing deadline. The
+        bound lives inside the shield that protects the write from a client
+        disconnect, and that shield swallows an outer cancellation too — so an
+        enclosing `fail_after` can never fire, and dropping the bound would make
+        this test slow instead of making it fail.
+        """
+
+        async def _hang(db: object, name: str) -> int:
+            await anyio.sleep(5)
+            raise AssertionError("unreachable")
+
+        with (
+            patch("phoenix.server.api.routers.agents._ensure_project_exists", new=_hang),
+            patch("phoenix.server.api.routers.agents._TRACE_PERSIST_TIMEOUT_SECONDS", 0.05),
+        ):
+            started = time.monotonic()
+            await _persist_agent_traces(
+                tracer=self._tracer(),
+                request=MagicMock(),
+                project_name="p",
+            )
+            elapsed = time.monotonic() - started
+        assert elapsed < 1, (
+            f"the persist waited {elapsed:.1f}s on a stalled database, so the bound never fired"
+        )
 
 
 class TestBuildMessageMetadataChunk:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -218,10 +218,9 @@ class TestEveryAgentEndpointScopesItsTracer:
 
 
 class TestPersistAgentTraces:
-    """Teardown and the remote drain both belong to the `async with` that owns
-    the tracer, so what is left to protect here is that a bookkeeping failure
-    never replaces the exception already in flight — every caller runs this
-    from a `finally`.
+    """Every caller runs this from a `finally`, so a bookkeeping failure here
+    must never replace the exception already in flight. Teardown and the remote
+    drain belong to the `async with` that owns the tracer, not to this.
     """
 
     @staticmethod

--- a/tests/unit/server/api/test_subscriptions_tracer_lifecycle.py
+++ b/tests/unit/server/api/test_subscriptions_tracer_lifecycle.py
@@ -7,11 +7,9 @@ from phoenix.server.api.subscriptions import _stream_single_chat_completion
 
 
 class TestStreamSingleChatCompletionReleasesItsTracer:
-    """The playground stream is the owner that previously tore its tracer down
-    on no path at all, so it is the one most worth pinning.
-
-    A `Tracer` holds every span it captured, message histories included, and one
-    is built per stream.
+    """The playground builds one `Tracer` per stream, and each holds every span
+    it captured, message histories included. The stream has to release its
+    tracer on every path it can leave by: completion, failure, and abandonment.
     """
 
     @staticmethod

--- a/tests/unit/server/api/test_subscriptions_tracer_lifecycle.py
+++ b/tests/unit/server/api/test_subscriptions_tracer_lifecycle.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, AsyncGenerator, AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from phoenix.server.api.subscriptions import _stream_single_chat_completion
+
+
+class TestStreamSingleChatCompletionReleasesItsTracer:
+    """The playground stream is the owner that previously tore its tracer down
+    on no path at all, so it is the one most worth pinning.
+
+    A `Tracer` holds every span it captured, message histories included, and one
+    is built per stream.
+    """
+
+    @staticmethod
+    def _tracer() -> MagicMock:
+        tracer = MagicMock()
+        tracer.get_db_traces.return_value = []
+        tracer.__aenter__ = AsyncMock(return_value=tracer)
+        tracer.__aexit__ = AsyncMock(return_value=None)
+        return tracer
+
+    @staticmethod
+    def _db() -> MagicMock:
+        session = MagicMock()
+        session.flush = AsyncMock()
+        db = MagicMock()
+        db.return_value.__aenter__ = AsyncMock(return_value=session)
+        db.return_value.__aexit__ = AsyncMock(return_value=None)
+        return db
+
+    def _stream(self, llm_client: MagicMock) -> AsyncGenerator[Any, None]:
+        return _stream_single_chat_completion(
+            input=MagicMock(),
+            llm_client=llm_client,
+            repetition_number=1,
+            db=self._db(),
+            project_id=1,
+            on_span_insertion=MagicMock(),
+            span_cost_calculator=MagicMock(),
+            otel_context=MagicMock(),
+        )
+
+    @staticmethod
+    def _client_yielding_one_chunk() -> MagicMock:
+        async def _chat_completion_create(**_: Any) -> AsyncIterator[MagicMock]:
+            yield MagicMock()
+
+        client = MagicMock()
+        client.chat_completion_create = _chat_completion_create
+        return client
+
+    async def test_the_tracer_is_released_when_the_stream_finishes(self) -> None:
+        tracer = self._tracer()
+        with patch("phoenix.server.api.subscriptions.Tracer", return_value=tracer):
+            stream = self._stream(self._client_yielding_one_chunk())
+            async for _ in stream:
+                pass
+        tracer.__aexit__.assert_awaited_once()
+
+    async def test_the_tracer_is_released_when_the_stream_fails(self) -> None:
+        """The failure is caught and turned into an error chunk, so the release
+        cannot rely on the exception reaching the caller.
+        """
+        tracer = self._tracer()
+        with (
+            patch("phoenix.server.api.subscriptions.Tracer", return_value=tracer),
+            patch(
+                "phoenix.server.api.subscriptions.prompt_chat_template_to_playground_messages",
+                side_effect=RuntimeError("the template is malformed"),
+            ),
+        ):
+            stream = self._stream(MagicMock())
+            async for _ in stream:
+                pass
+        tracer.__aexit__.assert_awaited_once()
+
+    async def test_the_tracer_is_released_when_the_consumer_abandons_the_stream(self) -> None:
+        """A playground client that navigates away leaves the stream part-read.
+        Closing it has to unwind the block rather than strand the tracer.
+        """
+        tracer = self._tracer()
+        with patch("phoenix.server.api.subscriptions.Tracer", return_value=tracer):
+            stream = self._stream(self._client_yielding_one_chunk())
+            await stream.__anext__()
+            tracer.__aexit__.assert_not_awaited()
+            await stream.aclose()
+        tracer.__aexit__.assert_awaited_once()

--- a/tests/unit/server/cost_tracking/test_token_cost_calculator.py
+++ b/tests/unit/server/cost_tracking/test_token_cost_calculator.py
@@ -1,0 +1,144 @@
+from typing import Any
+
+import pytest
+
+from phoenix.db.types.token_price_customization import (
+    ThresholdBasedTokenPriceCustomization,
+    TokenPriceCustomization,
+)
+from phoenix.server.cost_tracking.token_cost_calculator import (
+    ThresholdBasedTokenCostCalculator,
+    TokenCostCalculator,
+    create_token_cost_calculator,
+)
+
+PROMPT_KEY = "llm.token_count.prompt"
+BASE_RATE = 1.25e-06
+NEW_RATE = 2.5e-06
+THRESHOLD = 200_000.0
+TOKENS = 500
+
+
+def _attributes(prompt_tokens: Any) -> dict[str, Any]:
+    """Span attributes carrying `prompt_tokens` at `llm.token_count.prompt`.
+
+    Nested, because that is how spans store attributes and how
+    `get_attribute_value` reads them — it walks the dotted key through nested
+    dicts and finds nothing in a flat `{"llm.token_count.prompt": ...}` mapping.
+    A test written flat would fall back to the base rate for the wrong reason
+    and assert nothing about the threshold.
+    """
+    return {"llm": {"token_count": {"prompt": prompt_tokens}}}
+
+
+def _calculator() -> ThresholdBasedTokenCostCalculator:
+    """A tier-priced calculator shaped like the ones the manifest now ships.
+
+    Every flagship model in `model_cost_manifest.json` (claude-sonnet-4*,
+    gemini-2.5-pro, gpt-5.*) carries this customization on all four of its token
+    prices, keyed on the prompt token count.
+    """
+    return ThresholdBasedTokenCostCalculator(
+        base_rate=BASE_RATE,
+        key=PROMPT_KEY,
+        threshold=THRESHOLD,
+        new_rate=NEW_RATE,
+    )
+
+
+class TestThresholdBasedTokenCostCalculator:
+    def test_bills_base_rate_below_threshold(self) -> None:
+        cost = _calculator().calculate_cost(_attributes(1_000), TOKENS)
+        assert cost == pytest.approx(TOKENS * BASE_RATE)
+
+    def test_bills_new_rate_above_threshold(self) -> None:
+        cost = _calculator().calculate_cost(_attributes(250_000), TOKENS)
+        assert cost == pytest.approx(TOKENS * NEW_RATE)
+
+    def test_threshold_is_exclusive(self) -> None:
+        """Exactly at the threshold still bills at the base rate."""
+        cost = _calculator().calculate_cost(_attributes(int(THRESHOLD)), TOKENS)
+        assert cost == pytest.approx(TOKENS * BASE_RATE)
+
+    def test_float_token_count_above_threshold(self) -> None:
+        cost = _calculator().calculate_cost(_attributes(200_000.5), TOKENS)
+        assert cost == pytest.approx(TOKENS * NEW_RATE)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("250000", id="numeric_string"),
+            pytest.param("not-a-number", id="non_numeric_string"),
+            pytest.param([250_000], id="list"),
+            pytest.param({"value": 250_000}, id="dict"),
+            pytest.param(b"250000", id="bytes"),
+            pytest.param(True, id="bool"),
+        ],
+    )
+    def test_non_numeric_token_count_bills_base_rate(self, value: Any) -> None:
+        """A token count of the wrong type must not raise.
+
+        OTLP preserves whatever type the client sent, so this attribute can
+        arrive as a string, a list, or anything else. Comparing one of those
+        against the threshold used to raise `TypeError`, and because every span
+        ingestion path catches and logs per span, the span silently lost its
+        whole cost record. `get_aggregated_tokens` reads the same attribute and
+        falls back the same way.
+        """
+        cost = _calculator().calculate_cost(_attributes(value), TOKENS)
+        assert cost == pytest.approx(TOKENS * BASE_RATE)
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            pytest.param({}, id="missing"),
+            pytest.param(_attributes(0), id="zero"),
+            pytest.param(_attributes(None), id="none"),
+            pytest.param({"llm": {}}, id="empty_branch"),
+            pytest.param({"llm": "not-a-dict"}, id="non_dict_branch"),
+        ],
+    )
+    def test_absent_token_count_bills_base_rate(self, attributes: dict[str, Any]) -> None:
+        cost = _calculator().calculate_cost(attributes, TOKENS)
+        assert cost == pytest.approx(TOKENS * BASE_RATE)
+
+    def test_output_price_tiers_on_the_prompt_count(self) -> None:
+        """The output rate escalates on prompt size, not on the tokens billed.
+
+        This is what the manifest encodes: an `output` token price whose
+        customization is keyed on `llm.token_count.prompt`. A long prompt
+        therefore raises the price of a short completion.
+        """
+        cost = _calculator().calculate_cost(_attributes(250_000), 10)
+        assert cost == pytest.approx(10 * NEW_RATE)
+
+
+class TestCreateTokenCostCalculator:
+    def test_no_customization_yields_flat_calculator(self) -> None:
+        calculator = create_token_cost_calculator(BASE_RATE)
+        assert type(calculator) is TokenCostCalculator
+        assert calculator.calculate_cost(_attributes(250_000), TOKENS) == pytest.approx(
+            TOKENS * BASE_RATE
+        )
+
+    def test_threshold_customization_yields_threshold_calculator(self) -> None:
+        calculator = create_token_cost_calculator(
+            BASE_RATE,
+            ThresholdBasedTokenPriceCustomization(
+                key=PROMPT_KEY,
+                threshold=THRESHOLD,
+                new_rate=NEW_RATE,
+            ),
+        )
+        assert isinstance(calculator, ThresholdBasedTokenCostCalculator)
+        assert calculator.calculate_cost(_attributes(250_000), TOKENS) == pytest.approx(
+            TOKENS * NEW_RATE
+        )
+
+    def test_unrecognized_customization_falls_back_to_flat_calculator(self) -> None:
+        """A forward-compatible customization Phoenix does not implement yet."""
+        calculator = create_token_cost_calculator(
+            BASE_RATE,
+            TokenPriceCustomization.model_validate({"type": "something_new"}),
+        )
+        assert type(calculator) is TokenCostCalculator

--- a/tests/unit/server/cost_tracking/test_token_cost_calculator.py
+++ b/tests/unit/server/cost_tracking/test_token_cost_calculator.py
@@ -23,20 +23,19 @@ def _attributes(prompt_tokens: Any) -> dict[str, Any]:
     """Span attributes carrying `prompt_tokens` at `llm.token_count.prompt`.
 
     Nested, because that is how spans store attributes and how
-    `get_attribute_value` reads them — it walks the dotted key through nested
-    dicts and finds nothing in a flat `{"llm.token_count.prompt": ...}` mapping.
-    A test written flat would fall back to the base rate for the wrong reason
-    and assert nothing about the threshold.
+    `get_attribute_value` reads them. It walks the dotted key through nested
+    dicts and finds nothing in a flat `{"llm.token_count.prompt": ...}` mapping,
+    so a flat test would fall back to the base rate for the wrong reason and
+    assert nothing about the threshold.
     """
     return {"llm": {"token_count": {"prompt": prompt_tokens}}}
 
 
 def _calculator() -> ThresholdBasedTokenCostCalculator:
-    """A tier-priced calculator shaped like the ones the manifest now ships.
+    """A tier-priced calculator shaped like the ones the manifest ships.
 
-    Every flagship model in `model_cost_manifest.json` (claude-sonnet-4*,
-    gemini-2.5-pro, gpt-5.*) carries this customization on all four of its token
-    prices, keyed on the prompt token count.
+    The flagship models in `model_cost_manifest.json` carry this customization
+    on all four of their token prices, keyed on the prompt token count.
     """
     return ThresholdBasedTokenCostCalculator(
         base_rate=BASE_RATE,
@@ -80,10 +79,10 @@ class TestThresholdBasedTokenCostCalculator:
 
         OTLP preserves whatever type the client sent, so this attribute can
         arrive as a string, a list, or anything else. Comparing one of those
-        against the threshold used to raise `TypeError`, and because every span
-        ingestion path catches and logs per span, the span silently lost its
-        whole cost record. `get_aggregated_tokens` reads the same attribute and
-        falls back the same way.
+        against the threshold raises `TypeError`, and every span ingestion path
+        catches and logs per span, so the span would lose its whole cost
+        record. `get_aggregated_tokens` reads the same attribute and falls back
+        the same way.
         """
         cost = _calculator().calculate_cost(_attributes(value), TOKENS)
         assert cost == pytest.approx(TOKENS * BASE_RATE)

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -1089,11 +1089,11 @@ class TestEvalWorkItemPersistsErrorAnnotation:
 
 class TestWorkItemsReleaseTheirTracer:
     """One tracer is built per work item, and each holds every span it captured.
-
     An experiment over 1,000 examples that never releases retains 1,000 of them
-    for the life of the process. The failure path is the one worth pinning: both
-    items catch and report their errors rather than propagating, so nothing about
-    the exception forces the release.
+    for the life of the process.
+
+    These cover the failure path: both items catch and report their errors
+    rather than propagating, so nothing about the exception forces the release.
     """
 
     @staticmethod

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import heapq
 from datetime import datetime, timedelta, timezone
-from typing import Any, Hashable, Sequence
+from typing import Any, Hashable, Sequence, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
@@ -130,13 +130,25 @@ def _make_running_experiment(
     max_retries: int = 3,
     base_backoff_seconds: float = 0.01,
 ) -> RunningExperiment:
+    def _make_tracer_factory() -> MagicMock:
+        """A stand-in `Tracer` usable as the `async with` the work items open.
+
+        A bare `MagicMock` will not do: `async with` binds `__aenter__`'s return
+        value, which on a `MagicMock` is an `AsyncMock`, so every method on the
+        bound tracer would return a coroutine instead of a value.
+        """
+        tracer = MagicMock()
+        tracer.__aenter__ = AsyncMock(return_value=tracer)
+        tracer.__aexit__ = AsyncMock(return_value=None)
+        return MagicMock(return_value=tracer)
+
     return RunningExperiment(
         experiment=_make_experiment(experiment_id),
         experiment_job=_make_experiment_job(experiment_id, max_concurrency=max_concurrency),
         llm_client=_NoOpLLMClient(),
         db=MagicMock(spec=DbSessionFactory),
         decrypt=lambda b: b,
-        tracer_factory=MagicMock(),
+        tracer_factory=_make_tracer_factory(),
         token_buckets=token_buckets or _StubTokenBucketRegistry(),
         on_done=on_done or _make_on_done(),
         evaluator_run_specs=evaluator_run_specs,
@@ -1073,3 +1085,58 @@ class TestEvalWorkItemPersistsErrorAnnotation:
         assert failure_args is not None
         assert failure_args.args[0] is eval_item
         assert failure_args.args[1] is error
+
+
+class TestWorkItemsReleaseTheirTracer:
+    """One tracer is built per work item, and each holds every span it captured.
+
+    An experiment over 1,000 examples that never releases retains 1,000 of them
+    for the life of the process. The failure path is the one worth pinning: both
+    items catch and report their errors rather than propagating, so nothing about
+    the exception forces the release.
+    """
+
+    @staticmethod
+    def _tracer(experiment: RunningExperiment) -> MagicMock:
+        factory = cast(MagicMock, experiment._tracer_factory)
+        tracer: MagicMock = factory.return_value
+        return tracer
+
+    async def test_the_task_work_item_releases_when_the_task_fails(self) -> None:
+        exp = _make_running_experiment()
+        task = _make_task_work_item(exp, dataset_example_id=42)
+        persisted_run = MagicMock(spec=models.ExperimentRun)
+        persisted_run.id = 701
+
+        with (
+            patch.object(task, "_build_messages", return_value=[]),
+            patch.object(
+                task._llm_client,
+                "chat_completion_create",
+                side_effect=RuntimeError("Bad request (injected)"),
+                create=True,
+            ),
+            patch.object(exp, "on_failure", AsyncMock()),
+            patch.object(exp, "_broadcast", MagicMock()),
+            patch.object(task, "_persist_run", AsyncMock(return_value=persisted_run)),
+        ):
+            await task.execute()
+
+        self._tracer(exp).__aexit__.assert_awaited_once()
+
+    async def test_the_eval_work_item_releases_when_the_evaluator_fails(self) -> None:
+        exp = _make_running_experiment()
+        eval_item = _make_eval_work_item(exp)
+
+        with (
+            patch.object(
+                eval_item._evaluator,
+                "evaluate",
+                side_effect=RuntimeError("Bad request (injected)"),
+            ),
+            patch.object(exp, "on_failure", AsyncMock()),
+            patch.object(eval_item, "_persist_eval_results", AsyncMock()),
+        ):
+            await eval_item.execute()
+
+        self._tracer(exp).__aexit__.assert_awaited_once()

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -1,11 +1,14 @@
 import gc
 import json
 import re
+import threading
+import time
 import weakref
 from datetime import datetime, timezone
 from typing import Sequence, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+import anyio
 import pytest
 from openinference.semconv.trace import SpanAttributes
 from opentelemetry.exporter.otlp.proto.http import trace_exporter as otlp_http_trace_exporter
@@ -51,12 +54,57 @@ class TestExtractOtelContext:
         assert not get_current_span(extracted).get_span_context().is_valid
 
 
-class TestTracerLifecycle:
-    """A `Tracer` is request-scoped and must not outlive its owner.
+class _SlowExporter(SpanExporter):
+    """A remote exporter slow enough to make a blocking release measurable."""
 
-    One is built per agent turn and per experiment work item, and each holds
-    every span it captured — with full message histories, since the span limits
-    are raised so nothing is evicted.
+    DELAY = 0.3
+
+    def __init__(self) -> None:
+        self.exported: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        time.sleep(self.DELAY)
+        self.exported.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        return None
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+class _BlockingShutdownExporter(SpanExporter):
+    """A remote exporter that holds the drain open, as a slow collector does.
+
+    `draining` is set once the release is inside the drain, so a test can end a
+    span in that window.
+    """
+
+    DELAY = 0.3
+
+    def __init__(self) -> None:
+        self.draining = threading.Event()
+        self.exported: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self.exported.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        self.draining.set()
+        time.sleep(self.DELAY)
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+class TestTracerLifecycle:
+    """A `Tracer` is request-scoped and must not outlive the block that owns it.
+
+    One is built per agent turn, per experiment work item, and per playground
+    stream, and each holds every span it captured — with full message histories,
+    since the span limits are raised so nothing is evicted.
     """
 
     @staticmethod
@@ -89,6 +137,210 @@ class TestTracerLifecycle:
         tracer = self._tracer()
         tracer.shutdown()
         tracer.shutdown()
+
+    def test_leaving_the_block_releases_the_captured_spans(self) -> None:
+        """`shutdown()` alone does not: it reaches `_BufferedSpanExporter.shutdown()`,
+        which returns without touching the buffer. Only `clear()` empties it, so
+        `__exit__` has to do both or the message histories stay reachable.
+
+        See `test_a_span_ending_during_the_drain_is_still_released` for why the
+        two run in the order they do.
+        """
+        with self._tracer() as tracer:
+            with tracer.start_as_current_span("operation"):
+                pass
+            assert tracer._self_exporter.get_finished_spans()
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    def test_the_block_releases_on_an_exception_path(self) -> None:
+        """The work items re-raise cancellation through this block, and the
+        traceback pins the frame — so release cannot wait on the frame dying.
+        """
+        tracer = self._tracer()
+        with patch.object(tracer.tracer_provider, "shutdown") as shutdown:
+            with pytest.raises(RuntimeError):
+                with tracer:
+                    with tracer.start_as_current_span("operation"):
+                        pass
+                    raise RuntimeError("work item failed")
+        assert tracer._self_exporter.get_finished_spans() == []
+        shutdown.assert_called_once()
+
+    @staticmethod
+    def _remote_tracer(exporter: SpanExporter) -> Tracer:
+        return Tracer(
+            span_cost_calculator=cast(SpanCostCalculator, Mock()),
+            enable_remote_export=True,
+            remote_collector_endpoint="http://collector.invalid",
+            remote_span_exporter_factory=lambda _: exporter,
+        )
+
+    async def test_async_block_releases_and_exports(self) -> None:
+        exporter = _SlowExporter()
+        tracer = self._remote_tracer(exporter)
+        async with tracer:
+            with tracer.start_as_current_span("operation"):
+                pass
+        assert [s.name for s in exporter.exported] == ["operation"]
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    async def test_async_block_does_not_hold_the_event_loop(self) -> None:
+        """With a remote exporter the release drains the batch queue, which is a
+        full OTLP round-trip. On the loop that stalls every other request on the
+        worker, so `__aexit__` hands it to a thread.
+        """
+        ticks = 0
+
+        async def _heartbeat() -> None:
+            nonlocal ticks
+            while True:
+                await anyio.sleep(0.02)
+                ticks += 1
+
+        exporter = _SlowExporter()
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_heartbeat)
+            await anyio.sleep(0.05)
+            ticks = 0
+            async with self._remote_tracer(exporter) as tracer:
+                with tracer.start_as_current_span("operation"):
+                    pass
+            advanced = ticks
+            tg.cancel_scope.cancel()
+        assert advanced >= 5, (
+            f"the loop advanced only {advanced} times during a "
+            f"{_SlowExporter.DELAY}s release, so the release ran inline"
+        )
+
+    async def test_async_block_releases_under_cancellation(self) -> None:
+        """A client disconnecting cancels the scope the release runs in. Without
+        the shield in `__aexit__` the `await` raises before the release happens
+        and the tracer is never torn down at all.
+        """
+        exporter = _SlowExporter()
+        tracer = self._remote_tracer(exporter)
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            try:
+                async with tracer:
+                    with tracer.start_as_current_span("operation"):
+                        pass
+            except BaseException:  # noqa: S110 - the cancellation itself is not under test
+                pass
+        assert [s.name for s in exporter.exported] == ["operation"]
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    async def test_async_block_skips_the_thread_without_a_remote_exporter(self) -> None:
+        """Nothing to drain locally, so the hop would buy nothing."""
+        tracer = self._tracer()
+        with patch("anyio.to_thread.run_sync") as run_sync:
+            async with tracer:
+                with tracer.start_as_current_span("operation"):
+                    pass
+        run_sync.assert_not_called()
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    def test_a_span_ending_during_the_drain_is_still_released(self) -> None:
+        """`shutdown()` has to run before `clear()`, not after.
+
+        With a remote exporter the shutdown drains the batch queue, and
+        `SimpleSpanProcessor` keeps filling the buffer for as long as the
+        collector takes — it has no shutdown check. Clearing first leaves
+        whatever ended inside that window reachable, and the window is as wide
+        as the collector is slow.
+        """
+        exporter = _BlockingShutdownExporter()
+        tracer = self._remote_tracer(exporter)
+        ended_late = threading.Event()
+        failures: list[BaseException] = []
+
+        def _end_a_span_mid_drain() -> None:
+            # Nothing here reaches pytest on its own — an exception in this
+            # thread would leave the test passing on a window it never opened.
+            try:
+                assert exporter.draining.wait(5), "the release never reached the drain"
+                with tracer.start_as_current_span("ended-during-the-drain"):
+                    pass
+                ended_late.set()
+            except BaseException as error:
+                failures.append(error)
+
+        late = threading.Thread(target=_end_a_span_mid_drain)
+        with tracer:
+            with tracer.start_as_current_span("operation"):
+                pass
+            late.start()
+        late.join(5)
+        assert not failures, failures[0]
+        assert ended_late.is_set(), "no span ended during the drain, so nothing was exercised"
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    def test_a_teardown_failure_does_not_replace_the_original_error(self) -> None:
+        """`_persist_agent_traces` already learned this one level up: a failure
+        while tearing down must not stand in for the failure the block is
+        unwinding, or the caller sees a broken exporter instead of the agent
+        error — or instead of a cancellation.
+        """
+        tracer = self._tracer()
+        with patch.object(
+            tracer.tracer_provider, "shutdown", side_effect=RuntimeError("the exporter is down")
+        ):
+            with pytest.raises(ValueError, match="the agent turn failed"):
+                with tracer:
+                    with tracer.start_as_current_span("operation"):
+                        pass
+                    raise ValueError("the agent turn failed")
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    def test_a_teardown_failure_does_not_fail_a_block_that_succeeded(self) -> None:
+        tracer = self._tracer()
+        with patch.object(
+            tracer.tracer_provider, "shutdown", side_effect=RuntimeError("the exporter is down")
+        ):
+            with tracer:
+                with tracer.start_as_current_span("operation"):
+                    pass
+        assert tracer._self_exporter.get_finished_spans() == []
+
+    def test_a_tracer_cannot_be_entered_twice(self) -> None:
+        """Nesting the same tracer releases it at the inner exit, and the outer
+        block then records into a half-torn-down tracer.
+        """
+        tracer = self._tracer()
+        with tracer:
+            with pytest.raises(RuntimeError, match="already been entered"):
+                with tracer:
+                    pass
+
+    def test_a_tracer_cannot_be_reused_after_its_block(self) -> None:
+        """The failure this prevents is silent: the first release stops the batch
+        processor but not `SimpleSpanProcessor`, so a second block's spans reach
+        the local buffer while remote export refuses them.
+        """
+        tracer = self._tracer()
+        with tracer:
+            pass
+        with pytest.raises(RuntimeError, match="already been entered"):
+            with tracer:
+                pass
+
+    async def test_the_async_block_rejects_reuse_too(self) -> None:
+        """`__aenter__` delegates, so there is one gate rather than two."""
+        tracer = self._tracer()
+        async with tracer:
+            pass
+        with pytest.raises(RuntimeError, match="already been entered"):
+            async with tracer:
+                pass
+
+    def test_spans_are_still_readable_inside_the_block(self) -> None:
+        """`get_db_traces` runs inside the `with` at every call site, so the
+        release on exit must not race the models the caller still has to build.
+        """
+        with self._tracer() as tracer:
+            with tracer.start_as_current_span("operation"):
+                pass
+            assert [s.name for s in tracer._self_exporter.get_finished_spans()] == ["operation"]
 
 
 class TestTracer:

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -103,8 +103,8 @@ class TestTracerLifecycle:
     """A `Tracer` is request-scoped and must not outlive the block that owns it.
 
     One is built per agent turn, per experiment work item, and per playground
-    stream, and each holds every span it captured — with full message histories,
-    since the span limits are raised so nothing is evicted.
+    stream. Each holds every span it captured, including full message
+    histories: the span limits are raised so that nothing is evicted.
     """
 
     @staticmethod
@@ -112,11 +112,11 @@ class TestTracerLifecycle:
         return Tracer(span_cost_calculator=cast(SpanCostCalculator, Mock()))
 
     def test_provider_does_not_register_an_atexit_handler(self) -> None:
-        """`TracerProvider`'s `shutdown_on_exit` default has to stay off here.
+        """`shutdown_on_exit` has to stay disabled on a per-request provider.
 
-        It does `atexit.register(provider.shutdown)`, which stores a bound
-        method and so pins the provider for the life of the process. That is
-        meant for one process-wide provider, not for one per request.
+        The SDK default registers `atexit.register(provider.shutdown)`, which
+        stores a bound method and pins the provider for the life of the
+        process. That suits one process-wide provider, not one per request.
         """
         tracer = self._tracer()
         assert tracer.tracer_provider._atexit_handler is None
@@ -139,12 +139,12 @@ class TestTracerLifecycle:
         tracer.shutdown()
 
     def test_leaving_the_block_releases_the_captured_spans(self) -> None:
-        """`shutdown()` alone does not: it reaches `_BufferedSpanExporter.shutdown()`,
-        which returns without touching the buffer. Only `clear()` empties it, so
-        `__exit__` has to do both or the message histories stay reachable.
+        """`shutdown()` alone does not release them.
 
-        See `test_a_span_ending_during_the_drain_is_still_released` for why the
-        two run in the order they do.
+        It reaches `_BufferedSpanExporter.shutdown()`, which returns without
+        touching the buffer. Only `clear()` empties it, so `__exit__` does
+        both. `test_a_span_ending_during_the_drain_is_still_released` covers
+        the order the two run in.
         """
         with self._tracer() as tracer:
             with tracer.start_as_current_span("operation"):
@@ -154,7 +154,7 @@ class TestTracerLifecycle:
 
     def test_the_block_releases_on_an_exception_path(self) -> None:
         """The work items re-raise cancellation through this block, and the
-        traceback pins the frame — so release cannot wait on the frame dying.
+        traceback pins the frame. Release cannot wait on the frame dying.
         """
         tracer = self._tracer()
         with patch.object(tracer.tracer_provider, "shutdown") as shutdown:
@@ -215,7 +215,7 @@ class TestTracerLifecycle:
     async def test_async_block_releases_under_cancellation(self) -> None:
         """A client disconnecting cancels the scope the release runs in. Without
         the shield in `__aexit__` the `await` raises before the release happens
-        and the tracer is never torn down at all.
+        and the tracer is never torn down.
         """
         exporter = _SlowExporter()
         tracer = self._remote_tracer(exporter)
@@ -231,7 +231,7 @@ class TestTracerLifecycle:
         assert tracer._self_exporter.get_finished_spans() == []
 
     async def test_async_block_skips_the_thread_without_a_remote_exporter(self) -> None:
-        """Nothing to drain locally, so the hop would buy nothing."""
+        """There is no remote queue to drain, so the thread hop serves no purpose."""
         tracer = self._tracer()
         with patch("anyio.to_thread.run_sync") as run_sync:
             async with tracer:
@@ -243,9 +243,9 @@ class TestTracerLifecycle:
     def test_a_span_ending_during_the_drain_is_still_released(self) -> None:
         """`shutdown()` has to run before `clear()`, not after.
 
-        With a remote exporter the shutdown drains the batch queue, and
-        `SimpleSpanProcessor` keeps filling the buffer for as long as the
-        collector takes — it has no shutdown check. Clearing first leaves
+        With a remote exporter the shutdown drains the batch queue.
+        `SimpleSpanProcessor` has no shutdown check, so it keeps filling the
+        buffer for as long as the collector takes. Clearing first leaves
         whatever ended inside that window reachable, and the window is as wide
         as the collector is slow.
         """
@@ -255,8 +255,8 @@ class TestTracerLifecycle:
         failures: list[BaseException] = []
 
         def _end_a_span_mid_drain() -> None:
-            # Nothing here reaches pytest on its own — an exception in this
-            # thread would leave the test passing on a window it never opened.
+            # Failures on this thread do not reach pytest. Uncaptured, they
+            # would leave the test passing on a window it never opened.
             try:
                 assert exporter.draining.wait(5), "the release never reached the drain"
                 with tracer.start_as_current_span("ended-during-the-drain"):
@@ -276,10 +276,9 @@ class TestTracerLifecycle:
         assert tracer._self_exporter.get_finished_spans() == []
 
     def test_a_teardown_failure_does_not_replace_the_original_error(self) -> None:
-        """`_persist_agent_traces` already learned this one level up: a failure
-        while tearing down must not stand in for the failure the block is
-        unwinding, or the caller sees a broken exporter instead of the agent
-        error — or instead of a cancellation.
+        """A failure while tearing down must not stand in for the failure the
+        block is unwinding. Otherwise the caller sees a broken exporter in
+        place of the agent error, or in place of a cancellation.
         """
         tracer = self._tracer()
         with patch.object(
@@ -313,9 +312,9 @@ class TestTracerLifecycle:
                     pass
 
     def test_a_tracer_cannot_be_reused_after_its_block(self) -> None:
-        """The failure this prevents is silent: the first release stops the batch
-        processor but not `SimpleSpanProcessor`, so a second block's spans reach
-        the local buffer while remote export refuses them.
+        """The first release stops the batch processor but not
+        `SimpleSpanProcessor`, so a second block's spans would reach the local
+        buffer while remote export refuses them.
         """
         tracer = self._tracer()
         with tracer:

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -1,7 +1,10 @@
+import gc
 import json
 import re
+import weakref
 from datetime import datetime, timezone
-from typing import Sequence
+from typing import Sequence, cast
+from unittest.mock import Mock
 
 import pytest
 from openinference.semconv.trace import SpanAttributes
@@ -46,6 +49,46 @@ class TestExtractOtelContext:
     def test_returns_invalid_context_for_empty_carrier(self) -> None:
         extracted = extract_otel_context({})
         assert not get_current_span(extracted).get_span_context().is_valid
+
+
+class TestTracerLifecycle:
+    """A `Tracer` is request-scoped and must not outlive its owner.
+
+    One is built per agent turn and per experiment work item, and each holds
+    every span it captured — with full message histories, since the span limits
+    are raised so nothing is evicted.
+    """
+
+    @staticmethod
+    def _tracer() -> Tracer:
+        return Tracer(span_cost_calculator=cast(SpanCostCalculator, Mock()))
+
+    def test_provider_does_not_register_an_atexit_handler(self) -> None:
+        """`TracerProvider`'s `shutdown_on_exit` default has to stay off here.
+
+        It does `atexit.register(provider.shutdown)`, which stores a bound
+        method and so pins the provider for the life of the process. That is
+        meant for one process-wide provider, not for one per request.
+        """
+        tracer = self._tracer()
+        assert tracer.tracer_provider._atexit_handler is None
+
+    def test_provider_is_collected_once_the_tracer_is_dropped(self) -> None:
+        tracer = self._tracer()
+        with tracer.start_as_current_span("operation"):
+            pass
+        provider_ref = weakref.ref(tracer.tracer_provider)
+        del tracer
+        gc.collect()
+        assert provider_ref() is None, (
+            "the tracer provider outlived its tracer, so every span it captured is still reachable"
+        )
+
+    def test_shutdown_is_idempotent(self) -> None:
+        """Owners call `shutdown()` from a `finally`, which can run twice."""
+        tracer = self._tracer()
+        tracer.shutdown()
+        tracer.shutdown()
 
 
 class TestTracer:


### PR DESCRIPTION
Three independent bugs found while reviewing recently-changed code. Each is a separate commit and can be reviewed on its own.

## 1. `fix(cost-tracking)`: non-numeric token counts crash the threshold calculator

`ThresholdBasedTokenCostCalculator.calculate_cost` compared the prompt token count against its threshold without a type check. OTLP preserves whatever type the client sent, so a token count arriving as a string or list raised:

```
TypeError: '>' not supported between instances of 'str' and 'float'
```

Every span-ingestion path catches and logs per span, so the span **silently lost its entire cost record** rather than getting a wrong one. The exception is `Tracer.get_db_traces`, which is called outside a try in `tracers.py`.

This path only became reachable in #14329, which populated the manifest with 77 threshold customizations and taught the facilitator to sync them into `token_prices.customization` — covering the flagship models (`claude-sonnet-4*`, `gemini-2.5-pro`, `gpt-5.*`) on all four of their token prices. Note the `output` price tiers on the *prompt* count, so a span with a string prompt count and a valid integer completion count still reaches the calculator through phase 2 of the details calculator.

Non-numeric values now bill at the base rate, matching how `get_aggregated_tokens` and phase 1 of `calculate_details` already read the same attributes.

Adds the first test coverage for this calculator — there was no `test_token_cost_calculator.py`. **5 of the new cases fail against the previous implementation.**

## 2. `fix(tracing)`: a `TracerProvider` is retained per agent turn and per work item

`Tracer` builds a fresh `TracerProvider` per request, and the SDK's `shutdown_on_exit` default registers `atexit.register(provider.shutdown)`:

```
opentelemetry/sdk/trace/__init__.py:1316    shutdown_on_exit: bool = True,
opentelemetry/sdk/trace/__init__.py:1347        self._atexit_handler = atexit.register(self.shutdown)
opentelemetry/sdk/trace/__init__.py:1479            atexit.unregister(self._atexit_handler)
```

That stores a **bound method**, so the registry holds a strong reference and the provider is never collected — and neither is anything it reaches: its `SimpleSpanProcessor`, the `_BufferedSpanExporter`, and every captured span. Those spans carry full chat message histories by design, since span limits are raised to `max_span_attributes=100_000` so nothing is evicted.

Only `shutdown()` unregisters the handler, and the experiment runner never called it — `TaskWorkItem.execute` and `EvalWorkItem.execute` each build a tracer per work item with no teardown on any path. **An experiment over 1,000 examples retained ~1,000 providers plus every message history they captured, for the life of the server process, growing with each run.**

`shutdown_on_exit` is meant for one process-wide provider — which is what `server/telemetry.py` has, and it correctly keeps the default. I checked every other `TracerProvider(` construction in the repo; this is the only per-request one.

Both work items now shut down in a `finally`, and `TaskWorkItem`'s tracer moves below the template-error branch that returns without tracing anything, so the `finally` spans its whole lifetime.

The regression test takes a `weakref`, drops the tracer, and forces a collection — on the previous implementation the provider survives.

## 3. `fix(agents)`: trace persistence in `finally` masks errors and skips teardown

Three `finally` blocks flushed the tracer, persisted what it captured, and shut the provider down, with nothing guarded. Any DB hiccup in `_ensure_project_exists` / `_persist_db_traces_and_emit_event`, or a cost-calculation failure inside `get_db_traces` (bug 1), had two consequences:

**The exception replaced the one already in flight.** In the summarize endpoint that is unambiguous — `except SummarizationError: raise HTTPException(502, ...)` is immediately followed by this `finally`, so a telemetry-side failure discarded the intended 502 and its detail and answered an opaque 500. On the success path it turned a completed summarization into a 500 for a bookkeeping problem.

**And it skipped `shutdown()`**, retaining the provider (bug 2) and stranding the `BatchSpanProcessor` worker thread whenever remote export is on.

The three copies collapse into one guarded helper. Every other place that persists spans already guards this way (`bulk_inserter`, `span_cost_calculator`); walking every `finally` in `src/phoenix` for unguarded awaited DB work returns only these three sites, so this was an omission rather than house style.

## Verification

| Check | Result |
|---|---|
| `ruff check` | All checks passed |
| `ruff format --check` | 6 files already formatted |
| `mypy` | Success: no issues found in 1037 source files |
| Affected unit suites | 711 passed, 49 skipped |
| New tests vs. previous code | 7 of 22 fail as expected |

Affected suites: `test_experiment_runner.py`, `test_tracers.py`, `server/cost_tracking/`, `server/api/routers/test_agents.py`, `server/agents/`.

## Notes for reviewers

- No behavior change for valid input in bug 1 — a numeric `0` still falls through to the base rate exactly as the previous falsy check did.
- Bug 2's fix means providers are no longer shut down at process exit. That is safe here: the experiment-runner factory builds tracers with `enable_remote_export=False`, so there is no `BatchSpanProcessor` to flush, and the agent router paths shut down explicitly.
- Bugs 2 and 3 are related — 3 is one of the ways `shutdown()` was being skipped — but they are independent defects and either fix stands alone.

