### PR TITLE
feat(client): add a getProjects helper to the TypeScript client

### DIFF
--- a/js/.changeset/clean-pugs-guess.md
+++ b/js/.changeset/clean-pugs-guess.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add a `getProjects` helper to the new `@arizeai/phoenix-client/projects` entry point. It lists projects with automatic cursor pagination and accepts an optional `nameContains` filter, which maps to the `name_contains` query parameter on `GET /v1/projects` (case-insensitive substring match, requires Phoenix server >= 17.16.0).

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -729,6 +729,31 @@ await addSessionNote({
 });
 ```
 
+## Projects
+
+The `@arizeai/phoenix-client` package provides a `projects` export for listing projects.
+
+### Fetching Projects
+
+Use `getProjects` to list projects. Pagination is handled for you.
+
+```ts
+import { getProjects } from "@arizeai/phoenix-client/projects";
+
+// List every project
+const projects = await getProjects();
+
+for (const project of projects) {
+  console.log(`Project: ${project.name} (${project.id})`);
+}
+```
+
+Pass `nameContains` to filter by a case-insensitive substring of the project name. The filter is applied server-side and requires Phoenix server `17.16.0` or newer.
+
+```ts
+const agentProjects = await getProjects({ nameContains: "agent" });
+```
+
 ## Examples
 
 To run examples, install dependencies using `pnpm` and run:

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -53,6 +53,10 @@
       "import": "./dist/esm/sessions/index.js",
       "require": "./dist/src/sessions/index.js"
     },
+    "./projects": {
+      "import": "./dist/esm/projects/index.js",
+      "require": "./dist/src/projects/index.js"
+    },
     "./traces": {
       "import": "./dist/esm/traces/index.js",
       "require": "./dist/src/traces/index.js"

--- a/js/packages/phoenix-client/src/projects/getProjects.ts
+++ b/js/packages/phoenix-client/src/projects/getProjects.ts
@@ -12,7 +12,7 @@ export interface GetProjectsParams extends ClientFn {
    *
    * @requires Phoenix server >= 17.16.0
    */
-  nameContains?: string | null;
+  nameContains?: string;
 }
 
 type ProjectsResponse = components["schemas"]["GetProjectsResponseBody"];

--- a/js/packages/phoenix-client/src/projects/getProjects.ts
+++ b/js/packages/phoenix-client/src/projects/getProjects.ts
@@ -1,0 +1,69 @@
+import invariant from "tiny-invariant";
+
+import type { components } from "../__generated__/api/v1";
+import { createClient } from "../client";
+import type { ClientFn } from "../types/core";
+import type { Project } from "../types/projects";
+
+export interface GetProjectsParams extends ClientFn {
+  /**
+   * Return only projects whose name contains this substring
+   * (case-insensitive). The match is performed server-side.
+   *
+   * @requires Phoenix server >= 17.16.0
+   */
+  nameContains?: string | null;
+}
+
+type ProjectsResponse = components["schemas"]["GetProjectsResponseBody"];
+
+const DEFAULT_PAGE_SIZE = 100;
+
+/**
+ * List projects with automatic pagination handling.
+ *
+ * @example
+ * ```ts
+ * import { getProjects } from "@arizeai/phoenix-client/projects";
+ *
+ * // Every project
+ * const projects = await getProjects();
+ *
+ * // Only projects whose name contains "agent" (requires Phoenix server >= 17.16.0)
+ * const agentProjects = await getProjects({ nameContains: "agent" });
+ *
+ * for (const project of agentProjects) {
+ *   console.log(`Project: ${project.name} (${project.id})`);
+ * }
+ * ```
+ */
+export async function getProjects(
+  params: GetProjectsParams = {}
+): Promise<Project[]> {
+  const client = params.client || createClient();
+  const { nameContains } = params;
+
+  const projects: Project[] = [];
+  let cursor: string | null | undefined = null;
+
+  do {
+    const response: { data?: ProjectsResponse; error?: unknown } =
+      await client.GET("/v1/projects", {
+        params: {
+          query: {
+            cursor,
+            limit: DEFAULT_PAGE_SIZE,
+            name_contains: nameContains,
+          },
+        },
+      });
+
+    if (response.error) throw response.error;
+    invariant(response.data?.data, "Failed to list projects");
+
+    cursor = response.data.next_cursor ?? null;
+    projects.push(...response.data.data);
+  } while (cursor != null);
+
+  return projects;
+}

--- a/js/packages/phoenix-client/src/projects/index.ts
+++ b/js/packages/phoenix-client/src/projects/index.ts
@@ -1,0 +1,1 @@
+export * from "./getProjects";

--- a/js/packages/phoenix-client/src/types/projects.ts
+++ b/js/packages/phoenix-client/src/types/projects.ts
@@ -1,3 +1,10 @@
+import type { components } from "../__generated__/api/v1";
+
+/**
+ * A project as returned by the Phoenix REST API.
+ */
+export type Project = components["schemas"]["Project"];
+
 /**
  * Identifies a project. Accepts any of:
  * - `project` — a project ID or name (the server accepts either)

--- a/js/packages/phoenix-client/test/projects/getProjects.test.ts
+++ b/js/packages/phoenix-client/test/projects/getProjects.test.ts
@@ -1,0 +1,128 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { getProjects } from "../../src/projects/getProjects";
+import type { Project } from "../../src/types/projects";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+
+const firstProject: Project = {
+  id: "project-1",
+  name: "agent-alpha",
+  description: "First project",
+};
+
+const secondProject: Project = {
+  id: "project-2",
+  name: "agent-beta",
+  description: null,
+};
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("getProjects", () => {
+  it("should list projects without pagination if no next_cursor", async () => {
+    let projectsRequestCount = 0;
+    let receivedCursor: string | null = null;
+    let receivedLimit: string | null = null;
+    let receivedNameContains: string | null = null;
+
+    server.use(
+      http.get("/v1/projects", ({ request, response }) => {
+        projectsRequestCount += 1;
+        const searchParams = new URL(request.url).searchParams;
+        receivedCursor = searchParams.get("cursor");
+        receivedLimit = searchParams.get("limit");
+        receivedNameContains = searchParams.get("name_contains");
+        return response(200).json({
+          data: [firstProject, secondProject],
+          next_cursor: null,
+        });
+      })
+    );
+
+    const projects = await getProjects({ client: createTestClient() });
+
+    expect(projectsRequestCount).toBe(1);
+    // A null cursor is omitted from the query string entirely.
+    expect(receivedCursor).toBeNull();
+    expect(receivedLimit).toBe("100");
+    // An omitted nameContains must not send the filter at all, otherwise an
+    // unfiltered call would narrow the result set.
+    expect(receivedNameContains).toBeNull();
+
+    expect(projects).toHaveLength(2);
+    expect(projects[0]).toMatchObject({
+      id: "project-1",
+      name: "agent-alpha",
+      description: "First project",
+    });
+    expect(projects[1]).toMatchObject({ id: "project-2", name: "agent-beta" });
+  });
+
+  it("should forward nameContains on every page while paginating", async () => {
+    const receivedCursors: Array<string | null> = [];
+    const receivedNameContains: Array<string | null> = [];
+
+    server.use(
+      http.get("/v1/projects", ({ request, response }) => {
+        const searchParams = new URL(request.url).searchParams;
+        receivedCursors.push(searchParams.get("cursor"));
+        receivedNameContains.push(searchParams.get("name_contains"));
+        if (receivedCursors.length === 1) {
+          return response(200).json({
+            data: [firstProject],
+            next_cursor: "cursor1",
+          });
+        }
+        return response(200).json({
+          data: [secondProject],
+          next_cursor: null,
+        });
+      })
+    );
+
+    const projects = await getProjects({
+      client: createTestClient(),
+      nameContains: "agent",
+    });
+
+    expect(projects).toHaveLength(2);
+    // The first request omits the cursor; the second passes the cursor along.
+    expect(receivedCursors).toEqual([null, "cursor1"]);
+    // The filter must survive the pagination loop, not just the first request.
+    expect(receivedNameContains).toEqual(["agent", "agent"]);
+  });
+
+  it("should throw error if API returns no data", async () => {
+    server.use(
+      http.get("/v1/projects", ({ response }) =>
+        response.untyped(
+          new Response("{}", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      )
+    );
+
+    await expect(getProjects({ client: createTestClient() })).rejects.toThrow(
+      "Failed to list projects"
+    );
+  });
+});


### PR DESCRIPTION
Closes #14035

## What this does

Adds a `getProjects` helper to `@arizeai/phoenix-client`, exposed from a new
`@arizeai/phoenix-client/projects` entry point.

```ts
import { getProjects } from "@arizeai/phoenix-client/projects";

const projects = await getProjects();
const agentProjects = await getProjects({ nameContains: "agent" });
```

It handles cursor pagination internally and forwards `nameContains` to the
`name_contains` query parameter on `GET /v1/projects`, which was added in
#14029 and shipped in Phoenix server 17.16.0.

## How it is built

It follows `sessions/listSessions.ts`, which the issue named as the pattern:
same `do/while` cursor loop, same `DEFAULT_PAGE_SIZE = 100`, same
`if (response.error) throw response.error` plus `invariant(...)` handling, same
"return a plain array once every page is drained" shape.

`nameContains` is placed inside the query object rather than conditionally
appended. `openapi-fetch` drops `null` and `undefined` query values, which is
the same mechanism `listSessions` already relies on for its `cursor` on the
first request, so an unfiltered call sends no `name_contains` at all. There is
a test asserting exactly that, because sending an empty `name_contains` would
silently change the result set.

`Project` is added as an alias of the generated `components["schemas"]["Project"]`
in `types/projects.ts`, next to the existing `ProjectIdentifier`, so callers can
name the element type without reaching into `__generated__`.

## Acceptance criteria

- [x] `getProjects({ client, nameContains })` returns only matching projects
- [x] `nameContains` is forwarded on every page of the pagination loop
- [x] Helper exported from the package entry point
- [x] Tests cover filtered and unfiltered listing

## Tests

Three tests in `test/projects/getProjects.test.ts`, mirroring
`test/sessions/listSessions.test.ts`: unfiltered single page, filtered across
two pages asserting the filter is present on both requests, and the
no-data error path.

`pnpm run test` in `js/packages/phoenix-client` goes from 470 passing to 473
passing, 51 files, 1 pre-existing skip.

## Deliberately not included

- No `includeExperimentProjects` or `includeDatasetEvaluatorProjects`
  parameters. Both exist on the endpoint, but the issue scoped this to
  `nameContains`, and each one is a public API commitment. Happy to add them
  here if you would rather land the whole surface at once.
- No `ensureServerCapability` guard on `nameContains`. The sibling Python
  client (#14132) forwards `name_contains` with no version guard, so this
  matches it, and the JSDoc records the 17.16.0 requirement. If you would
  prefer a `ParameterRequirement` in `constants/serverRequirements.ts` for
  consistency with `getSpans`, say the word and I will add it.
- Named `getProjects` rather than `listProjects`. The issue title and the
  generated OpenAPI operation id are both `getProjects`. Easy to rename.

## Notes

I ran `pnpm run -r build`, `pnpm run test`, `pnpm run fmt:check`,
`pnpm run typecheck`, and `pnpm run lint`. All pass. One unrelated test in
`packages/phoenix-cli` (`pxiApp.test.tsx > uses Mac Delete predictably after
multiline pasted text`) times out at 5000ms on my machine, and it fails
identically on a clean checkout of `main` without this change, so it is not
from this PR.
