### PR TITLE
ci(phoenix-sqlean): build aarch64 wheels on an aarch64 runner

### DIFF
--- a/.github/workflows/phoenix-sqlean-build.yml
+++ b/.github/workflows/phoenix-sqlean-build.yml
@@ -25,13 +25,14 @@ on:
         required: false
         type: string
         default: ""
-      emulate-aarch64:
+      sdist-runner:
         description: >-
-          QEMU for cross-arch Linux builds. Defaults true to match
-          cibuildwheel.toml's aarch64; false only if a caller narrowed to native.
+          Runner that also builds the sdist. Named rather than "any Linux one"
+          because several Linux runners produce one wheelhouse each, and two
+          identical sdists would collide when the artifacts are merged.
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: ubuntu-latest
       dist-artifact-prefix:
         description: Upload wheels as <prefix>-<runner>. Empty skips the upload.
         required: false
@@ -57,11 +58,6 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.sources-artifact }}
-      - name: Set up QEMU for aarch64 wheels
-        if: runner.os == 'Linux' && inputs.emulate-aarch64
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
       # Not step env: an empty CIBW_* overrides cibuildwheel.toml rather than
       # being ignored, taking Linux from 10 identifiers to 36 (musllinux,
       # free-threaded, cp39, cp315).
@@ -84,7 +80,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.15"
       - name: Build sdist
-        if: runner.os == 'Linux'
+        if: matrix.os == inputs.sdist-runner
         run: pipx run build==1.5.0 --sdist --outdir wheelhouse .
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: inputs.dist-artifact-prefix != ''

--- a/.github/workflows/phoenix-sqlean-ci.yml
+++ b/.github/workflows/phoenix-sqlean-ci.yml
@@ -120,7 +120,6 @@ jobs:
       runners: '["ubuntu-latest"]'
       cibw-build: cp312-manylinux_x86_64
       cibw-archs-linux: x86_64
-      emulate-aarch64: false
 
   ci-required:
     name: phoenix-sqlean CI Required

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -338,7 +338,7 @@ jobs:
     uses: ./.github/workflows/phoenix-sqlean-build.yml
     with:
       sources-artifact: arize-phoenix-sqlean-sources
-      runners: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+      runners: '["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest", "windows-latest"]'
       dist-artifact-prefix: arize-phoenix-sqlean-dist
 
   publish-sqlean:

--- a/packages/phoenix-sqlean/cibuildwheel.toml
+++ b/packages/phoenix-sqlean/cibuildwheel.toml
@@ -17,7 +17,7 @@ test-requires = ["setuptools==83.0.0"]
 test-command = "python -m tests"
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64"]
+archs = ["auto"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
The `ubuntu-latest` leg of `build-sqlean` was taking over an hour ([run 31055348769](https://github.com/Arize-ai/phoenix/actions/runs/31055348769)). It built both Linux architectures on an x86_64 runner, so the five `manylinux_aarch64` wheels — SQLite's ~260k-line amalgamation plus pcre2 plus the sqlean sources, then the 361-test suite — ran entirely under QEMU user-mode emulation.

macOS and Windows don't pay this: they cross-compile, with the toolchain running natively against another target. manylinux can't, because the wheel is built inside a container that must actually execute the target architecture.

| leg | wheels | before | after |
|---|---|---|---|
| linux x86_64 | 5 | 61 min (both arches, emulated) | ~6 min |
| linux aarch64 | 5 | ↑ same job | ~6 min |
| macos | 10 | 6.5 min | 6.5 min |
| windows | 10 | 9 min | 9 min |
| **wall clock** | | **~65 min** | **~9 min** |

## Change

- `[tool.cibuildwheel.linux] archs = ["auto"]` — each runner builds only its native architecture.
- `ubuntu-24.04-arm` added to `build-sqlean`'s runners. It's a [standard runner](https://docs.github.com/en/actions/reference/runners/github-hosted-runners), free on public repositories, with the same 4 vCPU / 16 GB as `ubuntu-latest`. `phoenix-sqlean-ci.yml`'s test matrix has been using it all along — only the publish path was emulating.
- QEMU setup and the `emulate-aarch64` input both removed. With native runners there's no caller that needs emulation, and `docker/setup-qemu-action` was one more third-party action to keep SHA-pinned.
- `sdist-runner` input (default `ubuntu-latest`) replaces the sdist step's `runner.os == 'Linux'` gate. With two Linux runners both would build a `.tar.gz` of the same name, and the two wheelhouses collide when `publish-sqlean` merges them.

Net: **9 insertions, 14 deletions** — the workflow gets smaller.

## Verification

- **The 30 build identifiers are unchanged.** With `auto`, `cibuildwheel --print-build-identifiers` returns 5 `manylinux_x86_64` under `CIBW_ARCHS_LINUX=x86_64` and 5 `manylinux_aarch64` under `aarch64`. The union across all four runners diffs clean against the pre-change list — no wheel dropped or duplicated, just redistributed.
- CI's `wheel` job is unaffected: it already pins `cibw-archs-linux: x86_64`, and `sdist-runner` defaults to its only runner, so it still exercises the sdist path.
- actionlint and zizmor clean on all three workflows.

## Not changed

The CI `test` matrix keeps both `ubuntu-latest` and `ubuntu-24.04-arm`. ARM measures ~15% faster there (61–66s vs 73–80s per leg on the last green run), but architecture in that matrix is coverage for a C extension rather than a performance choice, and those legs run in parallel below the critical path — the run is bounded by the smoke test at 129s and `windows-11-arm` at 126s.