### PR TITLE
fix(agents): close abandoned turn traces and render parsed tool schemas

### DIFF
--- a/app/src/pages/trace/span/utils.ts
+++ b/app/src/pages/trace/span/utils.ts
@@ -301,11 +301,23 @@ export function getToolAttributes(
   spanAttributes: AttributeObject
 ): ToolSpanAttributes {
   const toolAttributes = spanAttributes[SemanticAttributePrefixes.tool] || {};
+  // Ingestion parses `tool.parameters` JSON strings into an object (see
+  // JSON_STRING_ATTRIBUTES server-side), so despite the generated type the
+  // schema reaches the client as either shape; rendering and copying expect
+  // the JSON text, and an object child inside <pre> crashes React.
+  const rawParameters: unknown =
+    toolAttributes[ToolAttributePostfixes.parameters];
+  const parameters =
+    typeof rawParameters === "string"
+      ? rawParameters
+      : rawParameters != null
+        ? JSON.stringify(rawParameters, null, 2)
+        : undefined;
   return {
     hasToolAttributes: Object.keys(toolAttributes).length > 0,
     name: toolAttributes[ToolAttributePostfixes.name],
     description: toolAttributes[ToolAttributePostfixes.description],
-    parameters: toolAttributes[ToolAttributePostfixes.parameters],
+    parameters,
   };
 }
 

--- a/src/phoenix/db/types/data_stream_protocol/phoenix_types.py
+++ b/src/phoenix/db/types/data_stream_protocol/phoenix_types.py
@@ -62,9 +62,6 @@ class AssistantMessageMetadata(CamelBaseModel):
     turn_trace_context: TurnTraceContext | None = None
     usage: AssistantMessageMetadataUsage | None = None
     interrupted: bool = False
-    """Whether the turn that produced this message was cut off before it
-    completed (stop button, CLI interrupt, or dropped connection). Cleared by
-    the completed turn's metadata when the message is later continued."""
 
 
 class UserMessageMetadata(CamelBaseModel):

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -984,7 +984,7 @@ def _synthesize_client_tool_spans(
             )
 
 
-def _close_abandoned_turn_trace(
+def _close_superseded_turn_trace(
     *,
     tracer: Tracer,
     turn_trace_context: TurnTraceContext,
@@ -993,7 +993,7 @@ def _close_abandoned_turn_trace(
     session_id: str,
     user_email: str | None,
 ) -> None:
-    """Emit the deferred root span of a pending turn its user abandoned.
+    """Emit the deferred root span of a pending turn this request superseded.
 
     A turn that ends awaiting client tool outputs defers its ``pxi.turn`` root
     span until a continuation completes the turn. When the next request is a
@@ -1711,12 +1711,17 @@ class _MergedTranscript:
     """The trailing assistant message this turn continues when the request
     carried only ``toolOutputs``; None for a new user turn."""
 
-    abandoned_assistant_message: PhoenixUIMessage | None
-    """The old trailing assistant message whose pending turn this request
-    abandoned: it still had unresolved tool calls when a new user message
-    arrived, so the continuation that would have completed the turn (and
-    emitted its deferred root span) will never run. None when the tail had
-    nothing pending or the request continues the turn."""
+    superseded_assistant_message: PhoenixUIMessage | None
+    """The trailing assistant message of a turn this request superseded.
+
+    A turn that stops on unresolved client tool calls stays open: only a
+    ``toolOutputs``-only request continues it, finishing the turn and emitting
+    its deferred ``pxi.turn`` root span. A request carrying a new user message
+    starts a new turn instead, superseding the open one — its dangling calls
+    are resolved at merge time (by ``toolOutputs`` sent alongside the message,
+    or repaired as interrupted without them), but the continuation that would
+    have emitted the root span never runs. None when the request continues
+    the turn or the tail had nothing pending."""
 
 
 def _merge_messages(
@@ -1749,18 +1754,20 @@ def _merge_messages(
     if new_message is not None:
         assert new_message.role == "user", "request validation rejects non-user messages"
         # A rewritten assistant tail means it still had pending tool calls —
-        # a turn that ended awaiting outputs and is now abandoned by the new
+        # a turn that ended awaiting outputs and is now superseded by the new
         # user message instead of continued.
-        abandoned_assistant_message = (
-            messages[-1]
-            if messages and messages[-1].role == "assistant" and messages[-1].id in updated_messages
-            else None
+        last_message = messages[-1] if messages else None
+        last_message_had_pending_tool_calls = (
+            last_message is not None
+            and last_message.role == "assistant"
+            and last_message.id in updated_messages
         )
+        superseded_assistant_message = last_message if last_message_had_pending_tool_calls else None
         return _MergedTranscript(
             messages=[*messages, new_message],
             updated_messages=updated_messages,
             continued_assistant_message=None,
-            abandoned_assistant_message=abandoned_assistant_message,
+            superseded_assistant_message=superseded_assistant_message,
         )
     assert tool_outputs, "request validation requires a message, toolOutputs, or both"
     assert messages[-1].role == "assistant", "the tool-output branch guarantees an assistant tail"
@@ -1768,7 +1775,7 @@ def _merge_messages(
         messages=messages,
         updated_messages=updated_messages,
         continued_assistant_message=messages[-1],
-        abandoned_assistant_message=None,
+        superseded_assistant_message=None,
     )
 
 
@@ -2956,8 +2963,8 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 run_agent_stream = _run_assistant_agent_stream
 
             continued_turn_trace_context = _message_turn_trace_context(continued_assistant_message)
-            abandoned_turn_trace_context = _message_turn_trace_context(
-                merged_transcript.abandoned_assistant_message
+            superseded_turn_trace_context = _message_turn_trace_context(
+                merged_transcript.superseded_assistant_message
             )
             turn_ids = _resolve_turn_trace_ids(
                 continued_turn_trace_context, now=request_received_at
@@ -3149,13 +3156,13 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             received_at=request_received_at,
                             session_id=otel_session_id,
                         )
-                    if tracer is not None and abandoned_turn_trace_context is not None:
-                        # This new user turn abandoned a pending turn whose root
+                    if tracer is not None and superseded_turn_trace_context is not None:
+                        # This new user turn superseded a pending turn whose root
                         # span was deferred; close that trace out (excluding the
                         # new user message) so its spans don't stay orphaned.
-                        _close_abandoned_turn_trace(
+                        _close_superseded_turn_trace(
                             tracer=tracer,
-                            turn_trace_context=abandoned_turn_trace_context,
+                            turn_trace_context=superseded_turn_trace_context,
                             messages=transcript_messages[:-1],
                             received_at=request_received_at,
                             session_id=otel_session_id,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -661,14 +661,13 @@ class _TurnTraceIds:
     started_at: datetime
 
 
-def _continued_turn_trace_context(
-    continued_assistant_message: PhoenixUIMessage | None,
+def _message_turn_trace_context(
+    assistant_message: PhoenixUIMessage | None,
 ) -> TurnTraceContext | None:
-    """The turn identity a client-tool continuation resumes, recovered from
-    the persisted trailing assistant message's metadata."""
-    if continued_assistant_message is None:
+    """The turn identity recorded in a persisted assistant message's metadata."""
+    if assistant_message is None:
         return None
-    metadata = continued_assistant_message.metadata
+    metadata = assistant_message.metadata
     if not isinstance(metadata, AssistantMessageMetadata):
         return None
     return metadata.turn_trace_context
@@ -983,6 +982,54 @@ def _synthesize_client_tool_spans(
                     instrumentation_scope=_PXI_INSTRUMENTATION_SCOPE,
                 )
             )
+
+
+def _close_abandoned_turn_trace(
+    *,
+    tracer: Tracer,
+    turn_trace_context: TurnTraceContext,
+    messages: Sequence[PhoenixUIMessage],
+    received_at: datetime,
+    session_id: str,
+    user_email: str | None,
+) -> None:
+    """Emit the deferred root span of a pending turn its user abandoned.
+
+    A turn that ends awaiting client tool outputs defers its ``pxi.turn`` root
+    span until a continuation completes the turn. When the next request is a
+    new user message instead, that continuation never runs — without this
+    close-out the turn's already-ingested child spans reference a root span id
+    that is never written and the trace renders as orphaned spans. The tool
+    calls the turn was still waiting on were repaired at merge time, so they
+    are synthesized as spans first and the root is emitted around them.
+    """
+    turn_ids = _resolve_turn_trace_ids(turn_trace_context, now=received_at)
+    _synthesize_client_tool_spans(
+        tracer=tracer,
+        turn_ids=turn_ids,
+        messages=messages,
+        received_at=received_at,
+        session_id=session_id,
+    )
+    trailing_message = messages[-1] if messages else None
+    output_text: str | None = None
+    if trailing_message is not None and trailing_message.role == "assistant":
+        output_text = (
+            "".join(
+                part.text for part in trailing_message.parts if isinstance(part, TextUIPart)
+            ).strip()
+            or None
+        )
+    _emit_turn_root_span(
+        tracer=tracer,
+        turn_ids=turn_ids,
+        session_id=session_id,
+        input_text=_get_last_user_text(messages),
+        output_text=output_text,
+        error_message="The turn was interrupted before its tool calls completed.",
+        end_time=received_at,
+        user_email=user_email,
+    )
 
 
 async def _persist_db_traces(
@@ -1664,6 +1711,13 @@ class _MergedTranscript:
     """The trailing assistant message this turn continues when the request
     carried only ``toolOutputs``; None for a new user turn."""
 
+    abandoned_assistant_message: PhoenixUIMessage | None
+    """The old trailing assistant message whose pending turn this request
+    abandoned: it still had unresolved tool calls when a new user message
+    arrived, so the continuation that would have completed the turn (and
+    emitted its deferred root span) will never run. None when the tail had
+    nothing pending or the request continues the turn."""
+
 
 def _merge_messages(
     *,
@@ -1694,10 +1748,19 @@ def _merge_messages(
             messages[index] = repaired_message
     if new_message is not None:
         assert new_message.role == "user", "request validation rejects non-user messages"
+        # A rewritten assistant tail means it still had pending tool calls —
+        # a turn that ended awaiting outputs and is now abandoned by the new
+        # user message instead of continued.
+        abandoned_assistant_message = (
+            messages[-1]
+            if messages and messages[-1].role == "assistant" and messages[-1].id in updated_messages
+            else None
+        )
         return _MergedTranscript(
             messages=[*messages, new_message],
             updated_messages=updated_messages,
             continued_assistant_message=None,
+            abandoned_assistant_message=abandoned_assistant_message,
         )
     assert tool_outputs, "request validation requires a message, toolOutputs, or both"
     assert messages[-1].role == "assistant", "the tool-output branch guarantees an assistant tail"
@@ -1705,6 +1768,7 @@ def _merge_messages(
         messages=messages,
         updated_messages=updated_messages,
         continued_assistant_message=messages[-1],
+        abandoned_assistant_message=None,
     )
 
 
@@ -2891,8 +2955,9 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 adapter = assistant_adapter
                 run_agent_stream = _run_assistant_agent_stream
 
-            continued_turn_trace_context = _continued_turn_trace_context(
-                continued_assistant_message
+            continued_turn_trace_context = _message_turn_trace_context(continued_assistant_message)
+            abandoned_turn_trace_context = _message_turn_trace_context(
+                merged_transcript.abandoned_assistant_message
             )
             turn_ids = _resolve_turn_trace_ids(
                 continued_turn_trace_context, now=request_received_at
@@ -3083,6 +3148,18 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             messages=transcript_messages,
                             received_at=request_received_at,
                             session_id=otel_session_id,
+                        )
+                    if tracer is not None and abandoned_turn_trace_context is not None:
+                        # This new user turn abandoned a pending turn whose root
+                        # span was deferred; close that trace out (excluding the
+                        # new user message) so its spans don't stay orphaned.
+                        _close_abandoned_turn_trace(
+                            tracer=tracer,
+                            turn_trace_context=abandoned_turn_trace_context,
+                            messages=transcript_messages[:-1],
+                            received_at=request_received_at,
+                            session_id=otel_session_id,
+                            user_email=phoenix_user_email if attach_user_id else None,
                         )
                     if session_needs_title:
                         summary_task = asyncio.create_task(_summarize_untitled_session())

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -3161,6 +3161,58 @@ async def test_chat_turn_trace_ingestion_merges_backend_spans_into_prior_turn_tr
     assert merged_trace.end_time > _PRIOR_TURN_TIME
 
 
+async def test_new_user_message_closes_abandoned_turn_trace(
+    db: DbSessionFactory,
+    app: FastAPI,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A turn that ends awaiting client tool outputs defers its root span to
+    the continuation. When the user abandons it with a new message instead,
+    the deferred ``pxi.turn`` root and a synthesized span for the repaired
+    tool call are emitted into the abandoned trace, so its already-ingested
+    child spans do not reference a root span id that never arrives."""
+    await _enable_local_trace_recording(app)
+    _mock_traced_test_model(monkeypatch)
+    session_id = "67676767-6767-4667-8667-676767676767"
+    assistant_tail = _assistant_tail_with_prior_turn_context(session_id)
+    agent_session_id = await _create_agent_session_row(
+        db,
+        title="Already titled",
+        messages=[_user_message("edit the prompt"), assistant_tail],
+    )
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            _user_message("never mind, new topic", message_id=_message_uuid("msg-user-2")),
+            ingestTraces=True,
+            lastMessageId=assistant_tail["id"],
+        ),
+    )
+    assert response.status_code == 200
+
+    async with db() as session:
+        spans = (
+            await session.scalars(
+                select(models.Span)
+                .join(models.Trace)
+                .where(models.Trace.trace_id == _PRIOR_TURN_TRACE_ID)
+            )
+        ).all()
+
+    root = next(span for span in spans if span.parent_id is None)
+    assert root.span_id == _PRIOR_TURN_ROOT_SPAN_ID
+    assert root.name == "pxi.turn"
+    assert root.status_code == "ERROR"
+    tool_spans = [span for span in spans if span.span_kind == "TOOL"]
+    assert len(tool_spans) == 1
+    assert tool_spans[0].parent_id == _PRIOR_TURN_ROOT_SPAN_ID
+    # The repaired call was interrupted, not failed: it renders neutrally.
+    assert tool_spans[0].status_code == "OK"
+
+
 async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warnings(
     db: DbSessionFactory,
     app: FastAPI,

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -3161,16 +3161,16 @@ async def test_chat_turn_trace_ingestion_merges_backend_spans_into_prior_turn_tr
     assert merged_trace.end_time > _PRIOR_TURN_TIME
 
 
-async def test_new_user_message_closes_abandoned_turn_trace(
+async def test_new_user_message_closes_superseded_turn_trace(
     db: DbSessionFactory,
     app: FastAPI,
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A turn that ends awaiting client tool outputs defers its root span to
-    the continuation. When the user abandons it with a new message instead,
-    the deferred ``pxi.turn`` root and a synthesized span for the repaired
-    tool call are emitted into the abandoned trace, so its already-ingested
+    the continuation. When a new user message supersedes it instead, the
+    deferred ``pxi.turn`` root and a synthesized span for the repaired tool
+    call are emitted into the superseded trace, so its already-ingested
     child spans do not reference a root span id that never arrives."""
     await _enable_local_trace_recording(app)
     _mock_traced_test_model(monkeypatch)


### PR DESCRIPTION
Stacked on #15167.

## Summary

Fixes the two trace defects observed on interrupted conversations (dogfooding session `pxi_dev`):

### Orphaned traces (broken parenting)
A turn that ends awaiting client tool outputs defers its `pxi.turn` root span until a continuation completes the turn. When the user abandons the pending turn — hits stop and moves on, or just replies with a new message instead of tool outputs — that continuation never runs. The trace's already-ingested LLM/tool child spans referenced a root span id that was never written, so the whole trace rendered as orphaned spans (e.g. traces `7b6df9cd…`, `400beae2…` in the dogfooding project).

Fix: `_merge_messages` now reports when a new user message abandons an assistant tail that still had unresolved tool calls, and the route closes that turn's trace out — synthesizing spans for the repaired client tool calls and emitting the deferred root span (status ERROR, "interrupted before its tool calls completed") using the `turnTraceContext` persisted on the message. Together with #15167 persisting `turnTraceContext` on interrupted turns, interrupted conversations now produce complete traces.

### Tool spans crashing the span-details UI
The new span-details tool card assumed `tool.parameters` arrives as a JSON string, but Phoenix ingestion deliberately parses it into an object (`JSON_STRING_ATTRIBUTES` in `phoenix/trace/attributes.py`), so selecting **any** tool span with a parameter schema crashed the panel with "Objects are not valid as a React child" (not actually interruption-specific). `getToolAttributes` now normalizes either shape to JSON text. Verified against the previously-crashing span: the panel renders input/output/tool schema correctly.

## Test plan
- `test_new_user_message_closes_abandoned_turn_trace`: posts a new message over a pending-tool assistant tail carrying a prior turn's trace context, asserts the deferred `pxi.turn` root and synthesized tool span land in the abandoned trace with correct parenting and neutral (OK) tool status.
- Existing trace-ingestion and merge tests still green (69 passed).
- Manually verified the previously-broken span page renders via agent-browser against the local dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)