### PR TITLE
feat(ui): add expandable rows to the Datasets table for inline details

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1242,6 +1242,10 @@ const tableCSS = (theme: Theme) => css`
     );
     --global-table-bordered-cell-border-color: var(--global-color-gray-100);
     --global-table-pagination-border-color: var(--global-color-gray-300);
+    /* Recessed surface behind the inline detail area an expanded row reveals,
+       matching the header so the detail area reads as table chrome rather than
+       as another row of values. */
+    --global-table-row-details-background-color: var(--global-color-gray-75);
 
     --global-table-cell-padding-y: var(--global-dimension-size-100);
     --global-table-cell-padding-x: var(--global-dimension-size-200);

--- a/app/src/components/table/RowDetails.tsx
+++ b/app/src/components/table/RowDetails.tsx
@@ -1,0 +1,130 @@
+import { css } from "@emotion/react";
+import type { ColumnDef, Row } from "@tanstack/react-table";
+import type { PropsWithChildren } from "react";
+
+import { EXPAND_COLUMN_ID } from "./constants";
+import { TableExpandButton } from "./TableExpandButton";
+
+/**
+ * Width of the disclosure column. Wide enough for the chevron and its focus
+ * ring, narrow enough to read as a gutter beside the first real column.
+ */
+export const EXPAND_COLUMN_SIZE = 36;
+
+/**
+ * The DOM id of the detail area a row's disclosure control reveals. Shared by
+ * the control's `aria-controls` and the detail area itself, so assistive
+ * technology can follow one to the other.
+ *
+ * @param rowId - the table row's id, which must be unique within the page
+ */
+export function getRowDetailsId(rowId: string) {
+  return `row-details-${rowId}`;
+}
+
+/**
+ * Creates the disclosure column that expands and collapses a row's inline
+ * detail area, to be pinned at the leading edge with `EXPAND_COLUMN_PINNING`.
+ *
+ * Requires `getRowCanExpand` on the table so tanstack treats every row as
+ * expandable — without subrows a row can otherwise never be expanded.
+ *
+ * @param params - expansion column options
+ * @param params.getRowLabel - names the row in the control's accessible label,
+ *   so a screen reader hears which row it is about to expand
+ * @param params.size - column size in pixels
+ */
+export function createRowExpandColumn<TData>({
+  getRowLabel,
+  size = EXPAND_COLUMN_SIZE,
+}: {
+  getRowLabel?: (row: Row<TData>) => string;
+  size?: number;
+} = {}): ColumnDef<TData> {
+  return {
+    id: EXPAND_COLUMN_ID,
+    header: () => null,
+    enableResizing: false,
+    enableSorting: false,
+    enableHiding: false,
+    size,
+    minSize: size,
+    maxSize: size,
+    cell: ({ row }) => {
+      const rowLabel = getRowLabel?.(row);
+      return (
+        <TableExpandButton
+          isExpanded={row.getIsExpanded()}
+          onClick={row.getToggleExpandedHandler()}
+          aria-label={
+            rowLabel ? `Toggle details for ${rowLabel}` : "Toggle row details"
+          }
+          aria-controls={getRowDetailsId(row.id)}
+        />
+      );
+    },
+  };
+}
+
+const rowDetailsPanelCSS = css`
+  // Pinned to the leading edge of the table's scroll port so the detail area
+  // stays where it can be read however far the columns are scrolled sideways
+  position: sticky;
+  left: 0;
+  box-sizing: border-box;
+  max-width: 100%;
+  padding-block: var(--global-dimension-size-200);
+  padding-right: var(--global-table-cell-padding-x);
+  // Indented past the disclosure column so the detail area starts on the same
+  // edge as the row's first value rather than under its chevron
+  padding-left: calc(
+    ${EXPAND_COLUMN_SIZE}px + var(--global-table-cell-padding-x)
+  );
+  // Long unbroken values (ids, serialized JSON) wrap here rather than widening
+  // the row and forcing the whole table to scroll sideways
+  overflow-wrap: anywhere;
+`;
+
+export type RowDetailsRowProps = PropsWithChildren<{
+  /** The id of the row this detail area belongs to. */
+  rowId: string;
+  /**
+   * How many columns to span, i.e. `table.getVisibleLeafColumns().length`, so
+   * the detail area runs the full width of the table.
+   */
+  colSpan: number;
+  /**
+   * Width of the table's scroll port in pixels, which the detail area takes so
+   * its content lays out against the visible area instead of against a table
+   * that may be far wider. Falls back to the full table width when unknown.
+   */
+  scrollPortWidth?: number;
+}>;
+
+/**
+ * A table row that renders a detail area inline beneath the row it belongs to,
+ * spanning every column.
+ *
+ * Render it only while the row is expanded, immediately after that row, and
+ * style the table with `rowDetailsTableCSS` so the pair reads as one block.
+ */
+export function RowDetailsRow({
+  rowId,
+  colSpan,
+  scrollPortWidth,
+  children,
+}: RowDetailsRowProps) {
+  return (
+    <tr data-row="details">
+      <td colSpan={colSpan}>
+        <div
+          id={getRowDetailsId(rowId)}
+          css={rowDetailsPanelCSS}
+          style={{ width: scrollPortWidth ?? "100%" }}
+        >
+          {children}
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/app/src/components/table/TableExpandButton.tsx
+++ b/app/src/components/table/TableExpandButton.tsx
@@ -1,10 +1,15 @@
 import { css } from "@emotion/react";
 
-import { DisclosureArrow } from "@phoenix/components";
+import { DisclosureArrow } from "@phoenix/components/core/icon";
 
 type TableExpandButtonProps = {
   onClick: (event: unknown) => void;
   ["aria-label"]: string;
+  /**
+   * The DOM id of the content the button reveals, so assistive technology can
+   * follow the control to what it expanded.
+   */
+  ["aria-controls"]?: string;
   isExpanded: boolean;
 };
 export function TableExpandButton(props: TableExpandButtonProps) {
@@ -17,6 +22,10 @@ export function TableExpandButton(props: TableExpandButtonProps) {
         props.onClick(e);
       }}
       aria-label={props["aria-label"]}
+      // The rotating chevron shows the state to sighted users; aria-expanded is
+      // how everyone else reads it, so the label can stay constant
+      aria-expanded={props.isExpanded}
+      aria-controls={props["aria-controls"]}
       css={css`
         cursor: pointer;
         display: flex;

--- a/app/src/components/table/__tests__/RowDetails.test.tsx
+++ b/app/src/components/table/__tests__/RowDetails.test.tsx
@@ -1,0 +1,214 @@
+import type { ColumnDef, ExpandedState } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import type { ReactElement } from "react";
+import { act, Fragment, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createRowExpandColumn,
+  getRowDetailsId,
+  RowDetailsRow,
+} from "../RowDetails";
+
+type Dataset = { id: string; name: string };
+
+const DATASETS: Dataset[] = [
+  { id: "one", name: "first dataset" },
+  { id: "two", name: "second dataset" },
+];
+
+const columns: ColumnDef<Dataset>[] = [
+  createRowExpandColumn<Dataset>({ getRowLabel: (row) => row.original.name }),
+  { id: "name", header: "name", accessorKey: "name" },
+];
+
+/**
+ * The smallest table that renders the disclosure column beside a detail row,
+ * standing in for the datasets table: rows do something of their own on click,
+ * and expansion is keyed by the row's id rather than by its position.
+ */
+function DetailsTable({
+  data = DATASETS,
+  onRowClick,
+}: {
+  data?: Dataset[];
+  onRowClick?: () => void;
+}) {
+  "use no memo";
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+  // eslint-disable-next-line react-hooks-js/incompatible-library
+  const table = useReactTable<Dataset>({
+    columns,
+    data,
+    state: { expanded },
+    onExpandedChange: setExpanded,
+    getRowCanExpand: () => true,
+    getRowId: (row) => row.id,
+    autoResetExpanded: false,
+    getCoreRowModel: getCoreRowModel(),
+  });
+  const visibleColumnCount = table.getVisibleLeafColumns().length;
+  return (
+    <table>
+      <tbody>
+        {table.getRowModel().rows.map((row) => {
+          const isExpanded = row.getIsExpanded();
+          return (
+            <Fragment key={row.id}>
+              <tr data-expanded={isExpanded} onClick={onRowClick}>
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+              {isExpanded ? (
+                <RowDetailsRow rowId={row.id} colSpan={visibleColumnCount}>
+                  <span>details for {row.original.name}</span>
+                </RowDetailsRow>
+              ) : null}
+            </Fragment>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+function expandButtons(): Element[] {
+  return Array.from(container.querySelectorAll("button[aria-expanded]"));
+}
+
+function expandButton(index: number): HTMLElement {
+  const button = expandButtons().at(index);
+  if (!(button instanceof HTMLElement)) {
+    throw new Error(`no disclosure control at index ${index}`);
+  }
+  return button;
+}
+
+function expandedStates(): (string | null)[] {
+  return expandButtons().map((button) => button.getAttribute("aria-expanded"));
+}
+
+function detailRows(): Element[] {
+  return Array.from(container.querySelectorAll('tr[data-row="details"]'));
+}
+
+function onlyDetailRow(): Element {
+  const rows = detailRows();
+  if (rows.length !== 1) {
+    throw new Error(`expected one detail row, found ${rows.length}`);
+  }
+  return rows[0];
+}
+
+function detailAreaId(detailRow: Element): string {
+  const area = detailRow.querySelector("td > div");
+  if (area == null) {
+    throw new Error("the detail row has no detail area");
+  }
+  return area.id;
+}
+
+describe("row details", () => {
+  it("gives every row a disclosure control that reads as collapsed", () => {
+    render(<DetailsTable />);
+
+    expect(expandedStates()).toEqual(["false", "false"]);
+    expect(expandButton(0).getAttribute("aria-label")).toBe(
+      "Toggle details for first dataset"
+    );
+    expect(detailRows()).toHaveLength(0);
+  });
+
+  it("reveals the detail area the control points at, spanning the row", () => {
+    render(<DetailsTable />);
+
+    act(() => {
+      expandButton(0).click();
+    });
+
+    expect(expandedStates()).toEqual(["true", "false"]);
+    const detailRow = onlyDetailRow();
+    const detailCell = detailRow.querySelector("td");
+    expect(detailCell?.getAttribute("colspan")).toBe("2");
+    expect(detailRow.textContent).toContain("details for first dataset");
+    // the control names the area it revealed, so assistive technology can
+    // follow one to the other
+    expect(detailAreaId(detailRow)).toBe(getRowDetailsId("one"));
+    expect(expandButton(0).getAttribute("aria-controls")).toBe(
+      getRowDetailsId("one")
+    );
+  });
+
+  it("collapses the detail area again", () => {
+    render(<DetailsTable />);
+
+    act(() => {
+      expandButton(0).click();
+    });
+    act(() => {
+      expandButton(0).click();
+    });
+
+    expect(expandedStates()).toEqual(["false", "false"]);
+    expect(detailRows()).toHaveLength(0);
+  });
+
+  it("does not trigger the row's own click when toggled", () => {
+    const onRowClick = vi.fn();
+    render(<DetailsTable onRowClick={onRowClick} />);
+
+    act(() => {
+      expandButton(0).click();
+    });
+    act(() => {
+      expandButton(0).click();
+    });
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps the same row expanded when sorting reorders the data", () => {
+    render(<DetailsTable />);
+
+    act(() => {
+      expandButton(0).click();
+    });
+    // a sort is served by a refetch, which hands the table the same datasets
+    // back in a different order
+    render(<DetailsTable data={[...DATASETS].reverse()} />);
+
+    expect(detailAreaId(onlyDetailRow())).toBe(getRowDetailsId("one"));
+    // the expanded dataset moved to the second row, and its state moved with it
+    expect(expandedStates()).toEqual(["false", "true"]);
+  });
+});

--- a/app/src/components/table/constants.ts
+++ b/app/src/components/table/constants.ts
@@ -11,9 +11,22 @@ export const CHECKBOX_COLUMN_ID = "select";
 export const ACTIONS_COLUMN_ID = "actions";
 
 /**
+ * Column id shared by every table's row-expansion disclosure column.
+ */
+export const EXPAND_COLUMN_ID = "expand";
+
+/**
  * Pins the checkbox column to the left so it stays visible while a table's
  * other columns scroll horizontally.
  */
 export const CHECKBOX_COLUMN_PINNING = {
   left: [CHECKBOX_COLUMN_ID],
+} satisfies ColumnPinningState;
+
+/**
+ * Pins the row-expansion column to the left so the disclosure control stays
+ * visible while a table's other columns scroll horizontally.
+ */
+export const EXPAND_COLUMN_PINNING = {
+  left: [EXPAND_COLUMN_ID],
 } satisfies ColumnPinningState;

--- a/app/src/components/table/index.tsx
+++ b/app/src/components/table/index.tsx
@@ -29,3 +29,6 @@ export * from "./addRowRangeToSelection";
 export * from "./constants";
 export * from "./RowSelectionColumn";
 export * from "./useShiftClickRowSelection";
+
+// Row expansion
+export * from "./RowDetails";

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -198,6 +198,35 @@ export const expandableSelectableTableCSS = css(
   expandableRowsTableCSS
 );
 
+/**
+ * Styling for tables that reveal an inline detail area beneath an expanded row,
+ * keyed off `data-row="details"` on the detail `<tr>` and `data-expanded` on the
+ * row it belongs to.
+ *
+ * A row and its detail area read as one block: the border that would divide them
+ * is dropped, the detail cell carries the recessed background across the full
+ * table width, and the detail row is not clickable the way the data rows are.
+ *
+ * @see RowDetailsRow, which renders the markup these selectors target
+ */
+export const rowDetailsTableCSS = css`
+  tbody:not(.is-empty) {
+    tr[data-expanded="true"]:not(:last-of-type) > td {
+      border-bottom: none;
+    }
+    tr[data-row="details"] > td {
+      // The detail area stands in for the whole row rather than holding one
+      // column's value, so it lays out its own padding
+      padding: 0;
+      background-color: var(--global-table-row-details-background-color);
+    }
+    // Only the row above navigates on click; the detail area is read in place
+    tr[data-row="details"] {
+      cursor: default;
+    }
+  }
+`;
+
 export const paginationCSS = css`
   display: flex;
   justify-content: flex-end;

--- a/app/src/pages/datasets/DatasetRowDetails.tsx
+++ b/app/src/pages/datasets/DatasetRowDetails.tsx
@@ -1,0 +1,84 @@
+import { css } from "@emotion/react";
+import type { PropsWithChildren } from "react";
+
+import { CopyToClipboardButton, Flex, Text } from "@phoenix/components";
+import { JSONText } from "@phoenix/components/code/JSONText";
+import { isObject } from "@phoenix/typeUtils";
+
+import type { DatasetsTable_datasets$data } from "./__generated__/DatasetsTable_datasets.graphql";
+
+type DatasetEdges = DatasetsTable_datasets$data["datasets"]["edges"];
+type Dataset = DatasetEdges[number]["node"];
+
+const datasetDetailsCSS = css`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  // Collapses to fewer, then to a single column as the table's scroll port
+  // narrows, so the detail area never has to be scrolled sideways to be read
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: var(--global-dimension-size-200);
+`;
+
+const datasetDetailsValueCSS = css`
+  margin-top: var(--global-dimension-size-50);
+  // Descriptions are authored as prose and may carry their own line breaks
+  white-space: pre-wrap;
+`;
+
+function DatasetDetail({
+  label,
+  children,
+}: PropsWithChildren<{ label: string }>) {
+  return (
+    <li>
+      <Text size="XS" color="text-700">
+        {label}
+      </Text>
+      <div css={datasetDetailsValueCSS}>{children}</div>
+    </li>
+  );
+}
+
+/**
+ * The secondary dataset information an expanded row in the datasets table
+ * reveals: the values the row itself has to clip to stay scannable, plus the
+ * dataset's id, which no column shows.
+ */
+export function DatasetRowDetails({ dataset }: { dataset: Dataset }) {
+  const hasMetadata =
+    isObject(dataset.metadata) && Object.keys(dataset.metadata).length > 0;
+  return (
+    <ul css={datasetDetailsCSS}>
+      <DatasetDetail label="Dataset ID">
+        <Flex direction="row" gap="size-50" alignItems="center">
+          <Text fontFamily="mono">{dataset.id}</Text>
+          <CopyToClipboardButton
+            text={dataset.id}
+            aria-label="Copy dataset ID"
+          />
+        </Flex>
+      </DatasetDetail>
+      <DatasetDetail label="Description">
+        {dataset.description ? (
+          <Text>{dataset.description}</Text>
+        ) : (
+          <Text color="text-500">No description</Text>
+        )}
+      </DatasetDetail>
+      <DatasetDetail label="Metadata">
+        {hasMetadata ? (
+          <JSONText
+            json={dataset.metadata}
+            space={2}
+            collapseSingleKey={false}
+            disableTitle
+          />
+        ) : (
+          <Text color="text-500">No metadata</Text>
+        )}
+      </DatasetDetail>
+    </ul>
+  );
+}

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import type {
   CellContext,
   ColumnDef,
+  ExpandedState,
   SortingState,
 } from "@tanstack/react-table";
 import {
@@ -12,6 +13,7 @@ import {
 } from "@tanstack/react-table";
 import type { Dispatch, SetStateAction } from "react";
 import {
+  Fragment,
   startTransition,
   useCallback,
   useEffect,
@@ -39,17 +41,23 @@ import {
   ColumnHeaderCell,
   ColumnOrderingProvider,
   CompactJSONCell,
+  createRowExpandColumn,
+  EXPAND_COLUMN_ID,
+  EXPAND_COLUMN_PINNING,
+  RowDetailsRow,
   useColumnOrder,
   UserCell,
 } from "@phoenix/components/table";
 import {
   getCommonPinningStyles,
+  rowDetailsTableCSS,
   selectableTableCSS,
 } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useNotifySuccess, useViewerCanModify } from "@phoenix/contexts";
 import { useDatasetsTableContext } from "@phoenix/contexts/DatasetsTableContext";
+import { useDimensions } from "@phoenix/hooks";
 import { toggleArrayItem } from "@phoenix/utils/arrayUtils";
 import { makeSafeColumnId } from "@phoenix/utils/tableUtils";
 
@@ -59,6 +67,7 @@ import type {
   DatasetsTableDatasetsQuery,
 } from "./__generated__/DatasetsTableDatasetsQuery.graphql";
 import { DatasetActionMenu } from "./DatasetActionMenu";
+import { DatasetRowDetails } from "./DatasetRowDetails";
 import { DatasetsEmpty } from "./DatasetsEmpty";
 const PAGE_SIZE = 100;
 
@@ -66,12 +75,27 @@ const defaultColumnSettings = {
   minSize: 100,
 } satisfies Partial<ColumnDef<unknown>>;
 
+const datasetsTableCSS = css(selectableTableCSS, rowDetailsTableCSS);
+
 type DatasetsTableProps = {
   query: DatasetsTable_datasets$key;
   filter: string;
   labelFilter?: string[];
   onLabelFilterChange?: Dispatch<SetStateAction<string[]>>;
 };
+
+/**
+ * Where a dataset row leads: its experiments when it has any, its examples
+ * otherwise.
+ */
+function datasetLandingPath(dataset: {
+  id: string;
+  experimentCount: number;
+}): string {
+  return dataset.experimentCount > 0
+    ? `${dataset.id}/experiments`
+    : `${dataset.id}/examples`;
+}
 
 function toGqlSort(sort: SortingState[number]): DatasetSort {
   const col = sort.id;
@@ -88,6 +112,9 @@ export function DatasetsTable(props: DatasetsTableProps) {
   "use no memo";
   const { filter, labelFilter, onLabelFilterChange } = props;
   const [sorting, setSorting] = useState<SortingState>([]);
+  // Keyed by dataset id (see getRowId), so a dataset that is expanded stays
+  // expanded as sorting, filtering and pagination move it around the table
+  const [expanded, setExpanded] = useState<ExpandedState>({});
 
   const toggleLabelFilter = useCallback(
     (labelId: string) => {
@@ -111,6 +138,9 @@ export function DatasetsTable(props: DatasetsTableProps) {
   );
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  // The detail area an expanded row reveals lays itself out against the visible
+  // width rather than against a table that is usually wider than it
+  const tableContainerDimensions = useDimensions(tableContainerRef);
   const navigate = useNavigate();
   const notifySuccess = useNotifySuccess();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
@@ -199,14 +229,14 @@ export function DatasetsTable(props: DatasetsTableProps) {
   const canModify = useViewerCanModify();
   const columns = useMemo(() => {
     const cols: ColumnDef<(typeof tableData)[number]>[] = [
+      createRowExpandColumn<(typeof tableData)[number]>({
+        getRowLabel: (row) => row.original.name,
+      }),
       {
         header: "name",
         accessorKey: "name",
         cell: ({ row }: CellContext<(typeof tableData)[number], unknown>) => {
-          const hasExperiments = row.original.experimentCount > 0;
-          const to = hasExperiments
-            ? `${row.original.id}/experiments`
-            : `${row.original.id}/examples`;
+          const to = datasetLandingPath(row.original);
           return (
             <CellWithControlsWrap
               controls={<CopyToClipboardButton text={row.original.name} />}
@@ -441,7 +471,8 @@ export function DatasetsTable(props: DatasetsTableProps) {
     columnOrder,
     onColumnOrderChange: setColumnOrder,
     columnVisibility,
-    nonOrderableColumnIds: [ACTIONS_COLUMN_ID],
+    // The disclosure and the pinned actions column stay at the edges
+    nonOrderableColumnIds: [EXPAND_COLUMN_ID, ACTIONS_COLUMN_ID],
   });
 
   const table = useReactTable({
@@ -449,10 +480,12 @@ export function DatasetsTable(props: DatasetsTableProps) {
     data: tableData,
     state: {
       sorting,
+      expanded,
       columnSizing,
       columnVisibility,
       columnOrder: leafColumnOrder,
       columnPinning: {
+        ...EXPAND_COLUMN_PINNING,
         right: [ACTIONS_COLUMN_ID],
       },
     },
@@ -463,6 +496,16 @@ export function DatasetsTable(props: DatasetsTableProps) {
     onSortingChange: setSorting,
     onColumnSizingChange: setColumnSizing,
     onColumnVisibilityChange: setColumnVisibility,
+    onExpandedChange: setExpanded,
+    // Datasets have no subrows; every row instead reveals its own detail area
+    getRowCanExpand: () => true,
+    // Ties the expansion state to the dataset rather than to a position in the
+    // table, which sorting, filtering and pagination all change
+    getRowId: (row) => row.id,
+    // Sorting, filtering and pagination are all served by a refetch, so leaving
+    // this on tanstack's default would collapse every row whenever the page
+    // asked the server for a different slice of the same datasets
+    autoResetExpanded: false,
     manualSorting: true,
   });
 
@@ -491,6 +534,7 @@ export function DatasetsTable(props: DatasetsTableProps) {
   }, [sorting, refetch, filter, labelFilter]);
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
+  const visibleColumnCount = table.getVisibleLeafColumns().length;
 
   const { columnSizingInfo, columnSizing: columnSizingState } =
     table.getState();
@@ -530,7 +574,7 @@ export function DatasetsTable(props: DatasetsTableProps) {
       >
         <table
           data-testid="datasets-table"
-          css={selectableTableCSS}
+          css={datasetsTableCSS}
           style={{
             ...columnSizeVars,
             width: table.getTotalSize(),
@@ -624,37 +668,43 @@ export function DatasetsTable(props: DatasetsTableProps) {
           ) : (
             <tbody>
               {rows.map((row) => {
+                const isExpanded = row.getIsExpanded();
                 return (
-                  <tr
-                    key={row.id}
-                    onClick={() => {
-                      const hasExperiments = row.original.experimentCount > 0;
-                      const to = hasExperiments
-                        ? `${row.original.id}/experiments`
-                        : `${row.original.id}/examples`;
-                      navigate(to);
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => {
-                      const colSizeVar = `--col-${makeSafeColumnId(cell.column.id)}-size`;
-                      return (
-                        <td
-                          key={cell.id}
-                          align={cell.column.columnDef.meta?.textAlign}
-                          style={{
-                            width: `calc(var(${colSizeVar}) * 1px)`,
-                            maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                            ...getCommonPinningStyles(cell.column),
-                          }}
-                        >
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
-                        </td>
-                      );
-                    })}
-                  </tr>
+                  <Fragment key={row.id}>
+                    <tr
+                      data-expanded={isExpanded}
+                      onClick={() => navigate(datasetLandingPath(row.original))}
+                    >
+                      {row.getVisibleCells().map((cell) => {
+                        const colSizeVar = `--col-${makeSafeColumnId(cell.column.id)}-size`;
+                        return (
+                          <td
+                            key={cell.id}
+                            align={cell.column.columnDef.meta?.textAlign}
+                            style={{
+                              width: `calc(var(${colSizeVar}) * 1px)`,
+                              maxWidth: `calc(var(${colSizeVar}) * 1px)`,
+                              ...getCommonPinningStyles(cell.column),
+                            }}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                    {isExpanded ? (
+                      <RowDetailsRow
+                        rowId={row.id}
+                        colSpan={visibleColumnCount}
+                        scrollPortWidth={tableContainerDimensions?.width}
+                      >
+                        <DatasetRowDetails dataset={row.original} />
+                      </RowDetailsRow>
+                    ) : null}
+                  </Fragment>
                 );
               })}
             </tbody>

--- a/app/stories/TableRowDetails.stories.tsx
+++ b/app/stories/TableRowDetails.stories.tsx
@@ -1,0 +1,188 @@
+import { css } from "@emotion/react";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ColumnDef, ExpandedState } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Fragment, useRef, useState } from "react";
+
+import { Flex, Text } from "@phoenix/components";
+import {
+  createRowExpandColumn,
+  EXPAND_COLUMN_PINNING,
+  RowDetailsRow,
+} from "@phoenix/components/table";
+import { useDimensions } from "@phoenix/hooks";
+
+import {
+  getCommonPinningStyles,
+  rowDetailsTableCSS,
+  selectableTableCSS,
+} from "../src/components/table/styles";
+
+type Person = {
+  id: string;
+  name: string;
+  team: string;
+  role: string;
+  notes: string;
+};
+
+const PEOPLE: Person[] = [
+  {
+    id: "1",
+    name: "John Doe",
+    team: "Engineering",
+    role: "Staff engineer",
+    notes:
+      "The detail area takes as much room as its content needs, so the row above can stay a single scannable line.",
+  },
+  {
+    id: "2",
+    name: "Jane Smith",
+    team: "Design",
+    role: "Design lead",
+    notes: "Short detail.",
+  },
+  {
+    id: "3",
+    name: "Bob Johnson",
+    team: "Marketing",
+    role: "Content strategist",
+    notes:
+      "Long unbroken values wrap rather than widening the row: 01JQK7ZC4V8W6R2H9NDXAB3TFY-01JQK7ZC4V8W6R2H9NDXAB3TFY.",
+  },
+];
+
+const columns: ColumnDef<Person>[] = [
+  createRowExpandColumn<Person>({ getRowLabel: (row) => row.original.name }),
+  { header: "name", accessorKey: "name" },
+  { header: "team", accessorKey: "team" },
+  { header: "role", accessorKey: "role" },
+];
+
+const tableWithRowDetailsCSS = css(selectableTableCSS, rowDetailsTableCSS);
+
+const scrollPortCSS = css`
+  overflow: auto;
+  border: 1px solid var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+`;
+
+/**
+ * A table whose every row reveals a detail area inline, wired up the way the
+ * datasets table does it: a pinned disclosure column, expansion keyed by row id,
+ * and the detail area sized to the scroll port.
+ */
+function TableWithRowDetails({ columnWidth = 160 }: { columnWidth?: number }) {
+  "use no memo";
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+  const scrollPortRef = useRef<HTMLDivElement>(null);
+  const scrollPortDimensions = useDimensions(scrollPortRef);
+  // eslint-disable-next-line react-hooks-js/incompatible-library
+  const table = useReactTable<Person>({
+    columns,
+    data: PEOPLE,
+    defaultColumn: { size: columnWidth },
+    state: { expanded, columnPinning: EXPAND_COLUMN_PINNING },
+    onExpandedChange: setExpanded,
+    getRowCanExpand: () => true,
+    getRowId: (row) => row.id,
+    autoResetExpanded: false,
+    getCoreRowModel: getCoreRowModel(),
+  });
+  const visibleColumnCount = table.getVisibleLeafColumns().length;
+  return (
+    <div css={scrollPortCSS} ref={scrollPortRef}>
+      <table
+        css={tableWithRowDetailsCSS}
+        style={{ width: table.getTotalSize(), minWidth: "100%" }}
+      >
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  style={getCommonPinningStyles(header.column)}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            const isExpanded = row.getIsExpanded();
+            return (
+              <Fragment key={row.id}>
+                <tr data-expanded={isExpanded}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td
+                      key={cell.id}
+                      style={getCommonPinningStyles(cell.column)}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  ))}
+                </tr>
+                {isExpanded ? (
+                  <RowDetailsRow
+                    rowId={row.id}
+                    colSpan={visibleColumnCount}
+                    scrollPortWidth={scrollPortDimensions?.width}
+                  >
+                    <Flex direction="column" gap="size-50">
+                      <Text size="XS" color="text-700">
+                        Notes
+                      </Text>
+                      <Text>{row.original.notes}</Text>
+                    </Flex>
+                  </RowDetailsRow>
+                ) : null}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: "Table/RowDetails",
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+/**
+ * Click a chevron — or focus it and press Enter — to reveal that row's detail
+ * area inline beneath it. The chevron carries `aria-expanded`, so the state is
+ * available to assistive technology as well as to the eye.
+ */
+export const Default: Story = {
+  render: () => <TableWithRowDetails />,
+};
+
+/**
+ * With columns wider than the viewport, the detail area stays pinned to the
+ * leading edge of the scroll port as the table is scrolled sideways, rather than
+ * running off with the columns.
+ */
+export const HorizontallyScrolled: Story = {
+  render: () => <TableWithRowDetails columnWidth={400} />,
+};

--- a/app/tests/datasets.spec.ts
+++ b/app/tests/datasets.spec.ts
@@ -163,4 +163,53 @@ test.describe("Datasets", () => {
     await expect(datasetRow(page, datasetNameA)).toBeVisible();
     await expect(datasetRow(page, datasetNameZ)).not.toBeVisible();
   });
+
+  test("can expand a dataset row to read its details inline", async ({
+    page,
+  }) => {
+    const datasetName = `test-dataset-${randomUUID()}`;
+    const description = "Secondary detail shown in the expanded row";
+
+    await page.goto("/datasets");
+    await page.waitForURL("**/datasets");
+    await createDataset(page, datasetName, description);
+
+    await page
+      .getByRole("searchbox", { name: "Search datasets by name" })
+      .fill(datasetName);
+    await expect(datasetRow(page, datasetName)).toBeVisible();
+
+    const toggle = page.getByRole("button", {
+      name: `Toggle details for ${datasetName}`,
+    });
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    const details = page
+      .getByTestId("datasets-table")
+      .locator('tr[data-row="details"]');
+    await expect(details).toHaveCount(0);
+
+    // the control is a button, so it opens from the keyboard
+    await toggle.focus();
+    await page.keyboard.press("Enter");
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(details).toHaveCount(1);
+    await expect(details).toContainText(description);
+    await expect(details).toContainText("Dataset ID");
+    // expanding must not follow the row into the dataset
+    expect(new URL(page.url()).pathname).toBe("/datasets");
+
+    // a refetching sort leaves the row expanded rather than snapping it shut
+    await clickSortableHeaderAndExpect(
+      page.getByRole("columnheader", { name: "name" }).first(),
+      "ascending"
+    );
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(details).toHaveCount(1);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(details).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
# Add expandable rows to the Datasets table for inline details

Closes #15055.

## What changed

The Datasets table gains a compact leading disclosure column. Expanding a row
reveals a detail area inline beneath it, spanning the table, that shows the
secondary dataset information the row itself has to clip.

### Shared table primitives (`app/src/components/table/`)

The mechanism lives with the other table primitives rather than as a
datasets-only special case, mirroring the existing
`createRowSelectionColumn` / `CHECKBOX_COLUMN_PINNING` pattern:

- `constants.ts` — `EXPAND_COLUMN_ID` and `EXPAND_COLUMN_PINNING`, which pin the
  disclosure column to the leading edge so it stays visible while the other
  columns scroll horizontally.
- `RowDetails.tsx` (new) — `createRowExpandColumn()` builds the fixed-width
  disclosure column; `RowDetailsRow` renders the `<tr>` / `<td colSpan>` that
  holds the detail area; `getRowDetailsId()` is the single id shared by the
  control's `aria-controls` and the region it reveals.
- `styles.ts` — `rowDetailsTableCSS`, which drops the border between a row and
  its detail area so the pair reads as one block, gives the detail cell the
  recessed background, and stops the detail row inheriting the data rows'
  pointer cursor.
- `TableExpandButton.tsx` — now sets `aria-expanded` and optional
  `aria-controls`. Because it is the shared control, the traces and evaluators
  tables get the same state exposure. The accessible label stays constant; the
  state is carried by `aria-expanded`, not by relabelling the button.

### Datasets table

- `DatasetRowDetails.tsx` (new) renders the detail content: the dataset ID with
  a copy button (no column shows it), the full untruncated description, and
  pretty-printed metadata. It is a responsive grid that collapses to a single
  column as the table's scroll port narrows.
- `DatasetsTable.tsx` wires the column and the detail row up, and adds
  `datasetLandingPath()` — the row's click target and the name cell's link were
  computing the same path two different times.
- `GlobalStyles.tsx` adds `--global-table-row-details-background-color`.

### Storybook

`app/stories/TableRowDetails.stories.tsx` (new) documents the primitive next to
the existing `Table` and `TableColumnOrdering` stories, with a
`HorizontallyScrolled` story that shows the detail area holding its position as
the columns scroll sideways.

## Design notes

- **No awkward horizontal overflow.** The detail cell spans every visible
  column, but its content sits in a `position: sticky; left: 0` panel sized to
  the scroll port (measured with the existing `useDimensions` hook). The detail
  area therefore stays where it can be read however far the columns are scrolled
  sideways, and it never widens the table. Long unbroken values wrap
  (`overflow-wrap: anywhere`) instead of forcing a scroll.
- **Alignment.** The panel is indented past the disclosure column so the detail
  area starts on the same edge as the row's first value.
- **Predictable expansion across sort / filter / pagination.** `getRowId` keys
  expansion on the dataset id rather than on a row position, and
  `autoResetExpanded: false` is set explicitly so a refetch — which is how
  sorting, filtering and pagination are all served here — does not snap open
  rows shut.
- **No unrelated navigation.** The row navigates on click; `TableExpandButton`
  already stops propagation, so toggling never follows the row into the dataset.
- **Accessibility.** The control is a native `<button>` (keyboard operable),
  exposes `aria-expanded`, and points at the detail region via `aria-controls`.
  The detail content is a `<ul>` of label/value items per the project's list
  conventions.

## How to verify

Automated:

- `make test-frontend` — new unit suite
  `app/src/components/table/__tests__/RowDetails.test.tsx` covers: every row gets
  a control that reads as collapsed; expanding reveals a detail row spanning
  every column whose id matches the control's `aria-controls`; collapsing hides
  it again; toggling does not fire the row's own click handler; and the same row
  stays expanded when the data is handed back in a different order.
- `app/tests/datasets.spec.ts` gains an end-to-end test that creates a dataset,
  opens its details **from the keyboard**, asserts the description and the
  "Dataset ID" label are visible, asserts the URL did not change, sorts the
  table and asserts the row is still expanded, then collapses it.

Manually, in Storybook (`Table/RowDetails`) or in the app:

1. `make dev`, go to `/datasets`.
2. Click the chevron on any row — the detail area opens beneath it with the
   dataset ID, description and metadata. Click the row itself and it still
   navigates.
3. Narrow the window until the table scrolls horizontally, then scroll right —
   the detail area follows the viewport rather than disappearing off-screen.
4. Narrow it further — the detail grid collapses to a single column.
5. Tab to the chevron and press Enter / Space; check the state with a screen
   reader or the accessibility inspector (`aria-expanded` flips, `aria-controls`
   points at the revealed region).
6. Sort by name and search — the expanded dataset stays expanded and its
   detail area travels with it.

## Notes

- No changeset: changesets in this repo cover the packages under `js/`, and this
  change is confined to `app/`.
- No docs updates: nothing under `docs/` or `.claude/skills/` documents the
  Datasets table's columns or the table primitives this touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
