### PR TITLE
fix(db): index uncovered FK columns and drop ix_latency

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -302,8 +302,6 @@ CREATE TABLE public.spans (
 
 CREATE INDEX ix_cumulative_llm_token_count_total ON public.spans
     USING btree (((cumulative_llm_token_count_prompt + cumulative_llm_token_count_completion)));
-CREATE INDEX ix_latency ON public.spans
-    USING btree (((end_time - start_time)));
 CREATE INDEX ix_spans_parent_id ON public.spans
     USING btree (parent_id);
 CREATE INDEX ix_spans_session_id ON public.spans
@@ -794,6 +792,8 @@ CREATE INDEX ix_dataset_evaluators_evaluator_id ON public.dataset_evaluators
     USING btree (evaluator_id);
 CREATE INDEX ix_dataset_evaluators_project_id ON public.dataset_evaluators
     USING btree (project_id);
+CREATE INDEX ix_dataset_evaluators_user_id ON public.dataset_evaluators
+    USING btree (user_id);
 
 
 -- Table: experiments
@@ -1154,6 +1154,9 @@ CREATE TABLE public.generative_model_custom_providers (
         ON DELETE SET NULL
 );
 
+CREATE INDEX ix_generative_model_custom_providers_user_id ON public.generative_model_custom_providers
+    USING btree (user_id);
+
 
 -- Table: agent_sessions
 -- ---------------------
@@ -1455,6 +1458,11 @@ CREATE TABLE public.experiment_prompt_tasks (
         ON DELETE CASCADE
 );
 
+CREATE INDEX ix_experiment_prompt_tasks_custom_provider_id ON public.experiment_prompt_tasks
+    USING btree (custom_provider_id);
+CREATE INDEX ix_experiment_prompt_tasks_prompt_version_id ON public.experiment_prompt_tasks
+    USING btree (prompt_version_id);
+
 
 -- Table: prompt_version_tags
 -- --------------------------
@@ -1715,6 +1723,9 @@ CREATE TABLE public.secrets (
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
+
+CREATE INDEX ix_secrets_user_id ON public.secrets
+    USING btree (user_id);
 
 
 -- Table: span_annotations

--- a/src/phoenix/db/migrations/versions/4aad9107d196_index_uncovered_fks_and_drop_ix_latency.py
+++ b/src/phoenix/db/migrations/versions/4aad9107d196_index_uncovered_fks_and_drop_ix_latency.py
@@ -1,0 +1,165 @@
+"""index uncovered FK columns and drop ix_latency
+
+Revision ID: 4aad9107d196
+Revises: e767d3c57f32
+Create Date: 2026-08-06 12:00:00.000000
+
+- Creates covering indexes for FK columns with a cascading or nulling
+  ondelete whose parent rows actually get deleted (custom providers, prompt
+  versions, users), so the delete no longer sequential-scans the child table.
+  FKs on tables where the scan is trivially cheap or never fires are
+  deliberately left unindexed: enum-like parents that never see deletes
+  (evaluator kinds, log categories, task types), the short-lived
+  oauth2_authorization_codes rows, and system_settings (one row per setting
+  key).
+- Drops ix_latency on spans: it indexes (end_time - start_time), an
+  expression no query emits (the application computes latency via
+  EXTRACT/unixepoch), and on SQLite string subtraction collapses every row to
+  a single key.
+
+CONCURRENTLY support (opt-in via PHOENIX_MIGRATE_INDEX_CONCURRENTLY=true):
+
+  CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction, but Alembic's
+  env.py wraps each migration in one. The workaround is to commit the current
+  transaction and enable autocommit at the DBAPI level (psycopg) before issuing
+  the DDL, then restore transactional mode afterward. See the spans session.id
+  index migration (f1a6b2f0c9d5) for the rationale and tradeoffs. Creates use
+  IF NOT EXISTS and drops IF EXISTS, so an interrupted non-transactional run
+  converges on rerun.
+
+  A failed concurrent build leaves an INVALID index behind, which IF NOT EXISTS
+  matches by name on rerun, so every created index is checked for validity
+  before anything is dropped and before the migration stamps itself successful.
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4aad9107d196"
+down_revision: Union[str, None] = "e767d3c57f32"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (index_name, table_name, [columns]) for the previously uncovered FK columns:
+# the parent-side delete runs one UPDATE ... SET <col> = NULL (or a cascade
+# probe) per deleted row, which is a sequential scan without these.
+_FK_INDEXES: list[tuple[str, str, list[str]]] = [
+    (
+        "ix_experiment_prompt_tasks_custom_provider_id",
+        "experiment_prompt_tasks",
+        ["custom_provider_id"],
+    ),
+    (
+        "ix_experiment_prompt_tasks_prompt_version_id",
+        "experiment_prompt_tasks",
+        ["prompt_version_id"],
+    ),
+    ("ix_dataset_evaluators_user_id", "dataset_evaluators", ["user_id"]),
+    (
+        "ix_generative_model_custom_providers_user_id",
+        "generative_model_custom_providers",
+        ["user_id"],
+    ),
+    ("ix_secrets_user_id", "secrets", ["user_id"]),
+]
+
+
+def _use_concurrently() -> bool:
+    """CONCURRENTLY is opt-in (PostgreSQL only) via PHOENIX_MIGRATE_INDEX_CONCURRENTLY."""
+    connection = op.get_bind()
+    if connection.dialect.name != "postgresql":
+        return False
+    return os.environ.get("PHOENIX_MIGRATE_INDEX_CONCURRENTLY", "").lower() == "true"
+
+
+def _enable_autocommit() -> None:
+    """Exit the current transaction and enable autocommit at the DBAPI level."""
+    dbapi_conn = op.get_bind().connection.dbapi_connection
+    assert dbapi_conn is not None
+    dbapi_conn.commit()
+    dbapi_conn.autocommit = True
+
+
+def _disable_autocommit() -> None:
+    """Restore transactional mode at the DBAPI level."""
+    dbapi_conn = op.get_bind().connection.dbapi_connection
+    assert dbapi_conn is not None
+    dbapi_conn.autocommit = False
+
+
+def _assert_index_is_valid(index_name: str) -> None:
+    """Fail loudly if the named index exists but is INVALID (PostgreSQL only).
+
+    A failed CREATE INDEX CONCURRENTLY leaves an INVALID index that IF NOT
+    EXISTS matches by name, so without this check the migration could stamp
+    itself successful while an index is unusable.
+    """
+    connection = op.get_bind()
+    if connection.dialect.name != "postgresql":
+        return
+    is_valid = connection.execute(
+        sa.text("SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(:name)"),
+        {"name": index_name},
+    ).scalar()
+    if is_valid is False:
+        raise RuntimeError(
+            f"Index {index_name} exists but is INVALID: a previous CONCURRENTLY build "
+            "failed, or another replica is still building it. If no build is in "
+            f"progress, run DROP INDEX CONCURRENTLY IF EXISTS {index_name} and rerun "
+            "the migration."
+        )
+
+
+def upgrade() -> None:
+    concurrently = _use_concurrently()
+    if concurrently:
+        _enable_autocommit()
+    try:
+        for index_name, table_name, columns in _FK_INDEXES:
+            op.create_index(
+                index_name,
+                table_name,
+                columns,
+                if_not_exists=True,
+                postgresql_concurrently=concurrently,
+            )
+        for index_name, _, _ in _FK_INDEXES:
+            _assert_index_is_valid(index_name)
+        op.drop_index(
+            "ix_latency",
+            table_name="spans",
+            if_exists=True,
+            postgresql_concurrently=concurrently,
+        )
+    finally:
+        if concurrently:
+            _disable_autocommit()
+
+
+def downgrade() -> None:
+    concurrently = _use_concurrently()
+    if concurrently:
+        _enable_autocommit()
+    try:
+        op.create_index(
+            "ix_latency",
+            "spans",
+            [sa.text("(end_time - start_time)")],
+            if_not_exists=True,
+            postgresql_concurrently=concurrently,
+        )
+        _assert_index_is_valid("ix_latency")
+        for index_name, table_name, _ in _FK_INDEXES:
+            op.drop_index(
+                index_name,
+                table_name=table_name,
+                if_exists=True,
+                postgresql_concurrently=concurrently,
+            )
+    finally:
+        if concurrently:
+            _disable_autocommit()

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -1050,7 +1050,6 @@ class Span(HasId):
             "span_id",
             sqlite_on_conflict="IGNORE",
         ),
-        Index("ix_latency", text("(end_time - start_time)")),
         Index(
             "ix_cumulative_llm_token_count_total",
             text("(cumulative_llm_token_count_prompt + cumulative_llm_token_count_completion)"),
@@ -1547,6 +1546,7 @@ class DatasetLabel(HasId):
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     user: Mapped[Optional["User"]] = relationship("User")
 
@@ -1980,6 +1980,7 @@ class ExperimentPromptTask(ExperimentJob):
     custom_provider_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("generative_model_custom_providers.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
 
     # Prompt definition (complex nested → JSON)
@@ -2003,6 +2004,7 @@ class ExperimentPromptTask(ExperimentJob):
     prompt_version_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("prompt_versions.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
 
     # Playground-specific settings (evolving, stored as JSON)
@@ -3291,6 +3293,7 @@ class DatasetEvaluators(HasId):
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     project_id: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="RESTRICT"),
@@ -3321,6 +3324,7 @@ class Secret(Base):
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
@@ -3357,6 +3361,7 @@ class GenerativeModelCustomProvider(HasId):
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
 
 


### PR DESCRIPTION
Fixes #15034
Fixes #15037

## Covering indexes for FK delete paths (#15034)

`experiment_prompt_tasks.custom_provider_id` is a `SET NULL` FK with no covering index, so deleting a custom provider sequential-scans the table. This adds the index, plus the subset of the issue's schema-wide audit where the parent tables actually see deletes:

- `experiment_prompt_tasks.custom_provider_id` and `.prompt_version_id`
- `dataset_evaluators.user_id`, `generative_model_custom_providers.user_id`, `secrets.user_id`

Deliberately left unindexed: FKs to enum-like parents that never see deletes (evaluator `kind`s, log `category`s, task `type`), short-lived `oauth2_authorization_codes` rows, and `system_settings` (one row per setting key — the scan is free).

Also declares `index=True` on `dataset_labels.user_id` in `models.py` to match the index its creating migration already builds — a models/DDL drift, no migration op needed.

## Drop `ix_latency` (#15037)

The index covers `(end_time - start_time)`, an expression no query emits — the application computes latency via `EXTRACT`/`unixepoch` — and on SQLite string subtraction collapses every row to a single key. It is maintained on every write to the busiest table and returns nothing; dropped on both backends.

## Migration

New revision `4aad9107d196` (parent `e767d3c57f32`, hence based on #14143's branch). Follows the recent index-migration pattern: opt-in `PHOENIX_MIGRATE_INDEX_CONCURRENTLY`, `IF [NOT] EXISTS` for rerun convergence, and an INVALID-index check before anything is dropped or the migration stamps itself successful. Downgrade recreates `ix_latency` and drops the new indexes.

Tested upgrade → downgrade → re-upgrade on fresh SQLite and ephemeral PostgreSQL, the latter with and without `PHOENIX_MIGRATE_INDEX_CONCURRENTLY=true`; no INVALID indexes remain. `scripts/ddl/postgresql_schema.sql` regenerated.