### PR TITLE
feat(client): support updating prompt description and metadata

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts.mdx
@@ -3,7 +3,7 @@ title: "Prompts"
 description: "Manage prompts with @arizeai/phoenix-client"
 ---
 
-The prompts module lets you create prompt versions in Phoenix, fetch them back by selector, list prompts, and adapt prompt versions to supported provider SDKs.
+The prompts module lets you create prompt versions in Phoenix, fetch them back by selector, list prompts, update a prompt's description and metadata, and adapt prompt versions to supported provider SDKs.
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
@@ -43,6 +43,22 @@ const prompt = await getPrompt({
 
 `prompt` can be selected by `{ name }`, `{ name, tag }`, or `{ versionId }`.
 
+## Update Description And Metadata
+
+```ts
+import { updatePrompt } from "@arizeai/phoenix-client/prompts";
+
+await updatePrompt({
+  promptIdentifier: "support-response",
+  description: "Customer support reply prompt",
+  metadata: { team: "ml", env: "production" },
+});
+```
+
+`promptIdentifier` is a prompt name or ID. Omit a field to leave it unchanged, and pass `description: null` to clear it. `metadata` replaces the existing metadata object as a whole rather than merging into it.
+
+Requires a Phoenix server on 19.18.0 or later.
+
 ## Convert To Another SDK
 
 ```ts
@@ -67,6 +83,7 @@ Supported `sdk` targets:
     <li><code>src/prompts/createPrompt.ts</code></li>
     <li><code>src/prompts/getPrompt.ts</code></li>
     <li><code>src/prompts/listPrompts.ts</code></li>
+    <li><code>src/prompts/updatePrompt.ts</code></li>
     <li><code>src/prompts/sdks/toSDK.ts</code></li>
     <li><code>src/types/prompts.ts</code></li>
   </ul>

--- a/js/.changeset/prompt-metadata-update.md
+++ b/js/.changeset/prompt-metadata-update.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `updatePrompt` for `PATCH /v1/prompts/{prompt_identifier}` (description and metadata; requires Phoenix server >= 19.18.0).

--- a/js/packages/phoenix-client/.cursor/rules/general.mdc
+++ b/js/packages/phoenix-client/.cursor/rules/general.mdc
@@ -33,6 +33,7 @@ functions should be prefixed with an action:
 - `get` - gets the entity. Corrolates to HTTP `GET` a specific entity. E.x. `/projects/1`
 - `create` - makes a new entity. Corrolates to HTTP `POST`
 - `list` - get a paginated list of an entity. E.g. `GET` a list `/projects`
+- `update` - modifies an existing entity. Corrolates to HTTP `PATCH` or `PUT`. E.x. `updatePrompt`
 - `add` - attach an entity to another. E.x. `addAnnotation` would be used to attach an annotation to a `span` or `trace`
 - `delete` - permanently delete an entity
 

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -138,6 +138,13 @@ export const ADD_SESSION_NOTE_IDENTIFIER: ParameterRequirement = {
   minServerVersion: [15, 5, 0],
 };
 
+export const PATCH_PROMPT: RouteRequirement = {
+  kind: "route",
+  method: "PATCH",
+  path: "/v1/prompts/{prompt_identifier}",
+  minServerVersion: [19, 18, 0],
+};
+
 /**
  * Aggregate list of every known capability requirement.
  *
@@ -161,4 +168,5 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   ADD_TRACE_NOTE_IDENTIFIER,
   ADD_SPAN_NOTE_IDENTIFIER,
   ADD_SESSION_NOTE_IDENTIFIER,
+  PATCH_PROMPT,
 ] as const;

--- a/js/packages/phoenix-client/src/prompts/index.ts
+++ b/js/packages/phoenix-client/src/prompts/index.ts
@@ -1,4 +1,5 @@
 export * from "./getPrompt";
 export * from "./createPrompt";
 export * from "./listPrompts";
+export * from "./updatePrompt";
 export * from "./sdks";

--- a/js/packages/phoenix-client/src/prompts/updatePrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/updatePrompt.ts
@@ -1,0 +1,95 @@
+import invariant from "tiny-invariant";
+
+import { createClient } from "../client";
+import { PATCH_PROMPT } from "../constants/serverRequirements";
+import { HttpError } from "../errors";
+import type { ClientFn } from "../types/core";
+import type { Prompt } from "../types/prompts";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+
+/**
+ * Parameters for updating a prompt's description and/or metadata.
+ *
+ * Omit a field to leave it unchanged. Pass `description: null` to clear the
+ * description. `metadata` replaces the existing metadata object as a whole.
+ */
+export interface UpdatePromptParams extends ClientFn {
+  /**
+   * The prompt name or ID.
+   */
+  promptIdentifier: string;
+  /**
+   * New description for the prompt. Pass `null` to clear it. Omit to leave
+   * unchanged.
+   */
+  description?: string | null;
+  /**
+   * New metadata object for the prompt (full replace). Omit to leave unchanged.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Update a prompt's description and/or metadata via
+ * `PATCH /v1/prompts/{prompt_identifier}`.
+ *
+ * @param params - The parameters to update the prompt.
+ * @returns The updated prompt.
+ *
+ * @requires Phoenix server >= 19.18.0
+ *
+ * @example
+ * ```ts
+ * import { updatePrompt } from "@arizeai/phoenix-client/prompts";
+ *
+ * const prompt = await updatePrompt({
+ *   promptIdentifier: "my-prompt",
+ *   description: "Production classifier",
+ *   metadata: { team: "ml", env: "prod" },
+ * });
+ *
+ * // Clear the description only
+ * await updatePrompt({
+ *   promptIdentifier: "my-prompt",
+ *   description: null,
+ * });
+ * ```
+ */
+export async function updatePrompt({
+  client: _client,
+  promptIdentifier,
+  description,
+  metadata,
+}: UpdatePromptParams): Promise<Prompt> {
+  if (description === undefined && metadata === undefined) {
+    throw new Error(
+      "At least one of description or metadata must be provided."
+    );
+  }
+
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: PATCH_PROMPT });
+
+  try {
+    const response = await client.PATCH("/v1/prompts/{prompt_identifier}", {
+      params: {
+        path: {
+          prompt_identifier: promptIdentifier,
+        },
+      },
+      body: {
+        ...(description !== undefined ? { description } : {}),
+        ...(metadata !== undefined ? { metadata } : {}),
+      },
+    });
+    invariant(response.data?.data, "Failed to update prompt");
+    return response.data.data;
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 404) {
+      throw new Error(`Prompt not found: ${promptIdentifier}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}

--- a/js/packages/phoenix-client/test/prompts/updatePrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/updatePrompt.test.ts
@@ -1,0 +1,160 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.unmock("../../src/utils/serverVersionUtils");
+
+import { HttpError } from "../../src/errors";
+import { updatePrompt } from "../../src/prompts";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+
+/**
+ * Handler that reports the given Phoenix server version. The capability guard
+ * in updatePrompt resolves the server version by fetching this endpoint, and
+ * the endpoint returns the version string as plain text.
+ */
+function serverVersionHandler(version: string) {
+  return http.get("/arize_phoenix_version", ({ response }) =>
+    response.untyped(new Response(version, { status: 200 }))
+  );
+}
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+const UPDATED_PROMPT = {
+  id: "prompt-001",
+  name: "my-prompt",
+  description: "updated",
+  metadata: { team: "ml" },
+};
+
+describe("updatePrompt", () => {
+  it("PATCHes description and metadata and returns the prompt", async () => {
+    const captured: { body?: unknown; identifier?: string } = {};
+    server.use(
+      serverVersionHandler("19.18.0"),
+      http.patch(
+        "/v1/prompts/{prompt_identifier}",
+        async ({ params, request, response }) => {
+          captured.identifier = params.prompt_identifier;
+          captured.body = await request.json();
+          return response(200).json({ data: UPDATED_PROMPT });
+        }
+      )
+    );
+
+    const prompt = await updatePrompt({
+      client: createTestClient(),
+      promptIdentifier: "my-prompt",
+      description: "updated",
+      metadata: { team: "ml" },
+    });
+
+    expect(captured.identifier).toBe("my-prompt");
+    expect(captured.body).toEqual({
+      description: "updated",
+      metadata: { team: "ml" },
+    });
+    expect(prompt).toEqual(UPDATED_PROMPT);
+  });
+
+  it("omits unset fields from the request body", async () => {
+    const captured: { body?: unknown } = {};
+    server.use(
+      serverVersionHandler("19.18.0"),
+      http.patch(
+        "/v1/prompts/{prompt_identifier}",
+        async ({ request, response }) => {
+          captured.body = await request.json();
+          return response(200).json({
+            data: { ...UPDATED_PROMPT, description: null },
+          });
+        }
+      )
+    );
+
+    await updatePrompt({
+      client: createTestClient(),
+      promptIdentifier: "my-prompt",
+      description: null,
+    });
+
+    expect(captured.body).toEqual({ description: null });
+  });
+
+  it("rejects an empty patch", async () => {
+    await expect(
+      updatePrompt({
+        client: createTestClient(),
+        promptIdentifier: "my-prompt",
+      })
+    ).rejects.toThrow(
+      "At least one of description or metadata must be provided."
+    );
+  });
+
+  it("reports a missing prompt by identifier", async () => {
+    server.use(
+      serverVersionHandler("19.18.0"),
+      http.patch("/v1/prompts/{prompt_identifier}", ({ response }) =>
+        response.untyped(new Response("Prompt not found", { status: 404 }))
+      )
+    );
+
+    const error = await updatePrompt({
+      client: createTestClient(),
+      promptIdentifier: "missing-prompt",
+      description: "updated",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Prompt not found: missing-prompt");
+    expect((error as Error).cause).toBeInstanceOf(HttpError);
+    expect(((error as Error).cause as HttpError).status).toBe(404);
+  });
+
+  it("fails fast on older Phoenix servers", async () => {
+    let patchRequestCount = 0;
+
+    server.use(
+      serverVersionHandler("19.17.0"),
+      http.patch("/v1/prompts/{prompt_identifier}", ({ response }) => {
+        patchRequestCount += 1;
+        return response(200).json({ data: UPDATED_PROMPT });
+      })
+    );
+
+    await expect(
+      updatePrompt({
+        client: createTestClient(),
+        promptIdentifier: "my-prompt",
+        description: "updated",
+      })
+    ).rejects.toThrow(/requires Phoenix server >= 19\.18\.0/);
+
+    expect(patchRequestCount).toBe(0);
+  });
+});

--- a/packages/phoenix-client/docs/source/api/types.rst
+++ b/packages/phoenix-client/docs/source/api/types.rst
@@ -14,3 +14,10 @@ Spans Types
 .. automodule:: client.types.spans
    :members:
    :show-inheritance:
+
+Sentinels
+---------
+
+.. automodule:: client.types.sentinels
+   :members:
+   :show-inheritance:

--- a/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
+++ b/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
@@ -90,3 +90,9 @@ DATASET_UPLOAD_SPLIT_KEY = ParameterRequirement(
     route="POST /v1/datasets/upload",
     min_server_version=Version(15, 0, 0),
 )
+
+PATCH_PROMPT = RouteRequirement(
+    method="PATCH",
+    path="/v1/prompts/{prompt_identifier}",
+    min_server_version=Version(19, 18, 0),
+)

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional, cast
+from collections.abc import Mapping
+from typing import Any, Optional, Union, cast
 
 import httpx
 from httpx import HTTPStatusError
 
 from phoenix.client.__generated__ import v1
+from phoenix.client.constants.server_requirements import PATCH_PROMPT
 from phoenix.client.types.prompts import PromptVersion
+from phoenix.client.types.sentinels import NOT_GIVEN, NotGiven
 from phoenix.client.utils.encode_path_param import encode_path_param
 from phoenix.client.utils.server_requirements import (
     AsyncServerVersionGuard,
@@ -17,10 +20,25 @@ from phoenix.client.utils.server_requirements import (
 logger = logging.getLogger(__name__)
 
 
+def _build_patch_prompt_body(
+    *,
+    prompt_description: Union[str, None, NotGiven],
+    prompt_metadata: Union[Mapping[str, Any], NotGiven],
+) -> dict[str, Any]:
+    if isinstance(prompt_description, NotGiven) and isinstance(prompt_metadata, NotGiven):
+        raise ValueError("At least one of prompt_description or prompt_metadata must be provided.")
+    body: dict[str, Any] = {}
+    if not isinstance(prompt_description, NotGiven):
+        body["description"] = prompt_description
+    if not isinstance(prompt_metadata, NotGiven):
+        body["metadata"] = dict(prompt_metadata)
+    return body
+
+
 class Prompts:
     """Provides methods for interacting with prompt resources.
 
-    This class allows you to retrieve and create prompt versions.
+    This class allows you to retrieve, create, and update prompts and prompt versions.
 
     Examples:
         Basic prompt operations::
@@ -169,6 +187,67 @@ class Prompts:
         response.raise_for_status()
         return PromptVersion._loads(cast(v1.CreatePromptResponseBody, response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 
+    def update(
+        self,
+        *,
+        prompt_identifier: str,
+        prompt_description: Union[str, None, NotGiven] = NOT_GIVEN,
+        prompt_metadata: Union[Mapping[str, Any], NotGiven] = NOT_GIVEN,
+    ) -> v1.Prompt:
+        """
+        Update a prompt's description and/or metadata.
+
+        Omit a field to leave it unchanged. Pass ``prompt_description=None`` to
+        clear the description. ``prompt_metadata`` replaces the existing metadata
+        object as a whole; it cannot be cleared to null.
+
+        Args:
+            prompt_identifier (str): The prompt name or ID.
+            prompt_description (Optional[str]): New description, or ``None`` to clear it.
+            prompt_metadata (Mapping[str, Any]): New metadata object (full replace).
+
+        Returns:
+            v1.Prompt: The updated prompt.
+
+        Raises:
+            ValueError: If neither prompt_description nor prompt_metadata is
+                provided, or the prompt is not found.
+            httpx.HTTPStatusError: If the HTTP request returned an unsuccessful
+                status code.
+
+        Example::
+
+            from phoenix.client import Client
+            client = Client()
+
+            prompt = client.prompts.update(
+                prompt_identifier="my-prompt",
+                prompt_description="Production classifier",
+                prompt_metadata={"team": "ml", "env": "prod"},
+            )
+            print(prompt.get("metadata"))
+
+            # Clear the description only
+            client.prompts.update(
+                prompt_identifier="my-prompt",
+                prompt_description=None,
+            )
+        """
+        body = _build_patch_prompt_body(
+            prompt_description=prompt_description,
+            prompt_metadata=prompt_metadata,
+        )
+        self._guard.require(PATCH_PROMPT)
+        url = f"v1/prompts/{encode_path_param(prompt_identifier)}"
+        try:
+            response = self._client.patch(url, json=body)
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Prompt not found: {prompt_identifier}") from e
+            raise
+        return cast(v1.PatchPromptResponseBody, response.json())["data"]
+
 
 class PromptVersionTags:
     """
@@ -309,7 +388,8 @@ class AsyncPrompts:
     """
     Provides asynchronous methods for interacting with prompt resources.
 
-    This class allows you to retrieve and create prompt versions asynchronously.
+    This class allows you to retrieve, create, and update prompts and prompt
+    versions asynchronously.
 
     Examples:
         Basic prompt operations::
@@ -457,6 +537,67 @@ class AsyncPrompts:
         response = await self._client.post(url=url, json=json_)
         response.raise_for_status()
         return PromptVersion._loads(cast(v1.CreatePromptResponseBody, response.json())["data"])  # pyright: ignore[reportPrivateUsage]
+
+    async def update(
+        self,
+        *,
+        prompt_identifier: str,
+        prompt_description: Union[str, None, NotGiven] = NOT_GIVEN,
+        prompt_metadata: Union[Mapping[str, Any], NotGiven] = NOT_GIVEN,
+    ) -> v1.Prompt:
+        """
+        Asynchronously update a prompt's description and/or metadata.
+
+        Omit a field to leave it unchanged. Pass ``prompt_description=None`` to
+        clear the description. ``prompt_metadata`` replaces the existing metadata
+        object as a whole; it cannot be cleared to null.
+
+        Args:
+            prompt_identifier (str): The prompt name or ID.
+            prompt_description (Optional[str]): New description, or ``None`` to clear it.
+            prompt_metadata (Mapping[str, Any]): New metadata object (full replace).
+
+        Returns:
+            v1.Prompt: The updated prompt.
+
+        Raises:
+            ValueError: If neither prompt_description nor prompt_metadata is
+                provided, or the prompt is not found.
+            httpx.HTTPStatusError: If the HTTP request returned an unsuccessful
+                status code.
+
+        Example::
+
+            from phoenix.client import AsyncClient
+            async_client = AsyncClient()
+
+            prompt = await async_client.prompts.update(
+                prompt_identifier="my-prompt",
+                prompt_description="Production classifier",
+                prompt_metadata={"team": "ml", "env": "prod"},
+            )
+            print(prompt.get("metadata"))
+
+            # Clear the description only
+            await async_client.prompts.update(
+                prompt_identifier="my-prompt",
+                prompt_description=None,
+            )
+        """
+        body = _build_patch_prompt_body(
+            prompt_description=prompt_description,
+            prompt_metadata=prompt_metadata,
+        )
+        await self._guard.require(PATCH_PROMPT)
+        url = f"v1/prompts/{encode_path_param(prompt_identifier)}"
+        try:
+            response = await self._client.patch(url, json=body)
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Prompt not found: {prompt_identifier}") from e
+            raise
+        return cast(v1.PatchPromptResponseBody, response.json())["data"]
 
 
 class AsyncPromptVersionTags:

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -70,7 +70,7 @@ class Prompts:
                     model_provider="OPENAI"
                 ),
                 prompt_description="Sentiment classification prompt",
-                metadata={"category": "classification", "version": "1.0"}
+                prompt_metadata={"category": "classification", "version": "1.0"}
             )
 
         Working with tags::

--- a/packages/phoenix-client/src/phoenix/client/types/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/types/__init__.py
@@ -1,5 +1,8 @@
 from .prompts import PromptVersion
+from .sentinels import NOT_GIVEN, NotGiven
 
 __all__ = [
+    "NOT_GIVEN",
+    "NotGiven",
     "PromptVersion",
 ]

--- a/packages/phoenix-client/src/phoenix/client/types/sentinels.py
+++ b/packages/phoenix-client/src/phoenix/client/types/sentinels.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Literal
+
+__all__ = [
+    "NOT_GIVEN",
+    "NotGiven",
+]
+
+
+class NotGiven:
+    """Sentinel type for an argument the caller did not supply.
+
+    Partial-update methods need to distinguish three states for a nullable
+    field: left alone, set to a value, and cleared. ``None`` means "clear", so
+    omission needs its own marker. Use the :data:`NOT_GIVEN` singleton rather
+    than instantiating this class. Test for it with ``x is NOT_GIVEN``, or with
+    ``isinstance(x, NotGiven)`` where a type checker needs to narrow the union.
+
+    Example::
+
+        from phoenix.client import Client
+        from phoenix.client.types import NOT_GIVEN, NotGiven
+
+        def rename(description: str | None | NotGiven = NOT_GIVEN) -> None:
+            Client().prompts.update(
+                prompt_identifier="my-prompt",
+                prompt_description=description,
+            )
+    """
+
+    __slots__ = ()
+
+    def __bool__(self) -> Literal[False]:
+        return False
+
+    def __repr__(self) -> str:
+        return "NOT_GIVEN"
+
+
+NOT_GIVEN = NotGiven()

--- a/packages/phoenix-client/tests/client/resources/prompts/test_prompts.py
+++ b/packages/phoenix-client/tests/client/resources/prompts/test_prompts.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from phoenix.client.__generated__ import v1
+from phoenix.client.constants.server_requirements import PATCH_PROMPT
+from phoenix.client.resources.prompts import AsyncPrompts, Prompts
+from phoenix.client.types import NOT_GIVEN
+
+
+def _make_prompt(
+    *,
+    id: str = "prompt-1",
+    name: str = "my-prompt",
+    description: str | None = "hello",
+    metadata: dict[str, object] | None = None,
+) -> v1.Prompt:
+    prompt: v1.Prompt = {"id": id, "name": name}
+    if description is not None:
+        prompt["description"] = description
+    if metadata is not None:
+        prompt["metadata"] = metadata
+    return prompt
+
+
+class _GuardSentinel(Exception):
+    pass
+
+
+class TestPromptsUpdate:
+    def test_update_sends_description_and_metadata(self) -> None:
+        updated = _make_prompt(
+            description="updated",
+            metadata={"team": "ml"},
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PATCH"
+            assert request.url.path == "/v1/prompts/my-prompt"
+            assert json.loads(request.content) == {
+                "description": "updated",
+                "metadata": {"team": "ml"},
+            }
+            return httpx.Response(200, json={"data": updated})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Prompts(client).update(
+            prompt_identifier="my-prompt",
+            prompt_description="updated",
+            prompt_metadata={"team": "ml"},
+        )
+        assert result == updated
+
+    def test_update_omits_unset_fields(self) -> None:
+        updated = _make_prompt(description="kept", metadata={"a": 1})
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content) == {"metadata": {"a": 1}}
+            return httpx.Response(200, json={"data": updated})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Prompts(client).update(
+            prompt_identifier="my-prompt",
+            prompt_metadata={"a": 1},
+        )
+        assert result.get("metadata") == {"a": 1}
+
+    def test_update_sends_null_description_to_clear(self) -> None:
+        updated = _make_prompt(description=None)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content) == {"description": None}
+            return httpx.Response(200, json={"data": updated})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Prompts(client).update(
+            prompt_identifier="my-prompt",
+            prompt_description=None,
+        )
+        assert result == updated
+        assert "description" not in result
+
+    def test_update_treats_explicit_not_given_as_omission(self) -> None:
+        updated = _make_prompt(description="kept", metadata={"a": 1})
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content) == {"metadata": {"a": 1}}
+            return httpx.Response(200, json={"data": updated})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Prompts(client).update(
+            prompt_identifier="my-prompt",
+            prompt_description=NOT_GIVEN,
+            prompt_metadata={"a": 1},
+        )
+        assert result == updated
+
+    def test_update_requires_at_least_one_field(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda r: pytest.fail("transport must not be reached")),
+            base_url="http://test",
+        )
+        with pytest.raises(
+            ValueError, match="At least one of prompt_description or prompt_metadata"
+        ):
+            Prompts(client).update(prompt_identifier="my-prompt")
+
+    def test_update_maps_404_to_value_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="Prompt not found")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        with pytest.raises(ValueError, match="Prompt not found: missing"):
+            Prompts(client).update(
+                prompt_identifier="missing",
+                prompt_description="x",
+            )
+
+    def test_update_calls_guard_before_request(self) -> None:
+        class _Guard:
+            def require(self, requirement: object) -> None:
+                if requirement is PATCH_PROMPT:
+                    raise _GuardSentinel
+
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda r: pytest.fail("transport must not be reached")),
+            base_url="http://test",
+        )
+        with pytest.raises(_GuardSentinel):
+            Prompts(client, _guard=_Guard()).update(  # type: ignore[arg-type]
+                prompt_identifier="my-prompt",
+                prompt_description="x",
+            )
+
+
+class TestAsyncPromptsUpdate:
+    @pytest.mark.asyncio
+    async def test_update_sends_description_and_metadata(self) -> None:
+        updated = _make_prompt(
+            description="updated",
+            metadata={"team": "ml"},
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PATCH"
+            assert request.url.path == "/v1/prompts/my-prompt"
+            assert json.loads(request.content) == {
+                "description": "updated",
+                "metadata": {"team": "ml"},
+            }
+            return httpx.Response(200, json={"data": updated})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = await AsyncPrompts(client).update(
+            prompt_identifier="my-prompt",
+            prompt_description="updated",
+            prompt_metadata={"team": "ml"},
+        )
+        assert result == updated
+
+    @pytest.mark.asyncio
+    async def test_update_calls_guard_before_request(self) -> None:
+        class _Guard:
+            async def require(self, requirement: object) -> None:
+                if requirement is PATCH_PROMPT:
+                    raise _GuardSentinel
+
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda r: pytest.fail("transport must not be reached")),
+            base_url="http://test",
+        )
+        with pytest.raises(_GuardSentinel):
+            await AsyncPrompts(client, _guard=_Guard()).update(  # type: ignore[arg-type]
+                prompt_identifier="my-prompt",
+                prompt_description="x",
+            )


### PR DESCRIPTION
Follow-up to #13731.

## Summary

#13731 added `PATCH /v1/prompts/{prompt_identifier}` so a prompt's description
and metadata can be edited after creation, but neither SDK exposes it: both
clients can set metadata when a prompt is created and never change it again.
The only edit paths are the UI (via GraphQL) or a hand-rolled HTTP call, which
breaks the workflows prompt metadata exists for.

This PR adds the write path to both clients:

- **Python**: `client.prompts.update(...)` on `Prompts` and `AsyncPrompts`
- **TypeScript**: `updatePrompt(...)` in `@arizeai/phoenix-client/prompts`

Both follow the endpoint's partial-update semantics: omit a field to leave it
unchanged, pass `None` / `null` as the description to clear it; `metadata`
replaces the stored object as a whole. Distinguishing "omitted" from
"explicitly None" in Python requires a sentinel, so this adds a public
`NotGiven` / `NOT_GIVEN` to `phoenix.client.types` (the OpenAI/Anthropic SDK
convention, and the same three-state semantics the GraphQL layer already uses
with strawberry's `UNSET`).

Both clients gate the call on Phoenix server >= 19.18.0 — the release that
shipped the endpoint.

## Usage

Python:

```python
from phoenix.client import Client

client = Client()
client.prompts.update(
    prompt_identifier="support-response",
    prompt_description="Production classifier",
    prompt_metadata={"team": "ml", "env": "prod"},
)

# Clear the description, leave metadata unchanged
client.prompts.update(prompt_identifier="support-response", prompt_description=None)
```

TypeScript:

```ts
import { updatePrompt } from "@arizeai/phoenix-client/prompts";

await updatePrompt({
  promptIdentifier: "support-response",
  description: "Production classifier",
  metadata: { team: "ml", env: "prod" },
});

// Clear the description, leave metadata unchanged
await updatePrompt({ promptIdentifier: "support-response", description: null });
```

Tested with unit tests in both clients.