### PR TITLE
fix(db): fold case with sqlean's text_casefold in CaseInsensitiveContains

### DIFF
--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -36,12 +36,6 @@ _POOL_RECYCLE_SECONDS = 3300
 
 
 def set_sqlite_pragma(connection: Connection, _: Any) -> None:
-    connection.create_function(
-        "text_lower",
-        1,
-        lambda value: value.lower() if isinstance(value, str) else value,
-        deterministic=True,
-    )
     cursor = connection.cursor()
     cursor.execute("PRAGMA foreign_keys = ON;")
     cursor.execute("PRAGMA journal_mode = WAL;")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -1219,10 +1219,11 @@ def _(element: Any, compiler: Any, **kw: Any) -> Any:
 
 @compiles(CaseInsensitiveContains, "sqlite")
 def _(element: Any, compiler: Any, **kw: Any) -> Any:
-    # Use sqlean's `text_lower` to handle non-ASCII characters
+    # sqlean's `text_casefold`, not `text_lower`: case folding is the operation
+    # Unicode defines for caseless matching.
     string, substring = list(element.clauses)
     result = compiler.process(
-        func.text_contains(func.text_lower(string), func.text_lower(substring)), **kw
+        func.text_contains(func.text_casefold(string), func.text_casefold(substring)), **kw
     )
     return result
 

--- a/tests/unit/db/test_engines.py
+++ b/tests/unit/db/test_engines.py
@@ -48,24 +48,6 @@ async def test_memory_sqlite_models_are_ready_when_created_inside_running_loop()
         await engine.dispose()
 
 
-async def test_sqlite_text_lower_override_handles_unicode() -> None:
-    engine = aio_sqlite_engine(get_async_db_url("sqlite:///:memory:"), migrate=False)
-    try:
-        async with engine.connect() as conn:
-            row = (
-                await conn.execute(
-                    text(
-                        "select "
-                        "text_contains(text_lower('istanbul branch'), text_lower('İstanbul')), "
-                        "text_contains(text_lower('Hello Wörld'), text_lower('WÖRLD'))"
-                    )
-                )
-            ).one()
-        assert row == (0, 1)
-    finally:
-        await engine.dispose()
-
-
 async def test_memory_sqlite_init_failure_propagates_to_caller() -> None:
     async def fail(_engine: object) -> None:
         raise RuntimeError("init failed")


### PR DESCRIPTION
Stacked on #15139.

Compiles `CaseInsensitiveContains` to sqlean's `text_casefold` instead of `text_lower` on SQLite, and drops the per-connection Python `text_lower` registered in `set_sqlite_pragma`.

## Why now — my upstream commits

I landed three fixes to sqlean's `text` extension upstream ([nalgeon/sqlean](https://github.com/nalgeon/sqlean/commits/main/)):

- [`text: preserve total order in UTF-8 nocase comparisons` (#163)](https://github.com/nalgeon/sqlean/commit/aa9ffe0f)
- [`text: fix case conversions that change UTF-8 width` (#164)](https://github.com/nalgeon/sqlean/commit/dc4c15eb)
- [`text: bound UTF-8 decoding and replace invalid input` (#165)](https://github.com/nalgeon/sqlean/commit/6b969da844d9c3c79a0b226b403b3d8227b4ed46)

`arize-phoenix-sqlean` pins sqlean at [`6b969da`](https://github.com/nalgeon/sqlean/commit/6b969da844d9c3c79a0b226b403b3d8227b4ed46) — that *is* #165 — so all three are in the build #15139 brings in. That's what makes this change safe to make now; it wasn't before.

**#164 is the one that matters here.** The old `utf8_transform` decoded a character from the buffer, wrote the converted character back **in place**, then advanced the cursor by the *result's* width rather than the *source's*:

```c
uint32_t c = transform(d.codep);
int len = utf8_encode(s, c);
s += len;   // result width...
n -= len;   // ...but the source character may have been wider
```

Any conversion that changes a character's UTF-8 width desynchronizes the cursor, and the next `utf8_decode` starts mid-sequence on a continuation byte and walks off the end of the buffer. Measured on upstream `sqlean.py` 3.50.4 (sqlean 0.27.2) versus the fork (`0.28.3+6b969da`):

| call | sqlean 0.27.2 | fork |
|---|---|---|
| `text_lower('İ')` | **SIGBUS — process dies** | `i` |
| `text_casefold('ſ')` | **SIGBUS — process dies** | `s` |
| `text_casefold('ǅ')` | `ǆ` | `ǆ` |

Both crashers are width changes: `İ` U+0130 and `ſ` U+017F encode to two bytes, their targets `i`/`s` to one. #164 gives the result its own buffer (`n + n/2 + 1`) and returns the real length; #165 bounds the decoder so malformed input is replaced rather than chased off the end.

## Why `text_casefold` over `text_lower`

Case folding, not lowercasing, is the operation Unicode specifies for caseless matching — and sqlean's fold table covers characters its lowercase table doesn't. Measured on the fork:

| input | `text_lower` | `text_casefold` | Python `.lower()` |
|---|---|---|---|
| `ǅ` U+01C5 | **unchanged** | `ǆ` | `ǆ` |
| `ſ` U+017F | unchanged | `s` | unchanged |
| `İ` U+0130 | `i` | unchanged | `i` + U+0307 |
| `ß` | `ß` | `ß` | `ß` |
| `Ä`, `Σ`, ASCII | same | same | same |

So `text_casefold` fixes the titlecase digraphs (`ǅ ǈ ǋ ǲ`) that `text_lower` silently leaves alone. For `İ` the user-visible outcome is unchanged — a dotted-I query still doesn't match ASCII `istanbul` — though because the character is left alone rather than mapped to `i`.

Known limitation, unchanged either way: `ß` does not fold to `ss`. Both sqlean functions implement *simple* case mapping and that's a full-mapping rule; only Python's `str.casefold()` does it, and delivering it on both backends would need a stored casefolded column.

## Dropping the Python `text_lower`

The function registered in `set_sqlite_pragma` was never a fallback. `sqlite3_create_function` replaces a same-name/arity definition, so it was *shadowing* sqlean's C `text_lower` on every connection — while `models.py`'s comment claimed "use sqlean's `text_lower`". That shadowing is also why the crash above never surfaced in Phoenix: no query ever reached the C implementation.

## Test removal

`test_sqlite_text_lower_override_handles_unicode` hand-wrote `text_lower(...)` in raw SQL, so it never exercised `CaseInsensitiveContains` — it would have kept passing through any change to the compiler. Its non-`İ` assertion (`Hello Wörld` / `WÖRLD`) is already covered by `TestCaseInsensitiveContains` in `test_models.py`, which runs the real construct against 25 rows on **both dialects**.

Worth knowing for follow-up: that suite's oracle is `search.lower() in description.lower()`, so it asserts SQL agrees with Python's casing. That holds today only because every fixture row is a case where simple and full mapping coincide. Adding `İ`-class data would need explicit expectations rather than the Python oracle.

## Verification

- `tests/unit/db` + `tests/unit/trace/dsl`: **1103 passed**, 304 skipped.
- `ruff check` and `ruff format --check` clean.
