### PR TITLE
fix(ui): keep overflow visible on selectable table cells so focus rings are not clipped

### DIFF
--- a/.agents/skills/phoenix-frontend/references/accessibility.md
+++ b/.agents/skills/phoenix-frontend/references/accessibility.md
@@ -8,3 +8,8 @@
 ## WCAG 2.1 AA baseline
 
 [WCAG 2.1 AA](https://www.w3.org/WAI/standards-guidelines/wcag/) MUST be followed: 4.5:1 contrast for text, keyboard operability, visible focus indicators, labeled form inputs.
+
+## Focus indicators
+
+- Focus rings MUST NOT be clipped by `overflow: hidden` on ancestor elements.
+- When a table cell contains a focusable control (e.g. a row-selection checkbox or action button), keep `overflow` visible on that cell and apply truncation/clipping only to dedicated text wrappers inside the cell.

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -4,12 +4,21 @@ import type { CSSProperties } from "react";
 
 import { truncateSingleCSS } from "@phoenix/components/core/utility/Truncate";
 
+import { ACTIONS_COLUMN_ID, CHECKBOX_COLUMN_ID } from "./constants";
+
 /**
  * Marks a `<td>` that holds one column's value, as opposed to the cells that
  * stand in for a whole row (empty state, load more). Table bodies put it on
  * every cell they render from a column definition.
  */
 export const TABLE_DATA_CELL_CLASS = "table__cell";
+
+/**
+ * Selector for data cells that contain text and should be clipped/truncated.
+ * Selection and action cells hold focusable controls whose focus rings must
+ * not be clipped by `overflow: hidden`.
+ */
+const CLIPPED_DATA_CELL_SELECTOR = `td.${TABLE_DATA_CELL_CLASS}:not([data-column-id="${CHECKBOX_COLUMN_ID}"]):not([data-column-id="${ACTIONS_COLUMN_ID}"])`;
 
 export const tableCSS = css`
   // fixes table row sizing issues with full height cell children
@@ -166,8 +175,10 @@ export const selectableTableCSS = css(
 export const expandableRowsTableCSS = css`
   // Only data cells take a row height; the cells that stand in for a whole row
   // (empty state, load more) lay themselves out.
+  // Selection and action cells are excluded from clipping so focus rings on
+  // checkboxes and action controls remain fully visible.
   &[data-rows="collapsed"] {
-    td.${TABLE_DATA_CELL_CLASS} {
+    ${CLIPPED_DATA_CELL_SELECTOR} {
       ${truncateSingleCSS};
       // a <pre> would keep its newlines and outgrow the single line; it also
       // overflows on its own terms, so the cell's ellipsis is repeated here
@@ -179,7 +190,7 @@ export const expandableRowsTableCSS = css`
     }
   }
   &[data-rows="expanded"] {
-    td.${TABLE_DATA_CELL_CLASS} {
+    ${CLIPPED_DATA_CELL_SELECTOR} {
       vertical-align: top;
       overflow: hidden;
       // long unbroken values (ids, serialized JSON) wrap within the cell

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -145,6 +145,7 @@ const TableBody = <T extends { id: string }>({
                 <td
                   key={cell.id}
                   className={TABLE_DATA_CELL_CLASS}
+                  data-column-id={cell.column.id}
                   style={{
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -171,6 +171,7 @@ const TableBody = <T extends { id: string }>({
                 <td
                   key={cell.id}
                   className={TABLE_DATA_CELL_CLASS}
+                  data-column-id={cell.column.id}
                   style={{
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -165,6 +165,7 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
                 <td
                   key={cell.id}
                   className={TABLE_DATA_CELL_CLASS}
+                  data-column-id={cell.column.id}
                   align={cell.column.columnDef.meta?.textAlign}
                   style={{
                     ...getCommonPinningStyles(cell.column),

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -173,6 +173,7 @@ const TableBody = <
                 <td
                   key={cell.id}
                   className={TABLE_DATA_CELL_CLASS}
+                  data-column-id={cell.column.id}
                   style={{
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,


### PR DESCRIPTION
Fixes #14639

## Problem

The spans, traces, sessions, and experiments tables use `expandableSelectableTableCSS`, which applies `overflow: hidden` to every data cell. This clips the focus ring on row-selection checkboxes (and any future action-cell controls) when navigating by keyboard.

The dataset examples table uses `selectableTableCSS` without the expandable-row rules, which is why its checkboxes keep a complete focus indicator.

## Change

- Update `expandableRowsTableCSS` so the clipping/truncation rules only target data cells that are **not** the selection or action columns.
- Add `data-column-id` to every `<td>` rendered by the four tables that use `expandableSelectableTableCSS` (`SpansTable`, `TracesTable`, `SessionsTable`, `ExperimentsTable`) so the CSS selector can identify select/action cells.
- Add a focus-indicator guardrail to the frontend accessibility skill reference.

## Verification

- `pnpm --dir app run fmt`
- `pnpm --dir app run typecheck`
- `pnpm --dir app run lint` (no new errors; pre-existing warnings only)
- `pnpm --dir app run test -- --run src/components/table src/pages/project/__tests__/SpansTableSeedIntegration.test.tsx src/pages/experiments/__tests__` (all passing)

## Notes

This is intentionally scoped to the clipping fix. Header checkbox focus and action-cell focus are covered by the same selector exemption; further Storybook/visual-regression work can follow if maintainers want it.