### PR TITLE
feat(agents): fall back to the client's default model when a session's custom provider is deleted

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -133,7 +133,11 @@ type AgentSession implements Node {
   Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
   """
   isActive: Boolean!
-  model: AgentModelSelection!
+
+  """
+  The session's persisted model selection, or null when the custom provider it referenced has been deleted. On null, clients fall back to their own default model; the session adopts the model asserted by the next chat or compaction request.
+  """
+  model: AgentModelSelection
 
   """
   The message ID of the most recently persisted transcript message, or null for an empty transcript.

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1797,7 +1797,8 @@ export interface components {
             updated_at: string;
             /** Is Ephemeral */
             is_ephemeral: boolean;
-            model: components["schemas"]["AgentModelSelection"];
+            /** @description The session's persisted model selection, or null when the custom provider it referenced has been deleted. On null, clients should fall back to their own default model; the session adopts the model asserted by the next chat or compaction request. */
+            model: components["schemas"]["AgentModelSelection"] | null;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -2223,7 +2224,7 @@ export interface components {
              * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
              */
             requestedSkills?: string[];
-            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. */
+            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. The one exception is a session whose model reads as null because its custom provider was deleted: the first request after deletion adopts the model it asserts — clients assert their own default — and the session persists that selection. */
             model: components["schemas"]["AgentModelSelection"];
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
             /**
@@ -2265,7 +2266,7 @@ export interface components {
          * @description Request a model-generated checkpoint for a persisted conversation.
          */
         CompactAgentSessionRequest: {
-            /** @description The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. */
+            /** @description The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. A session whose model reads as null (its custom provider was deleted) adopts the asserted model instead. */
             model: components["schemas"]["AgentModelSelection"];
         };
         /** CompactAgentSessionResponse */

--- a/app/src/components/agent/__generated__/agentSessionModel_session.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionModel_session.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1f6dd6c281fb4008be5c70c12ce07174>>
+ * @generated SignedSource<<b8e89048641235c3755cd591b1903fe9>>
  * @lightSyntaxTransform
  */
 
@@ -23,7 +23,7 @@ export type agentSessionModel_session$data = {
     // This will never be '%other', but we need some
     // value in case none of the concrete values match.
     readonly __typename: "%other";
-  };
+  } | null;
   readonly " $fragmentType": "agentSessionModel_session";
 };
 export type agentSessionModel_session$key = {

--- a/app/src/components/agent/__generated__/useAgentChatPanelStatePatchAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatPanelStatePatchAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<888c8c4d5a5fc113d8a748ece8c67bed>>
+ * @generated SignedSource<<6db351075e25b6232f2cc2058eb8847b>>
  * @lightSyntaxTransform
  */
 
@@ -55,7 +55,7 @@ export type useAgentChatPanelStatePatchAgentSessionMutation$rawResponse = {
         readonly providerId: string;
       } | {
         readonly __typename: string;
-      };
+      } | null;
     };
   };
 };

--- a/app/src/components/agent/agentSessionModel.ts
+++ b/app/src/components/agent/agentSessionModel.ts
@@ -56,10 +56,13 @@ export const sessionModelQuery = graphql`
   }
 `;
 
-/** A session's server-persisted model selection, minus Relay's `%other` arm. */
+/**
+ * A session's server-persisted model selection, minus Relay's `%other` arm and
+ * the null tombstone a deleted custom provider leaves behind.
+ */
 export type PersistedAgentModel = Exclude<
   agentSessionModel_session$data["model"],
-  { __typename: "%other" }
+  { __typename: "%other" } | null
 >;
 
 /**
@@ -207,7 +210,9 @@ export function useAgentSessionModelConfig(
       return undefined;
     }
     const { model } = readInlineData(agentSessionModelFragment, sessionKey);
-    if (model.__typename === "%other") {
+    // A null model is the deleted-custom-provider tombstone: resolving to
+    // undefined lets the panel fall back to the user's default model config.
+    if (model == null || model.__typename === "%other") {
       return undefined;
     }
     return resolvePersistedAgentModel({ model, customProviders });

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -172,7 +172,9 @@ export type PxiAppProps = {
   }) => PxiChatClient;
   modelLoader?: () => Promise<ModelSelection[]>;
   sessionClient?: PxiSessionClient;
-  sessionModelResolver?: (model: ModelSelection) => Promise<ModelSelection>;
+  sessionModelResolver?: (
+    model: ModelSelection | null
+  ) => Promise<ModelSelection>;
   initialMessages?: PxiMessage[];
 };
 
@@ -1055,8 +1057,14 @@ export function PxiApp({
   const resolveSessionModel = useMemo(
     () =>
       sessionModelResolver ??
-      ((model: ModelSelection) =>
-        resolveRestoredPxiModelSelection({
+      ((model: ModelSelection | null) => {
+        // A null persisted model is the deleted-custom-provider tombstone:
+        // fall back to the CLI's own selection (already preflighted at
+        // launch), which the session adopts on the next send.
+        if (model == null) {
+          return Promise.resolve(options.modelSelection);
+        }
+        return resolveRestoredPxiModelSelection({
           options,
           persistedModelSelection: model,
           onInvalidModel: ({ error }) => {
@@ -1069,7 +1077,8 @@ export function PxiApp({
               getPersistedModelWarningText({ message: error.message })
             );
           },
-        })),
+        });
+      }),
     [options, sessionModelResolver]
   );
 
@@ -1123,11 +1132,15 @@ export function PxiApp({
           // Only re-resolve when the session actually moved to a different
           // model: resolving validates against the server's model catalog,
           // and doing that on every tick would put a network round trip on
-          // the poll's steady state.
-          const hasModelChanged = !isSameModelSelection(
-            session.model,
-            activeModelSelectionRef.current
-          );
+          // the poll's steady state. A null persisted model (the session's
+          // custom provider was deleted) resolves to the CLI's own selection
+          // without a network round trip.
+          const hasModelChanged =
+            session.model == null ||
+            !isSameModelSelection(
+              session.model,
+              activeModelSelectionRef.current
+            );
           const restoredModel = hasModelChanged
             ? await resolveSessionModel(session.model)
             : activeModelSelectionRef.current;
@@ -1402,7 +1415,8 @@ export function PxiApp({
         // updated_at and reorders the session list.
         const shouldWriteExplicitModel =
           options.hasExplicitModelSelection &&
-          !isSameModelSelection(session.model, options.modelSelection);
+          (session.model == null ||
+            !isSameModelSelection(session.model, options.modelSelection));
         const restoredModel = shouldWriteExplicitModel
           ? await serverSessionClient.patchSessionModel({
               sessionId: session.id,

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -353,7 +353,7 @@ export function createPxiSessionClient({
             body: { model },
           }
         );
-        if (!payload) {
+        if (!payload?.data.model) {
           throw new Error(
             "Could not change the session's model because Phoenix returned no data."
           );

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -117,7 +117,12 @@ export type PxiSessionSummary = {
 /** A session and its canonical persisted transcript. */
 export type PxiSession = PxiSessionSummary & {
   messages: PxiMessage[];
-  model: ModelSelection;
+  /**
+   * The session's persisted model selection, or null when the custom provider
+   * it referenced has been deleted. On null the UI falls back to the CLI's
+   * own model selection; the session adopts the model the next turn asserts.
+   */
+  model: ModelSelection | null;
   /**
    * Whether another client currently holds the session's server-side lock.
    * Absent means no lock is held.

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -1691,6 +1691,122 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("falls back to the CLI's own model when a restored session's model is null", async () => {
+    // A null persisted model is the deleted-custom-provider tombstone. The
+    // real resolver (not an injected stub) must substitute the CLI's own
+    // selection without a catalog round trip; the next send adopts it
+    // server-side.
+    const patchSessionModel = vi.fn(
+      async ({ model }: { sessionId: string; model: ModelSelection }) => model
+    );
+    const sessionClient: PxiSessionClient = {
+      createSession: async () => {
+        throw new Error("not used");
+      },
+      listSessions: async () => [
+        {
+          id: "session-1",
+          title: "Orphaned session",
+          updatedAt: "2026-07-24T13:00:00Z",
+          isTemporary: false,
+        },
+      ],
+      getSession: async ({ sessionId }) => ({
+        id: sessionId,
+        title: "Orphaned session",
+        updatedAt: "2026-07-24T13:00:00Z",
+        isTemporary: false,
+        isActive: false,
+        messages: [],
+        model: null,
+      }),
+      patchSessionModel,
+      compactSession: async () => {
+        throw new Error("not used");
+      },
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions({ explicitModel: false })}
+        client={{ sendMessage: async () => null }}
+        sessionClient={sessionClient}
+      />
+    );
+
+    await writeInput({ stdin, input: "/sessions" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    // Without explicit flags, the fallback is display-only: nothing is
+    // written, and the header shows the CLI's default selection.
+    expect(patchSessionModel).not.toHaveBeenCalled();
+    expect(stripAnsi(lastFrame() ?? "")).toContain(
+      "model: ANTHROPIC/claude-opus-5"
+    );
+    unmount();
+  });
+
+  it("writes the explicit --provider/--model onto a restored session whose model is null", async () => {
+    // Explicit flags express an intent to move the session; a null persisted
+    // model (deleted custom provider) never equals the flags, so the write
+    // must happen rather than being skipped as already-matching.
+    const patchSessionModel = vi.fn(
+      async ({ model }: { sessionId: string; model: ModelSelection }) => model
+    );
+    const sessionClient: PxiSessionClient = {
+      createSession: async () => {
+        throw new Error("not used");
+      },
+      listSessions: async () => [
+        {
+          id: "session-1",
+          title: "Orphaned session",
+          updatedAt: "2026-07-24T13:00:00Z",
+          isTemporary: false,
+        },
+      ],
+      getSession: async ({ sessionId }) => ({
+        id: sessionId,
+        title: "Orphaned session",
+        updatedAt: "2026-07-24T13:00:00Z",
+        isTemporary: false,
+        isActive: false,
+        messages: [],
+        model: null,
+      }),
+      patchSessionModel,
+      compactSession: async () => {
+        throw new Error("not used");
+      },
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={{ sendMessage: async () => null }}
+        sessionClient={sessionClient}
+      />
+    );
+
+    await writeInput({ stdin, input: "/sessions" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    expect(patchSessionModel).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      model: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.4",
+      },
+    });
+    expect(stripAnsi(lastFrame() ?? "")).toContain("model: OPENAI/gpt-5.4");
+    unmount();
+  });
+
   it("keeps an in-flight /model pick when a send is rejected as model-stale", async () => {
     // The 409 refetch reads server state that predates the user's own write;
     // applying it would flip the header back and announce the reverse of

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1797,7 +1797,8 @@ export interface components {
             updated_at: string;
             /** Is Ephemeral */
             is_ephemeral: boolean;
-            model: components["schemas"]["AgentModelSelection"];
+            /** @description The session's persisted model selection, or null when the custom provider it referenced has been deleted. On null, clients should fall back to their own default model; the session adopts the model asserted by the next chat or compaction request. */
+            model: components["schemas"]["AgentModelSelection"] | null;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -2223,7 +2224,7 @@ export interface components {
              * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
              */
             requestedSkills?: string[];
-            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. */
+            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. The one exception is a session whose model reads as null because its custom provider was deleted: the first request after deletion adopts the model it asserts — clients assert their own default — and the session persists that selection. */
             model: components["schemas"]["AgentModelSelection"];
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
             /**
@@ -2265,7 +2266,7 @@ export interface components {
          * @description Request a model-generated checkpoint for a persisted conversation.
          */
         CompactAgentSessionRequest: {
-            /** @description The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. */
+            /** @description The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. A session whose model reads as null (its custom provider was deleted) adopts the asserted model instead. */
             model: components["schemas"]["AgentModelSelection"];
         };
         /** CompactAgentSessionResponse */

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1797,7 +1797,8 @@ export interface components {
             updated_at: string;
             /** Is Ephemeral */
             is_ephemeral: boolean;
-            model: components["schemas"]["AgentModelSelection"];
+            /** @description The session's persisted model selection, or null when the custom provider it referenced has been deleted. On null, clients should fall back to their own default model; the session adopts the model asserted by the next chat or compaction request. */
+            model: components["schemas"]["AgentModelSelection"] | null;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -2223,7 +2224,7 @@ export interface components {
              * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
              */
             requestedSkills?: string[];
-            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. */
+            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. The one exception is a session whose model reads as null because its custom provider was deleted: the first request after deletion adopts the model it asserts — clients assert their own default — and the session persists that selection. */
             model: components["schemas"]["AgentModelSelection"];
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
             /**
@@ -2265,7 +2266,7 @@ export interface components {
          * @description Request a model-generated checkpoint for a persisted conversation.
          */
         CompactAgentSessionRequest: {
-            /** @description The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. */
+            /** @description The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. A session whose model reads as null (its custom provider was deleted) adopts the asserted model instead. */
             model: components["schemas"]["AgentModelSelection"];
         };
         /** CompactAgentSessionResponse */

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1803,7 +1803,7 @@ class AgentSessionData(TypedDict):
     created_at: str
     updated_at: str
     is_ephemeral: bool
-    model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
+    model: Optional[Union[CustomProviderModelSelection, BuiltInProviderModelSelection]]
     is_active: bool
     last_message_id: NotRequired[str]
 

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9076,7 +9076,15 @@
             "title": "Is Ephemeral"
           },
           "model": {
-            "$ref": "#/components/schemas/AgentModelSelection"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentModelSelection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The session's persisted model selection, or null when the custom provider it referenced has been deleted. On null, clients should fall back to their own default model; the session adopts the model asserted by the next chat or compaction request."
           },
           "is_active": {
             "type": "boolean",
@@ -10155,7 +10163,7 @@
           },
           "model": {
             "$ref": "#/components/schemas/AgentModelSelection",
-            "description": "The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on \u2014 or switching to \u2014 an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``."
+            "description": "The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on \u2014 or switching to \u2014 an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. The one exception is a session whose model reads as null because its custom provider was deleted: the first request after deletion adopts the model it asserts \u2014 clients assert their own default \u2014 and the session persists that selection."
           },
           "turnTraceContext": {
             "anyOf": [
@@ -10260,7 +10268,7 @@
         "properties": {
           "model": {
             "$ref": "#/components/schemas/AgentModelSelection",
-            "description": "The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``."
+            "description": "The model the client believes the session is set to. As on the chat route this is a precondition: the summary is generated with the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale``. A session whose model reads as null (its custom provider was deleted) adopts the asserted model instead."
           }
         },
         "type": "object",

--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -124,12 +124,27 @@ async def set_session_model(
     agent_session.model_name = routing.model_name
     agent_session.custom_provider_id = routing.custom_provider_id
     agent_session.model_provider_type = routing.model_provider_type
-    return get_agent_session_model(agent_session)
+    selection = get_agent_session_model(agent_session)
+    assert selection is not None  # ``resolve_model_routing`` resolves every selection
+    return selection
 
 
-def model_selection_from_routing(routing: AgentModelRouting) -> AgentModelSelection:
-    """Reconstruct the model selection encoded by the routing column values."""
-    if routing.model_provider_type == "custom" and routing.custom_provider_id is not None:
+def model_selection_from_routing(routing: AgentModelRouting) -> Optional[AgentModelSelection]:
+    """Reconstruct the model selection encoded by the routing column values.
+
+    Returns ``None`` when a custom session's provider row is gone — the
+    tombstone the ``ON DELETE SET NULL`` foreign key leaves behind when the
+    session's custom provider is deleted. Callers surface the null so clients
+    substitute their own default; the session adopts the model asserted by
+    the next turn.
+    """
+    if routing.model_provider_type == "builtin":
+        return BuiltInProviderModelSelection(
+            provider_type="builtin",
+            provider=routing.model_provider,
+            model_name=routing.model_name,
+        )
+    if routing.custom_provider_id is not None:
         return CustomProviderModelSelection(
             provider_type="custom",
             provider_id=str(
@@ -140,17 +155,14 @@ def model_selection_from_routing(routing: AgentModelRouting) -> AgentModelSelect
             ),
             model_name=routing.model_name,
         )
-    return BuiltInProviderModelSelection(
-        provider_type="builtin",
-        provider=routing.model_provider,
-        model_name=routing.model_name,
-    )
+    return None
 
 
 def get_agent_session_model(
     agent_session: models.AgentSession,
-) -> AgentModelSelection:
-    """Return the model selection in effect for a session."""
+) -> Optional[AgentModelSelection]:
+    """Return the model selection in effect for a session, or ``None`` when the
+    session's custom provider has been deleted."""
     return model_selection_from_routing(
         AgentModelRouting(
             model_provider=agent_session.model_provider,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -349,7 +349,11 @@ class _ChatRequestMixin(_ObservabilityMixin):
             "HTTP 409 and code ``agent_session_model_stale`` rather than "
             "silently running on — or switching to — an unexpected model. "
             "Change the session's model with "
-            "``PATCH .../sessions/{session_id}``."
+            "``PATCH .../sessions/{session_id}``. The one exception is a "
+            "session whose model reads as null because its custom provider "
+            "was deleted: the first request after deletion adopts the model "
+            "it asserts — clients assert their own default — and the session "
+            "persists that selection."
         ),
     )
     turn_trace_context: TurnTraceContext | None = None
@@ -548,7 +552,14 @@ class AgentSessionSummary(V1RoutesBaseModel):
 
 
 class AgentSessionData(AgentSessionSummary):
-    model: AgentModelSelection
+    model: AgentModelSelection | None = Field(
+        description=(
+            "The session's persisted model selection, or null when the custom "
+            "provider it referenced has been deleted. On null, clients should "
+            "fall back to their own default model; the session adopts the "
+            "model asserted by the next chat or compaction request."
+        ),
+    )
     is_active: bool = Field(
         description=(
             "Whether a response is currently streaming on this session, i.e. its "
@@ -588,7 +599,9 @@ class CompactAgentSessionRequest(V1RoutesBaseModel):
             "The model the client believes the session is set to. As on the "
             "chat route this is a precondition: the summary is generated with "
             "the session's persisted selection, and a mismatch is rejected "
-            "with HTTP 409 and code ``agent_session_model_stale``."
+            "with HTTP 409 and code ``agent_session_model_stale``. A session "
+            "whose model reads as null (its custom provider was deleted) "
+            "adopts the asserted model instead."
         ),
     )
 
@@ -1815,24 +1828,42 @@ async def _clear_agent_session_turn_lock(
 async def _claim_agent_session_turn_lock_for_model(
     session: AsyncSession,
     *,
-    agent_session_rowid: int,
-    session_model: AgentModelSelection,
+    agent_session: models.AgentSession,
     requested_model: AgentModelSelection,
-) -> None:
+) -> AgentModelSelection:
     """Claim the session's turn lock while enforcing the request's model
-    precondition.
+    precondition, returning the model selection the turn runs on.
 
-    Raises ``AgentSessionConflict`` on failure; the raise rolls back the
-    caller's transaction, so a claim taken before a stale-model rejection is
-    never committed.
+    A session whose custom provider was deleted has no resolvable model (its
+    provider columns are the ``ON DELETE SET NULL`` tombstone). Rather than
+    rejecting every request as stale against a model that no longer exists,
+    the first request adopts the model it asserts — clients assert their own
+    default when the session's selection reads as null — and the adoption is
+    persisted under the turn lock so concurrent clients serialize through the
+    ordinary busy/stale preconditions.
+
+    Raises ``AgentSessionConflict`` on failure; any raise out of this helper
+    unwinds the caller's transaction, so neither the claim nor the adoption
+    outlives a rejected request.
+
+    Raises ``ProviderNotFoundError`` when the adopted selection itself names a
+    provider that does not exist.
     """
     if not await _claim_agent_session_turn_lock(
         session,
-        agent_session_rowid=agent_session_rowid,
+        agent_session_rowid=agent_session.id,
     ):
         raise AgentSessionConflict("agent_session_busy")
+    session_model = get_agent_session_model(agent_session)
+    if session_model is None:
+        return await set_session_model(
+            session,
+            agent_session=agent_session,
+            model=requested_model,
+        )
     if requested_model != session_model:
         raise AgentSessionConflict("agent_session_model_stale")
+    return session_model
 
 
 async def _release_agent_session_turn_lock(
@@ -2258,6 +2289,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 if title is not None:
                     agent_session.title = title
                 if request_body.model is not UNDEFINED:
+                    # An in-flight turn holds the model object it already built
+                    # and never re-reads the row, so it is not at risk here.
+                    # Rejecting mid-turn changes keeps the row's recorded model
+                    # matching the model the active turn is running, so
+                    # is_active + model reads stay coherent while streaming.
                     if is_turn_active(
                         agent_session.heartbeat_at,
                         now=datetime.now(timezone.utc),
@@ -2466,20 +2502,21 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         request_user_id = int(phoenix_user.identity) if phoenix_user is not None else None
         db_session_factory: DbSessionFactory = request.app.state.db
 
-        async with db_session_factory() as session:
-            agent_session = await _refresh_and_load_agent_session(
-                session,
-                agent_session_id=session_id,
-                user_id=request_user_id,
-            )
-            agent_session_rowid = agent_session.id
-            session_model = get_agent_session_model(agent_session)
-            await _claim_agent_session_turn_lock_for_model(
-                session,
-                agent_session_rowid=agent_session_rowid,
-                session_model=session_model,
-                requested_model=request_body.model,
-            )
+        try:
+            async with db_session_factory() as session:
+                agent_session = await _refresh_and_load_agent_session(
+                    session,
+                    agent_session_id=session_id,
+                    user_id=request_user_id,
+                )
+                agent_session_rowid = agent_session.id
+                session_model = await _claim_agent_session_turn_lock_for_model(
+                    session,
+                    agent_session=agent_session,
+                    requested_model=request_body.model,
+                )
+        except AgentError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
         heartbeat_task = asyncio.create_task(
             _heartbeat_agent_session_turn_lock(
@@ -2641,11 +2678,9 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     tool_outputs=body.tool_outputs,
                 )
                 transcript_messages = merged_transcript.messages
-                session_model = get_agent_session_model(agent_session)
-                await _claim_agent_session_turn_lock_for_model(
+                session_model = await _claim_agent_session_turn_lock_for_model(
                     session,
-                    agent_session_rowid=agent_session.id,
-                    session_model=session_model,
+                    agent_session=agent_session,
                     requested_model=body.model,
                 )
                 # Persist merge rewrites under the turn lock, before the model

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -131,10 +131,19 @@ class AgentSession(Node):
         assert heartbeat_at is None or isinstance(heartbeat_at, datetime)
         return is_turn_active(heartbeat_at, now=datetime.now(timezone.utc))
 
-    @strawberry.field(permission_classes=[CanAccessAgentSession])  # type: ignore
-    async def model(self, info: Info[Context, None]) -> AgentModelSelection:
+    @strawberry.field(
+        description=(
+            "The session's persisted model selection, or null when the custom "
+            "provider it referenced has been deleted. On null, clients fall "
+            "back to their own default model; the session adopts the model "
+            "asserted by the next chat or compaction request."
+        ),
+        permission_classes=[CanAccessAgentSession],
+    )  # type: ignore
+    async def model(self, info: Info[Context, None]) -> Optional[AgentModelSelection]:
         if self.db_record:
-            return to_gql_agent_model_selection(get_agent_session_model(self.db_record))
+            selection = get_agent_session_model(self.db_record)
+            return None if selection is None else to_gql_agent_model_selection(selection)
         (
             model_provider,
             model_name,
@@ -158,7 +167,8 @@ class AgentSession(Node):
             custom_provider_id=custom_provider_id,
             model_provider_type=model_provider_type,
         )
-        return to_gql_agent_model_selection(model_selection_from_routing(routing))
+        selection = model_selection_from_routing(routing)
+        return None if selection is None else to_gql_agent_model_selection(selection)
 
     @strawberry.field(
         description=(

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -6,6 +6,7 @@ from strawberry.relay import GlobalID
 from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart
+from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import _agent_session_model_kwargs, _message_uuid
 
@@ -176,6 +177,33 @@ class TestGetAgentSession:
         data = response.json()["data"]
         assert data["last_message_id"] is None
         assert "messages" not in data
+
+    async def test_reports_null_model_when_the_custom_provider_was_deleted(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """A deleted custom provider leaves the session's model unresolvable;
+        the route serializes it as null so clients fall back to their own
+        default model."""
+
+        async with db() as session:
+            agent_session = models.AgentSession(
+                model_provider=ModelProvider.OPENAI,
+                model_name="custom-model",
+                custom_provider_id=None,
+                model_provider_type="custom",
+                project_name="pxi-test",
+                title="Orphaned provider",
+            )
+            session.add(agent_session)
+            await session.flush()
+            session_id = str(GlobalID("AgentSession", str(agent_session.id)))
+
+        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
+
+        assert response.status_code == 200
+        assert response.json()["data"]["model"] is None
 
     async def test_gets_temporary_session(
         self,

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2790,6 +2790,205 @@ async def test_chat_rejects_a_turn_asserting_a_model_the_session_is_not_on(
         assert agent_session.heartbeat_at is None
 
 
+async def _create_tombstone_agent_session_row(
+    db: DbSessionFactory,
+    *,
+    messages: list[dict[str, Any]] | None = None,
+) -> str:
+    """Create a session whose custom provider has been deleted.
+
+    The ``ON DELETE SET NULL`` foreign key nulls ``custom_provider_id`` while
+    ``model_provider_type`` still reads ``custom``, so the session's model
+    selection resolves as ``None``.
+    """
+    async with db() as session:
+        agent_session = models.AgentSession(
+            model_provider=ModelProvider.OPENAI,
+            model_name="custom-model",
+            custom_provider_id=None,
+            model_provider_type="custom",
+            user_id=None,
+            title="",
+            project_name=get_env_phoenix_agents_assistant_project_name(),
+        )
+        session.add(agent_session)
+        await session.flush()
+        session.add_all(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session.id,
+                message=PhoenixUIMessage.model_validate(message),
+            )
+            for message in messages or []
+        )
+        return str(GlobalID("AgentSession", str(agent_session.id)))
+
+
+async def test_chat_adopts_the_asserted_model_when_the_sessions_provider_was_deleted(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting a session's custom provider leaves its model unresolvable
+    (it reads as null). Rather than rejecting every send as stale against a
+    model that no longer exists, the first turn adopts the model it asserts —
+    clients assert their own default when the session's model reads as null —
+    and the session persists that selection."""
+    built_selections = []
+
+    async def _fake_build_model(selection: object, **kwargs: object) -> TestModel:
+        built_selections.append(selection)
+        return TestModel(call_tools=[])
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+    agent_session_id = await _create_tombstone_agent_session_row(db)
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            "11111111-1111-4111-8111-111111111111",
+            _user_message("hello"),
+            model={
+                "providerType": "builtin",
+                "provider": "ANTHROPIC",
+                "modelName": "claude-opus-4-6",
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    assert built_selections == [
+        BuiltInProviderModelSelection(
+            provider_type="builtin",
+            provider=ModelProvider.ANTHROPIC,
+            model_name="claude-opus-4-6",
+        )
+    ]
+    global_id = GlobalID.from_id(agent_session_id)
+    async with db() as session:
+        agent_session = await session.get(models.AgentSession, int(global_id.node_id))
+        assert agent_session is not None
+        assert agent_session.model_provider.value == "ANTHROPIC"
+        assert agent_session.model_name == "claude-opus-4-6"
+        assert agent_session.custom_provider_id is None
+        assert agent_session.model_provider_type == "builtin"
+        assert agent_session.heartbeat_at is None
+
+
+async def test_chat_adoption_rejects_an_assertion_naming_a_missing_provider(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adoption still validates the asserted selection: a custom selection
+    naming a provider that does not exist is refused, and the turn lock is
+    handed back so the session stays usable."""
+    built_selections = []
+
+    async def _fake_build_model(selection: object, **kwargs: object) -> TestModel:
+        built_selections.append(selection)
+        return TestModel(call_tools=[])
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+    agent_session_id = await _create_tombstone_agent_session_row(db)
+    missing_provider_gid = str(GlobalID(models.GenerativeModelCustomProvider.__name__, "999"))
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            "11111111-1111-4111-8111-111111111111",
+            _user_message("hello"),
+            model={
+                "providerType": "custom",
+                "providerId": missing_provider_gid,
+                "modelName": "custom-model",
+            },
+        ),
+    )
+
+    assert response.status_code == 404
+    assert built_selections == []
+    global_id = GlobalID.from_id(agent_session_id)
+    async with db() as session:
+        agent_session = await session.get(models.AgentSession, int(global_id.node_id))
+        assert agent_session is not None
+        # The session keeps its unresolved model and a released lock.
+        assert agent_session.custom_provider_id is None
+        assert agent_session.model_provider_type == "custom"
+        assert agent_session.heartbeat_at is None
+
+
+async def test_compact_adopts_the_asserted_model_when_the_sessions_provider_was_deleted(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compaction shares the chat route's adoption semantics: on a session
+    whose model reads as null, the summary runs on — and the session adopts —
+    the asserted model."""
+    built_selections = []
+    checkpoint = {
+        "objectives": ["Investigate the trace"],
+        "constraints_and_preferences": [],
+        "decisions": [],
+        "completed_work": [],
+        "active_work": [],
+        "blockers": [],
+        "next_steps": [],
+        "important_details": [],
+    }
+
+    def compact_function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="conversation_checkpoint", args=checkpoint)]
+        )
+
+    async def _fake_build_model(selection: object, **kwargs: object) -> FunctionModel:
+        built_selections.append(selection)
+        return FunctionModel(function=compact_function)
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+    agent_session_id = await _create_tombstone_agent_session_row(
+        db,
+        messages=[
+            _user_message("Find the slow span", message_id=_message_uuid("user-1")),
+            {
+                "id": _message_uuid("assistant-1"),
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "The slow span is trace-id-123."}],
+            },
+        ],
+    )
+
+    response = await httpx_client.post(
+        _compact_url(agent_session_id),
+        json={
+            "model": {
+                "providerType": "builtin",
+                "provider": "ANTHROPIC",
+                "modelName": "claude-opus-4-6",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["compacted"] is True
+    assert built_selections == [
+        BuiltInProviderModelSelection(
+            provider_type="builtin",
+            provider=ModelProvider.ANTHROPIC,
+            model_name="claude-opus-4-6",
+        )
+    ]
+    global_id = GlobalID.from_id(agent_session_id)
+    async with db() as session:
+        agent_session = await session.get(models.AgentSession, int(global_id.node_id))
+        assert agent_session is not None
+        assert agent_session.model_provider.value == "ANTHROPIC"
+        assert agent_session.model_name == "claude-opus-4-6"
+        assert agent_session.model_provider_type == "builtin"
+        assert agent_session.heartbeat_at is None
+
+
 async def test_create_session_route_rejects_unknown_agents(
     httpx_client: httpx.AsyncClient,
 ) -> None:

--- a/tests/unit/server/api/helpers/test_agent_sessions.py
+++ b/tests/unit/server/api/helpers/test_agent_sessions.py
@@ -187,9 +187,12 @@ async def test_set_session_model_rejects_a_deleted_custom_provider(
             )
 
 
-async def test_deleted_custom_provider_reads_as_builtin_fallback(
+async def test_deleted_custom_provider_reads_as_unresolved_model(
     db: DbSessionFactory,
 ) -> None:
+    """Deleting a custom provider leaves the ``ON DELETE SET NULL`` tombstone,
+    which reads back as no selection at all — clients substitute their own
+    default and the next turn's assertion is adopted."""
     provider_id, provider_gid = await _add_custom_provider(db)
     agent_session_id = await _add_builtin_session(db)
 
@@ -212,8 +215,4 @@ async def test_deleted_custom_provider_reads_as_builtin_fallback(
         await session.flush()
         await session.refresh(agent_session)
 
-        assert get_agent_session_model(agent_session) == BuiltInProviderModelSelection(
-            provider_type="builtin",
-            provider=ModelProvider.OPENAI,
-            model_name="custom-model",
-        )
+        assert get_agent_session_model(agent_session) is None

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -140,10 +140,12 @@ async def test_agent_session_is_active_reflects_heartbeat_liveness(
         assert response.data["agentSession"]["isActive"] is expected, title
 
 
-async def test_agent_session_serializes_deleted_custom_provider_as_builtin_fallback(
+async def test_agent_session_serializes_deleted_custom_provider_as_null_model(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
+    """A deleted custom provider leaves the session's model unresolvable; the
+    field serializes as null so clients substitute their own default."""
     async with db() as session:
         provider = models.GenerativeModelCustomProvider(
             name="Deleted custom provider",
@@ -195,15 +197,7 @@ async def test_agent_session_serializes_deleted_custom_provider_as_builtin_fallb
     )
 
     assert not response.errors
-    assert response.data == {
-        "agentSession": {
-            "model": {
-                "__typename": "AgentBuiltinProviderModelSelection",
-                "provider": "OPENAI",
-                "modelName": "custom-model",
-            },
-        }
-    }
+    assert response.data == {"agentSession": {"model": None}}
 
 
 async def test_agent_sessions_excludes_temporary_sessions(


### PR DESCRIPTION
Stacked on #15122.

## Problem

When a custom provider is deleted, the `agent_sessions.custom_provider_id` FK (`ON DELETE SET NULL`) leaves the session with neither provider column set. The read path masked this: `model_selection_from_routing` silently fell back to the built-in provider matching the deleted provider's SDK while keeping the custom model name. That fabricates a selection that usually cannot run — e.g. an Azure deployment name sent to the OpenAI API — using env/secret-store credentials the user never chose, and it reverts `openai_api_type` to the default.

## Change

Surface the tombstone instead of masking it, and let clients fall back to **their own default model**:

**Server**
- `model_selection_from_routing` returns `None` for the tombstone; `AgentSession.model` (GraphQL) and `AgentSessionData.model` (REST) are now nullable and serialize the deleted-provider state as `null`.
- `_claim_agent_session_turn_lock_for_model` now resolves the session's model under the turn lock and returns the selection the turn runs on. When the session's model reads as null, the first chat/compaction request **adopts the model it asserts** (persisted under the lock) instead of failing the `agent_session_model_stale` precondition against a model that no longer exists. Concurrent clients still serialize through the ordinary busy/stale preconditions; an assertion naming a nonexistent provider still 404s, and explicit `PATCH` model changes naming a deleted provider still 404 (unchanged).

**Web app**
- `useAgentSessionModelConfig` resolves a null model to `undefined`, so the existing `sessionModelConfig ?? defaultModelConfig` fallback in `useAgentChatPanelState` shows the user's default; the send/compact paths already assert `readAgentSessionModelSelection(...) ?? defaultModelConfig`.

**pxi CLI**
- `PxiSession.model` is nullable. A null model resolves to the CLI's own launch selection without a catalog round trip; restoring with explicit `--provider`/`--model` writes the flags onto the session as before (null never "matches" the flags).

**Codegen**: `schemas/openapi.json`, `app/schema.graphql`, Relay artifacts, and the three generated clients are regenerated.

## Tests

- Router: chat and compact adopt the asserted model on a tombstone session; adoption asserting a missing provider 404s and releases the turn lock; GET serializes `model: null`.
- Helpers/GraphQL: tombstone reads as `None` / serializes as `null` (replacing the silent-fallback expectations).
- CLI: restoring a null-model session falls back to the CLI selection (no write without explicit flags; write with them).

Suites run: server unit (agents + session mutations, 471 passed), web agent tests (761 passed), pxi CLI (926 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)