### PR TITLE
refactor(agents): move the agents router under /v1

### DIFF
--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -25,8 +25,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
-            schemas/openapi.json > head.json
+          cp schemas/openapi.json head.json
           if [ -z "$BASE_REF" ]; then
             echo "::error::Could not determine base ref for OpenAPI schema comparison"
             exit 1
@@ -34,8 +33,7 @@ jobs:
           git checkout "$BASE_REF"
       - name: Snapshot base schema
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
-            schemas/openapi.json > base.json
+          cp schemas/openapi.json base.json
       - uses: docker://openapitools/openapi-diff@sha256:82291446e5554742d9c0725d7b315d18e93958c5526f9a663e8885227bdd6cb6 # latest
         with:
           args: --fail-on-incompatible base.json head.json

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -25,16 +25,13 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
-          cp schemas/openapi.json head.json
+          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
+            schemas/openapi.json > head.json
           if [ -z "$BASE_REF" ]; then
             echo "::error::Could not determine base ref for OpenAPI schema comparison"
             exit 1
           fi
           git checkout "$BASE_REF"
-      # The unversioned /agents/... paths (the deprecated legacy chat route)
-      # carry no compatibility guarantees and are dropped from the baseline
-      # only, so their removal never counts as a break. The head schema is
-      # checked in full, including the /v1/agents/... routes.
       - name: Snapshot base schema
         run: |
           jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -21,20 +21,20 @@ jobs:
           persist-credentials: false
           sparse-checkout: schemas/openapi.json
           sparse-checkout-cone-mode: false
-      # The unversioned /agents/... path is the deprecated legacy chat route,
-      # excluded so its eventual removal does not fail the check. The
-      # /v1/agents/... routes are subject to backward compatibility.
       - name: Snapshot head schema
         env:
           BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
-            schemas/openapi.json > head.json
+          cp schemas/openapi.json head.json
           if [ -z "$BASE_REF" ]; then
             echo "::error::Could not determine base ref for OpenAPI schema comparison"
             exit 1
           fi
           git checkout "$BASE_REF"
+      # The unversioned /agents/... paths (the deprecated legacy chat route)
+      # carry no compatibility guarantees and are dropped from the baseline
+      # only, so their removal never counts as a break. The head schema is
+      # checked in full, including the /v1/agents/... routes.
       - name: Snapshot base schema
         run: |
           jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
+          jq '.paths |= with_entries(select(.key | test("^(/v1)?/agent") | not))' \
             schemas/openapi.json > head.json
           if [ -z "$BASE_REF" ]; then
             echo "::error::Could not determine base ref for OpenAPI schema comparison"
@@ -34,7 +34,7 @@ jobs:
           git checkout "$BASE_REF"
       - name: Snapshot base schema
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
+          jq '.paths |= with_entries(select(.key | test("^(/v1)?/agent") | not))' \
             schemas/openapi.json > base.json
       - uses: docker://openapitools/openapi-diff@sha256:82291446e5554742d9c0725d7b315d18e93958c5526f9a663e8885227bdd6cb6 # latest
         with:

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -21,11 +21,14 @@ jobs:
           persist-credentials: false
           sparse-checkout: schemas/openapi.json
           sparse-checkout-cone-mode: false
+      # The unversioned /agents/... path is the deprecated legacy chat route,
+      # excluded so its eventual removal does not fail the check. The
+      # /v1/agents/... routes are subject to backward compatibility.
       - name: Snapshot head schema
         env:
           BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
-          jq '.paths |= with_entries(select(.key | test("^(/v1)?/agent") | not))' \
+          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
             schemas/openapi.json > head.json
           if [ -z "$BASE_REF" ]; then
             echo "::error::Could not determine base ref for OpenAPI schema comparison"
@@ -34,7 +37,7 @@ jobs:
           git checkout "$BASE_REF"
       - name: Snapshot base schema
         run: |
-          jq '.paths |= with_entries(select(.key | test("^(/v1)?/agent") | not))' \
+          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
             schemas/openapi.json > base.json
       - uses: docker://openapitools/openapi-diff@sha256:82291446e5554742d9c0725d7b315d18e93958c5526f9a663e8885227bdd6cb6 # latest
         with:

--- a/app/src/agent/chat/agentChatApi.ts
+++ b/app/src/agent/chat/agentChatApi.ts
@@ -2,9 +2,9 @@ import type { components, paths } from "@phoenix/api/__generated__/v1";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
 const CHAT_PATH_TEMPLATE =
-  "/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof paths;
+  "/v1/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof paths;
 const COMPACT_PATH_TEMPLATE =
-  "/agents/{agent_id}/sessions/{session_id}/compact" satisfies keyof paths;
+  "/v1/agents/{agent_id}/sessions/{session_id}/compact" satisfies keyof paths;
 const ASSISTANT_AGENT_ID = "assistant";
 
 /**

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1585,7 +1585,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions": {
+    "/v1/agents/{agent_id}/sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -1609,7 +1609,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agents/{agent_id}/sessions/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1633,7 +1633,7 @@ export interface paths {
         patch: operations["patchAgentSession"];
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -1653,7 +1653,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1670,7 +1670,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
         parameters: {
             query?: never;
             header?: never;
@@ -11649,7 +11649,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["LegacyChatRequest"] | components["schemas"]["ChatRequest"];
+                "application/json": components["schemas"]["LegacyChatRequest"];
             };
         };
         responses: {

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -29,7 +29,7 @@ import type {
 } from "./types";
 
 const AGENT_SESSION_CHAT_PATH =
-  "/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof pathsV1;
+  "/v1/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof pathsV1;
 const SERVER_AGENT_ID = "server";
 const AGENT_SESSION_PAGE_LIMIT = 100;
 /**
@@ -164,7 +164,7 @@ export async function createAgentSession({
   const client = createPhoenixClient({ config, fetch: fetchImpl });
   let agentSessionId: string | undefined;
   try {
-    const { data: payload } = await client.POST("/agents/{agent_id}/sessions", {
+    const { data: payload } = await client.POST("/v1/agents/{agent_id}/sessions", {
       params: { path: { agent_id: SERVER_AGENT_ID } },
       body: { title: "", is_ephemeral: temporary, model },
     });
@@ -206,7 +206,7 @@ async function fetchAgentSessionMessagesPage({
   cursor: string | null;
 }): Promise<{ messages: PxiMessage[]; nextCursor: string | null }> {
   const { data: payload } = await client.GET(
-    "/agents/{agent_id}/sessions/{session_id}/messages",
+    "/v1/agents/{agent_id}/sessions/{session_id}/messages",
     {
       params: {
         path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
@@ -247,7 +247,7 @@ export function createPxiSessionClient({
       let cursor: string | undefined;
       do {
         const { data: payload } = await client.GET(
-          "/agents/{agent_id}/sessions",
+          "/v1/agents/{agent_id}/sessions",
           {
             params: {
               path: { agent_id: SERVER_AGENT_ID },
@@ -277,7 +277,7 @@ export function createPxiSessionClient({
     async getSession({ sessionId }) {
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       const { data: payload } = await client.GET(
-        "/agents/{agent_id}/sessions/{session_id}",
+        "/v1/agents/{agent_id}/sessions/{session_id}",
         {
           params: {
             path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
@@ -318,7 +318,7 @@ export function createPxiSessionClient({
     async getSessionSyncState({ sessionId }): Promise<PxiSessionSyncState> {
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       const { data: payload } = await client.GET(
-        "/agents/{agent_id}/sessions/{session_id}",
+        "/v1/agents/{agent_id}/sessions/{session_id}",
         {
           params: {
             path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
@@ -342,7 +342,7 @@ export function createPxiSessionClient({
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       try {
         const { data: payload } = await client.PATCH(
-          "/agents/{agent_id}/sessions/{session_id}",
+          "/v1/agents/{agent_id}/sessions/{session_id}",
           {
             params: {
               path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
@@ -370,7 +370,7 @@ export function createPxiSessionClient({
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       try {
         const { data: payload } = await client.POST(
-          "/agents/{agent_id}/sessions/{session_id}/compact",
+          "/v1/agents/{agent_id}/sessions/{session_id}/compact",
           {
             params: {
               path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -164,10 +164,13 @@ export async function createAgentSession({
   const client = createPhoenixClient({ config, fetch: fetchImpl });
   let agentSessionId: string | undefined;
   try {
-    const { data: payload } = await client.POST("/v1/agents/{agent_id}/sessions", {
-      params: { path: { agent_id: SERVER_AGENT_ID } },
-      body: { title: "", is_ephemeral: temporary, model },
-    });
+    const { data: payload } = await client.POST(
+      "/v1/agents/{agent_id}/sessions",
+      {
+        params: { path: { agent_id: SERVER_AGENT_ID } },
+        body: { title: "", is_ephemeral: temporary, model },
+      }
+    );
     agentSessionId = payload?.data.id;
   } catch (error) {
     if (error instanceof HttpError) {

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -193,7 +193,7 @@ describe("PXI client", () => {
         agentSessionId: "QWdlbnRTZXNzaW9uOjE=",
       })
     ).toBe(
-      "http://localhost:6006/agents/server/sessions/QWdlbnRTZXNzaW9uOjE%3D/chat"
+      "http://localhost:6006/v1/agents/server/sessions/QWdlbnRTZXNzaW9uOjE%3D/chat"
     );
   });
 
@@ -332,7 +332,7 @@ describe("PXI client", () => {
     });
     expect(session.lastMessageId).toBe("user-1");
     expect(requestUrl(fetchImpl.mock.calls[2])).toBe(
-      "http://localhost:6006/agents/server/sessions/session-1/messages"
+      "http://localhost:6006/v1/agents/server/sessions/session-1/messages"
     );
   });
 
@@ -454,10 +454,10 @@ describe("PXI client", () => {
     ]);
     expect(session.lastMessageId).toBe("assistant-1");
     expect(requestUrl(fetchImpl.mock.calls[1])).toBe(
-      "http://localhost:6006/agents/server/sessions/session-1/messages"
+      "http://localhost:6006/v1/agents/server/sessions/session-1/messages"
     );
     expect(requestUrl(fetchImpl.mock.calls[2])).toBe(
-      "http://localhost:6006/agents/server/sessions/session-1/messages?cursor=cursor-1"
+      "http://localhost:6006/v1/agents/server/sessions/session-1/messages?cursor=cursor-1"
     );
   });
 
@@ -473,7 +473,7 @@ describe("PXI client", () => {
         const request =
           _input instanceof Request ? _input : new Request(_input, init);
         expect(request.url).toBe(
-          "http://localhost:6006/agents/server/sessions/session-1/compact"
+          "http://localhost:6006/v1/agents/server/sessions/session-1/compact"
         );
         expect(request.method).toBe("POST");
         expect(await request.json()).toEqual({

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1585,7 +1585,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions": {
+    "/v1/agents/{agent_id}/sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -1609,7 +1609,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agents/{agent_id}/sessions/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1633,7 +1633,7 @@ export interface paths {
         patch: operations["patchAgentSession"];
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -1653,7 +1653,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1670,7 +1670,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
         parameters: {
             query?: never;
             header?: never;
@@ -11649,7 +11649,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["LegacyChatRequest"] | components["schemas"]["ChatRequest"];
+                "application/json": components["schemas"]["LegacyChatRequest"];
             };
         };
         responses: {

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -141,21 +141,21 @@ export const ADD_SESSION_NOTE_IDENTIFIER: ParameterRequirement = {
 export const AGENT_SESSION_CREATE: RouteRequirement = {
   kind: "route",
   method: "POST",
-  path: "/agents/{agent_id}/sessions",
+  path: "/v1/agents/{agent_id}/sessions",
   minServerVersion: [20, 0, 0],
 };
 
 export const AGENT_SESSION_CHAT: RouteRequirement = {
   kind: "route",
   method: "POST",
-  path: "/agents/{agent_id}/sessions/{session_id}/chat",
+  path: "/v1/agents/{agent_id}/sessions/{session_id}/chat",
   minServerVersion: [20, 0, 0],
 };
 
 export const AGENT_SESSION_MESSAGES: RouteRequirement = {
   kind: "route",
   method: "GET",
-  path: "/agents/{agent_id}/sessions/{session_id}/messages",
+  path: "/v1/agents/{agent_id}/sessions/{session_id}/messages",
   minServerVersion: [20, 0, 0],
 };
 

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1585,7 +1585,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions": {
+    "/v1/agents/{agent_id}/sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -1609,7 +1609,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agents/{agent_id}/sessions/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1633,7 +1633,7 @@ export interface paths {
         patch: operations["patchAgentSession"];
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -1653,7 +1653,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1670,7 +1670,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
         parameters: {
             query?: never;
             header?: never;
@@ -11649,7 +11649,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["LegacyChatRequest"] | components["schemas"]["ChatRequest"];
+                "application/json": components["schemas"]["LegacyChatRequest"];
             };
         };
         responses: {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8092,15 +8092,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/LegacyChatRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/ChatRequest"
-                  }
-                ],
-                "title": "Request Body"
+                "$ref": "#/components/schemas/LegacyChatRequest"
               }
             }
           }
@@ -8177,7 +8169,7 @@
         }
       }
     },
-    "/agents/{agent_id}/sessions": {
+    "/v1/agents/{agent_id}/sessions": {
       "post": {
         "tags": [
           "chat"
@@ -8381,7 +8373,7 @@
         }
       }
     },
-    "/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agents/{agent_id}/sessions/{session_id}": {
       "patch": {
         "tags": [
           "chat"
@@ -8583,7 +8575,7 @@
         }
       }
     },
-    "/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
       "get": {
         "tags": [
           "chat"
@@ -8695,7 +8687,7 @@
         }
       }
     },
-    "/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
       "post": {
         "tags": [
           "chat"
@@ -8826,7 +8818,7 @@
         }
       }
     },
-    "/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
       "post": {
         "tags": [
           "chat"

--- a/src/phoenix/server/api/openapi/schema.py
+++ b/src/phoenix/server/api/openapi/schema.py
@@ -20,11 +20,8 @@ def get_openapi_schema() -> dict[str, Any]:
     router.include_router(create_v1_router(authentication_enabled=False))
     router.include_router(create_auth_router(ldap_enabled=True))
     router.include_router(oauth2_router)
-    agents_router, session_chat = create_agents_router(authentication_enabled=False)
-    router.include_router(
-        create_legacy_agents_router(authentication_enabled=False, session_chat=session_chat)
-    )
-    router.include_router(agents_router)
+    router.include_router(create_legacy_agents_router(authentication_enabled=False))
+    router.include_router(create_agents_router(authentication_enabled=False))
     router.include_router(app_root_router)
     schema = get_openapi(
         title="Arize-Phoenix REST API",

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1892,9 +1892,7 @@ def _to_agent_session_summary(agent_session: models.AgentSession) -> AgentSessio
     )
 
 
-def create_agents_router(
-    authentication_enabled: bool,
-) -> tuple[APIRouter, Callable[[str, str, Request, ChatRequest], Awaitable[Response]]]:
+def create_agents_router(authentication_enabled: bool) -> APIRouter:
     dependencies = [
         Depends(is_agent_assistant_enabled),
         Depends(prevent_access_in_read_only_mode),
@@ -1903,7 +1901,7 @@ def create_agents_router(
     ]
     if authentication_enabled:
         dependencies.append(Depends(is_authenticated))
-    router = APIRouter(tags=["chat"], dependencies=dependencies)
+    router = APIRouter(prefix="/v1", tags=["chat"], dependencies=dependencies)
 
     @router.post(
         "/agents/{agent_id}/sessions",
@@ -2903,4 +2901,4 @@ def create_agents_router(
             )
             raise
 
-    return router, chat
+    return router

--- a/src/phoenix/server/api/routers/legacy_agents.py
+++ b/src/phoenix/server/api/routers/legacy_agents.py
@@ -4,10 +4,10 @@ To be removed.
 """
 
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator
 from contextlib import aclosing
 from datetime import datetime, timezone
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from openinference.instrumentation import using_session
@@ -40,8 +40,6 @@ from phoenix.server.agents.model_selection import AgentModelSelection
 from phoenix.server.agents.prompts import AgentPrompts, ServerAgentPrompts
 from phoenix.server.agents.server_agents import build_server_agent
 from phoenix.server.api.routers.agents import (
-    _SERVER_AGENT_ID,
-    ChatRequest,
     _AgentSpanContextRecorder,
     _build_message_metadata_chunk,
     _ensure_project_exists,
@@ -144,16 +142,7 @@ def _log_run_complete(result: AgentRunResult[Any]) -> None:
         logger.info("%s", message)
 
 
-SessionChatHandler: TypeAlias = Callable[[str, str, Request, ChatRequest], Awaitable[Response]]
-"""Calling contract of the session chat endpoint, injected by the app so this
-route can delegate requests that carry the new single-``message`` body shape."""
-
-
-def create_legacy_agents_router(
-    authentication_enabled: bool,
-    *,
-    session_chat: SessionChatHandler,
-) -> APIRouter:
+def create_legacy_agents_router(authentication_enabled: bool) -> APIRouter:
     dependencies = [
         Depends(is_agent_assistant_enabled),
         Depends(prevent_access_in_read_only_mode),
@@ -173,13 +162,11 @@ def create_legacy_agents_router(
     async def run_server_agent(
         session_id: str,
         request: Request,
-        request_body: LegacyChatRequest | ChatRequest,
+        request_body: LegacyChatRequest,
     ) -> Response:
-        if isinstance(request_body, ChatRequest):
-            return await session_chat(_SERVER_AGENT_ID, session_id, request, request_body)
         logger.warning(
             "Deprecated route POST /agents/server/sessions/%s/chat was called; "
-            "clients should migrate to POST /agents/assistant/sessions/{session_id}/chat "
+            "clients should migrate to POST /v1/agents/assistant/sessions/{session_id}/chat "
             "with a session created via the createAgentSession GraphQL mutation.",
             session_id,
         )

--- a/src/phoenix/server/api/routers/legacy_agents.py
+++ b/src/phoenix/server/api/routers/legacy_agents.py
@@ -164,12 +164,6 @@ def create_legacy_agents_router(authentication_enabled: bool) -> APIRouter:
         request: Request,
         request_body: LegacyChatRequest,
     ) -> Response:
-        logger.warning(
-            "Deprecated route POST /agents/server/sessions/%s/chat was called; "
-            "clients should migrate to POST /v1/agents/assistant/sessions/{session_id}/chat "
-            "with a session created via the createAgentSession GraphQL mutation.",
-            session_id,
-        )
         if get_env_phoenix_agents_disable_bash():
             raise HTTPException(status_code=403, detail="Server agent is disabled")
 

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -1131,14 +1131,8 @@ def create_app(
     )
     app.include_router(create_v1_router(authentication_enabled))
     if not get_env_disable_agent_assistant():
-        # Starlette matches routes in registration order: the deprecated
-        # /agents/server/... route must precede the agents router, or the
-        # /agents/{agent_id}/... route captures it with agent_id="server".
-        agents_router, session_chat = create_agents_router(authentication_enabled)
-        app.include_router(
-            create_legacy_agents_router(authentication_enabled, session_chat=session_chat)
-        )
-        app.include_router(agents_router)
+        app.include_router(create_legacy_agents_router(authentication_enabled))
+        app.include_router(create_agents_router(authentication_enabled))
     app.include_router(router)
     app.include_router(graphql_router)
     app.include_router(auth_md_router)

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -1990,7 +1990,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_client = _httpx_client(_app, member.tokens)
         admin_client = _httpx_client(_app, admin.tokens)
         member_session_response = member_client.post(
-            "agents/assistant/sessions",
+            "v1/agents/assistant/sessions",
             json={
                 "title": "Member session",
                 "is_ephemeral": False,
@@ -2004,7 +2004,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_session_response.raise_for_status()
         member_session_id = member_session_response.json()["data"]["id"]
         admin_session_response = admin_client.post(
-            "agents/assistant/sessions",
+            "v1/agents/assistant/sessions",
             json={
                 "title": "Admin session",
                 "is_ephemeral": False,
@@ -2019,29 +2019,29 @@ class TestApiAccessViaCookiesOrApiKeys:
         admin_session_id = admin_session_response.json()["data"]["id"]
 
         member_api_client = _httpx_client(_app, member.create_api_key(_app))
-        list_response = member_api_client.get("agents/assistant/sessions")
+        list_response = member_api_client.get("v1/agents/assistant/sessions")
 
         assert list_response.status_code == 200
         session_ids = {session["id"] for session in list_response.json()["data"]}
         assert member_session_id in session_ids
         assert admin_session_id not in session_ids
         assert (
-            member_api_client.get(f"agents/assistant/sessions/{member_session_id}").status_code
+            member_api_client.get(f"v1/agents/assistant/sessions/{member_session_id}").status_code
             == 200
         )
         assert (
-            member_api_client.get(f"agents/assistant/sessions/{admin_session_id}").status_code
+            member_api_client.get(f"v1/agents/assistant/sessions/{admin_session_id}").status_code
             == 404
         )
         assert (
             member_api_client.get(
-                f"agents/assistant/sessions/{member_session_id}/messages"
+                f"v1/agents/assistant/sessions/{member_session_id}/messages"
             ).status_code
             == 200
         )
         assert (
             member_api_client.get(
-                f"agents/assistant/sessions/{admin_session_id}/messages"
+                f"v1/agents/assistant/sessions/{admin_session_id}/messages"
             ).status_code
             == 404
         )
@@ -2056,7 +2056,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_client = _httpx_client(_app, member.tokens)
         admin_client = _httpx_client(_app, admin.tokens)
         member_session_response = member_client.post(
-            "agents/assistant/sessions",
+            "v1/agents/assistant/sessions",
             json={
                 "title": "Member session",
                 "is_ephemeral": False,
@@ -2070,7 +2070,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_session_response.raise_for_status()
         member_session_id = member_session_response.json()["data"]["id"]
         admin_session_response = admin_client.post(
-            "agents/assistant/sessions",
+            "v1/agents/assistant/sessions",
             json={
                 "title": "Admin session",
                 "is_ephemeral": False,
@@ -2255,7 +2255,7 @@ class TestVercelChatStreamRouterAuth:
 
     @pytest.fixture
     def _path(self) -> str:
-        return "/agents/assistant/sessions/test-session-id/chat"
+        return "/v1/agents/assistant/sessions/test-session-id/chat"
 
     def test_unauthenticated_request_is_rejected(
         self,

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -59,7 +59,7 @@ class TestListAgentSessions:
             is_ephemeral=True,
         )
 
-        response = await httpx_client.get("/agents/assistant/sessions")
+        response = await httpx_client.get("/v1/agents/assistant/sessions")
 
         assert response.status_code == 200
         assert response.json() == {
@@ -97,14 +97,14 @@ class TestListAgentSessions:
             for offset in range(3)
         ]
 
-        first_response = await httpx_client.get("/agents/assistant/sessions?limit=2")
+        first_response = await httpx_client.get("/v1/agents/assistant/sessions?limit=2")
         assert first_response.status_code == 200
         first_page = first_response.json()
         assert [item["title"] for item in first_page["data"]] == ["Session 0", "Session 1"]
         assert first_page["next_cursor"]
 
         second_response = await httpx_client.get(
-            "/agents/assistant/sessions",
+            "/v1/agents/assistant/sessions",
             params={"limit": 2, "cursor": first_page["next_cursor"]},
         )
         assert second_response.status_code == 200
@@ -114,7 +114,7 @@ class TestListAgentSessions:
         assert second_response.json()["next_cursor"] is None
 
     async def test_rejects_invalid_cursor(self, httpx_client: httpx.AsyncClient) -> None:
-        response = await httpx_client.get("/agents/assistant/sessions?cursor=invalid")
+        response = await httpx_client.get("/v1/agents/assistant/sessions?cursor=invalid")
         assert response.status_code == 422
 
 
@@ -145,7 +145,7 @@ class TestGetAgentSession:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
         data = response.json()["data"]
@@ -171,7 +171,7 @@ class TestGetAgentSession:
         agent_session = await _insert_agent_session(db, title="Empty", updated_at=now)
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
         data = response.json()["data"]
@@ -192,7 +192,7 @@ class TestGetAgentSession:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
         assert response.json()["data"]["is_ephemeral"] is True
@@ -218,13 +218,13 @@ class TestGetAgentSession:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
         assert response.json()["data"]["is_ephemeral"] is True
 
     async def test_rejects_invalid_id(self, httpx_client: httpx.AsyncClient) -> None:
-        response = await httpx_client.get("/agents/assistant/sessions/invalid")
+        response = await httpx_client.get("/v1/agents/assistant/sessions/invalid")
         assert response.status_code == 404
 
 
@@ -253,7 +253,7 @@ class TestListAgentSessionMessages:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}/messages")
 
         assert response.status_code == 200
         payload = response.json()
@@ -293,7 +293,7 @@ class TestListAgentSessionMessages:
             if cursor is not None:
                 params["cursor"] = cursor
             response = await httpx_client.get(
-                f"/agents/assistant/sessions/{session_id}/messages",
+                f"/v1/agents/assistant/sessions/{session_id}/messages",
                 params=params,
             )
             assert response.status_code == 200
@@ -315,13 +315,13 @@ class TestListAgentSessionMessages:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}/messages")
 
         assert response.status_code == 200
         assert response.json() == {"data": [], "next_cursor": None}
 
     async def test_rejects_invalid_session_id(self, httpx_client: httpx.AsyncClient) -> None:
-        response = await httpx_client.get("/agents/assistant/sessions/invalid/messages")
+        response = await httpx_client.get("/v1/agents/assistant/sessions/invalid/messages")
         assert response.status_code == 404
 
     async def test_rejects_invalid_cursor(
@@ -335,7 +335,7 @@ class TestListAgentSessionMessages:
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
         response = await httpx_client.get(
-            f"/agents/assistant/sessions/{session_id}/messages",
+            f"/v1/agents/assistant/sessions/{session_id}/messages",
             params={"cursor": "invalid"},
         )
 
@@ -351,7 +351,7 @@ class TestListAgentSessionMessages:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/agents/nonexistent/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agents/nonexistent/sessions/{session_id}/messages")
 
         assert response.status_code == 404
 
@@ -361,6 +361,6 @@ class TestListAgentSessionMessages:
     ) -> None:
         session_id = str(GlobalID("AgentSession", "1000000"))
 
-        response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}/messages")
 
         assert response.status_code == 404

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -92,23 +92,23 @@ def _user_message(text: str, *, message_id: str = _DEFAULT_USER_MESSAGE_ID) -> d
 
 
 def _chat_url(agent_session_id: str) -> str:
-    return f"/agents/assistant/sessions/{agent_session_id}/chat"
+    return f"/v1/agents/assistant/sessions/{agent_session_id}/chat"
 
 
 def _server_agent_chat_url(agent_session_id: str) -> str:
-    return f"/agents/server/sessions/{agent_session_id}/chat"
+    return f"/v1/agents/server/sessions/{agent_session_id}/chat"
 
 
 def _compact_url(agent_session_id: str) -> str:
-    return f"/agents/assistant/sessions/{agent_session_id}/compact"
+    return f"/v1/agents/assistant/sessions/{agent_session_id}/compact"
 
 
 def _server_agent_compact_url(agent_session_id: str) -> str:
-    return f"/agents/server/sessions/{agent_session_id}/compact"
+    return f"/v1/agents/server/sessions/{agent_session_id}/compact"
 
 
 def _patch_session_url(agent_session_id: str) -> str:
-    return f"/agents/assistant/sessions/{agent_session_id}"
+    return f"/v1/agents/assistant/sessions/{agent_session_id}"
 
 
 def _compact_body() -> dict[str, Any]:
@@ -764,7 +764,7 @@ async def test_server_agent_compact_route_matches_chat_route_gating(
     )
 
     unknown_agent_response = await httpx_client.post(
-        f"/agents/nonexistent/sessions/{agent_session_id}/compact",
+        f"/v1/agents/nonexistent/sessions/{agent_session_id}/compact",
         json=_compact_body(),
     )
     assert unknown_agent_response.status_code == 404
@@ -2135,7 +2135,7 @@ async def test_create_session_route_creates_a_temporary_session(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/agents/server/sessions",
+        "/v1/agents/server/sessions",
         json=_create_session_body(title=" CLI session ", is_ephemeral=True),
     )
     assert response.status_code == 201
@@ -2160,7 +2160,7 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/agents/assistant/sessions",
+        "/v1/agents/assistant/sessions",
         json=_create_session_body(),
     )
     assert response.status_code == 201
@@ -2176,7 +2176,7 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
 async def test_create_session_route_requires_a_model(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    response = await httpx_client.post("/agents/assistant/sessions", json={})
+    response = await httpx_client.post("/v1/agents/assistant/sessions", json={})
 
     assert response.status_code == 422
 
@@ -2185,7 +2185,7 @@ async def test_create_session_route_rejects_long_title(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/agents/assistant/sessions",
+        "/v1/agents/assistant/sessions",
         json=_create_session_body(title="x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 1)),
     )
 
@@ -2204,7 +2204,7 @@ async def test_create_session_route_yields_a_chattable_session(
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
 
     created = await httpx_client.post(
-        "/agents/server/sessions",
+        "/v1/agents/server/sessions",
         json=_create_session_body(is_ephemeral=True),
     )
     assert created.status_code == 201
@@ -2399,7 +2399,7 @@ async def test_patch_session_route_rejects_unknown_agents(
 ) -> None:
     agent_session_id = await _create_agent_session_row(db)
     response = await httpx_client.patch(
-        f"/agents/unknown/sessions/{agent_session_id}",
+        f"/v1/agents/unknown/sessions/{agent_session_id}",
         json={
             "model": {
                 "providerType": "builtin",
@@ -2563,7 +2563,7 @@ async def test_create_session_route_rejects_unknown_agents(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/agents/unknown/sessions",
+        "/v1/agents/unknown/sessions",
         json=_create_session_body(),
     )
     assert response.status_code == 404
@@ -2578,7 +2578,7 @@ async def test_create_session_route_is_forbidden_when_agents_are_disabled(
     )
 
     response = await httpx_client.post(
-        "/agents/server/sessions",
+        "/v1/agents/server/sessions",
         json=_create_session_body(),
     )
     assert response.status_code == 403
@@ -2592,14 +2592,14 @@ async def test_create_session_route_forbids_the_server_agent_when_bash_is_disabl
     monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
 
     server_response = await httpx_client.post(
-        "/agents/server/sessions",
+        "/v1/agents/server/sessions",
         json=_create_session_body(),
     )
     assert server_response.status_code == 403
     assert "Server agent is disabled" in server_response.text
 
     assistant_response = await httpx_client.post(
-        "/agents/assistant/sessions",
+        "/v1/agents/assistant/sessions",
         json=_create_session_body(),
     )
     assert assistant_response.status_code == 201
@@ -2616,7 +2616,7 @@ async def test_agents_router_is_forbidden_in_read_only_mode(
     app.state.read_only = True
 
     create_response = await httpx_client.post(
-        "/agents/server/sessions",
+        "/v1/agents/server/sessions",
         json=_create_session_body(),
     )
     assert create_response.status_code == 403

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -201,8 +201,8 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The legacy router registers first so /agents/server/... isn't captured
-    by /agents/{agent_id}/...; the new route must keep working alongside it."""
+    """The session routes live under /v1 while the legacy route keeps its
+    original path; the new route must keep working alongside it."""
 
     async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
         return TestModel(call_tools=[])
@@ -221,7 +221,7 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
         agent_session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
     response = await httpx_client.post(
-        f"/agents/assistant/sessions/{agent_session_id}/chat",
+        f"/v1/agents/assistant/sessions/{agent_session_id}/chat",
         json={
             "trigger": "submit-message",
             "id": session_id,
@@ -239,35 +239,16 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
     assert "data-transcript-persisted" in response.text
 
 
-async def test_new_contract_body_on_the_server_agent_url_delegates_to_the_session_handler(
-    db: DbSessionFactory,
+async def test_new_contract_body_on_the_legacy_url_is_rejected(
     httpx_client: httpx.AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-
-    async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
-        return TestModel(call_tools=[])
-
-    # The delegated turn runs in the session handler, so its model seam —
-    # not the legacy route's — is the one in play.
-    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
-    session_id = "13131313-1313-4313-8313-131313131313"
-    async with db() as session:
-        agent_session = models.AgentSession(
-            **_agent_session_model_kwargs(),
-            user_id=None,
-            title="Already titled",
-            project_name=get_env_phoenix_agents_assistant_project_name(),
-        )
-        session.add(agent_session)
-        await session.flush()
-        agent_session_id = str(GlobalID("AgentSession", str(agent_session.id)))
-
+    """The legacy route only speaks the full-transcript shape; the session
+    routes' single-``message`` body belongs to /v1/agents/... instead."""
     response = await httpx_client.post(
-        f"/agents/server/sessions/{agent_session_id}/chat",
+        f"/agents/server/sessions/{_CLIENT_MINTED_SESSION_ID}/chat",
         json={
             "trigger": "submit-message",
-            "id": session_id,
+            "id": _CLIENT_MINTED_SESSION_ID,
             "message": _user_message("hello"),
             "model": {
                 "providerType": "builtin",
@@ -276,19 +257,14 @@ async def test_new_contract_body_on_the_server_agent_url_delegates_to_the_sessio
             },
         },
     )
-
-    assert response.status_code == 200
-    assert "deprecation" not in response.headers
-    assert "data-transcript-persisted" in response.text
-    async with db() as session:
-        assert (await session.scalars(select(models.AgentSessionMessage))).all()
+    assert response.status_code == 422
 
 
 async def test_unknown_agent_id_still_returns_not_found(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     """Only the literal ``server`` segment maps to the legacy route; other
-    unknown agent ids keep 404ing in the new handler."""
+    agent ids under the unversioned path match no route at all."""
     response = await httpx_client.post(
         f"/agents/other/sessions/{_CLIENT_MINTED_SESSION_ID}/chat",
         json={


### PR DESCRIPTION
Moves the agent session routes from `/agents/...` to `/v1/agents/...`, aligning them with the rest of the REST API surface.

resolves #15102

Stacked on #15097.

## Changes

- `create_agents_router` now builds its `APIRouter` with `prefix="/v1"` and returns just the router (previously a `(router, session_chat)` tuple).
- The deprecated `POST /agents/server/sessions/{session_id}/chat` route **stays at its original path** for published CLI clients (`@arizeai/phoenix-cli` <= 1.10.x).
- **Legacy router cleanup:** with the new router under `/v1`, the two path spaces can no longer collide, so the legacy route's routing logic is gone — no more `ChatRequest` body-shape sniffing, no more injected `session_chat` delegation handler, and the registration-order constraint in `app.py` disappears. The legacy route now only accepts the legacy full-transcript body shape (new-contract bodies get a 422, pinned by test).
- The agents API now **opts into backward-compatibility enforcement** as a side effect of the move: the OpenAPI compat workflow's unchanged `startswith("/agent")` exclusion no longer matches the relocated `/v1/agents/...` routes, so they are checked like the rest of the schema. The deprecated unversioned legacy route remains excluded.
- Regenerated `schemas/openapi.json` and the generated TS clients; updated the path templates in `app/src/agent/chat/agentChatApi.ts`, `js/packages/phoenix-cli/src/pxi/client.ts`, and `js/packages/phoenix-client/src/constants/serverRequirements.ts` (all path literals are `satisfies keyof paths`, so the compiler enforces agreement with the schema).

## Testing

- `tests/unit/server/agents/` suites updated to the `/v1/agents/...` paths and passing (including a new test pinning the 422 on new-contract bodies at the legacy URL)
- Integration auth tests updated to the new paths
- `make typecheck-python`, `make lint-python`, app + js typechecks, app test suite, and `@arizeai/phoenix-cli` / `@arizeai/phoenix-client` test suites all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
