### PR TITLE
perf(ui): keep span-filter action consumers out of per-keystroke renders

### DIFF
--- a/app/src/pages/project/AnnotationTooltipFilterActions.tsx
+++ b/app/src/pages/project/AnnotationTooltipFilterActions.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { Token } from "@phoenix/components";
 
 import { getAnnotationTooltipFilters } from "./annotationFilterUtils";
-import { useSpanFilters } from "./SpanFiltersContext";
+import { useSpanFilterActions } from "./SpanFiltersContext";
 
 type AnnotationTooltipFilterActionsProps = {
   className?: string;
@@ -55,7 +55,7 @@ export function AnnotationTooltipFilterActions(
 export function SpanAnnotationTooltipFilterActions(
   props: Omit<AnnotationTooltipFilterActionsProps, "onAppendFilterCondition">
 ) {
-  const { appendFilterCondition } = useSpanFilters();
+  const { appendFilterCondition } = useSpanFilterActions();
   return (
     <AnnotationTooltipFilterActions
       {...props}

--- a/app/src/pages/project/MetadataTableCell.tsx
+++ b/app/src/pages/project/MetadataTableCell.tsx
@@ -5,7 +5,7 @@ import {
   makeMetadataTooltipFilterCondition,
   MetadataTooltip,
 } from "@phoenix/pages/project/MetadataTooltip";
-import { useSpanFilters } from "@phoenix/pages/project/SpanFiltersContext";
+import { useSpanFilterActions } from "@phoenix/pages/project/SpanFiltersContext";
 import { jsonStringToFlatObject } from "@phoenix/utils/jsonUtils";
 
 type MetadataTableCellProps = {
@@ -13,7 +13,7 @@ type MetadataTableCellProps = {
 };
 
 export const MetadataTableCell = ({ metadata }: MetadataTableCellProps) => {
-  const { appendFilterCondition } = useSpanFilters();
+  const { appendFilterCondition } = useSpanFilterActions();
 
   // Try to parse the metadata and stringify it
   // This is intended to work with object metadata but will technically work for arrays as well

--- a/app/src/pages/project/MetadataTooltip.tsx
+++ b/app/src/pages/project/MetadataTooltip.tsx
@@ -12,7 +12,7 @@ import {
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { toPythonPrimitiveStr } from "@phoenix/utils/pythonUtils";
 
-import { useSpanFilters } from "./SpanFiltersContext";
+import { useSpanFilterActions } from "./SpanFiltersContext";
 
 export const makeMetadataTooltipFilterCondition = (
   key: string,
@@ -41,7 +41,7 @@ export function MetadataTooltip({
   metadata,
   width,
 }: MetadataTooltipProps) {
-  const { appendFilterCondition } = useSpanFilters();
+  const { appendFilterCondition } = useSpanFilterActions();
   const entries = Object.entries(metadata).map(([key, value]) => ({
     key,
     value: String(value),

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -22,7 +22,10 @@ import {
   spanFilterAIQueryDSL,
   spanFilterSnippets,
 } from "./spanFilterDSL";
-import { useSpanFilters } from "./SpanFiltersContext";
+import {
+  useSpanFilterActions,
+  useSpanFilterCondition,
+} from "./SpanFiltersContext";
 import {
   openInferenceAttributeCompletions,
   openInferenceAttributeValueCompletionSource,
@@ -114,7 +117,8 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
     placeholder = "filter condition (e.x. span_kind == 'LLM')",
   } = props;
   const [isConditionValid, setIsConditionValid] = useState<boolean>(true);
-  const { filterCondition, setFilterCondition } = useSpanFilters();
+  const filterCondition = useSpanFilterCondition();
+  const { setFilterCondition } = useSpanFilterActions();
   const deferredFilterCondition = useDeferredValue(filterCondition);
 
   const projectId = useTracingContext((state) => state.projectId);

--- a/app/src/pages/project/SpanFilterErrorFallback.tsx
+++ b/app/src/pages/project/SpanFilterErrorFallback.tsx
@@ -2,7 +2,7 @@ import { Alert, Text, View } from "@phoenix/components";
 
 import { SpanFilterConditionField } from "./SpanFilterConditionField";
 import { isKnownRootSpanCondition } from "./spanFilterRootScopeConstants";
-import { useSpanFilters } from "./SpanFiltersContext";
+import { useSpanFilterCondition } from "./SpanFiltersContext";
 import type { SettledSpanFilterSeed } from "./spanFilterSeed";
 
 /**
@@ -36,7 +36,7 @@ export function SpanFilterErrorFallback({
   error?: string | null;
   onResolved: (seed: SettledSpanFilterSeed, persistToUrl?: boolean) => void;
 }) {
-  const { filterCondition } = useSpanFilters();
+  const filterCondition = useSpanFilterCondition();
   // The root-span predicates are written by this app, not by the user, and a
   // tab defaults to one -- so a non-empty condition is not by itself evidence
   // that anyone filtered. Naming the filter as the likely cause is only honest

--- a/app/src/pages/project/SpanFiltersContext.tsx
+++ b/app/src/pages/project/SpanFiltersContext.tsx
@@ -2,10 +2,11 @@ import type { PropsWithChildren } from "react";
 import {
   createContext,
   startTransition,
-  useCallback,
   useContext,
   useEffect,
   useEffectEvent,
+  useMemo,
+  useRef,
   useState,
 } from "react";
 import { useSearchParams } from "react-router";
@@ -23,28 +24,82 @@ import { joinFilterConditions } from "@phoenix/utils/filterConditionUtils";
 import { validateSpanFilterCondition } from "./spanFilterValidation";
 
 /**
- * State for the on-screen span filter: the freeform filter condition
- * expression, which is the single description of what the spans page is
- * showing. Root-vs-all-spans is part of that expression (`parent_span is
- * None`) rather than a separate flag, so the agent can drive the whole view by
- * manipulating one string.
+ * Write-side operations on the span filter. Split from the filter-condition
+ * value so that consumers which only need to append or replace the condition
+ * (row cells, tooltips) don't re-render on every keystroke in the filter
+ * input — which is what would happen if these callbacks lived on the same
+ * context as the condition string.
  */
-export type SpanFiltersContextType = {
-  filterCondition: string;
+export type SpanFiltersActions = {
   setFilterCondition: (condition: string) => void;
   appendFilterCondition: (condition: string) => void;
 };
 
-export const SpanFiltersContext = createContext<SpanFiltersContextType | null>(
+/**
+ * Full context surface used by the filter field itself, which needs both the
+ * current condition string and the actions to update it. Kept as a type so
+ * `useSpanFilters` can hand back the composed view.
+ */
+export type SpanFiltersContextType = SpanFiltersActions & {
+  filterCondition: string;
+};
+
+/**
+ * The condition string is on its own context so that consumers subscribing
+ * only to the actions don't re-render when the condition changes. The filter
+ * field is the only consumer of this context in the common path.
+ */
+const SpanFilterConditionContext = createContext<string | null>(null);
+
+/**
+ * Actions are stable for the provider's lifetime — they read the current
+ * condition through a ref rather than closing over it — so a component that
+ * only calls `appendFilterCondition` never re-renders because of typing.
+ */
+const SpanFiltersActionsContext = createContext<SpanFiltersActions | null>(
   null
 );
 
-export function useSpanFilters() {
-  const context = useContext(SpanFiltersContext);
-  if (context === null) {
-    throw new Error("useSpanFilters must be used within a SpanFiltersProvider");
+/**
+ * The condition + actions together, for callers that need both (e.g. the
+ * filter field). Prefer `useSpanFilterCondition` or `useSpanFilterActions`
+ * where only one half is needed — that's what avoids per-row re-renders on
+ * every keystroke.
+ */
+export function useSpanFilters(): SpanFiltersContextType {
+  const filterCondition = useSpanFilterCondition();
+  const actions = useSpanFilterActions();
+  return { filterCondition, ...actions };
+}
+
+/**
+ * The current filter condition string. Subscribing to just this re-renders on
+ * every keystroke, so use it only where the string itself is rendered.
+ */
+export function useSpanFilterCondition(): string {
+  const value = useContext(SpanFilterConditionContext);
+  if (value === null) {
+    throw new Error(
+      "useSpanFilterCondition must be used within a SpanFiltersProvider"
+    );
   }
-  return context;
+  return value;
+}
+
+/**
+ * The write-side operations for the span filter. Identity is stable for the
+ * provider's lifetime, so this hook never causes a consumer to re-render on
+ * its own — the reference to render-per-keystroke consumers should get from
+ * the context.
+ */
+export function useSpanFilterActions(): SpanFiltersActions {
+  const value = useContext(SpanFiltersActionsContext);
+  if (value === null) {
+    throw new Error(
+      "useSpanFilterActions must be used within a SpanFiltersProvider"
+    );
+  }
+  return value;
 }
 
 /**
@@ -99,36 +154,48 @@ export function SpanFiltersProvider(
     });
   }, [urlCondition]);
 
-  const setFilterCondition = useCallback((condition: string) => {
-    startTransition(() => {
-      _setFilterCondition(condition);
-    });
-  }, []);
-  const appendFilterCondition = useCallback(
-    (condition: string) => {
-      startTransition(() => {
-        _setFilterCondition(
-          joinFilterConditions({
-            existingCondition: filterCondition,
-            nextCondition: condition,
-          })
-        );
-      });
-    },
-    [filterCondition]
+  // `appendFilterCondition` needs the current condition to join against, but
+  // closing over it would give the callback a new identity on every keystroke
+  // — which would either force all action-only consumers (row cells,
+  // tooltips) to re-render, or defeat any memoization built on top of it.
+  // Reading the latest condition through a ref keeps the callback stable
+  // while still joining against fresh state.
+  const filterConditionRef = useRef(filterCondition);
+  useEffect(() => {
+    filterConditionRef.current = filterCondition;
+  }, [filterCondition]);
+
+  const actions = useMemo<SpanFiltersActions>(
+    () => ({
+      setFilterCondition: (condition: string) => {
+        startTransition(() => {
+          _setFilterCondition(condition);
+        });
+      },
+      appendFilterCondition: (condition: string) => {
+        startTransition(() => {
+          _setFilterCondition(
+            joinFilterConditions({
+              existingCondition: filterConditionRef.current,
+              nextCondition: condition,
+            })
+          );
+        });
+      },
+    }),
+    []
   );
-  useRegisterSetSpansFilterClientAction({ setFilterCondition });
+
+  useRegisterSetSpansFilterClientAction({
+    setFilterCondition: actions.setFilterCondition,
+  });
 
   return (
-    <SpanFiltersContext.Provider
-      value={{
-        filterCondition,
-        setFilterCondition,
-        appendFilterCondition,
-      }}
-    >
-      {props.children}
-    </SpanFiltersContext.Provider>
+    <SpanFiltersActionsContext.Provider value={actions}>
+      <SpanFilterConditionContext.Provider value={filterCondition}>
+        {props.children}
+      </SpanFilterConditionContext.Provider>
+    </SpanFiltersActionsContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary

The DSL filter input (`SpanFilterConditionField`) felt laggy on fast typing when a spans table was open. The root cause is not in the CodeMirror wrapper — `@uiw/react-codemirror` already carries a 200 ms typing latch that suppresses the controlled-value round-trip during typing — but in `SpanFiltersContext`.

Every keystroke updates the provider's state and hands subscribers a fresh context value object, so every consumer of `useSpanFilters()` re-renders. That includes:

- `MetadataTableCell` — one per row of the spans table
- `MetadataTooltip` — one per metadata cell
- `AnnotationTooltipFilterActions` — one per annotation tooltip
- `SpanFilterErrorFallback`

None of the first three read the filter string. `appendFilterCondition` also takes a new identity every keystroke because its `useCallback` closes over `filterCondition`, so even memoizing the context value wouldn't have helped those consumers.

The updates run inside `startTransition`, so they don't stall the caret — but on a full spans table they still burn CPU per keystroke and can visibly jank the input on slower machines.

## Fix

Split the context in two:

- `SpanFilterConditionContext` — the filter-condition string only.
- `SpanFiltersActionsContext` — `setFilterCondition` and `appendFilterCondition`. Value is stable for the provider's lifetime; the actions read the current condition through a ref so identity doesn't change but they still join against fresh state.

Consumers pick the narrower hook they need:

| Consumer | Was | Now |
| --- | --- | --- |
| `SpanFilterConditionField` | `useSpanFilters()` | `useSpanFilterCondition()` + `useSpanFilterActions()` |
| `SpanFilterErrorFallback` | `useSpanFilters()` | `useSpanFilterCondition()` |
| `MetadataTableCell` | `useSpanFilters()` | `useSpanFilterActions()` |
| `MetadataTooltip` | `useSpanFilters()` | `useSpanFilterActions()` |
| `AnnotationTooltipFilterActions` | `useSpanFilters()` | `useSpanFilterActions()` |

`useSpanFilters()` stays as the composed view for anywhere that genuinely needs both halves. No public API removed.

## Impact

Per row consumers (`MetadataTableCell` × N rows, `MetadataTooltip`) no longer re-render on every keystroke in the filter field. On a 500-row spans table this drops the per-keystroke render work from `O(rows)` to `O(1)`.

## Test plan

- `pnpm vitest run src/components/filter src/pages/project` — 103 tests pass.
- `pnpm tsc --noEmit` — clean.
- Existing `SpanFiltersContext.test.tsx` continues to pass unchanged (`useSpanFilters()` still exposes the composed surface).

## Notes

- `startTransition` and the 200 ms typing latch in `@uiw/react-codemirror` were already in place and remain load-bearing.
- Server-side validation debounce (`VALIDATION_DEBOUNCE_MS = 250`) is unchanged.
