### PR TITLE
refactor(agents): drop builtin_provider column and openaiApiType, falling back to builtin routing when a custom provider is deleted

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -84,13 +84,11 @@ type AgentAssistantEnabled {
 type AgentBuiltinProviderModelSelection {
   provider: ModelProvider!
   modelName: String!
-  openaiApiType: OpenAIApiType!
 }
 
 input AgentBuiltinProviderModelSelectionInput {
   provider: ModelProvider!
   modelName: String!
-  openaiApiType: OpenAIApiType! = RESPONSES
 }
 
 type AgentCustomProviderModelSelection {

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -2033,8 +2033,7 @@ export interface components {
          *
          *     Credentials and connection details (base URL, Azure endpoint, AWS
          *     region) are resolved from the secret store first and the process
-         *     environment second. ``openai_api_type`` is honoured by the OpenAI and
-         *     Azure OpenAI branches; other providers ignore it.
+         *     environment second.
          */
         BuiltInProviderModelSelection: {
             /**
@@ -2045,12 +2044,6 @@ export interface components {
             provider: components["schemas"]["ModelProvider"];
             /** Modelname */
             modelName: string;
-            /**
-             * Openaiapitype
-             * @default responses
-             * @enum {string}
-             */
-            openaiApiType?: "chat_completions" | "responses";
         };
         /** CategoricalAnnotationConfig */
         CategoricalAnnotationConfig: {

--- a/app/src/components/agent/__generated__/EditAgentSessionTitleDialogMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/EditAgentSessionTitleDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<026b339fcafe4bb042796e63d3a88246>>
+ * @generated SignedSource<<74207101b1a6a6d07f8aac8da58816b9>>
  * @lightSyntaxTransform
  */
 
@@ -10,7 +10,6 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
-export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type PatchAgentSessionInput = {
   id: string;
   model?: AgentModelSelectionInput | null;
@@ -29,7 +28,6 @@ export type AgentCustomProviderModelSelectionInput = {
 };
 export type AgentBuiltinProviderModelSelectionInput = {
   modelName: string;
-  openaiApiType?: OpenAIApiType;
   provider: ModelProvider;
 };
 export type EditAgentSessionTitleDialogMutation$variables = {

--- a/app/src/components/agent/__generated__/agentSessionModelSessionQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionModelSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5f2419bb3b3965fbc5bcfe1ff86bcb14>>
+ * @generated SignedSource<<a99bb66ea73b807cae66205ab176783a>>
  * @lightSyntaxTransform
  */
 
@@ -84,14 +84,7 @@ v5 = [
             "name": "provider",
             "storageKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "openaiApiType",
-            "storageKey": null
-          }
+          (v4/*:: as any*/)
         ],
         "type": "AgentBuiltinProviderModelSelection",
         "abstractKey": null
@@ -181,12 +174,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9acd4350f116b56294bcc9f10a9ac759",
+    "cacheID": "8b4aa487112b6c2d68be979d6261d7bc",
     "id": null,
     "metadata": {},
     "name": "agentSessionModelSessionQuery",
     "operationKind": "query",
-    "text": "query agentSessionModelSessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      ...agentSessionModel_session\n    }\n    id\n  }\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n      openaiApiType\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
+    "text": "query agentSessionModelSessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      ...agentSessionModel_session\n    }\n    id\n  }\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/agentSessionModel_session.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionModel_session.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<547c754f7f8ece9ec83d326d2463ac60>>
+ * @generated SignedSource<<1f6dd6c281fb4008be5c70c12ce07174>>
  * @lightSyntaxTransform
  */
 
@@ -9,13 +9,11 @@
 
 import { ReaderInlineDataFragment } from 'relay-runtime';
 export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
-export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 import { FragmentRefs } from "relay-runtime";
 export type agentSessionModel_session$data = {
   readonly model: {
     readonly __typename: "AgentBuiltinProviderModelSelection";
     readonly modelName: string;
-    readonly openaiApiType: OpenAIApiType;
     readonly provider: ModelProvider;
   } | {
     readonly __typename: "AgentCustomProviderModelSelection";
@@ -38,6 +36,6 @@ const node: ReaderInlineDataFragment = {
   "name": "agentSessionModel_session"
 };
 
-(node as any).hash = "2f64a7c5853a228fc81892e53fe55c5e";
+(node as any).hash = "c175ed7c5f56f2a1075b6c5905e0ae79";
 
 export default node;

--- a/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84a9c1b25c0d41d4fd060de9fcabf0aa>>
+ * @generated SignedSource<<fe067fcd1fe20a69bac534a29465c1be>>
  * @lightSyntaxTransform
  */
 
@@ -166,14 +166,7 @@ v15 = {
           "name": "provider",
           "storageKey": null
         },
-        (v14/*:: as any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "openaiApiType",
-          "storageKey": null
-        }
+        (v14/*:: as any*/)
       ],
       "type": "AgentBuiltinProviderModelSelection",
       "abstractKey": null
@@ -318,12 +311,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0f5020e9f66d7d354fdcd72bb47a0cb7",
+    "cacheID": "56442597f627dab36057313fc8271f24",
     "id": null,
     "metadata": {},
     "name": "agentSessionRelaySessionQuery",
     "operationKind": "query",
-    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary: isEphemeral\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      lastMessageId\n      ...agentSessionModel_session\n      messages\n    }\n    id\n  }\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n      openaiApiType\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
+    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary: isEphemeral\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      lastMessageId\n      ...agentSessionModel_session\n      messages\n    }\n    id\n  }\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/useAgentChatPanelStatePatchAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatPanelStatePatchAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<57f24761f758e8710d93f63defaffadc>>
+ * @generated SignedSource<<888c8c4d5a5fc113d8a748ece8c67bed>>
  * @lightSyntaxTransform
  */
 
@@ -10,7 +10,6 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
-export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type PatchAgentSessionInput = {
   id: string;
   model?: AgentModelSelectionInput | null;
@@ -29,7 +28,6 @@ export type AgentCustomProviderModelSelectionInput = {
 };
 export type AgentBuiltinProviderModelSelectionInput = {
   modelName: string;
-  openaiApiType?: OpenAIApiType;
   provider: ModelProvider;
 };
 export type useAgentChatPanelStatePatchAgentSessionMutation$variables = {
@@ -50,7 +48,6 @@ export type useAgentChatPanelStatePatchAgentSessionMutation$rawResponse = {
       readonly model: {
         readonly __typename: "AgentBuiltinProviderModelSelection";
         readonly modelName: string;
-        readonly openaiApiType: OpenAIApiType;
         readonly provider: ModelProvider;
       } | {
         readonly __typename: "AgentCustomProviderModelSelection";
@@ -122,14 +119,7 @@ v4 = {
           "name": "provider",
           "storageKey": null
         },
-        (v3/*:: as any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "openaiApiType",
-          "storageKey": null
-        }
+        (v3/*:: as any*/)
       ],
       "type": "AgentBuiltinProviderModelSelection",
       "abstractKey": null
@@ -228,12 +218,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a8e21c8bef3ca088456d76330cc98752",
+    "cacheID": "cbd47e1cd326914b88a81a1aadaeb775",
     "id": null,
     "metadata": {},
     "name": "useAgentChatPanelStatePatchAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatPanelStatePatchAgentSessionMutation(\n  $input: PatchAgentSessionInput!\n) {\n  patchAgentSession(input: $input) {\n    agentSession {\n      id\n      ...agentSessionModel_session\n    }\n  }\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n      openaiApiType\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
+    "text": "mutation useAgentChatPanelStatePatchAgentSessionMutation(\n  $input: PatchAgentSessionInput!\n) {\n  patchAgentSession(input: $input) {\n    agentSession {\n      id\n      ...agentSessionModel_session\n    }\n  }\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/useAgentSessionHistoryBranchAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentSessionHistoryBranchAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66fb77f0fae1e4be7f4fce9c251865a1>>
+ * @generated SignedSource<<e565de80a7b379b9b7bcdc5967b5e401>>
  * @lightSyntaxTransform
  */
 
@@ -161,14 +161,7 @@ v14 = {
           "name": "provider",
           "storageKey": null
         },
-        (v13/*:: as any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "openaiApiType",
-          "storageKey": null
-        }
+        (v13/*:: as any*/)
       ],
       "type": "AgentBuiltinProviderModelSelection",
       "abstractKey": null
@@ -340,12 +333,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "40223b541f3b4b108079610d8825cd1b",
+    "cacheID": "a87bffea0bb7eb44c75052208d574ebe",
     "id": null,
     "metadata": {},
     "name": "useAgentSessionHistoryBranchAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentSessionHistoryBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n      ...agentSessionModel_session\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n      openaiApiType\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
+    "text": "mutation useAgentSessionHistoryBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n      ...agentSessionModel_session\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/useDraftSessionCreationCreateAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useDraftSessionCreationCreateAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd99f7c92aae7e453fb7bcd9d257c754>>
+ * @generated SignedSource<<e304065dfa7c3712a50abd32813a29ba>>
  * @lightSyntaxTransform
  */
 
@@ -10,7 +10,6 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
-export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type CreateAgentSessionInput = {
   isEphemeral?: boolean;
   model: AgentModelSelectionInput;
@@ -29,7 +28,6 @@ export type AgentCustomProviderModelSelectionInput = {
 };
 export type AgentBuiltinProviderModelSelectionInput = {
   modelName: string;
-  openaiApiType?: OpenAIApiType;
   provider: ModelProvider;
 };
 export type useDraftSessionCreationCreateAgentSessionMutation$variables = {
@@ -172,14 +170,7 @@ v13 = {
           "name": "provider",
           "storageKey": null
         },
-        (v12/*:: as any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "openaiApiType",
-          "storageKey": null
-        }
+        (v12/*:: as any*/)
       ],
       "type": "AgentBuiltinProviderModelSelection",
       "abstractKey": null
@@ -349,12 +340,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d58def5ecf154d0f05986d9a9881201a",
+    "cacheID": "a0fd7d24b668a972bf7ca669425983d9",
     "id": null,
     "metadata": {},
     "name": "useDraftSessionCreationCreateAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useDraftSessionCreationCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      ...agentSessionModel_session\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n      openaiApiType\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
+    "text": "mutation useDraftSessionCreationCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      ...agentSessionModel_session\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment agentSessionModel_session on AgentSession {\n  model {\n    __typename\n    ... on AgentBuiltinProviderModelSelection {\n      provider\n      modelName\n    }\n    ... on AgentCustomProviderModelSelection {\n      providerId\n      modelName\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__tests__/agentSessionModel.test.ts
+++ b/app/src/components/agent/__tests__/agentSessionModel.test.ts
@@ -10,21 +10,19 @@ import {
 } from "../agentSessionModel";
 
 describe("resolvePersistedAgentModel", () => {
-  it("restores a built-in selection with its persisted API type", () => {
+  it("restores a built-in selection", () => {
     expect(
       resolvePersistedAgentModel({
         model: {
           __typename: "AgentBuiltinProviderModelSelection",
           provider: "OPENAI",
           modelName: "gpt-5.5",
-          openaiApiType: "CHAT_COMPLETIONS",
         },
         customProviders: [],
       })
     ).toMatchObject({
       provider: "OPENAI",
       modelName: "gpt-5.5",
-      openaiApiType: "CHAT_COMPLETIONS",
     });
   });
 
@@ -89,14 +87,12 @@ describe("resolvePersistedAgentModel", () => {
           __typename: "AgentBuiltinProviderModelSelection",
           provider: "OPENAI",
           modelName: "free-typed-model",
-          openaiApiType: "RESPONSES",
         },
         customProviders: [],
       })
     ).toMatchObject({
       provider: "OPENAI",
       modelName: "free-typed-model",
-      openaiApiType: "RESPONSES",
     });
   });
 
@@ -118,25 +114,26 @@ describe("resolvePersistedAgentModel", () => {
 });
 
 describe("toAgentModelSelection", () => {
-  it.each(["OPENAI", "AZURE_OPENAI"] as const)(
-    "defaults built-in %s models to the Responses API",
+  it.each(["OPENAI", "AZURE_OPENAI", "ANTHROPIC"] as const)(
+    "builds a built-in %s selection from provider and model name",
     (provider) => {
       expect(
         toAgentModelSelection({
           provider,
-          modelName: "gpt-5.4",
+          modelName: "some-model",
           invocationParameters: getDefaultInvocationConfig(provider),
         })
       ).toEqual({
         providerType: "builtin",
         provider,
-        modelName: "gpt-5.4",
-        openaiApiType: "responses",
+        modelName: "some-model",
       });
     }
   );
 
-  it("preserves a configured Chat Completions API type", () => {
+  it("ignores a configured OpenAI API type", () => {
+    // The playground's ModelConfig can carry an API type, but the agent wire
+    // selection no longer exposes one — the server always uses its default.
     expect(
       toAgentModelSelection({
         provider: "OPENAI",
@@ -148,21 +145,6 @@ describe("toAgentModelSelection", () => {
       providerType: "builtin",
       provider: "OPENAI",
       modelName: "gpt-5.4",
-      openaiApiType: "chat_completions",
-    });
-  });
-
-  it("does not set an OpenAI API type for other built-in providers", () => {
-    expect(
-      toAgentModelSelection({
-        provider: "ANTHROPIC",
-        modelName: "claude-opus-4-6",
-        invocationParameters: getDefaultInvocationConfig("ANTHROPIC"),
-      })
-    ).toEqual({
-      providerType: "builtin",
-      provider: "ANTHROPIC",
-      modelName: "claude-opus-4-6",
     });
   });
 
@@ -187,7 +169,6 @@ describe("shouldNotifyModelChangedElsewhere", () => {
     providerType: "builtin",
     provider: "OPENAI",
     modelName,
-    openaiApiType: "responses",
   });
 
   it("notifies when another client moved the session's model", () => {

--- a/app/src/components/agent/agentSessionModel.ts
+++ b/app/src/components/agent/agentSessionModel.ts
@@ -29,7 +29,6 @@ const agentSessionModelFragment = graphql`
       ... on AgentBuiltinProviderModelSelection {
         provider
         modelName
-        openaiApiType
       }
       ... on AgentCustomProviderModelSelection {
         providerId
@@ -98,7 +97,6 @@ export function resolvePersistedAgentModel({
   return {
     provider: model.provider,
     modelName: model.modelName,
-    openaiApiType: model.openaiApiType,
     invocationParameters: getDefaultInvocationConfig(model.provider),
   };
 }
@@ -123,13 +121,6 @@ export function toAgentModelSelection(
     providerType: "builtin",
     provider: config.provider,
     modelName: config.modelName ?? "",
-    ...((config.provider === "OPENAI" ||
-      config.provider === "AZURE_OPENAI") && {
-      openaiApiType:
-        config.openaiApiType === "CHAT_COMPLETIONS"
-          ? "chat_completions"
-          : "responses",
-    }),
   };
 }
 
@@ -147,10 +138,6 @@ export function toAgentModelSelectionInput(model: AgentModelSelection) {
     builtin: {
       provider: model.provider,
       modelName: model.modelName,
-      openaiApiType:
-        model.openaiApiType === "chat_completions"
-          ? ("CHAT_COMPLETIONS" as const)
-          : ("RESPONSES" as const),
     },
   };
 }

--- a/app/src/components/agent/useAgentChatPanelState.ts
+++ b/app/src/components/agent/useAgentChatPanelState.ts
@@ -102,10 +102,6 @@ export function useAgentChatPanelState({
               __typename: "AgentBuiltinProviderModelSelection" as const,
               provider: selection.provider,
               modelName: selection.modelName,
-              openaiApiType:
-                selection.openaiApiType === "chat_completions"
-                  ? ("CHAT_COMPLETIONS" as const)
-                  : ("RESPONSES" as const),
             };
       commitModelChange({
         variables: {

--- a/js/packages/phoenix-cli/src/pxi/preflight.ts
+++ b/js/packages/phoenix-cli/src/pxi/preflight.ts
@@ -319,20 +319,11 @@ export function getRecommendedPxiModels({
     data.playgroundModels.some(
       (model) => model.providerKey === provider && model.name === modelName
     )
-  ).map(({ provider, modelName }) =>
-    provider === "OPENAI"
-      ? {
-          providerType: "builtin",
-          provider,
-          modelName,
-          openaiApiType: "responses",
-        }
-      : {
-          providerType: "builtin",
-          provider,
-          modelName,
-        }
-  );
+  ).map(({ provider, modelName }) => ({
+    providerType: "builtin",
+    provider,
+    modelName,
+  }));
 }
 
 /** Fetch the recommended model choices displayed by the interactive picker. */
@@ -470,11 +461,7 @@ export function isSameModelSelection(
       a.modelName === b.modelName
     );
   }
-  return (
-    a.provider === b.provider &&
-    a.modelName === b.modelName &&
-    (a.openaiApiType ?? "responses") === (b.openaiApiType ?? "responses")
-  );
+  return a.provider === b.provider && a.modelName === b.modelName;
 }
 
 /**

--- a/js/packages/phoenix-cli/test/pxiPreflight.test.ts
+++ b/js/packages/phoenix-cli/test/pxiPreflight.test.ts
@@ -107,37 +107,13 @@ function createFetch({
 describe("isSameModelSelection", () => {
   // The session poll uses this to decide whether the model actually moved.
   // A false negative would put a catalog round trip on every poll tick.
-  it("treats an omitted openaiApiType as the default", () => {
+  it("matches built-in selections on provider and model name", () => {
     expect(
       isSameModelSelection(
         { providerType: "builtin", provider: "OPENAI", modelName: "gpt-5.4" },
-        {
-          providerType: "builtin",
-          provider: "OPENAI",
-          modelName: "gpt-5.4",
-          openaiApiType: "responses",
-        }
+        { providerType: "builtin", provider: "OPENAI", modelName: "gpt-5.4" }
       )
     ).toBe(true);
-  });
-
-  it("distinguishes the OpenAI API type", () => {
-    expect(
-      isSameModelSelection(
-        {
-          providerType: "builtin",
-          provider: "OPENAI",
-          modelName: "gpt-5.4",
-          openaiApiType: "chat_completions",
-        },
-        {
-          providerType: "builtin",
-          provider: "OPENAI",
-          modelName: "gpt-5.4",
-          openaiApiType: "responses",
-        }
-      )
-    ).toBe(false);
   });
 
   it("distinguishes provider and model name", () => {
@@ -369,7 +345,6 @@ describe("PXI model preflight", () => {
         providerType: "builtin",
         provider: "OPENAI",
         modelName: "gpt-5.4",
-        openaiApiType: "responses",
       },
       {
         providerType: "builtin",

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2033,8 +2033,7 @@ export interface components {
          *
          *     Credentials and connection details (base URL, Azure endpoint, AWS
          *     region) are resolved from the secret store first and the process
-         *     environment second. ``openai_api_type`` is honoured by the OpenAI and
-         *     Azure OpenAI branches; other providers ignore it.
+         *     environment second.
          */
         BuiltInProviderModelSelection: {
             /**
@@ -2045,12 +2044,6 @@ export interface components {
             provider: components["schemas"]["ModelProvider"];
             /** Modelname */
             modelName: string;
-            /**
-             * Openaiapitype
-             * @default responses
-             * @enum {string}
-             */
-            openaiApiType?: "chat_completions" | "responses";
         };
         /** CategoricalAnnotationConfig */
         CategoricalAnnotationConfig: {

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -2033,8 +2033,7 @@ export interface components {
          *
          *     Credentials and connection details (base URL, Azure endpoint, AWS
          *     region) are resolved from the secret store first and the process
-         *     environment second. ``openai_api_type`` is honoured by the OpenAI and
-         *     Azure OpenAI branches; other providers ignore it.
+         *     environment second.
          */
         BuiltInProviderModelSelection: {
             /**
@@ -2045,12 +2044,6 @@ export interface components {
             provider: components["schemas"]["ModelProvider"];
             /** Modelname */
             modelName: string;
-            /**
-             * Openaiapitype
-             * @default responses
-             * @enum {string}
-             */
-            openaiApiType?: "chat_completions" | "responses";
         };
         /** CategoricalAnnotationConfig */
         CategoricalAnnotationConfig: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1279,7 +1279,6 @@ class BuiltInProviderModelSelection(TypedDict):
     ]
     modelName: str
     providerType: Literal["builtin"]
-    openaiApiType: NotRequired[Literal["chat_completions", "responses"]]
 
 
 class CategoricalAnnotationConfig(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9670,15 +9670,6 @@
           "modelName": {
             "type": "string",
             "title": "Modelname"
-          },
-          "openaiApiType": {
-            "type": "string",
-            "enum": [
-              "chat_completions",
-              "responses"
-            ],
-            "title": "Openaiapitype",
-            "default": "responses"
           }
         },
         "type": "object",
@@ -9688,7 +9679,7 @@
           "modelName"
         ],
         "title": "BuiltInProviderModelSelection",
-        "description": "Chat against a Phoenix built-in provider.\n\nCredentials and connection details (base URL, Azure endpoint, AWS\nregion) are resolved from the secret store first and the process\nenvironment second. ``openai_api_type`` is honoured by the OpenAI and\nAzure OpenAI branches; other providers ignore it."
+        "description": "Chat against a Phoenix built-in provider.\n\nCredentials and connection details (base URL, Azure endpoint, AWS\nregion) are resolved from the secret store first and the process\nenvironment second."
       },
       "CategoricalAnnotationConfig": {
         "properties": {

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1165,13 +1165,11 @@ CREATE TABLE public.agent_sessions (
     model_provider VARCHAR NOT NULL,
     model_name VARCHAR NOT NULL,
     custom_provider_id BIGINT,
-    builtin_provider JSONB NOT NULL,
     is_ephemeral BOOLEAN NOT NULL,
     heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
-    CHECK (((custom_provider_id IS NULL) OR (builtin_provider = '{}'::jsonb))),
     CONSTRAINT fk_agent_sessions_custom_provider_id_generative_model_c_af13
         FOREIGN KEY
         (custom_provider_id)

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -101,7 +101,6 @@ def upgrade() -> None:
             nullable=True,
             index=True,
         ),
-        sa.Column("builtin_provider", JSON_, nullable=False),
         sa.Column("is_ephemeral", sa.Boolean, nullable=False),
         sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column(
@@ -116,10 +115,6 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
             onupdate=sa.func.now(),
-        ),
-        sa.CheckConstraint(
-            "custom_provider_id IS NULL OR builtin_provider = '{}'",
-            name="at_most_one_provider_set",
         ),
         sqlite_autoincrement=True,
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -54,7 +54,6 @@ from typing_extensions import Self, TypeAlias
 
 from phoenix.config import get_env_database_schema
 from phoenix.datetime_utils import normalize_datetime
-from phoenix.db.types.agent_session_config import AgentBuiltinProviderConfig
 from phoenix.db.types.annotation_configs import (
     AnnotationConfig as AnnotationConfigModel,
 )
@@ -321,29 +320,6 @@ class _ModelProvider(TypeDecorator[ModelProvider]):
 
     def process_result_value(self, value: Optional[str], _: Dialect) -> Optional[ModelProvider]:
         return None if value is None else ModelProvider(value)
-
-
-class _AgentBuiltinProviderConfig(TypeDecorator[AgentBuiltinProviderConfig]):
-    cache_ok = True
-    impl = JSON_
-
-    def process_bind_param(
-        self,
-        value: Optional[AgentBuiltinProviderConfig],
-        _: Dialect,
-    ) -> dict[str, Any]:
-        if value is None:
-            return {}
-        return value.model_dump()
-
-    def process_result_value(
-        self,
-        value: Optional[dict[str, Any]],
-        _: Dialect,
-    ) -> Optional[AgentBuiltinProviderConfig]:
-        if not value:
-            return None
-        return AgentBuiltinProviderConfig.model_validate(value)
 
 
 class _InvocationParameters(TypeDecorator[PromptInvocationParameters]):
@@ -3425,14 +3401,11 @@ class AgentSession(HasId):
     model_provider: Mapped[ModelProvider] = mapped_column(_ModelProvider, nullable=False)
     model_name: Mapped[str] = mapped_column(String, nullable=False)
     custom_provider_id: Mapped[Optional[int]] = mapped_column(
+        # SET NULL turns a deleted custom provider's sessions into builtin
+        # selections of the model_provider and model_name columns.
         ForeignKey("generative_model_custom_providers.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
-    )
-    builtin_provider: Mapped[Optional[AgentBuiltinProviderConfig]] = mapped_column(
-        _AgentBuiltinProviderConfig,
-        nullable=False,
-        default=None,
     )
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
@@ -3456,10 +3429,6 @@ class AgentSession(HasId):
         back_populates="agent_session",
     )
     __table_args__ = (
-        CheckConstraint(
-            "custom_provider_id IS NULL OR builtin_provider = '{}'",
-            name="at_most_one_provider_set",
-        ),
         Index(
             "ix_agent_sessions_user_id_updated_at",
             "user_id",

--- a/src/phoenix/db/types/agent_session_config.py
+++ b/src/phoenix/db/types/agent_session_config.py
@@ -1,7 +1,0 @@
-from typing import Literal
-
-from pydantic import BaseModel
-
-
-class AgentBuiltinProviderConfig(BaseModel):
-    openai_api_type: Literal["chat_completions", "responses"] = "responses"

--- a/src/phoenix/server/agents/model_factory.py
+++ b/src/phoenix/server/agents/model_factory.py
@@ -391,7 +391,7 @@ def _get_pydantic_ai_model_from_builtin_provider(
         return _build_openai_model(
             model_name=params.model_name,
             provider=openai_provider,
-            openai_api_type=params.openai_api_type,
+            openai_api_type="responses",
         )
     if params.provider == ModelProvider.AZURE_OPENAI:
         api_key = _first_credential(credentials, "AZURE_OPENAI_API_KEY")
@@ -424,7 +424,7 @@ def _get_pydantic_ai_model_from_builtin_provider(
         return _build_openai_model(
             model_name=params.model_name,
             provider=openai_provider,
-            openai_api_type=params.openai_api_type,
+            openai_api_type="responses",
         )
     if params.provider == ModelProvider.ANTHROPIC:
         from anthropic import AsyncAnthropic

--- a/src/phoenix/server/agents/model_selection.py
+++ b/src/phoenix/server/agents/model_selection.py
@@ -30,8 +30,7 @@ class BuiltInProviderModelSelection(BaseModel):
 
     Credentials and connection details (base URL, Azure endpoint, AWS
     region) are resolved from the secret store first and the process
-    environment second. ``openai_api_type`` is honoured by the OpenAI and
-    Azure OpenAI branches; other providers ignore it.
+    environment second.
     """
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
@@ -39,7 +38,6 @@ class BuiltInProviderModelSelection(BaseModel):
     provider_type: Literal["builtin"]
     provider: ModelProvider
     model_name: str
-    openai_api_type: Literal["chat_completions", "responses"] = "responses"
 
 
 # TypeAliasType (rather than a plain ``Annotated`` alias) makes pydantic emit the

--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -7,7 +7,6 @@ from typing_extensions import assert_never
 
 from phoenix.db import models
 from phoenix.db.models import GenerativeModelSDK
-from phoenix.db.types.agent_session_config import AgentBuiltinProviderConfig
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.agents.exceptions import ProviderNotFoundError
 from phoenix.server.agents.model_selection import (
@@ -52,12 +51,11 @@ def model_provider_from_generative_model_sdk(
 
 
 class AgentModelRouting(NamedTuple):
-    """Values for the four model-routing columns on ``agent_sessions``."""
+    """Values for the three model-routing columns on ``agent_sessions``."""
 
     model_provider: ModelProvider
     model_name: str
     custom_provider_id: Optional[int]
-    builtin_provider: Optional[AgentBuiltinProviderConfig]
 
 
 async def get_custom_provider(
@@ -97,16 +95,12 @@ async def resolve_model_routing(
             model_provider=model_provider_from_generative_model_sdk(provider.sdk),
             model_name=model.model_name,
             custom_provider_id=provider.id,
-            builtin_provider=None,
         )
     if isinstance(model, BuiltInProviderModelSelection):
         return AgentModelRouting(
             model_provider=model.provider,
             model_name=model.model_name,
             custom_provider_id=None,
-            builtin_provider=AgentBuiltinProviderConfig(
-                openai_api_type=model.openai_api_type,
-            ),
         )
     assert_never(model)
 
@@ -126,19 +120,17 @@ async def set_session_model(
     agent_session.model_provider = routing.model_provider
     agent_session.model_name = routing.model_name
     agent_session.custom_provider_id = routing.custom_provider_id
-    agent_session.builtin_provider = routing.builtin_provider
     return get_agent_session_model(agent_session)
 
 
 def model_selection_from_routing(routing: AgentModelRouting) -> AgentModelSelection:
-    """Reconstruct the model selection encoded by the routing column values."""
-    if routing.builtin_provider is not None:
-        return BuiltInProviderModelSelection(
-            provider_type="builtin",
-            provider=routing.model_provider,
-            model_name=routing.model_name,
-            openai_api_type=routing.builtin_provider.openai_api_type,
-        )
+    """Reconstruct the model selection encoded by the routing column values.
+
+    A session is a custom-provider selection exactly when it references a live
+    custom provider row. Deleting that row nulls the reference (``ON DELETE
+    SET NULL``), so the session falls back to a builtin selection of the same
+    provider and model name.
+    """
     if routing.custom_provider_id is not None:
         return CustomProviderModelSelection(
             provider_type="custom",
@@ -166,6 +158,5 @@ def get_agent_session_model(
             model_provider=agent_session.model_provider,
             model_name=agent_session.model_name,
             custom_provider_id=agent_session.custom_provider_id,
-            builtin_provider=agent_session.builtin_provider,
         )
     )

--- a/src/phoenix/server/api/input_types/AgentModelSelectionInput.py
+++ b/src/phoenix/server/api/input_types/AgentModelSelectionInput.py
@@ -5,7 +5,6 @@ from strawberry import UNSET
 from strawberry.relay import GlobalID
 
 from phoenix.db.types.model_provider import ModelProvider
-from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 
 
 @strawberry.input
@@ -18,7 +17,6 @@ class AgentCustomProviderModelSelectionInput:
 class AgentBuiltinProviderModelSelectionInput:
     provider: ModelProvider
     model_name: str
-    openai_api_type: OpenAIApiType = OpenAIApiType.RESPONSES
 
 
 @strawberry.input(one_of=True)

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -163,7 +163,6 @@ class AgentSessionMutationMixin:
                 model_provider=routing.model_provider,
                 model_name=routing.model_name,
                 custom_provider_id=routing.custom_provider_id,
-                builtin_provider=routing.builtin_provider,
             )
             session.add(agent_session)
         return CreateAgentSessionMutationPayload(
@@ -269,7 +268,6 @@ class AgentSessionMutationMixin:
                 model_provider=source_session.model_provider,
                 model_name=source_session.model_name,
                 custom_provider_id=source_session.custom_provider_id,
-                builtin_provider=source_session.builtin_provider,
             )
             session.add(branch_session)
             await session.flush()
@@ -389,7 +387,6 @@ def _to_model_selection(input: AgentModelSelectionInput) -> AgentModelSelectionM
             provider_type="builtin",
             provider=input.builtin.provider,
             model_name=input.builtin.model_name,
-            openai_api_type=input.builtin.openai_api_type.value,
         )
     raise ValueError("Exactly one model selection must be provided.")
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -2153,7 +2153,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     model_provider=routing.model_provider,
                     model_name=routing.model_name,
                     custom_provider_id=routing.custom_provider_id,
-                    builtin_provider=routing.builtin_provider,
                 )
                 session.add(agent_session)
                 await session.flush()

--- a/src/phoenix/server/api/types/AgentModelSelection.py
+++ b/src/phoenix/server/api/types/AgentModelSelection.py
@@ -10,7 +10,6 @@ from phoenix.server.agents.model_selection import (
 from phoenix.server.agents.model_selection import (
     CustomProviderModelSelection,
 )
-from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 
 
 @strawberry.type
@@ -23,7 +22,6 @@ class AgentCustomProviderModelSelection:
 class AgentBuiltinProviderModelSelection:
     provider: ModelProvider
     model_name: str
-    openai_api_type: OpenAIApiType
 
 
 AgentModelSelection = Annotated[
@@ -43,5 +41,4 @@ def to_gql_agent_model_selection(
     return AgentBuiltinProviderModelSelection(
         provider=model.provider,
         model_name=model.model_name,
-        openai_api_type=OpenAIApiType(model.openai_api_type),
     )

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -8,7 +8,6 @@ from strawberry.scalars import JSON
 from strawberry.types import Info
 
 from phoenix.db import models
-from phoenix.db.types.agent_session_config import AgentBuiltinProviderConfig
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.api.agent_helpers import CanAccessAgentSession
 from phoenix.server.api.context import Context
@@ -140,24 +139,20 @@ class AgentSession(Node):
             model_provider,
             model_name,
             custom_provider_id,
-            builtin_provider,
         ) = await info.context.data_loaders.agent_session_fields.load_many(
             [
                 (self.id, models.AgentSession.model_provider),
                 (self.id, models.AgentSession.model_name),
                 (self.id, models.AgentSession.custom_provider_id),
-                (self.id, models.AgentSession.builtin_provider),
             ]
         )
         assert isinstance(model_provider, ModelProvider)
         assert isinstance(model_name, str)
         assert custom_provider_id is None or isinstance(custom_provider_id, int)
-        assert builtin_provider is None or isinstance(builtin_provider, AgentBuiltinProviderConfig)
         routing = AgentModelRouting(
             model_provider=model_provider,
             model_name=model_name,
             custom_provider_id=custom_provider_id,
-            builtin_provider=builtin_provider,
         )
         return to_gql_agent_model_selection(model_selection_from_routing(routing))
 

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -11,7 +11,6 @@ from strawberry.relay import GlobalID
 from typing_extensions import TypeAlias
 
 from phoenix.db import models
-from phoenix.db.types.agent_session_config import AgentBuiltinProviderConfig
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.api.types.node import from_global_id
 from phoenix.server.api.types.ProjectSession import ProjectSession
@@ -35,7 +34,6 @@ def _agent_session_model_kwargs() -> dict[str, Any]:
     return {
         "model_provider": ModelProvider.OPENAI,
         "model_name": "gpt-test",
-        "builtin_provider": AgentBuiltinProviderConfig(),
     }
 
 

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -156,7 +156,6 @@ class TestGetAgentSession:
             "providerType": "builtin",
             "provider": "OPENAI",
             "modelName": "gpt-test",
-            "openaiApiType": "responses",
         }
         assert data["is_active"] is False
         assert data["last_message_id"] == _message_uuid("assistant-message")

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2454,7 +2454,6 @@ async def test_create_session_route_creates_a_temporary_session(
         assert agent_session.model_provider.value == "OPENAI"
         assert agent_session.model_name == "gpt-test"
         assert agent_session.custom_provider_id is None
-        assert agent_session.builtin_provider is not None
 
 
 async def test_create_session_route_defaults_to_a_persistent_untitled_session(
@@ -2557,7 +2556,6 @@ async def test_chat_runs_on_the_sessions_persisted_model_without_rewriting_it(
         assert agent_session.model_provider.value == "OPENAI"
         assert agent_session.model_name == "gpt-test"
         assert agent_session.custom_provider_id is None
-        assert agent_session.builtin_provider is not None
 
 
 async def test_patch_session_route_moves_the_session_to_the_new_model(
@@ -2854,7 +2852,6 @@ async def test_chat_rejects_a_turn_asserting_a_model_the_session_is_not_on(
         assert agent_session.model_provider.value == "OPENAI"
         assert agent_session.model_name == "gpt-test"
         assert agent_session.custom_provider_id is None
-        assert agent_session.builtin_provider is not None
         # The rejected send claimed the turn lock to read the model under it,
         # so it must hand the lock back rather than block the session until
         # the heartbeat goes stale.

--- a/tests/unit/server/api/helpers/test_agent_sessions.py
+++ b/tests/unit/server/api/helpers/test_agent_sessions.py
@@ -2,7 +2,6 @@ import pytest
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
-from phoenix.db.types.agent_session_config import AgentBuiltinProviderConfig
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.agents.exceptions import ProviderNotFoundError
 from phoenix.server.agents.model_selection import (
@@ -42,7 +41,6 @@ async def _add_builtin_session(db: DbSessionFactory) -> int:
             title="Model persistence",
             model_provider=ModelProvider.ANTHROPIC,
             model_name="claude-opus-4-6",
-            builtin_provider=AgentBuiltinProviderConfig(),
         )
         session.add(agent_session)
         await session.flush()
@@ -66,7 +64,6 @@ async def test_resolve_model_routing_maps_each_selection_variant(
         assert custom_routing.model_provider is ModelProvider.OPENAI
         assert custom_routing.model_name == "custom-model"
         assert custom_routing.custom_provider_id == provider_id
-        assert custom_routing.builtin_provider is None
 
         builtin_routing = await resolve_model_routing(
             session,
@@ -74,15 +71,11 @@ async def test_resolve_model_routing_maps_each_selection_variant(
                 provider_type="builtin",
                 provider=ModelProvider.AZURE_OPENAI,
                 model_name="gpt-5.5",
-                openai_api_type="chat_completions",
             ),
         )
         assert builtin_routing.model_provider is ModelProvider.AZURE_OPENAI
         assert builtin_routing.model_name == "gpt-5.5"
         assert builtin_routing.custom_provider_id is None
-        assert builtin_routing.builtin_provider == AgentBuiltinProviderConfig(
-            openai_api_type="chat_completions"
-        )
 
 
 async def test_resolve_model_routing_rejects_nonexistent_custom_provider(
@@ -123,7 +116,6 @@ async def test_set_session_model_transitions_between_routing_modes(
         assert agent_session.model_provider is ModelProvider.OPENAI
         assert agent_session.model_name == "custom-model"
         assert agent_session.custom_provider_id == provider_id
-        assert agent_session.builtin_provider is None
         assert effective == CustomProviderModelSelection(
             provider_type="custom",
             provider_id=provider_gid,
@@ -137,21 +129,16 @@ async def test_set_session_model_transitions_between_routing_modes(
                 provider_type="builtin",
                 provider=ModelProvider.AZURE_OPENAI,
                 model_name="gpt-5.5",
-                openai_api_type="chat_completions",
             ),
         )
         await session.flush()
         assert agent_session.model_provider.value == "AZURE_OPENAI"
         assert agent_session.model_name == "gpt-5.5"
         assert agent_session.custom_provider_id is None
-        assert agent_session.builtin_provider == AgentBuiltinProviderConfig(
-            openai_api_type="chat_completions"
-        )
         assert effective == BuiltInProviderModelSelection(
             provider_type="builtin",
             provider=ModelProvider.AZURE_OPENAI,
             model_name="gpt-5.5",
-            openai_api_type="chat_completions",
         )
 
 

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -42,7 +42,6 @@ _CREATE_MUTATION = """
           ... on AgentBuiltinProviderModelSelection {
             provider
             modelName
-            openaiApiType
           }
         }
         messages
@@ -74,7 +73,6 @@ _BRANCH_MUTATION = """
           ... on AgentBuiltinProviderModelSelection {
             provider
             modelName
-            openaiApiType
           }
         }
         messages
@@ -488,7 +486,6 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
         "__typename": "AgentBuiltinProviderModelSelection",
         "provider": "OPENAI",
         "modelName": "gpt-test",
-        "openaiApiType": "RESPONSES",
     }
     branch_message_ids = [message["id"] for message in branch["messages"]]
     assert len(branch_message_ids) == 2
@@ -698,7 +695,6 @@ async def test_create_agent_session_creates_empty_owned_session(
         "__typename": "AgentBuiltinProviderModelSelection",
         "provider": "OPENAI",
         "modelName": "gpt-test",
-        "openaiApiType": "RESPONSES",
     }
     assert payload["messages"] == []
     async with db() as session:
@@ -711,7 +707,7 @@ async def test_create_agent_session_creates_empty_owned_session(
         assert agent_session.is_ephemeral is False
         assert agent_session.model_provider.value == "OPENAI"
         assert agent_session.model_name == "gpt-test"
-        assert agent_session.builtin_provider is not None
+        assert agent_session.custom_provider_id is None
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
 

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -142,7 +142,6 @@ class TestCreateChatCompletion:
         assert isinstance(selection, BuiltInProviderModelSelection)
         assert selection.provider is ModelProvider.ANTHROPIC
         assert selection.model_name == "claude-sonnet-4-5"
-        assert selection.openai_api_type == "chat_completions"
 
         system, user, assistant, followup = build_model_spy.messages
         assert isinstance(system, ModelRequest)

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -160,7 +160,6 @@ async def test_agent_session_serializes_deleted_custom_provider_as_builtin_fallb
             model_provider=ModelProvider.OPENAI,
             model_name="custom-model",
             custom_provider_id=provider.id,
-            builtin_provider=None,
         )
         session.add(agent_session)
         await session.flush()
@@ -185,7 +184,6 @@ async def test_agent_session_serializes_deleted_custom_provider_as_builtin_fallb
                   ... on AgentBuiltinProviderModelSelection {
                     provider
                     modelName
-                    openaiApiType
                   }
                 }
               }
@@ -202,7 +200,6 @@ async def test_agent_session_serializes_deleted_custom_provider_as_builtin_fallb
                 "__typename": "AgentBuiltinProviderModelSelection",
                 "provider": "OPENAI",
                 "modelName": "custom-model",
-                "openaiApiType": "RESPONSES",
             },
         }
     }


### PR DESCRIPTION
resolves #<issue-number>

Closes #15155
