### PR TITLE
feat(ui): collapse all but the last message in LLM spans

### DIFF
--- a/app/src/pages/trace/span/LLMInput.tsx
+++ b/app/src/pages/trace/span/LLMInput.tsx
@@ -24,6 +24,7 @@ import { defaultCardProps } from "./constants";
 import { LLMInvocationParams } from "./LLMInvocationParams";
 import type { LLMIOView } from "./LLMIOViewSelect";
 import { LLMIOViewSelect, useLLMIOView } from "./LLMIOViewSelect";
+import { LLMMessagesCollapseToggle } from "./LLMMessagesCollapseToggle";
 import { LLMMessagesList } from "./LLMMessagesList";
 import { LLMPromptsList } from "./LLMPromptsList";
 import { LLMPromptTemplate } from "./LLMPromptTemplate";
@@ -162,6 +163,7 @@ export function LLMInput({
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isRawView && <ConnectedMarkdownModeSelect />}
+            {view === "input-messages" && <LLMMessagesCollapseToggle />}
             {views.length > 0 && (
               <LLMIOViewSelect
                 label="Input view"

--- a/app/src/pages/trace/span/LLMInput.tsx
+++ b/app/src/pages/trace/span/LLMInput.tsx
@@ -163,7 +163,9 @@ export function LLMInput({
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isRawView && <ConnectedMarkdownModeSelect />}
-            {view === "input-messages" && <LLMMessagesCollapseToggle />}
+            {view === "input-messages" && (
+              <LLMMessagesCollapseToggle scope="input" />
+            )}
             {views.length > 0 && (
               <LLMIOViewSelect
                 label="Input view"

--- a/app/src/pages/trace/span/LLMMessage.tsx
+++ b/app/src/pages/trace/span/LLMMessage.tsx
@@ -1,6 +1,7 @@
 import { MessageAttributePostfixes } from "@arizeai/openinference-semantic-conventions";
 import { css } from "@emotion/react";
 
+import type { CardProps } from "@phoenix/components";
 import {
   Card,
   CardCollapsedPreview,
@@ -33,8 +34,17 @@ import { formatJSONForCopy, getMessagePreview, getToolCalls } from "./utils";
 /**
  * Displays a single LLM message (input or output) including its contents,
  * tool calls, and function calls.
+ *
+ * Whether the message is expanded is decided by the list it belongs to, so the
+ * collapse-all control and the reader's clicks act on the same state.
  */
-export function LLMMessage({ message }: { message: AttributeMessage }) {
+export function LLMMessage({
+  message,
+  isOpen,
+  onOpenChange,
+}: {
+  message: AttributeMessage;
+} & Pick<CardProps, "isOpen" | "onOpenChange">) {
   const messageContent = message[MessageAttributePostfixes.content];
   const normalizedContent = formatContentAsString(messageContent, {
     unquotePlainString: true,
@@ -55,6 +65,8 @@ export function LLMMessage({ message }: { message: AttributeMessage }) {
       <Card
         {...defaultCardProps}
         {...messageStyles}
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
         title={
           role +
           (message[MessageAttributePostfixes.name]

--- a/app/src/pages/trace/span/LLMMessagesCollapseContext.tsx
+++ b/app/src/pages/trace/span/LLMMessagesCollapseContext.tsx
@@ -1,0 +1,98 @@
+import type { PropsWithChildren } from "react";
+import { createContext, startTransition, useContext, useState } from "react";
+
+type LLMMessagesCollapseContextType = {
+  /** How many messages the list holds, which is what "the last one" refers to. */
+  messageCount: number;
+
+  /** Whether the message at `index` is currently expanded. */
+  isMessageOpen: (index: number) => boolean;
+
+  /** Records the open state the reader asked for on a single message. */
+  setMessageOpen: (index: number, isOpen: boolean) => void;
+
+  /** Whether every message is currently collapsed. Drives the toggle. */
+  areAllMessagesCollapsed: boolean;
+
+  /** Expands or collapses every message at once. */
+  setAllMessagesOpen: (isOpen: boolean) => void;
+};
+
+const LLMMessagesCollapseContext =
+  createContext<LLMMessagesCollapseContextType | null>(null);
+
+/**
+ * Shares the open state of a list of LLM messages between the messages and the
+ * control that expands or collapses them all.
+ *
+ * A conversation sent to a model is mostly history the reader has already seen;
+ * what they came for is the last message. So every message starts collapsed
+ * except that one, and the reader opens the earlier turns they actually want.
+ *
+ * Mount one provider per list — the input and output sides of a span each get
+ * their own — and remount it when the span changes, so open states never carry
+ * over to a different conversation's messages.
+ */
+export function LLMMessagesCollapseProvider({
+  messageCount,
+  children,
+}: PropsWithChildren<{ messageCount: number }>) {
+  const [openStateByIndex, setOpenStateByIndex] = useState<
+    Record<number, boolean>
+  >({});
+
+  const isMessageOpen = (index: number) =>
+    openStateByIndex[index] ?? index === messageCount - 1;
+
+  const setMessageOpen = (index: number, isOpen: boolean) => {
+    setOpenStateByIndex((prev) => ({ ...prev, [index]: isOpen }));
+  };
+
+  /**
+   * Applies a global expand/collapse as a non-urgent update — expanding a long
+   * conversation mounts every message's markdown and tool calls at once.
+   */
+  const setAllMessagesOpen = (isOpen: boolean) => {
+    startTransition(() => {
+      setOpenStateByIndex(
+        Object.fromEntries(
+          Array.from({ length: messageCount }, (_, index) => [index, isOpen])
+        )
+      );
+    });
+  };
+
+  const areAllMessagesCollapsed = Array.from(
+    { length: messageCount },
+    (_, index) => index
+  ).every((index) => !isMessageOpen(index));
+
+  return (
+    <LLMMessagesCollapseContext.Provider
+      value={{
+        messageCount,
+        isMessageOpen,
+        setMessageOpen,
+        areAllMessagesCollapsed,
+        setAllMessagesOpen,
+      }}
+    >
+      {children}
+    </LLMMessagesCollapseContext.Provider>
+  );
+}
+
+/**
+ * Returns the open state and actions for a list of LLM messages.
+ *
+ * @throws Error when called outside of an `LLMMessagesCollapseProvider`.
+ */
+export function useLLMMessagesCollapse() {
+  const context = useContext(LLMMessagesCollapseContext);
+  if (context === null) {
+    throw new Error(
+      "useLLMMessagesCollapse must be used within an LLMMessagesCollapseProvider"
+    );
+  }
+  return context;
+}

--- a/app/src/pages/trace/span/LLMMessagesCollapseContext.tsx
+++ b/app/src/pages/trace/span/LLMMessagesCollapseContext.tsx
@@ -1,5 +1,27 @@
 import type { PropsWithChildren } from "react";
-import { createContext, startTransition, useContext, useState } from "react";
+import { createContext, useContext, useState } from "react";
+
+import type { AttributeMessage } from "@phoenix/openInference/tracing/types";
+
+import { getMessagePreview } from "./utils";
+
+type MessagesOpenState = {
+  /**
+   * The state a bulk expand/collapse put the list in, or null when the reader
+   * has not used the toggle. Held for the list as a whole rather than as an
+   * entry per message so that a message arriving later — a span still being
+   * written — follows the reader's last choice instead of its own default.
+   */
+  allOpen: boolean | null;
+
+  /**
+   * The state the reader chose on individual messages, which wins over
+   * {@link MessagesOpenState.allOpen}.
+   */
+  openStateByIndex: Record<number, boolean>;
+};
+
+const UNTOUCHED: MessagesOpenState = { allOpen: null, openStateByIndex: {} };
 
 type LLMMessagesCollapseContextType = {
   /** How many messages the list holds, which is what "the last one" refers to. */
@@ -30,51 +52,68 @@ const LLMMessagesCollapseContext =
  * control that expands or collapses them all.
  *
  * A conversation sent to a model is mostly history the reader has already seen;
- * what they came for is the last message. So every message starts collapsed
- * except that one, and the reader opens the earlier turns they actually want.
+ * what they came for is the last message. So a message starts collapsed unless
+ * it is the last one, and the reader opens the earlier turns they actually
+ * want.
  *
  * Mount one provider per list — the input and output sides of a span each get
- * their own — and remount it when the span changes, so open states never carry
- * over to a different conversation's messages.
+ * their own.
  */
 export function LLMMessagesCollapseProvider({
-  messageCount,
+  messages,
+  spanId,
   children,
-}: PropsWithChildren<{ messageCount: number }>) {
-  const [openStateByIndex, setOpenStateByIndex] = useState<
-    Record<number, boolean>
-  >({});
+}: PropsWithChildren<{
+  messages: AttributeMessage[];
+  /** The span the messages belong to. Reading a different span starts over. */
+  spanId: string;
+}>) {
+  const [state, setState] = useState<MessagesOpenState>(UNTOUCHED);
+  const [renderedSpanId, setRenderedSpanId] = useState(spanId);
 
-  const isMessageOpen = (index: number) =>
-    openStateByIndex[index] ?? index === messageCount - 1;
-
-  const setMessageOpen = (index: number, isOpen: boolean) => {
-    setOpenStateByIndex((prev) => ({ ...prev, [index]: isOpen }));
-  };
+  // Adjusting the state during render rather than remounting on a `key`: the
+  // cards below hold state of their own — which of messages / tools / raw they
+  // are showing — that is meant to survive the reader moving between spans.
+  const openState = renderedSpanId === spanId ? state : UNTOUCHED;
+  if (renderedSpanId !== spanId) {
+    setRenderedSpanId(spanId);
+    setState(UNTOUCHED);
+  }
 
   /**
-   * Applies a global expand/collapse as a non-urgent update — expanding a long
-   * conversation mounts every message's markdown and tool calls at once.
+   * Whether a message the reader has not touched shows itself.
+   *
+   * A message with no preview has nothing to stand in for its body while
+   * collapsed — an image-only turn previews as nothing at all — so collapsing
+   * it would leave a bare role header and hide the only content it carries.
    */
-  const setAllMessagesOpen = (isOpen: boolean) => {
-    startTransition(() => {
-      setOpenStateByIndex(
-        Object.fromEntries(
-          Array.from({ length: messageCount }, (_, index) => [index, isOpen])
-        )
-      );
-    });
+  const isOpenByDefault = (index: number) =>
+    index === messages.length - 1 || getMessagePreview(messages[index]) == null;
+
+  const isMessageOpen = (index: number) =>
+    openState.openStateByIndex[index] ??
+    openState.allOpen ??
+    isOpenByDefault(index);
+
+  const setMessageOpen = (index: number, isOpen: boolean) => {
+    setState((prev) => ({
+      ...prev,
+      openStateByIndex: { ...prev.openStateByIndex, [index]: isOpen },
+    }));
   };
 
-  const areAllMessagesExpanded = Array.from(
-    { length: messageCount },
-    (_, index) => index
-  ).every((index) => isMessageOpen(index));
+  const setAllMessagesOpen = (isOpen: boolean) => {
+    setState({ allOpen: isOpen, openStateByIndex: {} });
+  };
+
+  const areAllMessagesExpanded = messages.every((_, index) =>
+    isMessageOpen(index)
+  );
 
   return (
     <LLMMessagesCollapseContext.Provider
       value={{
-        messageCount,
+        messageCount: messages.length,
         isMessageOpen,
         setMessageOpen,
         areAllMessagesExpanded,

--- a/app/src/pages/trace/span/LLMMessagesCollapseContext.tsx
+++ b/app/src/pages/trace/span/LLMMessagesCollapseContext.tsx
@@ -11,8 +11,12 @@ type LLMMessagesCollapseContextType = {
   /** Records the open state the reader asked for on a single message. */
   setMessageOpen: (index: number, isOpen: boolean) => void;
 
-  /** Whether every message is currently collapsed. Drives the toggle. */
-  areAllMessagesCollapsed: boolean;
+  /**
+   * Whether every message is currently expanded. Drives the toggle, which
+   * offers the expand until there is nothing left to expand — the list starts
+   * mostly collapsed, so opening it up is the move a reader reaches for first.
+   */
+  areAllMessagesExpanded: boolean;
 
   /** Expands or collapses every message at once. */
   setAllMessagesOpen: (isOpen: boolean) => void;
@@ -62,10 +66,10 @@ export function LLMMessagesCollapseProvider({
     });
   };
 
-  const areAllMessagesCollapsed = Array.from(
+  const areAllMessagesExpanded = Array.from(
     { length: messageCount },
     (_, index) => index
-  ).every((index) => !isMessageOpen(index));
+  ).every((index) => isMessageOpen(index));
 
   return (
     <LLMMessagesCollapseContext.Provider
@@ -73,7 +77,7 @@ export function LLMMessagesCollapseProvider({
         messageCount,
         isMessageOpen,
         setMessageOpen,
-        areAllMessagesCollapsed,
+        areAllMessagesExpanded,
         setAllMessagesOpen,
       }}
     >

--- a/app/src/pages/trace/span/LLMMessagesCollapseToggle.tsx
+++ b/app/src/pages/trace/span/LLMMessagesCollapseToggle.tsx
@@ -17,15 +17,23 @@ import { useLLMMessagesCollapse } from "./LLMMessagesCollapseContext";
  * Renders nothing for a list of one, where the message is already open and
  * there is nothing for the control to do.
  */
-export function LLMMessagesCollapseToggle() {
+export function LLMMessagesCollapseToggle({
+  /**
+   * Which side of the span the messages are, which names the control. An LLM
+   * span can show this toggle twice, and two buttons reading "expand all
+   * messages" would leave a screen reader with no way to tell the prompt from
+   * the completion.
+   */
+  scope,
+}: {
+  scope: "input" | "output";
+}) {
   const { messageCount, areAllMessagesExpanded, setAllMessagesOpen } =
     useLLMMessagesCollapse();
   if (messageCount < 2) {
     return null;
   }
-  const label = areAllMessagesExpanded
-    ? "Collapse all messages"
-    : "Expand all messages";
+  const label = `${areAllMessagesExpanded ? "Collapse" : "Expand"} all ${scope} messages`;
   return (
     <TooltipTrigger>
       <IconButton

--- a/app/src/pages/trace/span/LLMMessagesCollapseToggle.tsx
+++ b/app/src/pages/trace/span/LLMMessagesCollapseToggle.tsx
@@ -1,0 +1,46 @@
+import {
+  Icon,
+  IconButton,
+  Icons,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+
+import { useLLMMessagesCollapse } from "./LLMMessagesCollapseContext";
+
+/**
+ * Expands or collapses every message in an LLM message list at once.
+ *
+ * Renders nothing for a list of one, where the message is already open and
+ * there is nothing for the control to do.
+ */
+export function LLMMessagesCollapseToggle() {
+  const { messageCount, areAllMessagesCollapsed, setAllMessagesOpen } =
+    useLLMMessagesCollapse();
+  if (messageCount < 2) {
+    return null;
+  }
+  const label = areAllMessagesCollapsed
+    ? "Expand all messages"
+    : "Collapse all messages";
+  return (
+    <TooltipTrigger>
+      <IconButton
+        size="S"
+        aria-label={label}
+        onPress={() => setAllMessagesOpen(areAllMessagesCollapsed)}
+      >
+        <Icon
+          svg={
+            areAllMessagesCollapsed ? (
+              <Icons.RowExpand />
+            ) : (
+              <Icons.RowCollapse />
+            )
+          }
+        />
+      </IconButton>
+      <Tooltip offset={-5}>{label}</Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/pages/trace/span/LLMMessagesCollapseToggle.tsx
+++ b/app/src/pages/trace/span/LLMMessagesCollapseToggle.tsx
@@ -11,32 +11,31 @@ import { useLLMMessagesCollapse } from "./LLMMessagesCollapseContext";
 /**
  * Expands or collapses every message in an LLM message list at once.
  *
+ * The list arrives mostly collapsed, so the control offers the expand until
+ * every message is open, and only then offers the way back.
+ *
  * Renders nothing for a list of one, where the message is already open and
  * there is nothing for the control to do.
  */
 export function LLMMessagesCollapseToggle() {
-  const { messageCount, areAllMessagesCollapsed, setAllMessagesOpen } =
+  const { messageCount, areAllMessagesExpanded, setAllMessagesOpen } =
     useLLMMessagesCollapse();
   if (messageCount < 2) {
     return null;
   }
-  const label = areAllMessagesCollapsed
-    ? "Expand all messages"
-    : "Collapse all messages";
+  const label = areAllMessagesExpanded
+    ? "Collapse all messages"
+    : "Expand all messages";
   return (
     <TooltipTrigger>
       <IconButton
         size="S"
         aria-label={label}
-        onPress={() => setAllMessagesOpen(areAllMessagesCollapsed)}
+        onPress={() => setAllMessagesOpen(!areAllMessagesExpanded)}
       >
         <Icon
           svg={
-            areAllMessagesCollapsed ? (
-              <Icons.RowExpand />
-            ) : (
-              <Icons.RowCollapse />
-            )
+            areAllMessagesExpanded ? <Icons.RowCollapse /> : <Icons.RowExpand />
           }
         />
       </IconButton>

--- a/app/src/pages/trace/span/LLMMessagesList.tsx
+++ b/app/src/pages/trace/span/LLMMessagesList.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import type { AttributeMessage } from "@phoenix/openInference/tracing/types";
 
 import { LLMMessage } from "./LLMMessage";
+import { useLLMMessagesCollapse } from "./LLMMessagesCollapseContext";
 
 /**
  * A list of LLM messages (input or output).
@@ -19,6 +20,7 @@ export function LLMMessagesList({
    */
   leadingItems?: ReactNode[];
 }) {
+  const { isMessageOpen, setMessageOpen } = useLLMMessagesCollapse();
   return (
     <ul
       css={css`
@@ -34,7 +36,11 @@ export function LLMMessagesList({
       {messages.map((message, idx) => {
         return (
           <li key={idx}>
-            <LLMMessage message={message} />
+            <LLMMessage
+              message={message}
+              isOpen={isMessageOpen(idx)}
+              onOpenChange={(isOpen) => setMessageOpen(idx, isOpen)}
+            />
           </li>
         );
       })}

--- a/app/src/pages/trace/span/LLMOutput.tsx
+++ b/app/src/pages/trace/span/LLMOutput.tsx
@@ -9,6 +9,7 @@ import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import type { LLMIOView } from "./LLMIOViewSelect";
 import { LLMIOViewSelect, useLLMIOView } from "./LLMIOViewSelect";
+import { LLMMessagesCollapseToggle } from "./LLMMessagesCollapseToggle";
 import { LLMMessagesList } from "./LLMMessagesList";
 import { MimeTypeCodeBlock } from "./MimeTypeCodeBlock";
 import type { SpanIOValue } from "./types";
@@ -70,6 +71,7 @@ export function LLMOutput({
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isRawView && <ConnectedMarkdownModeSelect />}
+            {view === "output-messages" && <LLMMessagesCollapseToggle />}
             {views.length > 0 && (
               <LLMIOViewSelect
                 label="Output view"

--- a/app/src/pages/trace/span/LLMOutput.tsx
+++ b/app/src/pages/trace/span/LLMOutput.tsx
@@ -71,7 +71,9 @@ export function LLMOutput({
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isRawView && <ConnectedMarkdownModeSelect />}
-            {view === "output-messages" && <LLMMessagesCollapseToggle />}
+            {view === "output-messages" && (
+              <LLMMessagesCollapseToggle scope="output" />
+            )}
             {views.length > 0 && (
               <LLMIOViewSelect
                 label="Output view"

--- a/app/src/pages/trace/span/LLMSpanInfo.tsx
+++ b/app/src/pages/trace/span/LLMSpanInfo.tsx
@@ -31,12 +31,9 @@ export function LLMSpanInfo({
 
   return (
     <Flex direction="column" gap="size-200">
-      {/* keyed on the span so that expanding a message in one span does not
+      {/* the span is passed so that expanding a message in one span does not
           decide what the next span the reader opens looks like */}
-      <LLMMessagesCollapseProvider
-        key={`input-${span.id}`}
-        messageCount={inputMessages.length}
-      >
+      <LLMMessagesCollapseProvider spanId={span.id} messages={inputMessages}>
         <LLMInput
           modelName={modelName}
           provider={provider}
@@ -48,10 +45,7 @@ export function LLMSpanInfo({
           invocationParameters={invocationParameters}
         />
       </LLMMessagesCollapseProvider>
-      <LLMMessagesCollapseProvider
-        key={`output-${span.id}`}
-        messageCount={outputMessages.length}
-      >
+      <LLMMessagesCollapseProvider spanId={span.id} messages={outputMessages}>
         <LLMOutput output={output} outputMessages={outputMessages} />
       </LLMMessagesCollapseProvider>
     </Flex>

--- a/app/src/pages/trace/span/LLMSpanInfo.tsx
+++ b/app/src/pages/trace/span/LLMSpanInfo.tsx
@@ -1,6 +1,7 @@
 import { Flex } from "@phoenix/components";
 
 import { LLMInput } from "./LLMInput";
+import { LLMMessagesCollapseProvider } from "./LLMMessagesCollapseContext";
 import { LLMOutput } from "./LLMOutput";
 import type { AttributeObject, SpanInfoData } from "./types";
 import { getLLMAttributes } from "./utils";
@@ -30,17 +31,29 @@ export function LLMSpanInfo({
 
   return (
     <Flex direction="column" gap="size-200">
-      <LLMInput
-        modelName={modelName}
-        provider={provider}
-        input={input}
-        inputMessages={inputMessages}
-        toolSchemas={toolSchemas}
-        promptTemplate={promptTemplate}
-        prompts={prompts}
-        invocationParameters={invocationParameters}
-      />
-      <LLMOutput output={output} outputMessages={outputMessages} />
+      {/* keyed on the span so that expanding a message in one span does not
+          decide what the next span the reader opens looks like */}
+      <LLMMessagesCollapseProvider
+        key={`input-${span.id}`}
+        messageCount={inputMessages.length}
+      >
+        <LLMInput
+          modelName={modelName}
+          provider={provider}
+          input={input}
+          inputMessages={inputMessages}
+          toolSchemas={toolSchemas}
+          promptTemplate={promptTemplate}
+          prompts={prompts}
+          invocationParameters={invocationParameters}
+        />
+      </LLMMessagesCollapseProvider>
+      <LLMMessagesCollapseProvider
+        key={`output-${span.id}`}
+        messageCount={outputMessages.length}
+      >
+        <LLMOutput output={output} outputMessages={outputMessages} />
+      </LLMMessagesCollapseProvider>
     </Flex>
   );
 }

--- a/app/src/pages/trace/span/__tests__/LLMMessagesList.test.tsx
+++ b/app/src/pages/trace/span/__tests__/LLMMessagesList.test.tsx
@@ -20,15 +20,32 @@ const MESSAGES: AttributeMessage[] = [
   { role: "assistant", content: "Paris" },
 ];
 
+/** A turn carrying only an image, which previews as nothing at all. */
+const IMAGE_MESSAGE: AttributeMessage = {
+  role: "user",
+  contents: [
+    {
+      message_content: {
+        type: "image",
+        image: { image: { url: "data:image/png," } },
+      },
+    },
+  ],
+};
+
+const TOGGLE_SELECTOR =
+  'button[aria-label="Expand all input messages"],' +
+  'button[aria-label="Collapse all input messages"]';
+
 let container: HTMLDivElement;
 let root: Root;
 
-function renderMessages(messages: AttributeMessage[]) {
+function renderMessages(messages: AttributeMessage[], spanId = "span-1") {
   act(() => {
     root.render(
       <PreferencesProvider>
-        <LLMMessagesCollapseProvider messageCount={messages.length}>
-          <LLMMessagesCollapseToggle />
+        <LLMMessagesCollapseProvider spanId={spanId} messages={messages}>
+          <LLMMessagesCollapseToggle scope="input" />
           <LLMMessagesList messages={messages} />
         </LLMMessagesCollapseProvider>
       </PreferencesProvider>
@@ -44,11 +61,16 @@ function collapsedStates(): boolean[] {
 }
 
 function toggleButton(): HTMLElement {
-  const button = container.querySelector<HTMLElement>("button[aria-label]");
+  const button = container.querySelector<HTMLElement>(TOGGLE_SELECTOR);
   if (button === null) {
     throw new Error("no collapse toggle rendered");
   }
   return button;
+}
+
+/** The collapse toggle on the header of the message at `index`. */
+function messageHeaderButton(index: number): Element {
+  return container.querySelectorAll("li > .card button")[index];
 }
 
 function press(element: Element) {
@@ -85,10 +107,28 @@ describe("LLMMessagesList", () => {
     expect(collapsedStates()).toEqual([false]);
   });
 
+  // collapsing a message the preview cannot describe would leave a bare role
+  // header and hide the only thing the turn carries
+  it("leaves a message with no preview expanded", () => {
+    renderMessages([MESSAGES[0], IMAGE_MESSAGE, MESSAGES[2]]);
+    expect(collapsedStates()).toEqual([true, false, false]);
+  });
+
   it("lets a reader open an earlier message on its own", () => {
     renderMessages(MESSAGES);
-    press(container.querySelectorAll("li > .card button")[0]);
+    press(messageHeaderButton(0));
     expect(collapsedStates()).toEqual([false, true, false]);
+  });
+
+  // the provider stays mounted across spans so the cards around it keep their
+  // own state, so it has to start the messages over itself
+  it("starts over when the reader moves to another span", () => {
+    renderMessages(MESSAGES);
+    press(toggleButton());
+    expect(collapsedStates()).toEqual([false, false, false]);
+
+    renderMessages(MESSAGES, "span-2");
+    expect(collapsedStates()).toEqual([true, true, false]);
   });
 
   describe("the collapse toggle", () => {
@@ -97,7 +137,7 @@ describe("LLMMessagesList", () => {
     it("expands every message, then collapses every message", () => {
       renderMessages(MESSAGES);
       expect(toggleButton().getAttribute("aria-label")).toBe(
-        "Expand all messages"
+        "Expand all input messages"
       );
 
       press(toggleButton());
@@ -105,7 +145,7 @@ describe("LLMMessagesList", () => {
 
       // with nothing left to expand the control offers the way back
       expect(toggleButton().getAttribute("aria-label")).toBe(
-        "Collapse all messages"
+        "Collapse all input messages"
       );
       press(toggleButton());
       expect(collapsedStates()).toEqual([true, true, true]);
@@ -114,15 +154,45 @@ describe("LLMMessagesList", () => {
     // an expand that only reached the last message would look like a no-op
     it("keeps offering the expand while some messages are still collapsed", () => {
       renderMessages(MESSAGES);
-      press(container.querySelectorAll("li > .card button")[0]);
+      press(messageHeaderButton(0));
       expect(toggleButton().getAttribute("aria-label")).toBe(
-        "Expand all messages"
+        "Expand all input messages"
       );
+    });
+
+    // a message the span was still being written when the reader collapsed the
+    // list should not show up expanded on its own
+    it("holds a collapse across a message arriving later", () => {
+      renderMessages(MESSAGES);
+      press(toggleButton());
+      press(toggleButton());
+      expect(collapsedStates()).toEqual([true, true, true]);
+
+      renderMessages([
+        ...MESSAGES,
+        { role: "assistant", content: "…and Rome" },
+      ]);
+      expect(collapsedStates()).toEqual([true, true, true, true]);
+    });
+
+    it("names the side of the span it acts on", () => {
+      act(() => {
+        root.render(
+          <PreferencesProvider>
+            <LLMMessagesCollapseProvider spanId="span-1" messages={MESSAGES}>
+              <LLMMessagesCollapseToggle scope="output" />
+            </LLMMessagesCollapseProvider>
+          </PreferencesProvider>
+        );
+      });
+      expect(
+        container.querySelector("button")?.getAttribute("aria-label")
+      ).toBe("Expand all output messages");
     });
 
     it("is not rendered for a single message", () => {
       renderMessages(MESSAGES.slice(-1));
-      expect(container.querySelector("button[aria-label]")).toBeNull();
+      expect(container.querySelector(TOGGLE_SELECTOR)).toBeNull();
     });
   });
 });

--- a/app/src/pages/trace/span/__tests__/LLMMessagesList.test.tsx
+++ b/app/src/pages/trace/span/__tests__/LLMMessagesList.test.tsx
@@ -92,21 +92,32 @@ describe("LLMMessagesList", () => {
   });
 
   describe("the collapse toggle", () => {
-    it("collapses every message, then expands every message", () => {
+    // the list arrives mostly collapsed, so opening it up is the move the
+    // control has to offer first
+    it("expands every message, then collapses every message", () => {
       renderMessages(MESSAGES);
-      expect(toggleButton().getAttribute("aria-label")).toBe(
-        "Collapse all messages"
-      );
-
-      press(toggleButton());
-      expect(collapsedStates()).toEqual([true, true, true]);
-
-      // with nothing left to collapse the control offers the way back
       expect(toggleButton().getAttribute("aria-label")).toBe(
         "Expand all messages"
       );
+
       press(toggleButton());
       expect(collapsedStates()).toEqual([false, false, false]);
+
+      // with nothing left to expand the control offers the way back
+      expect(toggleButton().getAttribute("aria-label")).toBe(
+        "Collapse all messages"
+      );
+      press(toggleButton());
+      expect(collapsedStates()).toEqual([true, true, true]);
+    });
+
+    // an expand that only reached the last message would look like a no-op
+    it("keeps offering the expand while some messages are still collapsed", () => {
+      renderMessages(MESSAGES);
+      press(container.querySelectorAll("li > .card button")[0]);
+      expect(toggleButton().getAttribute("aria-label")).toBe(
+        "Expand all messages"
+      );
     });
 
     it("is not rendered for a single message", () => {

--- a/app/src/pages/trace/span/__tests__/LLMMessagesList.test.tsx
+++ b/app/src/pages/trace/span/__tests__/LLMMessagesList.test.tsx
@@ -1,0 +1,117 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installTestMatchMedia } from "@phoenix/__tests__/installTestMatchMedia";
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+import { PreferencesProvider } from "@phoenix/contexts";
+import type { AttributeMessage } from "@phoenix/openInference/tracing/types";
+
+import { LLMMessagesCollapseProvider } from "../LLMMessagesCollapseContext";
+import { LLMMessagesCollapseToggle } from "../LLMMessagesCollapseToggle";
+import { LLMMessagesList } from "../LLMMessagesList";
+
+installTestMatchMedia();
+installTestStorage();
+
+const MESSAGES: AttributeMessage[] = [
+  { role: "system", content: "you are a helpful assistant" },
+  { role: "user", content: "what is the capital of France?" },
+  { role: "assistant", content: "Paris" },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderMessages(messages: AttributeMessage[]) {
+  act(() => {
+    root.render(
+      <PreferencesProvider>
+        <LLMMessagesCollapseProvider messageCount={messages.length}>
+          <LLMMessagesCollapseToggle />
+          <LLMMessagesList messages={messages} />
+        </LLMMessagesCollapseProvider>
+      </PreferencesProvider>
+    );
+  });
+}
+
+/** The collapsed state of each message card, in list order. */
+function collapsedStates(): boolean[] {
+  return Array.from(container.querySelectorAll("li > .card")).map(
+    (card) => card.getAttribute("data-collapsed") === "true"
+  );
+}
+
+function toggleButton(): HTMLElement {
+  const button = container.querySelector<HTMLElement>("button[aria-label]");
+  if (button === null) {
+    throw new Error("no collapse toggle rendered");
+  }
+  return button;
+}
+
+function press(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("LLMMessagesList", () => {
+  // the history is mostly turns the reader has already seen; the last message
+  // is the one they opened the span for
+  it("collapses every message except the last", () => {
+    renderMessages(MESSAGES);
+    expect(collapsedStates()).toEqual([true, true, false]);
+  });
+
+  it("leaves a lone message expanded", () => {
+    renderMessages(MESSAGES.slice(-1));
+    expect(collapsedStates()).toEqual([false]);
+  });
+
+  it("lets a reader open an earlier message on its own", () => {
+    renderMessages(MESSAGES);
+    press(container.querySelectorAll("li > .card button")[0]);
+    expect(collapsedStates()).toEqual([false, true, false]);
+  });
+
+  describe("the collapse toggle", () => {
+    it("collapses every message, then expands every message", () => {
+      renderMessages(MESSAGES);
+      expect(toggleButton().getAttribute("aria-label")).toBe(
+        "Collapse all messages"
+      );
+
+      press(toggleButton());
+      expect(collapsedStates()).toEqual([true, true, true]);
+
+      // with nothing left to collapse the control offers the way back
+      expect(toggleButton().getAttribute("aria-label")).toBe(
+        "Expand all messages"
+      );
+      press(toggleButton());
+      expect(collapsedStates()).toEqual([false, false, false]);
+    });
+
+    it("is not rendered for a single message", () => {
+      renderMessages(MESSAGES.slice(-1));
+      expect(container.querySelector("button[aria-label]")).toBeNull();
+    });
+  });
+});

--- a/app/src/pages/trace/span/index.ts
+++ b/app/src/pages/trace/span/index.ts
@@ -3,6 +3,8 @@ export * from "./EmbeddingInput";
 export * from "./EmbeddingSpanInfo";
 export * from "./LLMInput";
 export * from "./LLMMessage";
+export * from "./LLMMessagesCollapseContext";
+export * from "./LLMMessagesCollapseToggle";
 export * from "./LLMMessagesList";
 export * from "./LLMOutput";
 export * from "./LLMPromptsList";


### PR DESCRIPTION
Closes #14734

## What

Messages in an LLM span's **Input** and **Output** cards now start collapsed — except the last one, which stays expanded. A conversation sent to a model is mostly history the reader has already seen; what they came for is the latest turn. Collapsed messages fall back to the `CardCollapsedPreview` that `getMessagePreview` already produces, so the shape of the conversation stays readable at a glance.

A toggle in the card header (the same `RowExpand`/`RowCollapse` pair the span info tab's collapse-all uses) expands or collapses every message at once. It's hidden for a single-message list, where there's nothing for it to do.

## How

`LLMMessagesCollapseContext` holds the open state for one message list and is consumed by both the toggle in the card header and the message cards themselves, so the two act on the same state — same shape as `SpanInfoCardsContext`. A message the reader hasn't touched resolves to open only if it's the last one.

`LLMSpanInfo` mounts one provider per list (input, output), keyed on the span id: opening a message in one span shouldn't decide what the next span the reader clicks looks like.

## Testing

New `LLMMessagesList` unit tests cover the default state, the single-message case, opening one message on its own, and the toggle's collapse-all → expand-all round trip.

- `pnpm vitest run` — 2197 passed, 12 skipped
- `pnpm typecheck`, `pnpm lint`, `pnpm fmt` clean