### PR TITLE
fix(agents): resolve dangling client tool calls durably at chat merge time

### DIFF
--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -289,7 +289,7 @@ describe("buildAgentChatRequestBody", () => {
 
     expect(body.trigger).toBe("submit-message");
     expect(body).not.toHaveProperty("messages");
-    expect("message" in body && body.message.id).toBe("user-2");
+    expect(body.message?.id).toBe("user-2");
     // The message before the submitted one is the transcript's persisted
     // tail — the send's optimistic-concurrency check.
     expect(body.lastMessageId).toBe("assistant-1");
@@ -364,11 +364,36 @@ describe("buildAgentChatRequestBody", () => {
     expect(body.lastMessageId).toBe("compaction-1");
   });
 
-  it("uses the trailing assistant message's own id as lastMessageId on continuations", () => {
+  it("sends resolved client tool outputs instead of the assistant message on continuations", () => {
     const continuationAssistant: AgentUIMessage = {
       id: "assistant-1",
       role: "assistant",
-      parts: [{ type: "text", text: "resolved tool output" }],
+      parts: [
+        { type: "text", text: "working on it" },
+        {
+          type: "tool-read_prompt",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: {},
+          output: { ok: true },
+          callProviderMetadata: {
+            phoenix: {
+              toolExecutionEnvironment: "client",
+              toolInputEmittedAt: "2026-07-10T12:00:00Z",
+            },
+          },
+        },
+        {
+          type: "tool-load_skill",
+          toolCallId: "call-2",
+          state: "output-available",
+          input: {},
+          output: "<skill/>",
+          callProviderMetadata: {
+            phoenix: { toolExecutionEnvironment: "server" },
+          },
+        },
+      ],
     };
 
     const body = buildAgentChatRequestBody({
@@ -392,7 +417,67 @@ describe("buildAgentChatRequestBody", () => {
       },
     });
 
+    // The server owns the assistant message; only the client-executed tool
+    // outputs travel, and the message field is omitted entirely.
+    expect(body.message).toBeUndefined();
+    expect(body.toolOutputs?.map((part) => part.toolCallId)).toEqual([
+      "call-1",
+    ]);
     // The continued assistant message is itself the persisted transcript tail.
+    expect(body.lastMessageId).toBe("assistant-1");
+  });
+
+  it("attaches interrupted client tool outputs to a superseding user message", () => {
+    const interruptedAssistant: AgentUIMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-edit_prompt",
+          toolCallId: "call-1",
+          state: "output-error",
+          input: {},
+          errorText: "The user has interrupted this tool call.",
+          callProviderMetadata: {
+            phoenix: {
+              toolExecutionEnvironment: "client",
+              toolInputEmittedAt: "2026-07-10T12:00:00Z",
+            },
+          },
+        },
+      ],
+    };
+    const newUserMessage: AgentUIMessage = {
+      id: "user-2",
+      role: "user",
+      parts: [{ type: "text", text: "never mind" }],
+    };
+
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      messages: [userMessage, interruptedAssistant, newUserMessage],
+      capabilities: createDefaultAgentCapabilities(),
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        attachUserId: false,
+        acknowledgedTraceConsent: null,
+      },
+      agentsConfig,
+      permissions: { edits: "manual" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body.message?.id).toBe("user-2");
+    expect(body.toolOutputs?.map((part) => part.toolCallId)).toEqual([
+      "call-1",
+    ]);
     expect(body.lastMessageId).toBe("assistant-1");
   });
 });

--- a/app/src/agent/chat/__tests__/pendingToolStateCleanup.test.ts
+++ b/app/src/agent/chat/__tests__/pendingToolStateCleanup.test.ts
@@ -15,7 +15,9 @@ import type { AgentState } from "@phoenix/store/agentStore";
 import {
   REWIND_CLEANUP_TOOL_NAMES,
   cleanupPendingToolState,
+  cleanupResolvedPendingToolState,
 } from "../pendingToolStateCleanup";
+import type { AgentUIMessage } from "../types";
 
 function createStateStub() {
   return {
@@ -65,6 +67,61 @@ describe("cleanupPendingToolState", () => {
     for (const setter of Object.values(state)) {
       expect(setter).not.toHaveBeenCalled();
     }
+  });
+});
+
+describe("cleanupResolvedPendingToolState", () => {
+  const editPromptPart = (
+    state: "input-available" | "approval-requested" | "output-error",
+    toolCallId: string
+  ) =>
+    ({
+      type: `tool-${EDIT_PROMPT_TOOL_NAME}`,
+      toolCallId,
+      state,
+      input: {},
+      ...(state === "output-error"
+        ? {
+            errorText:
+              "The tool call was interrupted before a result was produced.",
+          }
+        : {}),
+    }) as AgentUIMessage["parts"][number];
+
+  it("clears pending state for tool calls the transcript shows as resolved", () => {
+    const state = createStateStub();
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [editPromptPart("output-error", "call-1")],
+      },
+    ] as AgentUIMessage[];
+
+    cleanupResolvedPendingToolState(state as unknown as AgentState, messages);
+
+    expect(state.setPendingPromptEdit).toHaveBeenCalledExactlyOnceWith(
+      "call-1",
+      null
+    );
+  });
+
+  it("leaves pending state alone while the transcript still shows the call unresolved", () => {
+    const state = createStateStub();
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          editPromptPart("input-available", "call-1"),
+          editPromptPart("approval-requested", "call-2"),
+        ],
+      },
+    ] as AgentUIMessage[];
+
+    cleanupResolvedPendingToolState(state as unknown as AgentState, messages);
+
+    expect(state.setPendingPromptEdit).not.toHaveBeenCalled();
   });
 });
 

--- a/app/src/agent/chat/agentChatApi.ts
+++ b/app/src/agent/chat/agentChatApi.ts
@@ -37,7 +37,7 @@ const AGENT_SESSION_CONFLICT_CODES = [
   "agent_session_busy",
   "agent_session_model_stale",
   "agent_session_messages_stale",
-  "agent_session_messages_conflict",
+  "agent_session_tool_outputs_conflict",
   "agent_session_compaction_conflict",
 ] as const satisfies readonly AgentSessionConflictCode[];
 

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -10,6 +10,7 @@ import {
   type AgentPermissions,
   type AgentServerConfig,
 } from "@phoenix/store/agentStore";
+import { isRecord } from "@phoenix/utils/typeUtils";
 
 import type { ClientToolTimingRecorder } from "./clientToolTimings";
 import { toServerSafeUIMessages } from "./serverSafeMessages";
@@ -58,6 +59,45 @@ type ClientToolTimingMetadata = Pick<
   components["schemas"]["ToolCallCallbackProviderMetadata"],
   "clientStartedAt" | "clientEndedAt"
 >;
+
+/**
+ * A tool part in a terminal AI SDK output state (`output-available` /
+ * `output-error`), as the chat endpoint's `toolOutputs` field models it.
+ */
+type ChatToolOutput = NonNullable<
+  BuildAgentChatRequestBodyResult["toolOutputs"]
+>[number];
+
+/**
+ * Extract the assistant message's resolved client-executed tool parts — the
+ * `toolOutputs` a send may carry. The server matches them by `toolCallId`,
+ * applies them to its persisted copy of the message, and ignores outputs for
+ * tool calls it has already resolved, so resending is idempotent.
+ */
+function getClientToolOutputs(message: AgentUIMessage): ChatToolOutput[] {
+  const resolvedClientToolParts = message.parts.filter((part): boolean => {
+    if (!isToolUIPart(part)) {
+      return false;
+    }
+    if (part.state !== "output-available" && part.state !== "output-error") {
+      return false;
+    }
+    if (part.providerExecuted) {
+      return false;
+    }
+    const callProviderMetadata: unknown = part.callProviderMetadata;
+    const phoenixMetadata: unknown = isRecord(callProviderMetadata)
+      ? callProviderMetadata.phoenix
+      : null;
+    return (
+      isRecord(phoenixMetadata) &&
+      phoenixMetadata.toolExecutionEnvironment === "client"
+    );
+  });
+  // The AI SDK's tool UI parts and the generated wire schema describe the
+  // same Vercel data-stream shapes but spell optionality differently.
+  return resolvedClientToolParts as unknown as ChatToolOutput[];
+}
 
 export type AgentChatRequestBodyPatch = Pick<
   BuildAgentChatRequestBodyResult,
@@ -139,19 +179,61 @@ export function buildAgentChatRequestBody({
     model: modelSelection,
     turnTraceContext: turnTraceContext ?? undefined,
   };
+  const trailingMessage = messages.at(-1);
+  if (!trailingMessage) {
+    throw new Error("A chat submit request requires a message to send");
+  }
+  if (trailingMessage.role === "assistant") {
+    // Client-tool continuation: the server owns the assistant message, so
+    // only the resolved client tool outputs are sent, not the message itself.
+    const [enrichedAssistant] = enrichMessagesWithClientToolTimings({
+      messages: [trailingMessage],
+      toolTimings,
+    });
+    const toolOutputs = getClientToolOutputs(
+      enrichedAssistant ?? trailingMessage
+    );
+    if (toolOutputs.length === 0) {
+      throw new Error(
+        "A chat continuation requires resolved client tool outputs to send"
+      );
+    }
+    return {
+      ...base,
+      trigger: "submit-message",
+      toolOutputs,
+      lastMessageId: getLastPersistedMessageId(messages),
+    };
+  }
   const [message] = toServerSafeUIMessages(
     enrichMessagesWithClientToolTimings({
-      messages: messages.slice(-1),
+      messages: [trailingMessage],
       toolTimings,
     })
   );
   if (!message) {
     throw new Error("A chat submit request requires a message to send");
   }
+  // A new user message supersedes the previous assistant turn. Any of its
+  // client tool results that never reached the server (e.g. tools marked as
+  // interrupted after Stop) ride along as toolOutputs so the persisted
+  // transcript resolves them; the server ignores already-resolved calls and
+  // authoritatively marks anything still unresolved as interrupted.
+  const precedingMessage = messages.at(-2);
+  const toolOutputs =
+    precedingMessage?.role === "assistant"
+      ? getClientToolOutputs(
+          enrichMessagesWithClientToolTimings({
+            messages: [precedingMessage],
+            toolTimings,
+          })[0] ?? precedingMessage
+        )
+      : [];
   return {
     ...base,
     trigger: "submit-message",
     message,
+    ...(toolOutputs.length > 0 ? { toolOutputs } : {}),
     lastMessageId: getLastPersistedMessageId(messages),
   };
 }

--- a/app/src/agent/chat/pendingToolStateCleanup.ts
+++ b/app/src/agent/chat/pendingToolStateCleanup.ts
@@ -1,3 +1,5 @@
+import { getToolOrDynamicToolName, isToolUIPart, type UIMessage } from "ai";
+
 import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "@phoenix/agent/tools/batchSpanAnnotate";
 import { EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/codeEvaluatorDraft";
 import { EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/llmEvaluatorDraft";
@@ -65,4 +67,39 @@ export function cleanupPendingToolState(
   toolCallId: string
 ): void {
   PENDING_TOOL_STATE_CLEANUP[tool]?.(state, toolCallId);
+}
+
+const RESOLVED_TOOL_STATES: ReadonlySet<string> = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+]);
+
+/**
+ * Cleans up pending approval/edit store state owned by tool calls the
+ * transcript shows as resolved. Applied when a synced transcript replaces
+ * local messages: another client may have resolved — or interrupted — a tool
+ * call this client is still rendering an Accept/Reject affordance for, and
+ * that affordance must not outlive the call's persisted terminal state.
+ * Pending calls the transcript still shows as unresolved are left alone.
+ */
+export function cleanupResolvedPendingToolState(
+  state: AgentState,
+  messages: readonly UIMessage[]
+): void {
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    for (const part of message.parts) {
+      if (!isToolUIPart(part) || !RESOLVED_TOOL_STATES.has(part.state)) {
+        continue;
+      }
+      cleanupPendingToolState(
+        state,
+        getToolOrDynamicToolName(part),
+        part.toolCallId
+      );
+    }
+  }
 }

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1757,10 +1757,12 @@ export interface components {
          *     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
          *       matches the persisted transcript — another client appended; refetch the
          *       transcript and retry.
-         *     - ``agent_session_messages_conflict``: the submitted assistant message and
-         *       the request's ``lastMessageId`` contradict each other. Unlike
-         *       ``agent_session_messages_stale`` this is not a concurrent-writer race but
-         *       an inconsistent request; fix the client rather than retrying.
+         *     - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+         *       not match the transcript's trailing assistant message (no trailing
+         *       assistant message to continue, an unknown ``toolCallId``, or a tool-name
+         *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
+         *       concurrent-writer race but an inconsistent request; fix the client
+         *       rather than retrying.
          *     - ``agent_session_compaction_conflict``: the conversation changed while it
          *       was being compacted; retry.
          */
@@ -2231,8 +2233,13 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new message: a user message to append, or the transcript's trailing assistant message updated with client-executed tool results. */
-            message: components["schemas"]["PhoenixUIMessage"];
+            /** @description The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            message?: components["schemas"]["PhoenixUIMessage"] | null;
+            /**
+             * Tooloutputs
+             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``.
+             */
+            toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**
              * Lastmessageid
              * @description The id of the last transcript message the client has rendered, used for optimistic concurrency. Omit when the session has no messages; required (and validated against the persisted transcript) once it does. On mismatch the server rejects the send with HTTP 409 and code ``agent_session_messages_stale`` — the client should refetch the session before retrying.

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1757,7 +1757,7 @@ export interface components {
          *     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
          *       matches the persisted transcript — another client appended; refetch the
          *       transcript and retry.
-         *     - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+         *     - ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do
          *       not match the transcript's trailing assistant message (no trailing
          *       assistant message to continue, an unknown ``toolCallId``, or a tool-name
          *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
@@ -1772,7 +1772,7 @@ export interface components {
              * @description Machine-readable reason the request conflicted.
              * @enum {string}
              */
-            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_messages_conflict" | "agent_session_compaction_conflict";
+            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_compaction_conflict";
             /**
              * Message
              * @description Optional human-readable elaboration on the conflict.
@@ -2233,11 +2233,11 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            /** @description The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
             message?: components["schemas"]["PhoenixUIMessage"] | null;
             /**
              * Tooloutputs
-             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``.
+             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs.
              */
             toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -39,6 +39,7 @@ import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import {
   DRAFT_SESSION_ID,
   hasAcknowledgedCurrentTraceConsent,
+  selectIsSessionOccupied,
   selectSessionNotice,
 } from "@phoenix/store/agentStore";
 
@@ -525,6 +526,12 @@ export function ChatView({
     selectSessionNotice(state, sessionId)
   );
   const isBusyElsewhere = sessionNotice === "busyElsewhere";
+  // A turn is in motion here or on another client. Shared with the tool
+  // approval affordances (ToolPartApprovalActions), which pause themselves on
+  // the same selector.
+  const isSessionOccupied = useAgentContext((state) =>
+    selectIsSessionOccupied(state, sessionId)
+  );
   const setDraftInput = useAgentContext((state) => state.setDraftInput);
   const setSessionNotice = useAgentContext((state) => state.setSessionNotice);
   const [elicitationDraft, setElicitationDraft] =
@@ -653,14 +660,14 @@ export function ChatView({
   const hasChatSettled = status === "ready" || status === "error";
 
   const onRewindRequest = useMemo<MessageRewindRequest | undefined>(() => {
-    if (!hasChatSettled || isBusyElsewhere || !rewindToMessage) {
+    if (isSessionOccupied || !rewindToMessage) {
       return undefined;
     }
     return (request) => {
       setHistoryActionError(null);
       setRewindRequest(request);
     };
-  }, [hasChatSettled, isBusyElsewhere, rewindToMessage]);
+  }, [isSessionOccupied, rewindToMessage]);
 
   const handleConfirmRewind = async () => {
     if (!rewindRequest) {

--- a/app/src/components/agent/ToolPartPrimitives.tsx
+++ b/app/src/components/agent/ToolPartPrimitives.tsx
@@ -4,6 +4,8 @@ import { useCallback, useRef, useState } from "react";
 
 import { Button, CopyToClipboardButton, Flex } from "@phoenix/components";
 import { ExpandableContent } from "@phoenix/components/core/content/ExpandableContent";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import { selectIsSessionOccupied } from "@phoenix/store/agentStore";
 
 import { useScrollAnchor } from "./scrollAnchor";
 
@@ -130,7 +132,11 @@ const approvalActionsRowCSS = css`
  * The right-aligned Accept/Reject buttons rendered at the bottom of a tool part
  * awaiting user approval. When the proposal can no longer be acted on (e.g. it
  * was made in an earlier session), pass `staleMessage` to explain why the
- * disabled buttons can't be used.
+ * disabled buttons can't be used. The buttons are also disabled — without the
+ * stale explanation — while the active session is occupied (a response is
+ * streaming, or another client's turn holds the session lock): responding
+ * then would race the turn that is about to resolve — or supersede — the
+ * pending tool call.
  */
 export function ToolPartApprovalActions({
   onAccept,
@@ -143,6 +149,10 @@ export function ToolPartApprovalActions({
   isDisabled?: boolean;
   staleMessage?: string;
 }) {
+  const isPaused = useAgentContext((state) =>
+    selectIsSessionOccupied(state, state.activeSessionId)
+  );
+  const isActionDisabled = isDisabled || isPaused;
   return (
     <>
       <div css={approvalActionsRowCSS}>
@@ -150,12 +160,12 @@ export function ToolPartApprovalActions({
           <Button
             size="S"
             variant="primary"
-            isDisabled={isDisabled}
+            isDisabled={isActionDisabled}
             onPress={onAccept}
           >
             Accept
           </Button>
-          <Button size="S" isDisabled={isDisabled} onPress={onReject}>
+          <Button size="S" isDisabled={isActionDisabled} onPress={onReject}>
             Reject
           </Button>
         </Flex>

--- a/app/src/components/agent/__tests__/ToolPartApprovalActions.test.tsx
+++ b/app/src/components/agent/__tests__/ToolPartApprovalActions.test.tsx
@@ -1,0 +1,122 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+import { AgentContext } from "@phoenix/contexts/AgentContext";
+import { createAgentStore, type AgentStore } from "@phoenix/store/agentStore";
+
+import { ToolPartApprovalActions } from "../ToolPartPrimitives";
+
+installTestStorage();
+
+const SESSION_ID = "session-1";
+
+describe("ToolPartApprovalActions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: AgentStore;
+
+  beforeEach(() => {
+    localStorage.removeItem("arize-phoenix-assistant");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    store = createAgentStore({});
+    store.getState().setActiveSession(SESSION_ID);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderActions(props?: {
+    isDisabled?: boolean;
+    staleMessage?: string;
+  }) {
+    act(() => {
+      root.render(
+        <AgentContext.Provider value={store}>
+          <ToolPartApprovalActions
+            onAccept={vi.fn()}
+            onReject={vi.fn()}
+            {...props}
+          />
+        </AgentContext.Provider>
+      );
+    });
+  }
+
+  function getButtons() {
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const accept = buttons.find(
+      (button) => button.textContent === "Accept"
+    ) as HTMLButtonElement;
+    const reject = buttons.find(
+      (button) => button.textContent === "Reject"
+    ) as HTMLButtonElement;
+    return { accept, reject };
+  }
+
+  it("enables Accept and Reject while the active session is idle", () => {
+    renderActions();
+    const { accept, reject } = getButtons();
+    expect(accept.disabled).toBe(false);
+    expect(reject.disabled).toBe(false);
+  });
+
+  it("disables both buttons while the active session's response streams", () => {
+    renderActions({
+      staleMessage: "This proposal was made in an earlier session.",
+    });
+    act(() => {
+      store.getState().setSessionChatStatus(SESSION_ID, "streaming");
+    });
+    const { accept, reject } = getButtons();
+    expect(accept.disabled).toBe(true);
+    expect(reject.disabled).toBe(true);
+    // Occupation is transient — it must not surface the stale explanation.
+    expect(container.textContent).not.toContain(
+      "This proposal was made in an earlier session."
+    );
+  });
+
+  it("disables both buttons while the session is busy on another client", () => {
+    renderActions();
+    act(() => {
+      store.getState().setSessionBusyElsewhere(SESSION_ID, true);
+    });
+    const { accept, reject } = getButtons();
+    expect(accept.disabled).toBe(true);
+    expect(reject.disabled).toBe(true);
+  });
+
+  it("re-enables the buttons when the turn settles", () => {
+    renderActions();
+    act(() => {
+      store.getState().setSessionChatStatus(SESSION_ID, "streaming");
+    });
+    act(() => {
+      store.getState().setSessionChatStatus(SESSION_ID, "ready");
+    });
+    const { accept, reject } = getButtons();
+    expect(accept.disabled).toBe(false);
+    expect(reject.disabled).toBe(false);
+  });
+
+  it("still shows the stale explanation when explicitly disabled", () => {
+    renderActions({
+      isDisabled: true,
+      staleMessage: "This proposal was made in an earlier session.",
+    });
+    const { accept, reject } = getButtons();
+    expect(accept.disabled).toBe(true);
+    expect(reject.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      "This proposal was made in an earlier session."
+    );
+  });
+});

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -216,8 +216,11 @@ export function useAgentChat({
     clearError,
   });
 
-  // Anthropic doesn't accept unresolved tool calls, so we resolve them by
-  // marking them as error before the next request goes out.
+  // Local lifecycle cleanup for interrupted client tools: pending calls are
+  // resolved as output-error so the UI settles, pending dialogs are cleared,
+  // and the next send carries the errors to the server as toolOutputs so the
+  // persisted transcript resolves them too. Anything the client can't report
+  // (e.g. a killed tab) is repaired authoritatively server-side at merge time.
   const addInterruptedToolOutputs = async ({
     messages,
     errorText,

--- a/app/src/components/agent/useAgentSessionSync.ts
+++ b/app/src/components/agent/useAgentSessionSync.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, type RefObject } from "react";
 import { useRelayEnvironment } from "react-relay";
 
 import { isRequestActive } from "@phoenix/agent/chat/chatUtils";
+import { cleanupResolvedPendingToolState } from "@phoenix/agent/chat/pendingToolStateCleanup";
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { useInterval } from "@phoenix/hooks/useInterval";
@@ -163,9 +164,14 @@ export function useAgentSessionSync({
       if (wasBusyElsewhere) {
         chatInstance.clearError();
       }
-      chatInstance.messages = Array.isArray(agentSession.messages)
+      const syncedMessages = Array.isArray(agentSession.messages)
         ? (agentSession.messages as AgentUIMessage[])
         : [];
+      chatInstance.messages = syncedMessages;
+      // Another client may have resolved — or interrupted — tool calls this
+      // client still shows Accept/Reject affordances for; drop any pending
+      // approval state the synced transcript marks as terminal.
+      cleanupResolvedPendingToolState(store.getState(), syncedMessages);
       // Record the applied tail (from the full fetch, not the probe: the
       // transcript may have moved again in between) so unchanged idle ticks
       // stop at the probe.

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -11,6 +11,7 @@ import {
   getEffectiveTraceRecordingSettings,
   hasAcknowledgedCurrentTraceConsent,
   resolveAssistantStorageKey,
+  selectIsSessionOccupied,
   selectSessionNotice,
 } from "../agentStore";
 
@@ -546,6 +547,50 @@ describe("agentStore", () => {
       store.getState().clearSessionEphemeralState("s1");
 
       expect(selectSessionNotice(store.getState(), "s1")).toBeNull();
+    });
+  });
+
+  describe("selectIsSessionOccupied", () => {
+    it("is unoccupied for unknown or absent sessions", () => {
+      const store = createAgentStore();
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(false);
+      expect(selectIsSessionOccupied(store.getState(), null)).toBe(false);
+      expect(selectIsSessionOccupied(store.getState(), undefined)).toBe(false);
+    });
+
+    it("is occupied while this client's response is in flight", () => {
+      const store = createAgentStore();
+
+      store.getState().setSessionChatStatus("s1", "submitted");
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(true);
+
+      store.getState().setSessionChatStatus("s1", "streaming");
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(true);
+
+      // The settled statuses — including error — release the occupation. A
+      // ready status with a pending client tool call is the window in which
+      // the user must still be able to respond to approvals.
+      store.getState().setSessionChatStatus("s1", "ready");
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(false);
+
+      store.getState().setSessionChatStatus("s1", "error");
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(false);
+    });
+
+    it("is occupied while another client's turn holds the session lock", () => {
+      const store = createAgentStore();
+
+      store.getState().setSessionBusyElsewhere("s1", true);
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(true);
+
+      store.getState().setSessionBusyElsewhere("s1", false);
+      expect(selectIsSessionOccupied(store.getState(), "s1")).toBe(false);
+    });
+
+    it("scopes occupation to the queried session", () => {
+      const store = createAgentStore();
+      store.getState().setSessionChatStatus("s1", "streaming");
+      expect(selectIsSessionOccupied(store.getState(), "s2")).toBe(false);
     });
   });
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -161,6 +161,37 @@ export function selectSessionNotice(
 }
 
 /**
+ * Whether a turn is in motion for this session — this client's own response
+ * is in flight (the model is thinking), or another client's turn holds the
+ * session's server lock. Surfaces use this to pause affordances (e.g. tool
+ * approval Accept/Reject) whose activation would race the running turn.
+ *
+ * Deliberately reads `chatStatusBySessionId` — the live AI SDK status that
+ * `AgentChatRuntimeContext` mirrors for every runtime chat — rather than
+ * `isResponsePendingBySessionId`. The response-pending flag stays true across
+ * the whole multi-request turn, including the gap while a client tool
+ * executes between HTTP requests: exactly the window in which the user must
+ * still be able to Accept or Reject.
+ */
+export function selectIsSessionOccupied(
+  state: Pick<
+    AgentState,
+    "chatStatusBySessionId" | "isBusyElsewhereBySessionId"
+  >,
+  sessionId: string | null | undefined
+): boolean {
+  if (!sessionId) {
+    return false;
+  }
+  const chatStatus = state.chatStatusBySessionId[sessionId];
+  return (
+    chatStatus === "submitted" ||
+    chatStatus === "streaming" ||
+    state.isBusyElsewhereBySessionId[sessionId] === true
+  );
+}
+
+/**
  * Sentinel session key for the not-yet-persisted "new chat" draft surface.
  *
  * Sessions are otherwise identified by their canonical Relay node ID. The

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -107,6 +107,20 @@ const RUNNING_TOOL_STATES: ReadonlySet<ToolProgressState> = new Set([
   "input-available",
   "approval-responded",
 ]);
+/**
+ * Tool states that have not reached a terminal output. The CLI executes no
+ * client tools and has no approval affordance, so it can never resolve one of
+ * these itself: a pending call either belongs to the turn currently streaming
+ * here, is still resolvable by the client that owns it (e.g. a browser
+ * approval), or gets closed out as interrupted by the server on this CLI's
+ * next send.
+ */
+const PENDING_TOOL_STATES: ReadonlySet<ToolProgressState> = new Set([
+  ...RUNNING_TOOL_STATES,
+  "approval-requested",
+]);
+const PENDING_ELSEWHERE_TOOL_STATUS_TEXT =
+  "Pending in another client — sending a message here interrupts it";
 const ESCAPE_INPUT = "\x1B";
 const BACKSPACE_INPUTS = new Set(["\b", "\x7F"]);
 const FORWARD_DELETE_INPUTS = new Set([
@@ -235,9 +249,20 @@ function ToolSpinner() {
  * The leading state glyph of a tool row: a spinner while the call is in
  * flight, then a settled glyph — `✓` success, `✗` failure (including a
  * non-zero exit code surfaced via `statusSuffix`), `?` awaiting approval,
- * `⊘` denied.
+ * `⊘` denied. Pending calls this CLI cannot resolve (restored from
+ * persistence; the owning client may still submit them) show a warning
+ * instead of a spinner.
  */
-function ToolStateIndicator({ tool }: { tool: ToolProgress }) {
+function ToolStateIndicator({
+  tool,
+  isPendingElsewhere,
+}: {
+  tool: ToolProgress;
+  isPendingElsewhere?: boolean;
+}) {
+  if (isPendingElsewhere) {
+    return <Text color="yellow">⚠</Text>;
+  }
   if (RUNNING_TOOL_STATES.has(tool.state)) {
     return <ToolSpinner />;
   }
@@ -267,10 +292,12 @@ function ToolStateIndicator({ tool }: { tool: ToolProgress }) {
  */
 function InlineToolProgress({
   tool,
+  isPendingElsewhere,
   marginTop,
   marginBottom,
 }: {
   tool: ToolProgress;
+  isPendingElsewhere?: boolean;
   marginTop: number;
   marginBottom: number;
 }) {
@@ -294,11 +321,18 @@ function InlineToolProgress({
       marginBottom={marginBottom}
     >
       <Text wrap="truncate-end">
-        <ToolStateIndicator tool={tool} />{" "}
+        <ToolStateIndicator
+          tool={tool}
+          isPendingElsewhere={isPendingElsewhere}
+        />{" "}
         <Text color="yellow">
           {tool.icon} {tool.toolName}
         </Text>
-        {showStatusText ? <Text color="yellow"> {tool.statusText}</Text> : null}
+        {isPendingElsewhere ? (
+          <Text color="yellow"> {PENDING_ELSEWHERE_TOOL_STATUS_TEXT}</Text>
+        ) : showStatusText ? (
+          <Text color="yellow"> {tool.statusText}</Text>
+        ) : null}
         {tool.previewText ? <Text dimColor> · {tool.previewText}</Text> : null}
         {tool.statusSuffix ? (
           <Text color="red"> ({tool.statusSuffix})</Text>
@@ -334,9 +368,18 @@ function InlineToolProgress({
  */
 function MessageParts({
   message,
+  hasLivePendingTools,
   phoenixBaseUrl,
 }: {
   message: PxiMessage;
+  /**
+   * Whether this message's pending tool calls belong to a turn this CLI is
+   * watching live (streaming here, or busy on another client). When false,
+   * pending tool parts render as pending-elsewhere warnings instead of
+   * spinners: the owning client may still submit them, and sending a message
+   * from here interrupts them.
+   */
+  hasLivePendingTools: boolean;
   phoenixBaseUrl?: string;
 }) {
   const toolProgressByPart = message.parts.map((part) =>
@@ -361,6 +404,9 @@ function MessageParts({
             <InlineToolProgress
               key={tool.toolCallId}
               tool={tool}
+              isPendingElsewhere={
+                !hasLivePendingTools && PENDING_TOOL_STATES.has(tool.state)
+              }
               marginTop={toolProgressByPart[index - 1] ? 0 : 1}
               marginBottom={toolProgressByPart[index + 1] ? 0 : 1}
             />
@@ -378,9 +424,18 @@ function MessageParts({
  */
 function Transcript({
   messages,
+  liveMessageId,
   phoenixBaseUrl,
 }: {
   messages: PxiMessage[];
+  /**
+   * The id of the one message whose pending tool calls a live turn (streaming
+   * here, or busy on another client) is actively driving; null when the
+   * session is idle. Pending tools outside that message aren't resolvable by
+   * this CLI — though the client that owns them may still submit results — so
+   * they render as pending-elsewhere warnings instead of spinners.
+   */
+  liveMessageId: string | null;
   phoenixBaseUrl?: string;
 }) {
   if (messages.length === 0) {
@@ -408,7 +463,11 @@ function Transcript({
             <Text color={color} bold>
               {label}
             </Text>
-            <MessageParts message={message} phoenixBaseUrl={phoenixBaseUrl} />
+            <MessageParts
+              message={message}
+              hasLivePendingTools={message.id === liveMessageId}
+              phoenixBaseUrl={phoenixBaseUrl}
+            />
           </Box>
         );
       })}
@@ -2012,6 +2071,11 @@ export function PxiApp({
       <Box marginTop={1} flexDirection="column">
         <Transcript
           messages={messages}
+          liveMessageId={
+            status === "streaming" || isSessionBusy
+              ? (messages.at(-1)?.id ?? null)
+              : null
+          }
           phoenixBaseUrl={options.config.endpoint}
         />
       </Box>

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -530,13 +530,17 @@ export function buildPxiChatRequest({
   if (!message) {
     throw new Error("A chat submit request requires a message to send");
   }
+  if (message.role !== "user") {
+    // The chat contract only accepts user messages; client tool results are
+    // submitted as `toolOutputs`, which the CLI never produces because it
+    // executes no client tools.
+    throw new Error("A chat submit request requires a trailing user message");
+  }
   // The send's optimistic-concurrency check: the id of the last transcript
-  // message this client believes is persisted. A new user message at the tail
-  // is the turn being submitted, so the message before it is the persisted
-  // tail; a trailing assistant message (client-tool continuation) is itself
-  // the persisted tail. Null while the transcript is empty.
-  const lastMessageId =
-    (message.role === "assistant" ? message.id : messages.at(-2)?.id) ?? null;
+  // message this client believes is persisted. The new user message at the
+  // tail is the turn being submitted, so the message before it is the
+  // persisted tail. Null while the transcript is empty.
+  const lastMessageId = messages.at(-2)?.id ?? null;
   return {
     ...buildPxiRequestBase({ options }),
     message,

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -68,12 +68,13 @@ export type PxiEditPermission = NonNullable<
  * Derived from the generated `ChatRequest` schema, with every field the CLI
  * sends made required (the schema marks server-defaulted fields optional) and
  * `message` swapped for the SDK-typed {@link PxiMessage}. Fields the CLI never
- * sends (`requestedSkills`, `turnTraceContext`) are omitted.
+ * sends (`requestedSkills`, `turnTraceContext`, and `toolOutputs` — the CLI
+ * executes no client tools, so it has no tool outputs to submit) are omitted.
  */
 export type PxiChatRequest = Required<
   Omit<
     SchemasV1["ChatRequest"],
-    "message" | "requestedSkills" | "turnTraceContext"
+    "message" | "requestedSkills" | "turnTraceContext" | "toolOutputs"
   >
 > & {
   message: PxiMessage;

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -846,7 +846,50 @@ describe("PXI app", () => {
     unmount();
   });
 
-  it("shows a bash summary and a spinner while its input streams in", () => {
+  it("shows a bash summary and a spinner while its input streams in", async () => {
+    const partialAssistantMessage: PxiMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "tool-1",
+          toolName: "bash",
+          state: "input-streaming",
+          input: { summary: "Run the unit test suite" },
+        },
+      ],
+    };
+    const client: PxiChatClient = {
+      sendMessage: async ({ abortSignal, onAssistantMessage }) => {
+        onAssistantMessage(partialAssistantMessage);
+        // Keep the turn streaming so the pending tool stays live.
+        return new Promise((resolve) => {
+          abortSignal?.addEventListener("abort", () => resolve(null), {
+            once: true,
+          });
+        });
+      },
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "run the tests" });
+    await writeInput({ stdin, input: "\r" });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("$ bash · Run the unit test suite");
+    expect(frame).toContain("⠋");
+    expect(frame).not.toContain("✓");
+    unmount();
+  });
+
+  it("marks a restored pending tool as pending elsewhere instead of running", () => {
+    // A pending tool restored from persistence isn't running in this CLI:
+    // the client that owns it (e.g. a browser approval) may still submit its
+    // result, and sending a message from here interrupts it. Either way the
+    // spinner would misrepresent it as work this CLI is watching.
     const assistantMessage: PxiMessage = {
       id: "assistant-1",
       role: "assistant",
@@ -865,8 +908,11 @@ describe("PXI app", () => {
     );
 
     const frame = stripAnsi(lastFrame() ?? "");
-    expect(frame).toContain("$ bash · Run the unit test suite");
-    expect(frame).toContain("⠋");
+    expect(frame).toContain(
+      "$ bash Pending in another client — sending a message here interrupts it"
+    );
+    expect(frame).toContain("⚠");
+    expect(frame).not.toContain("⠋");
     expect(frame).not.toContain("✓");
     unmount();
   });

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1757,10 +1757,12 @@ export interface components {
          *     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
          *       matches the persisted transcript — another client appended; refetch the
          *       transcript and retry.
-         *     - ``agent_session_messages_conflict``: the submitted assistant message and
-         *       the request's ``lastMessageId`` contradict each other. Unlike
-         *       ``agent_session_messages_stale`` this is not a concurrent-writer race but
-         *       an inconsistent request; fix the client rather than retrying.
+         *     - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+         *       not match the transcript's trailing assistant message (no trailing
+         *       assistant message to continue, an unknown ``toolCallId``, or a tool-name
+         *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
+         *       concurrent-writer race but an inconsistent request; fix the client
+         *       rather than retrying.
          *     - ``agent_session_compaction_conflict``: the conversation changed while it
          *       was being compacted; retry.
          */
@@ -2231,8 +2233,13 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new message: a user message to append, or the transcript's trailing assistant message updated with client-executed tool results. */
-            message: components["schemas"]["PhoenixUIMessage"];
+            /** @description The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            message?: components["schemas"]["PhoenixUIMessage"] | null;
+            /**
+             * Tooloutputs
+             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``.
+             */
+            toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**
              * Lastmessageid
              * @description The id of the last transcript message the client has rendered, used for optimistic concurrency. Omit when the session has no messages; required (and validated against the persisted transcript) once it does. On mismatch the server rejects the send with HTTP 409 and code ``agent_session_messages_stale`` — the client should refetch the session before retrying.

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1757,7 +1757,7 @@ export interface components {
          *     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
          *       matches the persisted transcript — another client appended; refetch the
          *       transcript and retry.
-         *     - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+         *     - ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do
          *       not match the transcript's trailing assistant message (no trailing
          *       assistant message to continue, an unknown ``toolCallId``, or a tool-name
          *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
@@ -1772,7 +1772,7 @@ export interface components {
              * @description Machine-readable reason the request conflicted.
              * @enum {string}
              */
-            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_messages_conflict" | "agent_session_compaction_conflict";
+            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_compaction_conflict";
             /**
              * Message
              * @description Optional human-readable elaboration on the conflict.
@@ -2233,11 +2233,11 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            /** @description The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
             message?: components["schemas"]["PhoenixUIMessage"] | null;
             /**
              * Tooloutputs
-             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``.
+             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs.
              */
             toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1757,10 +1757,12 @@ export interface components {
          *     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
          *       matches the persisted transcript — another client appended; refetch the
          *       transcript and retry.
-         *     - ``agent_session_messages_conflict``: the submitted assistant message and
-         *       the request's ``lastMessageId`` contradict each other. Unlike
-         *       ``agent_session_messages_stale`` this is not a concurrent-writer race but
-         *       an inconsistent request; fix the client rather than retrying.
+         *     - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+         *       not match the transcript's trailing assistant message (no trailing
+         *       assistant message to continue, an unknown ``toolCallId``, or a tool-name
+         *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
+         *       concurrent-writer race but an inconsistent request; fix the client
+         *       rather than retrying.
          *     - ``agent_session_compaction_conflict``: the conversation changed while it
          *       was being compacted; retry.
          */
@@ -2231,8 +2233,13 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new message: a user message to append, or the transcript's trailing assistant message updated with client-executed tool results. */
-            message: components["schemas"]["PhoenixUIMessage"];
+            /** @description The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            message?: components["schemas"]["PhoenixUIMessage"] | null;
+            /**
+             * Tooloutputs
+             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``.
+             */
+            toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**
              * Lastmessageid
              * @description The id of the last transcript message the client has rendered, used for optimistic concurrency. Omit when the session has no messages; required (and validated against the persisted transcript) once it does. On mismatch the server rejects the send with HTTP 409 and code ``agent_session_messages_stale`` — the client should refetch the session before retrying.

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1757,7 +1757,7 @@ export interface components {
          *     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
          *       matches the persisted transcript — another client appended; refetch the
          *       transcript and retry.
-         *     - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+         *     - ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do
          *       not match the transcript's trailing assistant message (no trailing
          *       assistant message to continue, an unknown ``toolCallId``, or a tool-name
          *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
@@ -1772,7 +1772,7 @@ export interface components {
              * @description Machine-readable reason the request conflicted.
              * @enum {string}
              */
-            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_messages_conflict" | "agent_session_compaction_conflict";
+            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_compaction_conflict";
             /**
              * Message
              * @description Optional human-readable elaboration on the conflict.
@@ -2233,11 +2233,11 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            /** @description The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
             message?: components["schemas"]["PhoenixUIMessage"] | null;
             /**
              * Tooloutputs
-             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``.
+             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs.
              */
             toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -2028,7 +2028,6 @@ class PromptMessage(TypedDict):
 class ChatRequest(TypedDict):
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
     id: str
-    message: PhoenixUIMessage
     ingestTraces: NotRequired[bool]
     exportRemoteTraces: NotRequired[bool]
     attachUserId: NotRequired[bool]
@@ -2056,6 +2055,17 @@ class ChatRequest(TypedDict):
     requestedSkills: NotRequired[Sequence[str]]
     turnTraceContext: NotRequired[TurnTraceContext]
     trigger: NotRequired[str]
+    message: NotRequired[PhoenixUIMessage]
+    toolOutputs: NotRequired[
+        Sequence[
+            Union[
+                PhoenixDbTypesDataStreamProtocolRequestTypesToolOutputAvailablePart,
+                PhoenixDbTypesDataStreamProtocolRequestTypesToolOutputErrorPart,
+                PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputAvailablePart,
+                PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputErrorPart,
+            ]
+        ]
+    ]
     lastMessageId: NotRequired[str]
 
 

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -13,7 +13,7 @@ class AgentSessionConflictError(TypedDict):
         "agent_session_busy",
         "agent_session_model_stale",
         "agent_session_messages_stale",
-        "agent_session_messages_conflict",
+        "agent_session_tool_outputs_conflict",
         "agent_session_compaction_conflict",
     ]
     message: NotRequired[str]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9025,7 +9025,7 @@
               "agent_session_busy",
               "agent_session_model_stale",
               "agent_session_messages_stale",
-              "agent_session_messages_conflict",
+              "agent_session_tool_outputs_conflict",
               "agent_session_compaction_conflict"
             ],
             "title": "Code",
@@ -9049,7 +9049,7 @@
           "code"
         ],
         "title": "AgentSessionConflictError",
-        "description": "Body of every HTTP 409 returned by the agent session routes.\n\n- ``agent_session_busy``: another turn holds the session's turn lock.\n- ``agent_session_model_stale``: the request asserted a model the session\n  is no longer set to; refetch the session before retrying.\n- ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer\n  matches the persisted transcript \u2014 another client appended; refetch the\n  transcript and retry.\n- ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do\n  not match the transcript's trailing assistant message (no trailing\n  assistant message to continue, an unknown ``toolCallId``, or a tool-name\n  mismatch). Unlike ``agent_session_messages_stale`` this is not a\n  concurrent-writer race but an inconsistent request; fix the client\n  rather than retrying.\n- ``agent_session_compaction_conflict``: the conversation changed while it\n  was being compacted; retry."
+        "description": "Body of every HTTP 409 returned by the agent session routes.\n\n- ``agent_session_busy``: another turn holds the session's turn lock.\n- ``agent_session_model_stale``: the request asserted a model the session\n  is no longer set to; refetch the session before retrying.\n- ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer\n  matches the persisted transcript \u2014 another client appended; refetch the\n  transcript and retry.\n- ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do\n  not match the transcript's trailing assistant message (no trailing\n  assistant message to continue, an unknown ``toolCallId``, or a tool-name\n  mismatch). Unlike ``agent_session_messages_stale`` this is not a\n  concurrent-writer race but an inconsistent request; fix the client\n  rather than retrying.\n- ``agent_session_compaction_conflict``: the conversation changed while it\n  was being compacted; retry."
       },
       "AgentSessionData": {
         "properties": {
@@ -10193,7 +10193,7 @@
                 "type": "null"
               }
             ],
-            "description": "The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead."
+            "description": "The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead."
           },
           "toolOutputs": {
             "items": {
@@ -10214,7 +10214,7 @@
             },
             "type": "array",
             "title": "Tooloutputs",
-            "description": "Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``."
+            "description": "Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs."
           },
           "lastMessageId": {
             "anyOf": [

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9049,7 +9049,7 @@
           "code"
         ],
         "title": "AgentSessionConflictError",
-        "description": "Body of every HTTP 409 returned by the agent session routes.\n\n- ``agent_session_busy``: another turn holds the session's turn lock.\n- ``agent_session_model_stale``: the request asserted a model the session\n  is no longer set to; refetch the session before retrying.\n- ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer\n  matches the persisted transcript \u2014 another client appended; refetch the\n  transcript and retry.\n- ``agent_session_messages_conflict``: the submitted assistant message and\n  the request's ``lastMessageId`` contradict each other. Unlike\n  ``agent_session_messages_stale`` this is not a concurrent-writer race but\n  an inconsistent request; fix the client rather than retrying.\n- ``agent_session_compaction_conflict``: the conversation changed while it\n  was being compacted; retry."
+        "description": "Body of every HTTP 409 returned by the agent session routes.\n\n- ``agent_session_busy``: another turn holds the session's turn lock.\n- ``agent_session_model_stale``: the request asserted a model the session\n  is no longer set to; refetch the session before retrying.\n- ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer\n  matches the persisted transcript \u2014 another client appended; refetch the\n  transcript and retry.\n- ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do\n  not match the transcript's trailing assistant message (no trailing\n  assistant message to continue, an unknown ``toolCallId``, or a tool-name\n  mismatch). Unlike ``agent_session_messages_stale`` this is not a\n  concurrent-writer race but an inconsistent request; fix the client\n  rather than retrying.\n- ``agent_session_compaction_conflict``: the conversation changed while it\n  was being compacted; retry."
       },
       "AgentSessionData": {
         "properties": {
@@ -10185,8 +10185,36 @@
             "title": "Id"
           },
           "message": {
-            "$ref": "#/components/schemas/PhoenixUIMessage",
-            "description": "The turn's new message: a user message to append, or the transcript's trailing assistant message updated with client-executed tool results."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PhoenixUIMessage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The turn's new user message to append. Omit it for a client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead."
+          },
+          "toolOutputs": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"
+                },
+                {
+                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"
+                },
+                {
+                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"
+                },
+                {
+                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Tooloutputs",
+            "description": "Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal states (``output-available`` / ``output-error``). Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls (typically as ``output-error``) before the new user turn runs. Outputs for already-resolved tool calls are ignored; outputs that match no pending tool call are rejected with ``agent_session_messages_conflict``."
           },
           "lastMessageId": {
             "anyOf": [
@@ -10204,8 +10232,7 @@
         "type": "object",
         "required": [
           "model",
-          "id",
-          "message"
+          "id"
         ],
         "title": "ChatRequest",
         "description": "Assistant chat submit request payload."

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -43,6 +43,7 @@ from pydantic import (
     ConfigDict,
     Field,
     TypeAdapter,
+    model_validator,
 )
 from pydantic.alias_generators import to_camel
 from pydantic_ai import AgentRunResult
@@ -89,18 +90,27 @@ from phoenix.db.types.data_stream_protocol import (
     AssistantMessageMetadataUsage,
     AssistantMessageMetadataUsageTokenDetails,
     AssistantMessageMetadataUsageTokens,
+    DynamicToolApprovalRequestedPart,
+    DynamicToolApprovalRespondedPart,
+    DynamicToolInputAvailablePart,
+    DynamicToolInputStreamingPart,
     DynamicToolOutputAvailablePart,
     DynamicToolOutputErrorPart,
     PhoenixUIMessage,
     ProviderMetadata,
     TextUIPart,
+    ToolApprovalRequestedPart,
+    ToolApprovalRespondedPart,
     ToolCallCallbackProviderMetadata,
     ToolCallProviderMetadata,
     ToolExecutionEnvironment,
+    ToolInputAvailablePart,
+    ToolInputStreamingPart,
     ToolOutputAvailablePart,
     ToolOutputErrorPart,
     TurnTraceContext,
     UIMessage,
+    UIMessagePart,
     UserMessageMetadata,
 )
 from phoenix.db.types.db_helper_types import UNDEFINED
@@ -343,16 +353,46 @@ class _ChatRequestMixin(_ObservabilityMixin):
     turn_trace_context: TurnTraceContext | None = None
 
 
+ToolOutputUIPart = (
+    ToolOutputAvailablePart
+    | ToolOutputErrorPart
+    | DynamicToolOutputAvailablePart
+    | DynamicToolOutputErrorPart
+)
+"""A tool part in a terminal output state, mirroring the AI SDK's
+``addToolOutput`` states (``output-available`` / ``output-error``)."""
+
+_ToolCallCallbackProviderMetadataAdapter: TypeAdapter[ToolCallCallbackProviderMetadata] = (
+    TypeAdapter(ToolCallCallbackProviderMetadata)
+)
+
+
 class ChatSubmitMessage(_ChatRequestMixin):
-    """Assistant chat submit request carrying only the turn's new message."""
+    """Assistant chat submit request carrying the turn's new inputs."""
 
     trigger: Literal["submit-message"] = "submit-message"
     id: str
-    message: PhoenixUIMessage = Field(
+    message: PhoenixUIMessage | None = Field(
+        default=None,
         description=(
-            "The turn's new message: a user message to append, or the "
-            "transcript's trailing assistant message updated with "
-            "client-executed tool results."
+            "The turn's new user message to append. Omit it for a client-tool "
+            "continuation, where ``toolOutputs`` resolve the trailing "
+            "assistant message's pending tool calls instead."
+        ),
+    )
+    tool_outputs: list[ToolOutputUIPart] = Field(
+        default_factory=list,
+        description=(
+            "Client-executed tool results for pending tool calls on the "
+            "transcript's trailing assistant message, matched by "
+            "``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal "
+            "states (``output-available`` / ``output-error``). Submitted "
+            "alone they continue the assistant turn; submitted with "
+            "``message`` they resolve dangling tool calls (typically as "
+            "``output-error``) before the new user turn runs. Outputs for "
+            "already-resolved tool calls are ignored; outputs that match no "
+            "pending tool call are rejected with "
+            "``agent_session_messages_conflict``."
         ),
     )
     last_message_id: str | None = Field(
@@ -366,6 +406,23 @@ class ChatSubmitMessage(_ChatRequestMixin):
             "client should refetch the session before retrying."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_turn_inputs(self) -> "ChatSubmitMessage":
+        if self.message is None and not self.tool_outputs:
+            raise ValueError("A chat submit request requires a message, toolOutputs, or both")
+        if self.message is not None and self.message.role != "user":
+            raise ValueError(
+                "Only user messages can be submitted; resolve client tool calls via toolOutputs"
+            )
+        for tool_output in self.tool_outputs:
+            call_provider_metadata = tool_output.call_provider_metadata
+            if not isinstance(call_provider_metadata, dict):
+                continue
+            phoenix_metadata = call_provider_metadata.get(_PHOENIX_PROVIDER_METADATA_KEY)
+            if phoenix_metadata is not None:
+                _ToolCallCallbackProviderMetadataAdapter.validate_python(phoenix_metadata)
+        return self
 
 
 class ChatRequest(ChatSubmitMessage):
@@ -415,10 +472,12 @@ class AgentSessionConflictError(V1RoutesBaseModel):
     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
       matches the persisted transcript — another client appended; refetch the
       transcript and retry.
-    - ``agent_session_messages_conflict``: the submitted assistant message and
-      the request's ``lastMessageId`` contradict each other. Unlike
-      ``agent_session_messages_stale`` this is not a concurrent-writer race but
-      an inconsistent request; fix the client rather than retrying.
+    - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+      not match the transcript's trailing assistant message (no trailing
+      assistant message to continue, an unknown ``toolCallId``, or a tool-name
+      mismatch). Unlike ``agent_session_messages_stale`` this is not a
+      concurrent-writer race but an inconsistent request; fix the client
+      rather than retrying.
     - ``agent_session_compaction_conflict``: the conversation changed while it
       was being compacted; retry.
     """
@@ -579,6 +638,7 @@ def _to_pydantic_ai_request_data(
     history pydantic-ai expects.
     """
     payload = request_data.model_dump(mode="json", by_alias=True, exclude_none=True)
+    payload.pop("toolOutputs", None)
     if messages is not None:
         payload.pop("message", None)
         payload["messages"] = [
@@ -1434,31 +1494,234 @@ async def _load_phoenix_user_email(
     )
 
 
-def _merge_messages(
-    *,
-    old_messages: Sequence[PhoenixUIMessage],
-    new_message: PhoenixUIMessage,
-) -> list[PhoenixUIMessage]:
-    """Merge a submit request's single message into the persisted transcript.
+_UNRESOLVED_TOOL_PART_TYPES = (
+    ToolInputStreamingPart,
+    ToolInputAvailablePart,
+    ToolApprovalRequestedPart,
+    ToolApprovalRespondedPart,
+    DynamicToolInputStreamingPart,
+    DynamicToolInputAvailablePart,
+    DynamicToolApprovalRequestedPart,
+    DynamicToolApprovalRespondedPart,
+)
+"""Tool parts that have not reached a terminal output state."""
 
-    - A **user** message is appended.
-    - An **assistant** message replaces the transcript's trailing message with
-      the same id — the continuation path for client-executed tool results.
+_DYNAMIC_UNRESOLVED_TOOL_PART_TYPES = (
+    DynamicToolInputStreamingPart,
+    DynamicToolInputAvailablePart,
+    DynamicToolApprovalRequestedPart,
+    DynamicToolApprovalRespondedPart,
+)
+
+_UnresolvedToolUIPart = (
+    ToolInputStreamingPart
+    | ToolInputAvailablePart
+    | ToolApprovalRequestedPart
+    | ToolApprovalRespondedPart
+    | DynamicToolInputStreamingPart
+    | DynamicToolInputAvailablePart
+    | DynamicToolApprovalRequestedPart
+    | DynamicToolApprovalRespondedPart
+)
+
+
+def _get_tool_execution_environment(part: UIMessagePart) -> str | None:
+    """Read the server-stamped execution environment off a tool part, if any."""
+    call_provider_metadata = getattr(part, "call_provider_metadata", None)
+    if not isinstance(call_provider_metadata, dict):
+        return None
+    phoenix_metadata = call_provider_metadata.get(_PHOENIX_PROVIDER_METADATA_KEY)
+    if not isinstance(phoenix_metadata, dict):
+        return None
+    environment = phoenix_metadata.get("toolExecutionEnvironment")
+    return environment if isinstance(environment, str) else None
+
+
+def _interrupted_tool_error_text(part: _UnresolvedToolUIPart) -> str:
+    environment = _get_tool_execution_environment(part)
+    if environment is not None:
+        return (
+            "The tool call was interrupted before a result was produced: the "
+            f"{environment} environment that executes this tool did not "
+            "complete it."
+        )
+    return "The tool call was interrupted before a result was produced."
+
+
+def _build_interrupted_tool_output(
+    part: _UnresolvedToolUIPart,
+) -> ToolOutputErrorPart | DynamicToolOutputErrorPart:
+    """Close out an unresolved tool part with an authoritative ``output-error``."""
+    error_text = _interrupted_tool_error_text(part)
+    if isinstance(part, _DYNAMIC_UNRESOLVED_TOOL_PART_TYPES):
+        return DynamicToolOutputErrorPart(
+            tool_name=part.tool_name,
+            tool_call_id=part.tool_call_id,
+            title=part.title,
+            input=part.input,
+            error_text=error_text,
+            provider_executed=part.provider_executed,
+            call_provider_metadata=part.call_provider_metadata,
+            approval=part.approval,
+        )
+    return ToolOutputErrorPart(
+        type=part.type,
+        tool_call_id=part.tool_call_id,
+        title=part.title,
+        input=part.input,
+        error_text=error_text,
+        provider_executed=part.provider_executed,
+        call_provider_metadata=part.call_provider_metadata,
+        approval=part.approval,
+    )
+
+
+def _resolve_interrupted_tool_parts(message: PhoenixUIMessage) -> PhoenixUIMessage | None:
+    """Rewrite an assistant message's unresolved tool parts as interrupted.
+
+    Returns the rewritten message, or None when nothing was unresolved.
     """
-    if new_message.role == "user":
-        return [*old_messages, new_message]
-    if new_message.role == "assistant":
-        if not old_messages or old_messages[-1].id != new_message.id:
+    if message.role != "assistant":
+        return None
+    changed = False
+    parts: list[UIMessagePart] = []
+    for part in message.parts:
+        if isinstance(part, _UNRESOLVED_TOOL_PART_TYPES):
+            parts.append(_build_interrupted_tool_output(part))
+            changed = True
+        else:
+            parts.append(part)
+    if not changed:
+        return None
+    return message.model_copy(update={"parts": parts})
+
+
+def _tool_part_identity(part: UIMessagePart) -> tuple[str, str | None]:
+    """The (type, tool name) pair a tool output must share with its call."""
+    return (part.type, getattr(part, "tool_name", None))
+
+
+def _apply_tool_outputs(
+    message: PhoenixUIMessage,
+    tool_outputs: Sequence[ToolOutputUIPart],
+) -> PhoenixUIMessage:
+    """Resolve the assistant message's pending tool calls with submitted outputs.
+
+    Outputs are matched by ``toolCallId``. An output for an already-resolved
+    call is ignored so retried sends stay idempotent; an output that matches
+    no call (or renames the tool) is an inconsistent request and conflicts.
+    Returns the input message unchanged when nothing was applied.
+    """
+    part_indices_by_tool_call_id: dict[str, int] = {}
+    for index, part in enumerate(message.parts):
+        tool_call_id = getattr(part, "tool_call_id", None)
+        if isinstance(tool_call_id, str):
+            part_indices_by_tool_call_id[tool_call_id] = index
+    parts = list(message.parts)
+    changed = False
+    for tool_output in tool_outputs:
+        matched_index = part_indices_by_tool_call_id.get(tool_output.tool_call_id)
+        if matched_index is None:
             raise _AgentSessionConflict(
                 "agent_session_messages_conflict",
                 (
-                    "The submitted assistant message does not match the session's "
-                    "latest transcript message; reload the conversation"
+                    f"Tool output {tool_output.tool_call_id!r} does not match a "
+                    "tool call on the session's latest assistant message; "
+                    "reload the conversation"
                 ),
             )
-        # Client tool results extend this assistant message rather than create a new one.
-        return [*old_messages[:-1], new_message]
-    raise HTTPException(status_code=400, detail="Only user or assistant messages can be submitted")
+        existing_part = parts[matched_index]
+        if _tool_part_identity(existing_part) != _tool_part_identity(tool_output):
+            raise _AgentSessionConflict(
+                "agent_session_messages_conflict",
+                (
+                    f"Tool output {tool_output.tool_call_id!r} names a different "
+                    "tool than the persisted tool call; reload the conversation"
+                ),
+            )
+        if not isinstance(existing_part, _UNRESOLVED_TOOL_PART_TYPES):
+            # Already resolved (e.g. a retried send); keep the persisted result.
+            continue
+        parts[matched_index] = tool_output
+        changed = True
+    if not changed:
+        return message
+    return message.model_copy(update={"parts": parts})
+
+
+@dataclass
+class _MergedTranscript:
+    """A submit request merged into the persisted transcript."""
+
+    messages: list[PhoenixUIMessage]
+    """The model-facing transcript for this turn."""
+
+    updated_messages: dict[str, PhoenixUIMessage]
+    """Persisted messages rewritten by the merge — applied ``toolOutputs`` and
+    authoritative interrupted-tool repairs — keyed by message id. Persist these
+    under the turn lock before the model runs so the transcript stays accurate
+    even if the turn later fails."""
+
+    continued_assistant_message: PhoenixUIMessage | None
+    """The trailing assistant message this turn continues when the request
+    carried only ``toolOutputs``; None for a new user turn."""
+
+
+def _merge_messages(
+    *,
+    old_messages: Sequence[PhoenixUIMessage],
+    new_message: PhoenixUIMessage | None,
+    tool_outputs: Sequence[ToolOutputUIPart] = (),
+) -> _MergedTranscript:
+    """Merge a submit request into the persisted transcript.
+
+    - ``tool_outputs`` resolve pending tool calls on the transcript's trailing
+      assistant message — the client-tool continuation path.
+    - Any tool call still unresolved after the outputs are applied can never
+      be resolved (this request was the only mechanism that could have
+      supplied its result), so it is authoritatively rewritten as interrupted
+      (``output-error``). The rewrite applies to the whole loaded history, not
+      just the trailing message, so a transcript can't advance past a dangling
+      tool call.
+    - A **user** ``new_message`` is appended; without one the turn continues
+      the trailing assistant message.
+    """
+    messages = list(old_messages)
+    updated_messages: dict[str, PhoenixUIMessage] = {}
+    if tool_outputs:
+        if not messages or messages[-1].role != "assistant":
+            raise _AgentSessionConflict(
+                "agent_session_messages_conflict",
+                (
+                    "Tool outputs were submitted but the session's latest "
+                    "transcript message is not an assistant message; reload "
+                    "the conversation"
+                ),
+            )
+        merged_tail = _apply_tool_outputs(messages[-1], tool_outputs)
+        if merged_tail is not messages[-1]:
+            updated_messages[merged_tail.id] = merged_tail
+            messages[-1] = merged_tail
+    for index, message in enumerate(messages):
+        repaired_message = _resolve_interrupted_tool_parts(message)
+        if repaired_message is not None:
+            updated_messages[repaired_message.id] = repaired_message
+            messages[index] = repaired_message
+    if new_message is not None:
+        if new_message.role != "user":
+            raise HTTPException(status_code=400, detail="Only user messages can be submitted")
+        return _MergedTranscript(
+            messages=[*messages, new_message],
+            updated_messages=updated_messages,
+            continued_assistant_message=None,
+        )
+    # Request validation guarantees tool_outputs is non-empty here, and the
+    # tool-output branch above guarantees the tail is an assistant message.
+    return _MergedTranscript(
+        messages=messages,
+        updated_messages=updated_messages,
+        continued_assistant_message=messages[-1],
+    )
 
 
 async def _refresh_and_load_agent_session(
@@ -2372,10 +2635,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 )
                 if body.last_message_id != expected_last_message_id:
                     return _conflict_response("agent_session_messages_stale")
-                transcript_messages = _merge_messages(
+                merged_transcript = _merge_messages(
                     old_messages=[row.message for row in session_history],
                     new_message=body.message,
+                    tool_outputs=body.tool_outputs,
                 )
+                transcript_messages = merged_transcript.messages
                 session_model = get_agent_session_model(agent_session)
                 if (
                     conflict := await _claim_agent_session_turn_lock_for_model(
@@ -2386,6 +2651,14 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     )
                 ) is not None:
                     return conflict
+                # Applied tool outputs and authoritative interrupted-tool
+                # repairs are persisted under the turn lock, before the model
+                # runs, so the transcript stays accurate even if the turn
+                # later fails.
+                for message_row in session_history:
+                    updated_message = merged_transcript.updated_messages.get(message_row.message_id)
+                    if updated_message is not None:
+                        message_row.message = updated_message
                 project_name = agent_session.project_name
                 session_needs_title = not agent_session.title
                 agent_session_rowid = agent_session.id
@@ -2477,8 +2750,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
 
             agent_prompts = AgentPrompts()
             forced_skills: list[Skill] = []
+            continued_assistant_message = merged_transcript.continued_assistant_message
             server_message_id = (
-                body.message.id if body.message.role == "assistant" else str(uuid4())
+                continued_assistant_message.id
+                if continued_assistant_message is not None
+                else str(uuid4())
             )
             model_transcript_messages = transcript_messages
             compaction_history: list[ModelMessage] = []
@@ -2729,7 +3005,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 summary_task: asyncio.Task[str | None] | None = None
                 message_state = create_streaming_ui_message_state(
                     message_id=server_message_id,
-                    last_message=body.message if body.message.role == "assistant" else None,
+                    last_message=continued_assistant_message,
                 )
 
                 async def _persist_turn() -> TranscriptPersistedChunk:
@@ -2740,12 +3016,14 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             exclude_none=True,
                         )
                     )
-                    if body.message.role == "assistant":
-                        # Continue the submitted assistant message with the generated response.
+                    if continued_assistant_message is not None:
+                        # Continue the trailing assistant message with the generated response.
                         turn_messages = [generated_assistant_message]
-                    else:
+                    elif body.message is not None:
                         # Persist the submitted user message and its generated response.
                         turn_messages = [body.message, generated_assistant_message]
+                    else:  # pragma: no cover — request validation requires one of the two
+                        raise RuntimeError("A chat turn requires a message or tool outputs")
                     try:
                         await _persist_agent_session_turn(
                             request.app.state.db,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -50,7 +50,7 @@ from pydantic_ai import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 from pydantic_ai.ui.vercel_ai.request_types import (
-    RequestData as PydanticAIRequestData,
+    SubmitMessage as PydanticAISubmitMessage,
 )
 from pydantic_ai.ui.vercel_ai.request_types import (
     UIMessage as PydanticAIUIMessage,
@@ -96,6 +96,7 @@ from phoenix.db.types.data_stream_protocol import (
     DynamicToolInputStreamingPart,
     DynamicToolOutputAvailablePart,
     DynamicToolOutputErrorPart,
+    DynamicToolUIPart,
     PhoenixUIMessage,
     ProviderMetadata,
     TextUIPart,
@@ -108,6 +109,7 @@ from phoenix.db.types.data_stream_protocol import (
     ToolInputStreamingPart,
     ToolOutputAvailablePart,
     ToolOutputErrorPart,
+    ToolUIPart,
     TurnTraceContext,
     UIMessage,
     UIMessagePart,
@@ -359,8 +361,6 @@ ToolOutputUIPart = (
     | DynamicToolOutputAvailablePart
     | DynamicToolOutputErrorPart
 )
-"""A tool part in a terminal output state, mirroring the AI SDK's
-``addToolOutput`` states (``output-available`` / ``output-error``)."""
 
 _ToolCallCallbackProviderMetadataAdapter: TypeAdapter[ToolCallCallbackProviderMetadata] = (
     TypeAdapter(ToolCallCallbackProviderMetadata)
@@ -375,7 +375,7 @@ class ChatSubmitMessage(_ChatRequestMixin):
     message: PhoenixUIMessage | None = Field(
         default=None,
         description=(
-            "The turn's new user message to append. Omit it for a client-tool "
+            "The turn's new user message to append. May be omitted for client-tool "
             "continuation, where ``toolOutputs`` resolve the trailing "
             "assistant message's pending tool calls instead."
         ),
@@ -385,14 +385,9 @@ class ChatSubmitMessage(_ChatRequestMixin):
         description=(
             "Client-executed tool results for pending tool calls on the "
             "transcript's trailing assistant message, matched by "
-            "``toolCallId``. Mirrors the AI SDK's ``addToolOutput`` terminal "
-            "states (``output-available`` / ``output-error``). Submitted "
-            "alone they continue the assistant turn; submitted with "
-            "``message`` they resolve dangling tool calls (typically as "
-            "``output-error``) before the new user turn runs. Outputs for "
-            "already-resolved tool calls are ignored; outputs that match no "
-            "pending tool call are rejected with "
-            "``agent_session_messages_conflict``."
+            "``toolCallId``. Submitted alone they continue the assistant "
+            "turn; submitted with ``message`` they resolve dangling tool "
+            "calls before the new user turn runs."
         ),
     )
     last_message_id: str | None = Field(
@@ -412,9 +407,10 @@ class ChatSubmitMessage(_ChatRequestMixin):
         if self.message is None and not self.tool_outputs:
             raise ValueError("A chat submit request requires a message, toolOutputs, or both")
         if self.message is not None and self.message.role != "user":
-            raise ValueError(
-                "Only user messages can be submitted; resolve client tool calls via toolOutputs"
-            )
+            raise ValueError("Only user messages can be submitted")
+        tool_call_ids = [tool_output.tool_call_id for tool_output in self.tool_outputs]
+        if len(tool_call_ids) != len(set(tool_call_ids)):
+            raise ValueError("Each toolOutputs entry must have a distinct toolCallId")
         for tool_output in self.tool_outputs:
             call_provider_metadata = tool_output.call_provider_metadata
             if not isinstance(call_provider_metadata, dict):
@@ -458,7 +454,7 @@ AgentSessionConflictCode = Literal[
     "agent_session_busy",
     "agent_session_model_stale",
     "agent_session_messages_stale",
-    "agent_session_messages_conflict",
+    "agent_session_tool_outputs_conflict",
     "agent_session_compaction_conflict",
 ]
 
@@ -472,7 +468,7 @@ class AgentSessionConflictError(V1RoutesBaseModel):
     - ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer
       matches the persisted transcript — another client appended; refetch the
       transcript and retry.
-    - ``agent_session_messages_conflict``: the submitted ``toolOutputs`` do
+    - ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do
       not match the transcript's trailing assistant message (no trailing
       assistant message to continue, an unknown ``toolCallId``, or a tool-name
       mismatch). Unlike ``agent_session_messages_stale`` this is not a
@@ -618,9 +614,6 @@ def _compact_agent_session_response(
     return JSONResponse(response.model_dump(mode="json", by_alias=True, exclude_none=True))
 
 
-_PydanticAIRequestDataAdapter: TypeAdapter[PydanticAIRequestData] = TypeAdapter(
-    PydanticAIRequestData
-)
 _PydanticAIUIMessageListAdapter: TypeAdapter[list[PydanticAIUIMessage]] = TypeAdapter(
     list[PydanticAIUIMessage]
 )
@@ -629,23 +622,18 @@ _PydanticAIUIMessageListAdapter: TypeAdapter[list[PydanticAIUIMessage]] = TypeAd
 def _to_pydantic_ai_request_data(
     request_data: ChatSubmitMessage,
     *,
-    messages: Sequence[PhoenixUIMessage] | None = None,
-) -> PydanticAIRequestData:
-    """Validate wire types into pydantic-ai's runtime request classes.
-
-    ``messages`` supplies the server-merged transcript for assistant chat
-    requests, whose wire shape carries a single message rather than the full
-    history pydantic-ai expects.
-    """
-    payload = request_data.model_dump(mode="json", by_alias=True, exclude_none=True)
-    payload.pop("toolOutputs", None)
-    if messages is not None:
-        payload.pop("message", None)
-        payload["messages"] = [
-            message.model_dump(mode="json", by_alias=True, exclude_none=True)
-            for message in messages
-        ]
-    return _PydanticAIRequestDataAdapter.validate_python(payload)
+    messages: Sequence[PhoenixUIMessage],
+) -> PydanticAISubmitMessage:
+    """Validate wire types into pydantic-ai's runtime request classes."""
+    return PydanticAISubmitMessage(
+        id=request_data.id,
+        messages=_PydanticAIUIMessageListAdapter.validate_python(
+            [
+                message.model_dump(mode="json", by_alias=True, exclude_none=True)
+                for message in messages
+            ]
+        ),
+    )
 
 
 def _to_pydantic_ai_messages(messages: Sequence[PhoenixUIMessage]) -> list[ModelMessage]:
@@ -1513,6 +1501,13 @@ _DYNAMIC_UNRESOLVED_TOOL_PART_TYPES = (
     DynamicToolApprovalRespondedPart,
 )
 
+_STATIC_UNRESOLVED_TOOL_PART_TYPES = (
+    ToolInputStreamingPart,
+    ToolInputAvailablePart,
+    ToolApprovalRequestedPart,
+    ToolApprovalRespondedPart,
+)
+
 _UnresolvedToolUIPart = (
     ToolInputStreamingPart
     | ToolInputAvailablePart
@@ -1525,16 +1520,17 @@ _UnresolvedToolUIPart = (
 )
 
 
-def _get_tool_execution_environment(part: UIMessagePart) -> str | None:
+def _get_tool_execution_environment(
+    part: _UnresolvedToolUIPart,
+) -> ToolExecutionEnvironment | None:
     """Read the server-stamped execution environment off a tool part, if any."""
-    call_provider_metadata = getattr(part, "call_provider_metadata", None)
-    if not isinstance(call_provider_metadata, dict):
+    if part.call_provider_metadata is None:
         return None
-    phoenix_metadata = call_provider_metadata.get(_PHOENIX_PROVIDER_METADATA_KEY)
-    if not isinstance(phoenix_metadata, dict):
+    phoenix_metadata = part.call_provider_metadata.get(_PHOENIX_PROVIDER_METADATA_KEY)
+    if phoenix_metadata is None:
         return None
-    environment = phoenix_metadata.get("toolExecutionEnvironment")
-    return environment if isinstance(environment, str) else None
+    metadata = _ToolCallCallbackProviderMetadataAdapter.validate_python(phoenix_metadata)
+    return metadata.tool_execution_environment
 
 
 def _interrupted_tool_error_text(part: _UnresolvedToolUIPart) -> str:
@@ -1564,16 +1560,18 @@ def _build_interrupted_tool_output(
             call_provider_metadata=part.call_provider_metadata,
             approval=part.approval,
         )
-    return ToolOutputErrorPart(
-        type=part.type,
-        tool_call_id=part.tool_call_id,
-        title=part.title,
-        input=part.input,
-        error_text=error_text,
-        provider_executed=part.provider_executed,
-        call_provider_metadata=part.call_provider_metadata,
-        approval=part.approval,
-    )
+    if isinstance(part, _STATIC_UNRESOLVED_TOOL_PART_TYPES):
+        return ToolOutputErrorPart(
+            type=part.type,
+            tool_call_id=part.tool_call_id,
+            title=part.title,
+            input=part.input,
+            error_text=error_text,
+            provider_executed=part.provider_executed,
+            call_provider_metadata=part.call_provider_metadata,
+            approval=part.approval,
+        )
+    assert_never(part)
 
 
 def _resolve_interrupted_tool_parts(message: PhoenixUIMessage) -> PhoenixUIMessage | None:
@@ -1596,56 +1594,68 @@ def _resolve_interrupted_tool_parts(message: PhoenixUIMessage) -> PhoenixUIMessa
     return message.model_copy(update={"parts": parts})
 
 
-def _tool_part_identity(part: UIMessagePart) -> tuple[str, str | None]:
-    """The (type, tool name) pair a tool output must share with its call."""
-    return (part.type, getattr(part, "tool_name", None))
+def _tool_output_matches_call(
+    call: ToolUIPart | DynamicToolUIPart,
+    output: ToolOutputUIPart,
+) -> bool:
+    """Whether a submitted output names the same tool as its persisted call."""
+    if isinstance(output, DynamicToolOutputAvailablePart | DynamicToolOutputErrorPart):
+        return isinstance(call, DynamicToolUIPart) and call.tool_name == output.tool_name
+    if isinstance(output, ToolOutputAvailablePart | ToolOutputErrorPart):
+        return isinstance(call, ToolUIPart) and call.type == output.type
+    assert_never(output)
+
+
+_ToolCallId = str
+_MessageId = str
+_PartIndex = int
+"""A tool part's position within its message's ``parts`` list."""
 
 
 def _apply_tool_outputs(
     message: PhoenixUIMessage,
     tool_outputs: Sequence[ToolOutputUIPart],
-) -> PhoenixUIMessage:
+) -> PhoenixUIMessage | None:
     """Resolve the assistant message's pending tool calls with submitted outputs.
 
     Outputs are matched by ``toolCallId``. An output for an already-resolved
     call is ignored so retried sends stay idempotent; an output that matches
     no call (or renames the tool) is an inconsistent request and conflicts.
-    Returns the input message unchanged when nothing was applied.
+    Returns the updated message, or None when no outputs were applied.
     """
-    part_indices_by_tool_call_id: dict[str, int] = {}
+    tool_calls_by_id: dict[_ToolCallId, tuple[_PartIndex, ToolUIPart | DynamicToolUIPart]] = {}
     for index, part in enumerate(message.parts):
-        tool_call_id = getattr(part, "tool_call_id", None)
-        if isinstance(tool_call_id, str):
-            part_indices_by_tool_call_id[tool_call_id] = index
+        if isinstance(part, ToolUIPart | DynamicToolUIPart):
+            tool_calls_by_id[part.tool_call_id] = (index, part)
     parts = list(message.parts)
     changed = False
     for tool_output in tool_outputs:
-        matched_index = part_indices_by_tool_call_id.get(tool_output.tool_call_id)
-        if matched_index is None:
+        matched_call = tool_calls_by_id.get(tool_output.tool_call_id)
+        if matched_call is None:
             raise _AgentSessionConflict(
-                "agent_session_messages_conflict",
+                "agent_session_tool_outputs_conflict",
                 (
                     f"Tool output {tool_output.tool_call_id!r} does not match a "
                     "tool call on the session's latest assistant message; "
                     "reload the conversation"
                 ),
             )
-        existing_part = parts[matched_index]
-        if _tool_part_identity(existing_part) != _tool_part_identity(tool_output):
+        matched_index, call_part = matched_call
+        if not _tool_output_matches_call(call_part, tool_output):
             raise _AgentSessionConflict(
-                "agent_session_messages_conflict",
+                "agent_session_tool_outputs_conflict",
                 (
                     f"Tool output {tool_output.tool_call_id!r} names a different "
                     "tool than the persisted tool call; reload the conversation"
                 ),
             )
-        if not isinstance(existing_part, _UNRESOLVED_TOOL_PART_TYPES):
+        if not isinstance(call_part, _UNRESOLVED_TOOL_PART_TYPES):
             # Already resolved (e.g. a retried send); keep the persisted result.
             continue
         parts[matched_index] = tool_output
         changed = True
     if not changed:
-        return message
+        return None
     return message.model_copy(update={"parts": parts})
 
 
@@ -1656,11 +1666,9 @@ class _MergedTranscript:
     messages: list[PhoenixUIMessage]
     """The model-facing transcript for this turn."""
 
-    updated_messages: dict[str, PhoenixUIMessage]
-    """Persisted messages rewritten by the merge — applied ``toolOutputs`` and
-    authoritative interrupted-tool repairs — keyed by message id. Persist these
-    under the turn lock before the model runs so the transcript stays accurate
-    even if the turn later fails."""
+    updated_messages: dict[_MessageId, PhoenixUIMessage]
+    """Persisted messages rewritten by the merge (applied ``toolOutputs`` and
+    interrupted-tool repairs); persist under the turn lock before the model runs."""
 
     continued_assistant_message: PhoenixUIMessage | None
     """The trailing assistant message this turn continues when the request
@@ -1673,25 +1681,12 @@ def _merge_messages(
     new_message: PhoenixUIMessage | None,
     tool_outputs: Sequence[ToolOutputUIPart] = (),
 ) -> _MergedTranscript:
-    """Merge a submit request into the persisted transcript.
-
-    - ``tool_outputs`` resolve pending tool calls on the transcript's trailing
-      assistant message — the client-tool continuation path.
-    - Any tool call still unresolved after the outputs are applied can never
-      be resolved (this request was the only mechanism that could have
-      supplied its result), so it is authoritatively rewritten as interrupted
-      (``output-error``). The rewrite applies to the whole loaded history, not
-      just the trailing message, so a transcript can't advance past a dangling
-      tool call.
-    - A **user** ``new_message`` is appended; without one the turn continues
-      the trailing assistant message.
-    """
     messages = list(old_messages)
-    updated_messages: dict[str, PhoenixUIMessage] = {}
+    updated_messages: dict[_MessageId, PhoenixUIMessage] = {}
     if tool_outputs:
         if not messages or messages[-1].role != "assistant":
             raise _AgentSessionConflict(
-                "agent_session_messages_conflict",
+                "agent_session_tool_outputs_conflict",
                 (
                     "Tool outputs were submitted but the session's latest "
                     "transcript message is not an assistant message; reload "
@@ -1699,7 +1694,7 @@ def _merge_messages(
                 ),
             )
         merged_tail = _apply_tool_outputs(messages[-1], tool_outputs)
-        if merged_tail is not messages[-1]:
+        if merged_tail is not None:
             updated_messages[merged_tail.id] = merged_tail
             messages[-1] = merged_tail
     for index, message in enumerate(messages):
@@ -1708,15 +1703,14 @@ def _merge_messages(
             updated_messages[repaired_message.id] = repaired_message
             messages[index] = repaired_message
     if new_message is not None:
-        if new_message.role != "user":
-            raise HTTPException(status_code=400, detail="Only user messages can be submitted")
+        assert new_message.role == "user", "request validation rejects non-user messages"
         return _MergedTranscript(
             messages=[*messages, new_message],
             updated_messages=updated_messages,
             continued_assistant_message=None,
         )
-    # Request validation guarantees tool_outputs is non-empty here, and the
-    # tool-output branch above guarantees the tail is an assistant message.
+    assert tool_outputs, "request validation requires a message, toolOutputs, or both"
+    assert messages[-1].role == "assistant", "the tool-output branch guarantees an assistant tail"
     return _MergedTranscript(
         messages=messages,
         updated_messages=updated_messages,
@@ -2651,10 +2645,8 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     )
                 ) is not None:
                     return conflict
-                # Applied tool outputs and authoritative interrupted-tool
-                # repairs are persisted under the turn lock, before the model
-                # runs, so the transcript stays accurate even if the turn
-                # later fails.
+                # Persist merge rewrites under the turn lock, before the model
+                # runs, so the transcript stays accurate even if the turn fails.
                 for message_row in session_history:
                     updated_message = merged_transcript.updated_messages.get(message_row.message_id)
                     if updated_message is not None:
@@ -3019,11 +3011,13 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     if continued_assistant_message is not None:
                         # Continue the trailing assistant message with the generated response.
                         turn_messages = [generated_assistant_message]
-                    elif body.message is not None:
+                    else:
                         # Persist the submitted user message and its generated response.
+                        assert body.message is not None, (
+                            "request validation requires a message or toolOutputs, and "
+                            "the merge continues the assistant turn for toolOutputs-only"
+                        )
                         turn_messages = [body.message, generated_assistant_message]
-                    else:  # pragma: no cover — request validation requires one of the two
-                        raise RuntimeError("A chat turn requires a message or tool outputs")
                     try:
                         await _persist_agent_session_turn(
                             request.app.state.db,

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -1972,7 +1972,7 @@ def test_merge_rejects_tool_outputs_that_match_no_tool_call() -> None:
                 ToolOutputAvailablePart.model_validate(_tool_output(toolCallId="tool-call-missing"))
             ],
         )
-    assert exc_info.value.code == "agent_session_messages_conflict"
+    assert exc_info.value.code == "agent_session_tool_outputs_conflict"
 
 
 def test_merge_rejects_tool_outputs_that_rename_the_tool() -> None:
@@ -1986,7 +1986,7 @@ def test_merge_rejects_tool_outputs_that_rename_the_tool() -> None:
             new_message=None,
             tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output(type="tool-python"))],
         )
-    assert exc_info.value.code == "agent_session_messages_conflict"
+    assert exc_info.value.code == "agent_session_tool_outputs_conflict"
 
 
 def test_merge_rejects_tool_outputs_without_a_trailing_assistant_message() -> None:
@@ -1998,7 +1998,7 @@ def test_merge_rejects_tool_outputs_without_a_trailing_assistant_message() -> No
             new_message=None,
             tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
         )
-    assert exc_info.value.code == "agent_session_messages_conflict"
+    assert exc_info.value.code == "agent_session_tool_outputs_conflict"
 
 
 async def test_chat_endpoint_rejects_assistant_message_submissions(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -993,14 +993,20 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
     tool_part = next(
         part for part in resolved_assistant_message["parts"] if part["type"] == "tool-list_datasets"
     )
-    tool_part["state"] = "output-available"
-    tool_part["output"] = {"datasets": []}
+    tool_output = {
+        "type": "tool-list_datasets",
+        "toolCallId": tool_part["toolCallId"],
+        "state": "output-available",
+        "input": tool_part.get("input"),
+        "output": {"datasets": []},
+    }
 
     continuation_response = await httpx_client.post(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            resolved_assistant_message,
+            None,
+            toolOutputs=[tool_output],
             lastMessageId=assistant_message_id,
         ),
     )
@@ -1036,6 +1042,133 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
         isinstance(part, TextUIPart) and part.text == "done"
         for part in persisted_assistant.message.parts
     )
+
+
+def _assistant_message_with_pending_client_tool() -> dict[str, Any]:
+    """A persisted assistant tail whose client tool call never resolved — the
+    transcript an interrupted browser leaves behind."""
+    return {
+        "id": _message_uuid("assistant-1"),
+        "role": "assistant",
+        "parts": [
+            {"type": "text", "text": "Editing the prompt"},
+            {
+                "type": "tool-edit_prompt_instance",
+                "toolCallId": "tool-call-pending",
+                "state": "input-available",
+                "input": {"instanceId": 3},
+                "callProviderMetadata": {
+                    "phoenix": {
+                        "toolExecutionEnvironment": "client",
+                        "toolInputEmittedAt": "2026-08-05T20:35:35+00:00",
+                    }
+                },
+            },
+        ],
+    }
+
+
+async def _load_pending_tool_part(
+    db: DbSessionFactory,
+) -> dict[str, Any]:
+    async with db() as session:
+        agent_session_rowid = await session.scalar(select(models.AgentSession.id))
+        assert agent_session_rowid is not None
+        stored_messages = await _load_session_messages(session, agent_session_rowid)
+    assistant_message = next(
+        message for message in stored_messages if message["id"] == _message_uuid("assistant-1")
+    )
+    return next(
+        part for part in assistant_message["parts"] if part.get("toolCallId") == "tool-call-pending"
+    )
+
+
+async def test_user_turn_persists_interrupted_repair_for_dangling_client_tool(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
+        return TestModel(call_tools=[])
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+    session_id = "47474747-4747-4447-8447-474747474747"
+    agent_session_id = await _create_agent_session_row(
+        db,
+        title="Already titled",
+        messages=[
+            _user_message("edit the prompt"),
+            _assistant_message_with_pending_client_tool(),
+        ],
+    )
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            _user_message("what happened", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("assistant-1"),
+        ),
+    )
+    assert response.status_code == 200
+
+    repaired_part = await _load_pending_tool_part(db)
+    assert repaired_part["state"] == "output-error"
+    assert "interrupted" in repaired_part["errorText"]
+    assert "client environment" in repaired_part["errorText"]
+    # The original call's input and server-stamped metadata survive the repair.
+    assert repaired_part["input"] == {"instanceId": 3}
+    phoenix_metadata = repaired_part["callProviderMetadata"]["phoenix"]
+    assert phoenix_metadata["toolExecutionEnvironment"] == "client"
+
+
+async def test_user_turn_applies_submitted_tool_output_error_resolutions(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
+        return TestModel(call_tools=[])
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+    session_id = "48484848-4848-4448-8448-484848484848"
+    agent_session_id = await _create_agent_session_row(
+        db,
+        title="Already titled",
+        messages=[
+            _user_message("edit the prompt"),
+            _assistant_message_with_pending_client_tool(),
+        ],
+    )
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            _user_message("never mind", message_id=_message_uuid("msg-user-2")),
+            toolOutputs=[
+                {
+                    "type": "tool-edit_prompt_instance",
+                    "toolCallId": "tool-call-pending",
+                    "state": "output-error",
+                    "input": {"instanceId": 3},
+                    "errorText": "The user has interrupted this tool call.",
+                    "callProviderMetadata": {
+                        "phoenix": {
+                            "toolExecutionEnvironment": "client",
+                            "toolInputEmittedAt": "2026-08-05T20:35:35+00:00",
+                        }
+                    },
+                }
+            ],
+            lastMessageId=_message_uuid("assistant-1"),
+        ),
+    )
+    assert response.status_code == 200
+
+    resolved_part = await _load_pending_tool_part(db)
+    assert resolved_part["state"] == "output-error"
+    assert resolved_part["errorText"] == "The user has interrupted this tool call."
 
 
 def test_message_metadata_can_use_propagated_root_span_context() -> None:
@@ -1733,7 +1866,26 @@ def _assistant_message_with_tool_states() -> dict[str, Any]:
     }
 
 
-def test_merge_appends_user_message_without_modifying_persisted_messages() -> None:
+def _parts_by_tool_call_id(message: PhoenixUIMessage) -> dict[str, Any]:
+    return {
+        tool_call_id: part
+        for part in message.parts
+        if (tool_call_id := getattr(part, "tool_call_id", None)) is not None
+    }
+
+
+def _tool_output(**overrides: Any) -> dict[str, Any]:
+    return {
+        "type": "tool-bash",
+        "toolCallId": "tool-call-unresolved",
+        "state": "output-available",
+        "input": {"command": "ls"},
+        "output": {"stdout": "README.md"},
+        **overrides,
+    }
+
+
+def test_merge_appends_user_message_and_repairs_unresolved_tool_calls() -> None:
     persisted = _validated_messages(
         [_user_message("run a command"), _assistant_message_with_tool_states()]
     )
@@ -1745,58 +1897,137 @@ def test_merge_appends_user_message_without_modifying_persisted_messages() -> No
         ),
     )
 
-    assert [message.id for message in merged] == [
+    assert [message.id for message in merged.messages] == [
         _message_uuid("msg-user-1"),
         _message_uuid("assistant-1"),
         _message_uuid("msg-user-2"),
     ]
-    assert merged[1] is persisted[1]
+    assert merged.continued_assistant_message is None
+    repaired = merged.updated_messages[_message_uuid("assistant-1")]
+    assert merged.messages[1] is repaired
+    parts = _parts_by_tool_call_id(repaired)
+    assert parts["tool-call-unresolved"].state == "output-error"
+    assert "interrupted" in parts["tool-call-unresolved"].error_text
+    assert parts["tool-call-streaming"].state == "output-error"
+    assert parts["tool-call-done"].state == "output-available"
+    assert parts["tool-call-done"].output == {"stdout": "/"}
 
 
-def test_merge_replaces_the_trailing_assistant_message() -> None:
+def test_merge_applies_tool_outputs_to_the_trailing_assistant_message() -> None:
     persisted = _validated_messages(
         [_user_message("run a command"), _assistant_message_with_tool_states()]
-    )
-    resolved_assistant = PhoenixUIMessage.model_validate(
-        {
-            "id": _message_uuid("assistant-1"),
-            "role": "assistant",
-            "parts": [
-                {
-                    "type": "tool-bash",
-                    "toolCallId": "tool-call-unresolved",
-                    "state": "output-available",
-                    "input": {"command": "ls"},
-                    "output": {"stdout": "README.md"},
-                },
-            ],
-        }
     )
 
     merged = _merge_messages(
         old_messages=persisted,
-        new_message=resolved_assistant,
+        new_message=None,
+        tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
     )
 
-    assert [message.id for message in merged] == [
-        _message_uuid("msg-user-1"),
-        _message_uuid("assistant-1"),
-    ]
-    assert merged[-1] is resolved_assistant
+    continued = merged.continued_assistant_message
+    assert continued is not None
+    assert continued.id == _message_uuid("assistant-1")
+    assert merged.messages[-1] is continued
+    assert set(merged.updated_messages) == {_message_uuid("assistant-1")}
+    parts = _parts_by_tool_call_id(continued)
+    assert parts["tool-call-unresolved"].state == "output-available"
+    assert parts["tool-call-unresolved"].output == {"stdout": "README.md"}
+    # The streaming call the outputs did not cover can never be resolved, so
+    # it is authoritatively closed out before the turn continues.
+    assert parts["tool-call-streaming"].state == "output-error"
 
 
-def test_merge_rejects_an_assistant_message_that_is_not_the_trailing_one() -> None:
-    persisted = _validated_messages([_user_message("hello")])
-    stale_assistant = PhoenixUIMessage.model_validate(
-        {"id": _message_uuid("assistant-stale"), "role": "assistant", "parts": []}
+def test_merge_ignores_tool_outputs_for_already_resolved_tool_calls() -> None:
+    persisted = _validated_messages(
+        [_user_message("run a command"), _assistant_message_with_tool_states()]
+    )
+
+    merged = _merge_messages(
+        old_messages=persisted,
+        new_message=None,
+        tool_outputs=[
+            ToolOutputAvailablePart.model_validate(_tool_output()),
+            ToolOutputAvailablePart.model_validate(
+                _tool_output(toolCallId="tool-call-done", output={"stdout": "overwritten"})
+            ),
+        ],
+    )
+
+    continued = merged.continued_assistant_message
+    assert continued is not None
+    parts = _parts_by_tool_call_id(continued)
+    assert parts["tool-call-done"].output == {"stdout": "/"}
+
+
+def test_merge_rejects_tool_outputs_that_match_no_tool_call() -> None:
+    persisted = _validated_messages(
+        [_user_message("run a command"), _assistant_message_with_tool_states()]
     )
 
     with pytest.raises(_AgentSessionConflict) as exc_info:
         _merge_messages(
             old_messages=persisted,
-            new_message=stale_assistant,
+            new_message=None,
+            tool_outputs=[
+                ToolOutputAvailablePart.model_validate(_tool_output(toolCallId="tool-call-missing"))
+            ],
         )
     assert exc_info.value.code == "agent_session_messages_conflict"
+
+
+def test_merge_rejects_tool_outputs_that_rename_the_tool() -> None:
+    persisted = _validated_messages(
+        [_user_message("run a command"), _assistant_message_with_tool_states()]
+    )
+
+    with pytest.raises(_AgentSessionConflict) as exc_info:
+        _merge_messages(
+            old_messages=persisted,
+            new_message=None,
+            tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output(type="tool-python"))],
+        )
+    assert exc_info.value.code == "agent_session_messages_conflict"
+
+
+def test_merge_rejects_tool_outputs_without_a_trailing_assistant_message() -> None:
+    persisted = _validated_messages([_user_message("hello")])
+
+    with pytest.raises(_AgentSessionConflict) as exc_info:
+        _merge_messages(
+            old_messages=persisted,
+            new_message=None,
+            tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
+        )
+    assert exc_info.value.code == "agent_session_messages_conflict"
+
+
+async def test_chat_endpoint_rejects_assistant_message_submissions(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    response = await httpx_client.post(
+        _chat_url(str(GlobalID("AgentSession", "999999"))),
+        json=_chat_body(
+            session_id,
+            {
+                "id": _message_uuid("assistant-1"),
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "stale answer"}],
+            },
+        ),
+    )
+    assert response.status_code == 422
+
+
+async def test_chat_endpoint_requires_a_message_or_tool_outputs(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    session_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    response = await httpx_client.post(
+        _chat_url(str(GlobalID("AgentSession", "999999"))),
+        json=_chat_body(session_id, None),
+    )
+    assert response.status_code == 422
 
 
 async def test_chat_endpoint_rejects_regenerate_requests(


### PR DESCRIPTION
Part of #14948

## Problem

When a browser agent turn is interrupted while a client-executed tool call is pending, the browser cleans up only its local state. The persisted assistant message keeps the tool part in `input-available` forever, so any resume from another surface (CLI, page reload) rebuilds model history around an unmatched tool call. pydantic-ai ≥2.21 masks the provider failure with a transient synthesized return, but the database, restored UIs, and model history all disagree about what happened (see issue repro: DB says *pending*, UI shows a stale *Running* spinner, model was told *interrupted*).

## Approach

Replace the chat contract's whole-assistant-message continuation with a granular, Vercel-typed `toolOutputs` field, and make the server authoritative for anything the clients can't report.

### Contract (breaking, feature branch)

- `ChatRequest.message` is now **optional and user-role only**.
- New `toolOutputs`: tool parts in terminal AI SDK output states (`output-available` / `output-error`, mirroring `addToolOutput`), matched to pending calls on the trailing assistant message by `toolCallId`.
  - **A** — user message only: a normal new turn.
  - **B** — `toolOutputs` only: client-tool continuation of the trailing assistant message (replaces resubmitting the whole message, so clients can no longer rewrite assistant text/reasoning).
  - **C** — both: interrupted-tool error resolutions are applied and the new user turn starts, in one atomic request.
  - Outputs for already-resolved calls are ignored (idempotent retries); unknown `toolCallId`/tool-name mismatches reject with `agent_session_messages_conflict`.

### Server-authoritative repair

After applying submitted outputs, any tool call still unresolved in active history can never be resolved, so the server rewrites it as `output-error` (noting the execution environment that failed to service it) and **persists the rewrite under the turn lock before the model runs** — the transcript stays accurate even if the turn later fails or the client is gone (killed tab, CLI resume).

### Clients

- **Browser**: sends resolved client tool outputs (with client timing metadata) instead of the trailing assistant message; locally-interrupted outputs ride along with the next user message so persistence records the client's own error text.
- **CLI**: contract types updated; the CLI executes no client tools, so it just sends user messages and relies on server repair when resuming an interrupted browser session.

## Testing

- New unit tests: merge/apply/repair semantics, request validation (422s), route-level persistence of repairs (case A) and submitted error resolutions (case C), updated continuation test (case B).
- `tests/unit/server/agents` suite, app `src/agent` + `src/components/agent` vitest suites, and phoenix-cli vitest suite all green; mypy/pyright/oxlint clean.
- Manual happy path on a dev server: playground → PXI proposes a prompt edit → reload before accepting (dangling `input-available` persisted) → follow-up message succeeds, DB shows the call durably resolved as `output-error` with the client's interrupt reason → model re-proposes → Accept → `toolOutputs` continuation applies the edit, prompt updates, and the call persists as `output-available`; repeated edit/accept rounds after further reloads work.