### PR TITLE
docs(skills): weekly audit — 2026-08-05

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -24,20 +24,31 @@ px trace list
 px trace get <trace-id>
 px trace annotate <trace-id>
 px trace add-note <trace-id>
+px trace delete <trace-identifier>
 px trace-annotations delete
 px span list
 px span annotate <span-id>
 px span add-note <span-id>
+px span delete <span-identifier>
 px span-annotations delete
 px session list
 px session get <session-id>
 px session annotate <session-id>
 px session add-note <session-id>
+px session delete <session-id>
 px session-annotations delete
 px dataset list
 px dataset get <name>
+px dataset delete <dataset-identifier>
+px experiment list
+px experiment get <id>
+px experiment delete <experiment-id>
+px prompt list
+px prompt get <prompt-identifier>
+px prompt delete <prompt-identifier>
 px project list
 px project get <name>
+px project delete <project-identifier>
 px annotation-config list
 px annotation-config get <identifier>
 px annotation-config create
@@ -52,7 +63,17 @@ px profile create <name>
 px profile use <name>
 px profile edit <name>
 px profile delete <name>
+px api graphql <query>
+px docs fetch
+px setup
+px self update
 ```
+
+Every `delete` above is gated: it requires
+`PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` in the environment and prompts for
+confirmation unless `-y`/`--yes` is passed (`px profile delete` is local-only and
+takes `--yes` without the env gate). Without the env var the command exits
+without deleting anything.
 
 ## Setup
 
@@ -346,7 +367,12 @@ px session annotate <session-id> --name reviewer --label pass --identifier "<cod
 px session add-note <session-id> --text "verified by agent"
 px session add-note <session-id> --text "verified by agent" --identifier "<coding-annotation-id>"  # tag + upsert on identifier
 px session-annotations delete --identifier "<coding-annotation-id>" --all -y              # nuke every annotation tied to this coding annotation identifier
+px session delete <session-id> -y                                                        # requires PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true
 ```
+
+`session list` has no filter flag. To select sessions by shape — error counts,
+token totals, tool use, annotation labels — use the session filter expression
+language through GraphQL (see [Session filter expressions](#session-filter-expressions)).
 
 ### Session JSON shape
 
@@ -418,6 +444,61 @@ px api graphql '{ __type(name: "Project") { fields { name type { name } } } }' |
 ```
 
 Key root fields: `projects`, `datasets`, `prompts`, `evaluators`, `projectCount`, `datasetCount`, `promptCount`, `evaluatorCount`, `viewer`.
+
+### Session filter expressions
+
+`px session list` has no filter flag, so selecting sessions by shape means going
+through GraphQL. `Project.sessions` takes a `sessionFilterCondition` — a Python
+expression over per-session values, the session-grain sibling of the span filter
+language:
+
+```bash
+px api graphql '{
+  projects(first: 1) { edges { node { sessions(
+    first: 10
+    sessionFilterCondition: "num_traces > 5 and any(span.status_code == \"ERROR\" for span in spans)"
+  ) { edges { node { sessionId numTraces numTracesWithError } } } } } }
+}' | jq '.data.projects.edges[0].node.sessions.edges[].node'
+```
+
+Discover the bindable names for a project rather than guessing — the vocabulary
+is generated from the compiler's own bindings, so it cannot drift from what
+compiles:
+
+```bash
+px api graphql '{ projects(first: 1) { edges { node { sessionFilterVocabulary {
+  name type category description iterableName } } } } }' \
+  | jq '.data.projects.edges[0].node.sessionFilterVocabulary[] | {name, type, category}'
+
+# Check an expression before running it
+px api graphql '{ projects(first: 1) { edges { node {
+  validateSessionFilterCondition(condition: "num_traces > 5") { isValid errorMessage }
+} } } }'
+```
+
+Commonly bound names: `session_id`, `start_time`, `end_time`, `duration_ms`,
+`num_traces`, `num_traces_with_error`, `token_count_prompt`,
+`token_count_completion`, `token_count_total`, `prompt_cost`, `completion_cost`,
+`total_cost`, `tool_span_count`, `llm_span_count`, the root-span text values
+`first_input` / `last_output` and their existential counterparts `any_input` /
+`any_output`, root-span attribute access via `attributes["llm.model_name"]`
+(with `user.id` and `metadata["key"]` accepted as proxies), the iterables
+`spans`, `traces`, `session_annotations`, and `span_annotations` for
+comprehensions (`any(...)` / `all(...)` / `len([...])`), and
+`annotations["name"].score|.label` for session annotations. Three rules the DSL
+legislates and an agent will otherwise get wrong:
+
+- **A missing value fails every comparison, in both directions.** A session with
+  no recorded input matches neither `'x' in first_input` nor its negation. Target
+  the missing case explicitly with `is None`.
+- **`in` against a string ignores case; `==` matches exactly.** This holds at
+  every grain, so the same query gives the same answer in the spans view.
+- **`any_input` / `any_output` are containment tests, not values.** Write
+  `'refund' in any_input`, never `any_input == 'refund'`.
+
+On fields that accept both grains (e.g. `Project.recordCount`),
+`sessionFilterCondition` and the span-grain `filterCondition` are mutually
+exclusive — passing both is a request error.
 
 ## Docs
 

--- a/.agents/skills/phoenix-evals/references/common-mistakes-python.md
+++ b/.agents/skills/phoenix-evals/references/common-mistakes-python.md
@@ -216,15 +216,29 @@ an evaluator with `ClassificationEvaluator` and run it with `async_evaluate_data
 ## Using HallucinationEvaluator
 
 ```python
-# WRONG — deprecated
+# WRONG — not a top-level export, and takes an LLM, not a model string
 from phoenix.evals import HallucinationEvaluator
 eval = HallucinationEvaluator(model)
 
-# RIGHT — use FaithfulnessEvaluator
-from phoenix.evals.metrics import FaithfulnessEvaluator
+# WRONG — there is no `context` field
+eval.evaluate({"input": question, "output": answer, "context": retrieved_docs})
+
+# RIGHT
+from phoenix.evals.metrics import HallucinationEvaluator
 from phoenix.evals import LLM
-eval = FaithfulnessEvaluator(llm=LLM(provider="openai", model="gpt-4o"))
+eval = HallucinationEvaluator(llm=LLM(provider="openai", model="gpt-4o"))
+eval.evaluate({"input": conversation_so_far, "output": assistant_reply})
 ```
 
-**Why**: `HallucinationEvaluator` is deprecated. `FaithfulnessEvaluator` is its replacement,
-using "faithful"/"unfaithful" labels with maximized score (1.0 = faithful).
+**Why**: pre-built evaluators live in `phoenix.evals.metrics`, not the top-level
+`phoenix.evals`. `HallucinationEvaluator` grounds a response against **the conversation**
+— `input` is the full history the assistant had access to (prior turns, tool calls, tool
+results), `output` is the reply being judged. There is no separate `context` field: if your
+source of truth is a supplied context such as retrieved documents, that is
+`FaithfulnessEvaluator`, not this one.
+
+Labels are `hallucinated`/`grounded` and the score is **minimized** — `hallucinated` is
+`1.0`, `grounded` is `0.0`. Do not assume "1.0 = good"; read the returned `Score`'s
+`direction` before thresholding. Results are also not comparable with previously stored
+`hallucination` annotations that used `factual`/`hallucinated` labels — dashboards and
+thresholds built on those need migrating, not reinterpreting.

--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -4,12 +4,13 @@ Use for exploration only. Validate before production.
 
 Pre-built evaluators are importable from `phoenix.evals.metrics` (Python) and
 `@arizeai/phoenix-evals` (TypeScript). They cover RAG quality (faithfulness,
-correctness, document relevance), response quality (conciseness, refusal),
-safety (toxicity), conversation signals (user friction), agent tool use
-(tool selection, invocation, response handling), and code-based checks
-(regex match, exact match, precision/recall/F-score). Naming follows
-`<Name>Evaluator` in Python and `create<Name>Evaluator` in TypeScript —
-enumerate the module exports for the full list.
+correctness, document relevance), conversation grounding (hallucination),
+response quality (conciseness, refusal), safety (toxicity), conversation
+signals (user friction), agent tool use (tool selection, invocation, response
+handling), and code-based checks (regex match, exact match,
+precision/recall/F-score). Naming follows `<Name>Evaluator` in Python and
+`create<Name>Evaluator` in TypeScript — enumerate the module exports for the
+full list.
 
 ## Python
 
@@ -38,6 +39,58 @@ convention: snake_case in Python, camelCase in TypeScript.
 Code-based evaluators (precision/recall/F-score) are also available in
 TypeScript via `@arizeai/phoenix-evals/code` — see
 [evaluators-code-typescript.md](evaluators-code-typescript.md).
+
+## Grounding: faithfulness vs. hallucination
+
+Two pre-built evaluators check whether a response is supported by its source of
+truth. They differ in *what* the source of truth is, and picking the wrong one
+scores against the wrong evidence:
+
+| Evaluator | Source of truth | Reach for it when |
+| --------- | --------------- | ----------------- |
+| Faithfulness | A separately supplied context (e.g. retrieved documents) | RAG — you have the retrieved chunks and want claims checked against them |
+| Hallucination | The conversation itself — prior turns, tool calls, tool results | Multi-turn agents and chat, where what the assistant was told *is* the history |
+
+`HallucinationEvaluator` takes `input` (the full conversation the assistant had
+access to; its last message is the turn being answered) and `output` (the reply
+being judged). It accepts no `context` field. Labels are
+`hallucinated` / `grounded`, and the score is **minimized** — `hallucinated` is
+`1.0`, `grounded` is `0.0`.
+
+```python
+from phoenix.evals import LLM
+from phoenix.evals.metrics import HallucinationEvaluator
+
+hallucination_eval = HallucinationEvaluator(llm=LLM(provider="openai", model="gpt-4o-mini"))
+scores = hallucination_eval.evaluate({
+    "input": (
+        "User: What's our refund window?\n"
+        "Tool (lookup_policy): Refunds: 30 days from delivery.\n"
+        "Assistant: 30 days from delivery.\n"
+        "User: And for electronics?"
+    ),
+    "output": "Electronics can be returned within 90 days.",
+})
+print(scores[0].label)  # "hallucinated"
+```
+
+```typescript
+import { createHallucinationEvaluator } from "@arizeai/phoenix-evals";
+import { openai } from "@ai-sdk/openai";
+
+const evaluator = createHallucinationEvaluator({ model: openai("gpt-4o-mini") });
+const result = await evaluator.evaluate({
+  input:
+    "User: What's our refund window?\nTool (lookup_policy): Refunds: 30 days from delivery.\nAssistant: 30 days from delivery.\nUser: And for electronics?",
+  output: "Electronics can be returned within 90 days.",
+});
+console.log(result.label); // "hallucinated"
+```
+
+The TypeScript evaluator changed shape: it previously took a separate `context`
+field and returned `factual` / `hallucinated`. Existing stored evaluations,
+dashboards, thresholds, and label filters built on the old labels need migrating
+— do not compare old and new scores directly.
 
 ## When to Use
 

--- a/.agents/skills/phoenix-tracing/references/instrumentation-auto-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-auto-python.md
@@ -62,6 +62,13 @@ Phoenix automatically converts [OTel GenAI semantic convention](https://opentele
 
 If a span already has OpenInference attributes set (e.g. from a dual-emitting instrumentor), those values take precedence over the synthesized ones.
 
+Message parts are converted structurally, not concatenated. A `gen_ai` message's
+text, image, blob, and reasoning parts each become an entry under
+`llm.{input,output}_messages.{i}.message.contents.{j}`, tagged with
+`message_content.type` (`text`, `image`, `reasoning`, …) — so a model's reasoning
+survives the conversion as a `reasoning` part rather than being folded into the
+answer text. See [span-llm](span-llm.md#messages) for the full content-part shape.
+
 No client-side changes required. Send OTLP to Phoenix as usual:
 
 ```python

--- a/.agents/skills/phoenix-tracing/references/span-llm.md
+++ b/.agents/skills/phoenix-tracing/references/span-llm.md
@@ -36,10 +36,24 @@ Represent calls to language models (OpenAI, Anthropic, local models, etc.).
 **Input messages:**
 - `llm.input_messages.{i}.message.role` - "user", "assistant", "system", "tool"
 - `llm.input_messages.{i}.message.content` - Text content
-- `llm.input_messages.{i}.message.contents.{j}` - Multimodal (text + images)
+- `llm.input_messages.{i}.message.contents.{j}` - Structured content parts (multimodal)
 - `llm.input_messages.{i}.message.tool_calls` - Tool invocations
 
 **Output messages:** Same structure as input messages.
+
+**Structured content parts.** Each entry under `message.contents.{j}` carries a
+type tag and its payload:
+
+- `llm.output_messages.{i}.message.contents.{j}.message_content.type` - one of
+  `text`, `image`, `audio`, `reasoning`, `tool_use`
+- `llm.output_messages.{i}.message.contents.{j}.message_content.text` - the text
+  payload, set for both `text` and `reasoning` parts
+
+Reasoning content is a content part, not a separate attribute — a model's
+thinking tokens arrive as a part with `type = "reasoning"` alongside the `text`
+parts of the same message. Code that reads message text should filter on
+`message_content.type` rather than concatenating every part, or reasoning text
+will be mixed into the visible answer.
 
 ## Example: Basic LLM Call
 


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-07-29 → 2026-08-05

**Audited against:** `origin/main` at `3ca14d227` (working-tree tip of this branch)
**Commits analyzed:** 44 release-recorded changes across `arize-phoenix` 19.11.0 → 19.17.0 plus 4 unreleased tip commits (9 user-facing, ~39 skipped)

> **Method caveat — please read.** `git` was not runnable in this environment: every
> `Bash` invocation failed with `bwrap: Can't create file at /home/.mcp.json:
> Permission denied`, sandboxed and unsandboxed alike, and outbound network (GitHub
> API via `WebFetch`) was not permitted either. The commit window was therefore
> reconstructed from the **dated** release-please changelogs (`CHANGELOG.md`,
> `packages/*/CHANGELOG.md`) and the undated changesets changelogs
> (`js/packages/*/CHANGELOG.md`), cross-checked against the four tip commits listed
> in the session's git status. Every edit below is still grounded in files read from
> the tree at the audited SHA — no edit rests on a changelog claim alone. The
> consequence of the missing `git log` is **dating precision, not grounding**: for
> TypeScript packages (changesets, no dates) I could not always prove a change fell
> inside the 7-day window. Where that mattered I say so explicitly.

## Edits applied

### phoenix-evals

- `references/common-mistakes-python.md` — **corrected a wrong claim.** The entry said
  "`HallucinationEvaluator` is deprecated. `FaithfulnessEvaluator` is its replacement."
  That is no longer true: `HallucinationEvaluator` is a live, exported evaluator
  (`packages/phoenix-evals/src/phoenix/evals/metrics/__init__.py:6,22`, class at
  `metrics/hallucination.py:13`), redesigned as a **conversation-grounding** evaluator
  in `1aa1a84` (#14708, released in `arize-phoenix` 19.14.0, 2026-08-03). Rewrote the
  entry around the real mistakes — wrong import path (`phoenix.evals` vs
  `phoenix.evals.metrics`), passing a `context` field that does not exist, and assuming
  "1.0 = good" when the score is minimized. Labels/direction quoted from
  `__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py:7,9,16`
  (`name="hallucination"`, `optimization_direction="minimize"`,
  `choices={"hallucinated": 1.0, "grounded": 0.0}`). This was the highest-severity
  finding of the sweep: the skill was steering agents *away* from a shipped evaluator.
- `references/evaluators-pre-built.md` — added a **"Grounding: faithfulness vs.
  hallucination"** section with a decision table (supplied context vs. the conversation
  itself) and verified runnable examples for both runtimes. Python example mirrors the
  docstring at `metrics/hallucination.py:39-64`; TypeScript example mirrors the JSDoc at
  `js/packages/phoenix-evals/src/llm/createHallucinationEvaluator.ts:51-60`. Export
  confirmed at `js/packages/phoenix-evals/src/llm/index.ts:8`. Also added "conversation
  grounding (hallucination)" to the category summary in the file's opening paragraph.
  Noted the TS breaking change (old `context` field, old `factual`/`hallucinated` labels)
  per the changeset in `js/packages/phoenix-evals/CHANGELOG.md` 2.2.0.

### phoenix-tracing

- `references/span-llm.md` — the Messages section described
  `message.contents.{j}` as "Multimodal (text + images)", which is now incomplete.
  Documented the actual content-part shape: `message_content.type` ∈
  `text | image | audio | reasoning | tool_use` and `message_content.text` (set for both
  `text` and `reasoning`). Grounded in `src/phoenix/trace/gen_ai/conversion.py:482,490,
  510-524` (from `05d5999`, #14995, released in 19.14.0, 2026-08-03) and consistent with
  `docs/phoenix/tracing/concepts-tracing/otel-openinference/span-kinds.mdx:146-147`.
  Added the practical consequence: code reading message text must filter on
  `message_content.type` or reasoning tokens leak into the visible answer.
- `references/instrumentation-auto-python.md` — the "OTel GenAI Native Instrumentation"
  section said Phoenix converts "message content" without saying how. Added that parts
  are converted **structurally, not concatenated**, and that reasoning parts survive as
  `message_content.type = "reasoning"`. Same source: `gen_ai/conversion.py:486-524`.
  Cross-links to `span-llm.md#messages` (anchor verified — heading is `## Messages`).

### phoenix-cli

- `SKILL.md` (Invocation) — **the command inventory was missing eight real commands.**
  Added `px trace delete`, `px span delete`, `px session delete`, `px dataset delete`,
  `px experiment delete`, `px project delete`, `px prompt delete`, `px self update`, and
  the previously unlisted `px experiment list|get`, `px prompt list|get`,
  `px api graphql`, `px docs fetch`, `px setup`. Argument spellings quoted verbatim from
  each `new Command("delete")` definition: `trace.ts:1084-1089`, `span.ts:722-724`,
  `session.ts:874-879`, `dataset.ts:411-413`, `experiment.ts:438-440`,
  `project.ts:215-217`, `prompt.ts:346-348`; `self.ts:593-611`. Registration confirmed
  against `js/packages/phoenix-cli/src/cli.ts:42-58` and each file's `addCommand` block.
  Added the gating note — `assertDeletesEnabled()` requires
  `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` (`src/confirm.ts:82-89`), called by every
  entity delete handler; `px profile delete` is the documented exception (local-only, no
  env gate, `profile.ts:527-531`).
  **Dating:** these commands predate the audit window — `px self update` appears far down
  `js/packages/phoenix-cli/CHANGELOG.md` (entry `4444b46`). This is a pre-existing
  inventory gap surfaced by the sweep, not a window regression. Included because the
  skill's job is to be truthful about the command surface, and an agent reading the old
  list would conclude these commands do not exist.
- `SKILL.md` (GraphQL) — added a **"Session filter expressions"** subsection for the
  session filter DSL from `64f505b9` (#14101, `feat(sessions): expression filter DSL`,
  unreleased at the audited SHA). Grounded in:
  `src/phoenix/server/api/types/Project.py:696-713` (`sessions(..., sessionFilterCondition)`),
  `:1340-1409` (`sessionFilterVocabulary`), `:1287-1310`
  (`validateSessionFilterCondition(condition:) → ValidationResult { isValid errorMessage }`),
  `:386-397` (the both-grains request error on `recordCount`),
  `src/phoenix/server/api/types/FilterVocabularyTerm.py:33-60` (term fields
  `name type description category iterableName`), and the bindable-name catalogue in
  `src/phoenix/trace/dsl/session_filter.py:111-128, 319-433`. The filter example
  (`num_traces > 5 and any(span.status_code == "ERROR" for span in spans)`) is the one the
  compiler's own gloss uses (`session_filter.py:416-419`). Documented the three
  legislated rules an agent gets wrong unaided — missing values fail comparisons in both
  directions (target with `is None`), `in` ignores case while `==` stays exact
  (`filter.py:215-217`, and `case_insensitive_containment=True` on the span grain at
  `filter.py:288`, so the rule genuinely holds at every grain), and
  `any_input`/`any_output` are containment-only tests (`session_filter.py:370-383`).
- `SKILL.md` (Sessions) — added `px session delete` to the command block and a pointer
  from Sessions to the new GraphQL subsection, since `px session list` has no filter flag
  (verified against the full option list in `session.ts:592-611`).

## Skipped commits

Internal, non-user-facing, or outside the three skills' surfaces:

- `#14195` `feat(evals): harbor poc` — despite the `evals:` prefix, this is the internal
  agent-eval harness under `evals/harbor/` (Harbor task definitions, fixture publishing,
  container assets). No public evaluator or client surface. **Tagged `evals` in triage
  and dropped after reading the diff paths**, per the reconciliation rule.
- `#14843` `feat(evals): count subagent tool calls online` — PXI server-side online
  evals (`tests/unit/pxi/evals/online_evals/`, `src/phoenix/server/agents/`). Internal.
  **Tagged `evals`, dropped after grounding.**
- `#14295` harden span filter validation, `#14963` `fix(dsl): one NUL message on every
  Python` — span-filter DSL internals. **Tagged `cli`**; the one user-visible effect
  (case-insensitive `in` at the span grain) is now stated in the new session-filter
  subsection, so no separate edit.
- `#14904` `fix(cli): make px setup's trace verdict the run's result` — **tagged `cli`**;
  already documented. `phoenix-cli/SKILL.md` covers exit `6`, `tracesVerified`, and the
  `verification` field (`verified`/`notVerified`/`deferred`). Self-patched by an earlier
  audit; no edit needed.
- AI SDK v7 migration (`@arizeai/phoenix-otel` 2.0.0/2.1.0, `@arizeai/phoenix-client`
  7.0.0/7.0.1/7.1.x, `@arizeai/phoenix-evals` 2.0.0) — **tagged `tracing` + `evals`**;
  verified already documented by the 2026-07-29 audit (`f56e31b`, #14873):
  `phoenix-tracing/references/setup-typescript.md:73-119` and
  `instrumentation-auto-typescript.md:41-87` cover the `/vercel` subpath,
  `LazyOpenInferenceSpanProcessor`, and the v6/v7 constraint;
  `phoenix-evals/references/setup-typescript.md:18-19` and
  `experiments-running-typescript.md:53-71` cover the per-call `@ai-sdk/otel`
  integration. No edit needed. (Exact dates unavailable — changesets carry no dates.)
- `#14636` toxicity gallery template, `#14193`/`#14561` user friction evaluator — dated
  2026-07-21/07-23 in `packages/phoenix-evals/CHANGELOG.md`, i.e. before the window and
  already reflected in `evaluators-pre-built.md`.
- Frontend/UI only: `#15047`, `#15027`, `#15041`, `#15028`, `#14993`, `#14990`, `#14987`,
  `#14968`, `#14938`, `#14481`, `#14901`, `#14900`, `#14841`, `#14845`, `#14599`,
  `#14847`, `#14849`, `#14826`, `#14814`, `#14917`.
- Infra / deps / bookkeeping: `#15094` (CI uv pin), `#15091` (Amp orb),
  `chore(main): release arize-phoenix-sqlean 0.1.0` (#15088), `#14946`/`#14764`
  (built-in model token prices — data, not API), `#14935` (Docker monty binary),
  `#14853` (release-notes doc), `#14873` (the prior skills audit itself).
- `#14854` move span/trace link formatting into the PXI system prompt — internal prompt
  change.

## Out-of-scope findings

For the maintainer — real user-facing changes that belong to skills this audit does not own:

1. **`POST /v1/chat/completions` — OpenAI-compatible proxy with server-side credentials**
   (`6ab57db`, #14980, 19.16.0, 2026-08-04). New REST surface at
   `src/phoenix/server/api/routers/v1/chat_completions.py`. Model strings are
   `"{provider}:{model_name}"` or `"custom:{provider_id}:{model_name}"` (`:49-54`). It
   appears in the generated OpenAPI types
   (`js/packages/phoenix-client/src/__generated__/api/v1.ts`) but has **no hand-written
   client method, no Python client method, and no CLI wrapper**, so none of the three
   skills has a surface to document it against. It is plausibly useful for pointing an
   evals run at server-held credentials, but nothing in the code states that intent —
   flagging rather than inventing a rationale. Belongs in `phoenix-server` / REST docs.

2. **`PATCH /v1/prompts/{prompt_identifier}` — update prompt description and metadata**
   (`244ef9c7e`, #13731, unreleased at the audited SHA).
   `src/phoenix/server/api/routers/v1/prompts.py:792-828`, request body at `:111-134`
   (omit a field to leave it unchanged; `metadata` replaces wholesale and rejects null;
   at least one field required). **No wrapper anywhere the three skills cover:** no
   `px prompt update` (`prompt.ts:359-366` registers only `list`/`get`/`delete`), no
   `patchPrompt`/`updatePrompt` in the hand-written TypeScript client, no
   `update` in `packages/phoenix-client/.../resources/prompts/`. Worth deciding whether
   the CLI and clients should wrap it; nothing to patch in these skills until they do.

3. **Python/TypeScript mirror check on the hallucination evaluator:** both runtimes
   shipped in `#14708` and both are now documented. The one asymmetry is that the
   TypeScript changeset records it as a **redesign of an existing** evaluator (breaking:
   `context` field dropped, `factual` → `grounded`), while the `arize-phoenix` changelog
   records it as "add hallucination evaluator". If the Python evaluator is genuinely new
   rather than redesigned, the migration warning I added to
   `common-mistakes-python.md` is conservative but harmless; if it replaced an earlier
   Python evaluator, someone should confirm the stored-annotation migration note is
   reaching Python users too. I could not settle this without `git log`.
