### PR TITLE
feat(agents): add agent session indexes and message updated_at column

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1202,6 +1202,7 @@ CREATE TABLE public.agent_session_messages (
     message_id VARCHAR GENERATED ALWAYS AS (((message ->> 'id'::text))::character varying) STORED NOT NULL,
     is_compaction_message BOOLEAN GENERATED ALWAYS AS (COALESCE(((message #>> '{metadata,isCompactionMessage}'::text[]))::boolean, false)) STORED NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_session_messages PRIMARY KEY (id),
     CONSTRAINT uq_agent_session_messages_message_id
         UNIQUE (message_id),

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1211,6 +1211,8 @@ CREATE TABLE public.agent_session_messages (
         ON DELETE CASCADE
 );
 
+CREATE INDEX ix_agent_session_messages_agent_session_id_id ON public.agent_session_messages
+    USING btree (agent_session_id, id);
 CREATE INDEX ix_agent_session_messages_compaction ON public.agent_session_messages
     USING btree (agent_session_id, id DESC) WHERE is_compaction_message;
 

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1187,6 +1187,8 @@ CREATE INDEX ix_agent_sessions_custom_provider_id ON public.agent_sessions
     USING btree (custom_provider_id);
 CREATE INDEX ix_agent_sessions_ephemeral_updated_at ON public.agent_sessions
     USING btree (updated_at) WHERE (is_ephemeral IS TRUE);
+CREATE INDEX ix_agent_sessions_updated_at_id ON public.agent_sessions
+    USING btree (updated_at, id);
 CREATE INDEX ix_agent_sessions_user_id_updated_at ON public.agent_sessions
     USING btree (user_id, updated_at DESC);
 

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -177,6 +177,13 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
         sa.CheckConstraint(
             _uuid_format_check("message_id", _bind_dialect_name()),
             name="valid_message_id",

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -135,6 +135,11 @@ def upgrade() -> None:
         postgresql_where=sa.text("is_ephemeral IS TRUE"),
         sqlite_where=sa.text("is_ephemeral IS TRUE"),
     )
+    op.create_index(
+        "ix_agent_sessions_updated_at_id",
+        "agent_sessions",
+        ["updated_at", "id"],
+    )
 
     message = sa.Column("message", JSON_, nullable=False)
     op.create_table(

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -179,6 +179,11 @@ def upgrade() -> None:
         sqlite_autoincrement=True,
     )
     op.create_index(
+        "ix_agent_session_messages_agent_session_id_id",
+        "agent_session_messages",
+        ["agent_session_id", "id"],
+    )
+    op.create_index(
         "ix_agent_session_messages_compaction",
         "agent_session_messages",
         ["agent_session_id", sa.column("id").desc()],

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3493,6 +3493,9 @@ class AgentSessionMessage(HasId):
         nullable=False,
     )
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
 
     @property
     def is_compaction_point(self) -> bool:

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3459,6 +3459,11 @@ class AgentSession(HasId):
             postgresql_where=text("is_ephemeral IS TRUE"),
             sqlite_where=text("is_ephemeral IS TRUE"),
         ),
+        Index(
+            "ix_agent_sessions_updated_at_id",
+            "updated_at",
+            "id",
+        ),
         dict(sqlite_autoincrement=True),
     )
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3501,6 +3501,11 @@ class AgentSessionMessage(HasId):
     __table_args__ = (
         CheckConstraint(matches_uuid_format("message_id"), name="valid_message_id"),
         Index(
+            "ix_agent_session_messages_agent_session_id_id",
+            "agent_session_id",
+            "id",
+        ),
+        Index(
             "ix_agent_session_messages_compaction",
             "agent_session_id",
             sa.desc("id"),


### PR DESCRIPTION
resolves #15049

Schema additions to the agent session tables introduced in #14143.

## Indexes and the queries they serve

**`agent_session_messages (agent_session_id, id)`**
- History load, every turn: `WHERE agent_session_id = ? AND id >= <latest compaction> ORDER BY id`
- Transcript pagination: `WHERE agent_session_id = ? AND id > <cursor> ORDER BY id LIMIT n+1`
- Latest-message lookup: `WHERE agent_session_id = ? ORDER BY id DESC LIMIT 1`
- FK `ON DELETE CASCADE` row lookups when sessions/users are deleted

Equality on the leading column pins an id-sorted slice of the index, so these become index range reads with no sort node. Previously the only leading-`agent_session_id` index was the partial compaction index, which covers only compaction rows — so all of the above were full-table scans.

**`agent_sessions (updated_at, id)`**
- Recency keyset pagination of the sessions list: `WHERE (updated_at, id) < <cursor> ORDER BY updated_at DESC, id DESC LIMIT n+1` — the `id` tiebreak is what makes the cursor total-order stable, since `updated_at` is not unique
- Sweeper retention scans: `WHERE updated_at < <cutoff>` (leading-column range)

The owner-scoped list keeps using the existing `(user_id, updated_at)` index; this one serves the recency scans that carry no user filter.

## `agent_session_messages.updated_at`

Message rows are mutated in place — the trailing assistant message when a turn continues it, and merge-time rewrites that resolve `toolOutputs` or repair interrupted tool calls — but the table only recorded `created_at`. Adds `updated_at` with the same server-default/`onupdate` shape as the other agent session tables so in-place rewrites are observable.

Also pins uv 0.11.31 in the DDL schema CI job to satisfy `required-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #15151
