### PR TITLE
refactor(prompts): make metadata non-nullable in prompt PATCH OpenAPI schema

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -3781,11 +3781,11 @@ export interface components {
             description?: string | null;
             /**
              * Metadata
-             * @description New metadata object for the prompt (replaces the existing metadata as a whole; null is rejected)
+             * @description New metadata object for the prompt (replaces the existing metadata as a whole)
              */
             metadata?: {
                 [key: string]: unknown;
-            } | null;
+            };
         };
         /** PatchPromptResponseBody */
         PatchPromptResponseBody: {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -3781,11 +3781,11 @@ export interface components {
             description?: string | null;
             /**
              * Metadata
-             * @description New metadata object for the prompt (replaces the existing metadata as a whole; null is rejected)
+             * @description New metadata object for the prompt (replaces the existing metadata as a whole)
              */
             metadata?: {
                 [key: string]: unknown;
-            } | null;
+            };
         };
         /** PatchPromptResponseBody */
         PatchPromptResponseBody: {

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -3781,11 +3781,11 @@ export interface components {
             description?: string | null;
             /**
              * Metadata
-             * @description New metadata object for the prompt (replaces the existing metadata as a whole; null is rejected)
+             * @description New metadata object for the prompt (replaces the existing metadata as a whole)
              */
             metadata?: {
                 [key: string]: unknown;
-            } | null;
+            };
         };
         /** PatchPromptResponseBody */
         PatchPromptResponseBody: {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -13715,17 +13715,10 @@
             "description": "New description for the prompt (null clears the description)"
           },
           "metadata": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "additionalProperties": true,
+            "type": "object",
             "title": "Metadata",
-            "description": "New metadata object for the prompt (replaces the existing metadata as a whole; null is rejected)"
+            "description": "New metadata object for the prompt (replaces the existing metadata as a whole)"
           }
         },
         "type": "object",

--- a/src/phoenix/server/api/routers/v1/prompts.py
+++ b/src/phoenix/server/api/routers/v1/prompts.py
@@ -117,18 +117,15 @@ class PatchPromptRequestBody(V1RoutesBaseModel):
         default=UNDEFINED,
         description="New description for the prompt (null clears the description)",
     )
-    metadata: Optional[dict[str, Any]] = Field(
+    metadata: dict[str, Any] = Field(
         default=UNDEFINED,
         description=(
-            "New metadata object for the prompt (replaces the existing metadata as a "
-            "whole; null is rejected)"
+            "New metadata object for the prompt (replaces the existing metadata as a whole)"
         ),
     )
 
     @model_validator(mode="after")
     def _validate_patch(self) -> Self:
-        if self.metadata is None:
-            raise ValueError("metadata cannot be null")
         if self.description is UNDEFINED and self.metadata is UNDEFINED:
             raise ValueError("at least one field must be provided")
         return self
@@ -821,7 +818,6 @@ async def patch_prompt(
         if (description := request_body.description) is not UNDEFINED:
             prompt.description = description.strip() if description is not None else None
         if (metadata := request_body.metadata) is not UNDEFINED:
-            assert metadata is not None
             prompt.metadata_ = metadata
         data = _prompt_from_orm_prompt(prompt)
 


### PR DESCRIPTION
## Summary

Follow-up to #13731. The `PatchPromptRequestBody.metadata` field was declared `Optional[dict[str, Any]]`, which rendered as `anyOf: [object, null]` in the OpenAPI schema (`metadata?: {...} | null` in the generated TS clients) — even though the route rejects an explicit `null` at runtime with a 422 via a custom model validator.

Since the `UNDEFINED` sentinel is typed `Any`, the field can be declared as a plain `dict[str, Any]` with `default=UNDEFINED`:

- The OpenAPI schema now advertises `metadata` as a non-nullable `object` (still omittable), matching actual runtime behavior.
- Pydantic rejects explicit `null` natively with a 422, so the custom `metadata cannot be null` validator check and the handler's `assert metadata is not None` are removed.
- `description` is unchanged — `null` there legitimately clears the description, so it stays nullable.

Behavior is identical (omit = unchanged, `null` metadata = 422, empty body = 422); only the advertised schema and generated client types tighten.

Note for openapi-diff CI: removing the null branch from a request field is technically a narrowing change, but the endpoint only just landed on main and has not shipped in a release.

## Test plan

- `make openapi` — regenerated schema + all three generated clients (Python client output unchanged)
- `uv run pytest tests/unit/server/api/routers/v1/test_prompts.py` — all pass, including the existing `metadata: null` → 422 test
- `make lint-python`, `mypy` on the touched file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)