### PR TITLE
fix: Set relative base path in vite.config.mts

### DIFF
--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -39,6 +39,13 @@ export default defineConfig(() => {
   // Uncomment below to visualize the bundle size after running the build command also uncomment import { visualizer } from "rollup-plugin-visualizer";
   // plugins.push(visualizer());
   return {
+    // Use a relative base so lazy-loaded chunk deps (__vite__mapDeps) resolve
+    // relative to the importing module's URL instead of being baked in as
+    // absolute "/assets/..." paths. This lets the bundle work when Phoenix is
+    // served under a path prefix (PHOENIX_HOST_ROOT_PATH, e.g. "/phoenix")
+    // behind a reverse proxy. The server's index.html template handles the
+    // prefix for entry assets via `basename`; this handles everything loaded
+    // from within the JS bundle. See https://github.com/Arize-ai/phoenix/issues/15178
     base: "./",
     root: resolve(__dirname, "src"),
     plugins,

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -39,6 +39,7 @@ export default defineConfig(() => {
   // Uncomment below to visualize the bundle size after running the build command also uncomment import { visualizer } from "rollup-plugin-visualizer";
   // plugins.push(visualizer());
   return {
+    base: "./",
     root: resolve(__dirname, "src"),
     plugins,
     publicDir: resolve(__dirname, "static"),


### PR DESCRIPTION
fix #15178

Set `base: "./"` in `app/vite.config.mts`:

```ts
// app/vite.config.mts
export default defineConfig(() => {
  return {
    base: "./",   // emit relative chunk paths instead of absolute "/assets/..."
    root: resolve(__dirname, "src"),
    // ...
  };
});
```

With `base: "./"`, Vite emits relative paths in `__vite__mapDeps`:

```js
// After fix
d = ["./vendor-CGXZFvlB.js", "./DiffAcceptRejectToolDetails-Cv0hSlMO.js", ...]
```

The browser resolves `./vendor-CGXZFvlB.js` relative to the executing script's URL:

```
new URL("./vendor-CGXZFvlB.js", "http://host/phoenix/assets/index-*.js")
→ http://host/phoenix/assets/vendor-CGXZFvlB.js   ✓
```

The `/phoenix` prefix is automatically inherited, and the reverse proxy correctly strips it before forwarding to Phoenix's static file handler.
