### PR TITLE
ci(phoenix-sqlean): build wheels from the workspace root so the tests can run

### DIFF
--- a/.agents/skills/phoenix-sqlean/SKILL.md
+++ b/.agents/skills/phoenix-sqlean/SKILL.md
@@ -5,13 +5,13 @@ description: >
   Maintaining packages/phoenix-sqlean, the vendored fork of nalgeon/sqlean.py published as
   arize-phoenix-sqlean. Use when bumping the bundled SQLite, sqlean, or xxHash versions,
   changing its wheel matrix, or touching its publish path. Trigger on any change under
-  packages/phoenix-sqlean/ or the sqlean jobs in .github/workflows/publish.yaml.
+  packages/phoenix-sqlean/, .github/workflows/phoenix-sqlean-*.yml, or the sqlean jobs in
+  .github/workflows/publish.yaml.
 ---
 
 # phoenix-sqlean
 
-Vendored fork of [nalgeon/sqlean.py](https://github.com/nalgeon/sqlean.py). It exists because
-upstream dropped Windows wheels at SQLite 3.50.4 and ships none today.
+Vendored fork of [nalgeon/sqlean.py](https://github.com/nalgeon/sqlean.py).
 
 ## Bumping a bundled version
 
@@ -27,7 +27,13 @@ Pins live in `packages/phoenix-sqlean/Makefile`. Each has a partner that must mo
 `check-sqlean-pin`, a prerequisite of `download-sqlean`, enforces the `SQLEAN_*` rows for one
 `ls-remote`: suffix prefixes the commit, base is a real tag, suffix present iff ahead, `setup.py`
 agrees. It cannot tell you the base names the *wrong* release — the single-commit fetch carries no
-ancestry. `SQLITE_*` and `XXHASH_*` have only their hash checks.
+ancestry. `SQLITE_*` and `XXHASH_*` get no equivalent cross-check — only their hashes, at fetch.
+
+sqlean is fetched over git by commit: GitHub's source archives are generated on demand and not
+byte-stable, so they cannot be checksum-pinned, while git hashes every object it receives. Hence
+`download-sqlean` needs `git` on PATH and no checksum. The other two arrive over plain HTTP, where
+curl verifies nothing — `XXHASH_COMMIT` fixes which bytes are correct and `XXHASH_SHA256` proves
+they are those. `src/test_windirent.h` needs neither; it is committed to this repo.
 
 ### With the script
 
@@ -39,9 +45,6 @@ cd packages/phoenix-sqlean
 ./scripts/check-upstream.sh sqlite --apply    # rewrite pins, print a Markdown summary
 ./scripts/check-upstream.sh sqlean [--apply]  # also moves XXHASH_* if sqlean moved its own
 ```
-
-`phoenix-sqlean-upstream.yml` runs this weekly. It verifies nothing by design — run the prep chain
-afterwards.
 
 ### By hand
 
@@ -66,11 +69,12 @@ python -m tests
 ## Staying current
 
 Dependabot cannot see these pins — no custom-regex manager — and there is no Renovate here.
-`phoenix-sqlean-upstream.yml` fills the gap: weekly, one draft PR per component, no model involved.
+`phoenix-sqlean-upstream.yml` fills the gap: weekly, one draft PR per component, running
+`check-upstream.sh --apply`, no model involved.
 
-**It builds and tests nothing.** `phoenix-sqlean-ci.yml` verifies on the PR across the full
-OS/arch/interpreter matrix; verifying in the bump job would be a subset of that, on the one platform
-where the likeliest failure — `patch(1)` on the MSVC patch — cannot reproduce.
+**It builds and tests nothing.** CI covers that on the PR; verifying inside the bump job would
+re-run a subset of it, on the one platform where the likeliest failure — `patch(1)` on the MSVC
+patch — cannot reproduce.
 
 A failure of the script itself is different: upstream changed shape, so it exits before writing and
 the job goes red with no PR, because there is no computed bump to review.
@@ -94,39 +98,28 @@ sqlean moves its own pin.
 - **Changing `SQLEAN_VERSION` alone does not trigger a recompile.** It only moves a `-D` flag, and
   `build_ext` keys on source mtime. `touch src/sqlean.c` after editing, or the version test fails
   against a merely stale build.
-- **sqlean is fetched over git, not as a source archive.** GitHub archives are not byte-stable, so
-  they cannot be checksum-pinned; a commit fetch needs no checksum because git hashes every object
-  it receives. Hence `download-sqlean` needs `git` on PATH.
-- **The other two downloads are plain HTTP and get SHA-256 checks.** curl verifies nothing.
-  `XXHASH_COMMIT` fixes which bytes are correct, the hash proves they are those.
-  `src/test_windirent.h` needs neither — it is committed to this repo.
 - **Keep the package version plain SemVer.** release-please's version regex is unanchored, so
   `3.53.4.1` and `3.53.4.post1` truncate to `3.53.4` and collide with an existing tag, silently.
   For the same reason `VERSION` must stay above `SQLEAN_VERSION` in `setup.py`. The package version
   is intentionally independent of the bundled SQLite version.
-- **pyright's `exclude` in the root `pyproject.toml` must restate all three defaults**
-  (`**/node_modules`, `**/__pycache__`, `**/.*`). Dropping `**/.*` makes pyright walk `.venv`.
-  Nothing in CI runs pyright, so this fails silently in editors only.
 
 ## Wheels and publishing
 
-- Matrix is in `publish.yaml` (`build-sqlean`): cp310–cp314 across Linux x86_64/aarch64, macOS
-  x86_64/arm64, Windows AMD64/ARM64, plus an sdist carrying the C sources.
-- `phoenix-sqlean-ci.yml` covers every OS/arch pair the publish job ships. `windows-11-arm` skips
-  3.10 — CPython publishes no Windows ARM64 build for it.
+- Settings are in `cibuildwheel.toml`, steps in `phoenix-sqlean-build.yml` — a `workflow_call`
+  workflow that both `build-sqlean` in `publish.yaml` and CI's `wheel` job invoke, so a PR runs
+  the build a release runs.
+- The matrix is cp310–cp314 across Linux x86_64/aarch64, macOS x86_64/arm64, Windows AMD64/ARM64,
+  plus an sdist of the C sources. A misspelled key in the toml errors; a misspelled `CIBW_*` env
+  var is a silent no-op.
+- **An empty `CIBW_*` is an override, not a no-op.** It replaces the toml's value with
+  cibuildwheel's own default — Linux goes from 10 identifiers to 36, musllinux and free-threaded
+  included. Hence the `cibw-*` inputs reach the environment only when non-empty.
+- **`test-sources` resolves against cibuildwheel's working directory, not `package-dir`** — hence
+  the workspace-root unpack, which the shared workflow puts under CI.
+- CI's `test` matrix compiles in place across every OS/arch pair the publish job ships;
+  `windows-11-arm` skips 3.10 — CPython publishes no Windows ARM64 build for it. It never runs
+  cibuildwheel, which is what the `wheel` job is for.
 - Publishing is gated on the tag `arize-phoenix-sqlean-v<manifest version>`. Until release-please
   creates it, `sqlean-sources` skips and nothing builds.
 - PyPI uses trusted publishing with **no** GitHub environment; the publisher's Environment field
   must stay blank to match.
-
-## Release-please paths
-
-The root `arize-phoenix` component ignores a commit when **every** file it touches is under its
-`exclude-paths` in `release-please-config.json` — `packages`, `.github`, `.agents`, `.claude`,
-`.gitignore`, `scripts`, `docs`, `tests`, and more. Treat that list as the source of truth; it is
-easy to assume a dot-directory is excluded when it is not.
-
-`pyproject.toml` and `release-please-config.json` are **not** excluded, and the repo squash-merges,
-so either one drags the whole commit into the root component — a `feat:`/`fix:` PR mixing them with
-package work bumps `arize-phoenix` as a side effect. Split by PR; a `chore:` commit alone does not
-prevent it.

--- a/.github/workflows/phoenix-sqlean-build.yml
+++ b/.github/workflows/phoenix-sqlean-build.yml
@@ -1,0 +1,93 @@
+name: Build arize-phoenix-sqlean wheels
+
+# Called by build-sqlean in publish.yaml and wheel in phoenix-sqlean-ci.yml, so
+# a PR runs the build a release runs. cibuildwheel.toml carries the settings;
+# the layout they depend on lives here.
+
+on:
+  workflow_call:
+    inputs:
+      sources-artifact:
+        description: Artifact holding the prepared package sources.
+        required: true
+        type: string
+      runners:
+        description: JSON array of runner labels to build on.
+        required: true
+        type: string
+      cibw-build:
+        description: CIBW_BUILD override. Empty uses cibuildwheel.toml's matrix.
+        required: false
+        type: string
+        default: ""
+      cibw-archs-linux:
+        description: CIBW_ARCHS_LINUX override. Empty uses cibuildwheel.toml's.
+        required: false
+        type: string
+        default: ""
+      emulate-aarch64:
+        description: >-
+          QEMU for cross-arch Linux builds. Defaults true to match
+          cibuildwheel.toml's aarch64; false only if a caller narrowed to native.
+        required: false
+        type: boolean
+        default: true
+      dist-artifact-prefix:
+        description: Upload wheels as <prefix>-<runner>. Empty skips the upload.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.runners) }}
+    steps:
+      # Workspace root: cibuildwheel resolves test-sources against its cwd, not
+      # package-dir.
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ inputs.sources-artifact }}
+      - name: Set up QEMU for aarch64 wheels
+        if: runner.os == 'Linux' && inputs.emulate-aarch64
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+      # Not step env: an empty CIBW_* overrides cibuildwheel.toml rather than
+      # being ignored, taking Linux from 10 identifiers to 36 (musllinux,
+      # free-threaded, cp39, cp315).
+      - name: Narrow the matrix
+        if: inputs.cibw-build != '' || inputs.cibw-archs-linux != ''
+        shell: bash
+        env:
+          BUILD: ${{ inputs.cibw-build }}
+          ARCHS_LINUX: ${{ inputs.cibw-archs-linux }}
+        run: |
+          if [ -n "$BUILD" ]; then echo "CIBW_BUILD=$BUILD" >> "$GITHUB_ENV"; fi
+          if [ -n "$ARCHS_LINUX" ]; then echo "CIBW_ARCHS_LINUX=$ARCHS_LINUX" >> "$GITHUB_ENV"; fi
+      - name: Build wheels
+        # Must be >= v3.4.0: earlier releases reference actions/setup-python@v6
+        # inside their own action.yml, and this org rejects unpinned actions
+        # transitively, so the job fails while preparing actions.
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        with:
+          config-file: cibuildwheel.toml
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.15"
+      - name: Build sdist
+        if: runner.os == 'Linux'
+        run: pipx run build==1.5.0 --sdist --outdir wheelhouse .
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: inputs.dist-artifact-prefix != ''
+        with:
+          name: ${{ inputs.dist-artifact-prefix }}-${{ matrix.os }}
+          path: wheelhouse/

--- a/.github/workflows/phoenix-sqlean-ci.yml
+++ b/.github/workflows/phoenix-sqlean-ci.yml
@@ -57,6 +57,8 @@ jobs:
             packages/phoenix-sqlean/Makefile
             packages/phoenix-sqlean/README.md
             packages/phoenix-sqlean/LICENSE
+            packages/phoenix-sqlean/THIRD_PARTY_LICENSES
+            packages/phoenix-sqlean/cibuildwheel.toml
             packages/phoenix-sqlean/setup.cfg
             packages/phoenix-sqlean/setup.py
             packages/phoenix-sqlean/sqlean
@@ -106,12 +108,27 @@ jobs:
           python setup.py build_ext -i
           python -m tests
 
+  # The test job compiles in place, so nothing else here runs cibuildwheel. One
+  # interpreter suffices: this covers the build, not the compiler matrix.
+  wheel:
+    name: cibuildwheel smoke test
+    needs: [changes, download-sources]
+    if: needs.changes.outputs.sqlean == 'true'
+    uses: ./.github/workflows/phoenix-sqlean-build.yml
+    with:
+      sources-artifact: sqlean-sources
+      runners: '["ubuntu-latest"]'
+      cibw-build: cp312-manylinux_x86_64
+      cibw-archs-linux: x86_64
+      emulate-aarch64: false
+
   ci-required:
     name: phoenix-sqlean CI Required
     needs:
       - changes
       - download-sources
       - test
+      - wheel
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -327,61 +327,19 @@ jobs:
           name: arize-phoenix-sqlean-sources
           path: packages/phoenix-sqlean
 
+  # phoenix-sqlean-ci.yml calls the same workflow, so a PR runs this build. No
+  # cibw-* overrides here: the shipped matrix is cibuildwheel.toml's business.
   build-sqlean:
-    name: Build arize-phoenix-sqlean (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Build arize-phoenix-sqlean
     needs: sqlean-sources
     if: needs.sqlean-sources.result == 'success' && needs.sqlean-sources.outputs.needed == 'true'
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: arize-phoenix-sqlean-sources
-          path: pkg
-      - name: Set up QEMU for aarch64 wheels
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
-      - name: Build wheels
-        # Must be >= v3.4.0: earlier releases reference actions/setup-python@v6
-        # inside their own action.yml, and this org rejects unpinned actions
-        # transitively, so the job fails while preparing actions.
-        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
-        with:
-          package-dir: pkg
-        env:
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_ARCHS_WINDOWS: AMD64 ARM64
-          CIBW_BUILD: "cp310-macosx* cp311-macosx* cp312-macosx* cp313-macosx* cp314-macosx* cp310-manylinux* cp311-manylinux* cp312-manylinux* cp313-manylinux* cp314-manylinux* cp310-win* cp311-win* cp312-win* cp313-win* cp314-win*"
-          # Import and exercise each wheel before it is uploaded. The command
-          # runs in a temp dir against the installed wheel, not the source
-          # tree, so CIBW_TEST_SOURCES must supply everything the suite reads
-          # from the working directory: tests/ plus setup.py and README.md,
-          # because tests/extensions.py imports SQLEAN_VERSION from setup.py
-          # and setup.py reads README.md at import time (hence setuptools).
-          # cibuildwheel skips tests for cross-compiled wheels (macOS x86_64,
-          # win_arm64); the native ARM legs in phoenix-sqlean-ci.yml cover those.
-          CIBW_TEST_SOURCES: tests setup.py README.md
-          CIBW_TEST_REQUIRES: setuptools==83.0.0
-          CIBW_TEST_COMMAND: python -m tests
-          MACOSX_DEPLOYMENT_TARGET: "10.15"
-      - name: Build sdist
-        if: runner.os == 'Linux'
-        run: pipx run build==1.5.0 --sdist --outdir wheelhouse pkg
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: arize-phoenix-sqlean-dist-${{ matrix.os }}
-          path: wheelhouse/
+    uses: ./.github/workflows/phoenix-sqlean-build.yml
+    with:
+      sources-artifact: arize-phoenix-sqlean-sources
+      runners: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+      dist-artifact-prefix: arize-phoenix-sqlean-dist
 
   publish-sqlean:
     name: Publish arize-phoenix-sqlean

--- a/packages/phoenix-sqlean/cibuildwheel.toml
+++ b/packages/phoenix-sqlean/cibuildwheel.toml
@@ -1,0 +1,26 @@
+# Read by .github/workflows/phoenix-sqlean-build.yml, which publish.yaml and
+# phoenix-sqlean-ci.yml both call. CIBW_* env vars still win; that is how CI
+# narrows the matrix.
+
+[tool.cibuildwheel]
+# Anything not listed installs from the sdist, which needs a C toolchain --
+# currently musllinux and PyPy, and whatever gets dropped from here.
+build = "cp310-macosx* cp311-macosx* cp312-macosx* cp313-macosx* cp314-macosx* cp310-manylinux* cp311-manylinux* cp312-manylinux* cp313-manylinux* cp314-manylinux* cp310-win* cp311-win* cp312-win* cp313-win* cp314-win*"
+
+# test-sources must carry everything the suite reads from cwd:
+# tests/extensions.py imports SQLEAN_VERSION from setup.py, which reads README.md
+# at import (hence setuptools). These resolve against cibuildwheel's cwd, not
+# package-dir. Cross-compiled wheels (macOS x86_64, win_arm64) go untested;
+# phoenix-sqlean-ci.yml's native ARM legs cover them.
+test-sources = ["tests", "setup.py", "README.md"]
+test-requires = ["setuptools==83.0.0"]
+test-command = "python -m tests"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64", "ARM64"]


### PR DESCRIPTION
Fixes the failure in [run 31034401298](https://github.com/Arize-ai/phoenix/actions/runs/31034401298), where all three `Build arize-phoenix-sqlean` legs died with:

```
cibuildwheel: Test source tests does not exist.
```

## Cause

cibuildwheel resolves `test-sources` against **its own working directory**, not `package-dir`:

```python
copy_test_sources(build_options.test_sources, Path.cwd(), test_cwd)
```

`build-sqlean` has no `actions/checkout`, so it unpacked the sources artifact into `pkg/` and passed `package-dir: pkg` while CWD stayed at the workspace root. `tests` resolved to `<workspace>/tests` and wasn't there. The log shows both halves of the split: `python -m build /project/pkg --wheel` honored `package-dir`, then the test stage looked under `/project`.

Two things worth stating plainly:

- **Not a regression from the v4.2.0 bump.** v3.2.1 has the identical call. The unpinned-nested-action failure killed the job before the test stage and masked this, so this publish path has never succeeded.
- **CI could not have caught it.** `phoenix-sqlean-ci.yml`'s `test` matrix compiles the extension in place and never invokes cibuildwheel. Its 24 green legs cover the sources artifact and the test suite; nothing on a PR touched the cibuildwheel config.

## Change

- Unpack the artifact at the workspace root and drop `package-dir`, so CWD and the package dir coincide. This is also cibuildwheel's default layout (`.` + `wheelhouse`).
- Move the cibuildwheel **settings** into `packages/phoenix-sqlean/cibuildwheel.toml`, and the **steps** into `.github/workflows/phoenix-sqlean-build.yml`, a `workflow_call` workflow that `build-sqlean` and the new CI `wheel` job both invoke. A PR now runs the same build a release runs — layout included, which is the half that produced this bug. `publish.yaml`'s sqlean section drops from 42 lines to 13.
- New `wheel` job in `phoenix-sqlean-ci.yml`: calls that workflow with `cp312-manylinux_x86_64` on x86_64, no QEMU, no artifact upload. Added to `phoenix-sqlean CI Required`.
- Artifact allowlist gained `THIRD_PARTY_LICENSES` (setup.py's `license_files`) and `cibuildwheel.toml`.
- `MACOSX_DEPLOYMENT_TARGET` deliberately stays a step env rather than moving into `[tool.cibuildwheel.macos] environment`, which would change how the deployment target reaches the build.

### Empty `CIBW_*` is an override, not a no-op

Worth calling out because it nearly shipped: the obvious way to write the overrides is `env: {CIBW_BUILD: ${{ inputs.cibw-build }}}`. When a caller omits the input that sets `CIBW_BUILD=""`, which cibuildwheel treats as an override to its own default rather than as absent — **Linux goes from 10 build identifiers to 36**, pulling in musllinux, free-threaded `cp314t`, `cp315` and `cp39`. Publish would have silently shipped wheels we never intended. The `cibw-*` inputs are therefore exported through `$GITHUB_ENV` only when non-empty, and the publish caller passes neither.
- `MACOSX_DEPLOYMENT_TARGET` deliberately stays a step env rather than moving into `[tool.cibuildwheel.macos] environment`, which would change how the deployment target reaches the build.

## Sequencing — please read before dispatching a publish

`sqlean-sources` builds from the tag `arize-phoenix-sqlean-v<manifest version>`, and **`arize-phoenix-sqlean-v0.1.0` does not contain `cibuildwheel.toml`** (it was cut at `55509f650`, before this PR). A missing `--config-file` is a hard error, so a publish dispatched against v0.1.0 fails immediately — loudly, not silently with the wrong config.

This PR does **not** force a release. It carries no `Release-As` trailer: pinning a version in a commit overrides whatever release-please would compute, and with the window for this package currently empty, a `feat:` landing alongside it would be released as a patch. Versioning stays release-please's job.

So the order is: merge this → land a change that actually releases the package (#14546, `fix(phoenix-sqlean): fix memory-safety and correctness bugs in the C driver`, is already open and would cut 0.1.1 with a real changelog) → dispatch publish against the resulting tag. The release PR must land after *both* are on main, or the tag still won't carry the config.

If nothing releasable is imminent, `.agents/skills/phoenix-release-please` documents the standalone `chore: release arize-phoenix-sqlean <version>` + `Release-As` PR — the right tool, used deliberately and on its own.

All four files are under the root component's `exclude-paths` (`.github`, `.agents`, `packages`), so `arize-phoenix` is unaffected.

## Verification

- Build identifiers before vs after: 30 each, identical sets across linux/macos/windows.
- Resolved `test-sources` / `test-requires` / `test-command` out of cibuildwheel's own options loader for `cp312-{macosx_arm64,manylinux_x86_64,win_amd64}` — all correct.
- CI's env override selects exactly `cp312-manylinux_x86_64`.
- Built a wheel from *only* the files in CI's narrower artifact allowlist, then ran the test step the way cibuildwheel does — fresh venv, wheel + `setuptools==83.0.0`, temp cwd containing only `tests setup.py README.md`: **361 tests, OK (2 skipped)**. Confirms both the allowlist and the `test-sources` list are complete.
- sdist built with `wheelhouse/` present (it now sits inside the package dir): no wheels or config leaked in — `MANIFEST.in` is an explicit `include` allowlist.
- zizmor clean on both workflows.



