### PR TITLE
ci: fix stale uv pin in Build DDL Schema job

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.12"
+          version: "0.11.31"
       - name: Create virtual environment
         # `make schema-ddl` installs its dependencies with `uv pip install`,
         # which requires an existing environment.


### PR DESCRIPTION
## Summary

The `Build DDL Schema` job fails on every PR that touches migrations:

```
error: Required uv version `==0.11.31` does not match the running version `0.11.12`.
```

Two PRs crossed: #15044 added the job with `setup-uv` pinned to `0.11.12`, and #15046 bumped `required-version` in `pyproject.toml` to `0.11.31` and updated every other pin in the workflow. #15044 merged after the bump, so the new job landed with the stale pin — uv installs 0.11.12 and then refuses to run against the `==0.11.31` requirement.

This bumps the one remaining `0.11.12` pin to `0.11.31`, matching all other jobs in the workflow.

Example failure: https://github.com/Arize-ai/phoenix/actions/runs/31014627060/job/92335442636

🤖 Generated with [Claude Code](https://claude.com/claude-code)