### PR TITLE
docs: add Cohere Python instrumentor integration page (#15192)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -532,6 +532,13 @@
                 ]
               },
               {
+                "group": "Cohere",
+                "pages": [
+                  "docs/phoenix/integrations/llm-providers/cohere",
+                  "docs/phoenix/integrations/llm-providers/cohere/cohere-tracing"
+                ]
+              },
+              {
                 "group": "Google",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/google-gen-ai",

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -142,6 +142,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="Anthropic" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic" />
   <Card title="Amazon Bedrock" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/db8ae712-image.avif" href="/docs/phoenix/integrations/llm-providers/amazon-bedrock" />
   <Card title="Google" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/7b413cbf-image.jpeg" href="/docs/phoenix/integrations/llm-providers/google-gen-ai" />
+  <Card title="Cohere" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/cohere" />
   <Card title="Groq" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/612c738c-image.avif" href="/docs/phoenix/integrations/llm-providers/groq" />
   <Card title="MistralAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/mistralai" />
   <Card title="VertexAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/9a7aa063-image.avif" href="/docs/phoenix/integrations/llm-providers/vertexai" />

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -142,7 +142,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="Anthropic" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic" />
   <Card title="Amazon Bedrock" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/db8ae712-image.avif" href="/docs/phoenix/integrations/llm-providers/amazon-bedrock" />
   <Card title="Google" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/7b413cbf-image.jpeg" href="/docs/phoenix/integrations/llm-providers/google-gen-ai" />
-  <Card title="Cohere" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/cohere" />
+  <Card title="Cohere" icon="robot" href="/docs/phoenix/integrations/llm-providers/cohere" />
   <Card title="Groq" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/612c738c-image.avif" href="/docs/phoenix/integrations/llm-providers/groq" />
   <Card title="MistralAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/mistralai" />
   <Card title="VertexAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/9a7aa063-image.avif" href="/docs/phoenix/integrations/llm-providers/vertexai" />

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -142,7 +142,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="Anthropic" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/5d0ed01c-image.avif" href="/docs/phoenix/integrations/llm-providers/anthropic" />
   <Card title="Amazon Bedrock" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/db8ae712-image.avif" href="/docs/phoenix/integrations/llm-providers/amazon-bedrock" />
   <Card title="Google" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/7b413cbf-image.jpeg" href="/docs/phoenix/integrations/llm-providers/google-gen-ai" />
-  <Card title="Cohere" icon="robot" href="/docs/phoenix/integrations/llm-providers/cohere" />
+  <Card title="Cohere" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cohere-card.avif" href="/docs/phoenix/integrations/llm-providers/cohere" />
   <Card title="Groq" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/612c738c-image.avif" href="/docs/phoenix/integrations/llm-providers/groq" />
   <Card title="MistralAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/mistralai" />
   <Card title="VertexAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/9a7aa063-image.avif" href="/docs/phoenix/integrations/llm-providers/vertexai" />

--- a/docs/phoenix/integrations/llm-providers/cohere.mdx
+++ b/docs/phoenix/integrations/llm-providers/cohere.mdx
@@ -1,0 +1,13 @@
+---
+title: "Cohere"
+sidebarTitle: "Overview"
+description: Cohere builds enterprise-grade large language models for chat, search, and retrieval-augmented generation.
+---
+
+<Card title="Website" href="https://cohere.com/" icon="globe" horizontal>
+  [](https://cohere.com/)
+</Card>
+
+<Columns cols={2}>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing" title="Cohere Tracing"/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/cohere.mdx
+++ b/docs/phoenix/integrations/llm-providers/cohere.mdx
@@ -4,10 +4,12 @@ sidebarTitle: "Overview"
 description: Cohere builds enterprise-grade large language models for chat, search, and retrieval-augmented generation.
 ---
 
+<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cohere-card.avif"/>
+
 <Card title="Website" href="https://cohere.com/" icon="globe" horizontal>
   [](https://cohere.com/)
 </Card>
 
 <Columns cols={2}>
-  <Card title="Cohere Tracing" href="/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing" icon="robot" description="Trace Cohere v2 chat calls with the CohereInstrumentor"/>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/cohere-card.avif" href="/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing" title="Cohere Tracing"/>
 </Columns>

--- a/docs/phoenix/integrations/llm-providers/cohere.mdx
+++ b/docs/phoenix/integrations/llm-providers/cohere.mdx
@@ -9,5 +9,5 @@ description: Cohere builds enterprise-grade large language models for chat, sear
 </Card>
 
 <Columns cols={2}>
-  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/808d1f26-image.avif" href="/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing" title="Cohere Tracing"/>
+  <Card title="Cohere Tracing" href="/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing" icon="robot" description="Trace Cohere v2 chat calls with the CohereInstrumentor"/>
 </Columns>

--- a/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing.mdx
@@ -1,0 +1,66 @@
+---
+title: "Cohere Tracing"
+description: Instrument LLM calls made using Cohere's Python client via the CohereInstrumentor
+---
+
+Cohere builds enterprise-grade large language models for chat, search, and retrieval-augmented generation. The Cohere Python client can be instrumented using the [`openinference-instrumentation-cohere`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-cohere) package.
+
+## Install
+
+```bash
+pip install openinference-instrumentation-cohere cohere
+```
+
+The instrumentor requires `cohere >= 5.13.0`.
+
+## Setup
+
+Set the `CO_API_KEY` environment variable to authenticate calls made using the client.
+
+```bash
+export CO_API_KEY=[your_key_here]
+```
+
+Connect your application to Phoenix with the `register` function, then enable the `CohereInstrumentor`:
+
+```python
+from openinference.instrumentation.cohere import CohereInstrumentor
+from phoenix.otel import register
+
+# configure the Phoenix tracer
+tracer_provider = register(project_name="my-llm-app")
+
+CohereInstrumentor().instrument(tracer_provider=tracer_provider)
+```
+
+## Run Cohere
+
+```python
+import cohere
+
+co = cohere.ClientV2()
+response = co.chat(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "Why is the sky blue?"}],
+)
+print(response.message.content[0].text)
+```
+
+## Observe
+
+Now that you have tracing setup, all chat calls made with the Cohere v2 client will be streamed to your running Phoenix for observability and evaluation. Spans capture the input messages, output message, invocation parameters, tool definitions and tool calls, and token counts from Cohere's `usage.tokens`.
+
+## Coverage
+
+The instrumentor traces the Cohere **v2** client (`cohere.ClientV2` and `cohere.AsyncClientV2`), covering both the `chat` and `chat_stream` methods. Streamed calls finish their span when the returned iterator is exhausted, with the accumulated output message, tool calls, and token counts.
+
+The following are **not** traced and produce no spans:
+
+* The v1 client (`cohere.Client`)
+* The embed, rerank, and classify endpoints
+
+## Resources
+
+* [Example chat script](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-cohere/examples/chat.py)
+
+* [OpenInference package](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-cohere)

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -260,6 +260,7 @@
 - [Amazon Bedrock SDK JS](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock/amazon-bedrock-sdk-js): Instrument Bedrock SDK in TypeScript
 - [Google GenAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-genai-tracing): Auto-instrument Google GenAI SDK
 - [Gemini Go SDK](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/gemini-go-sdk): Instrument google.golang.org/genai using OTel GenAI semantic conventions (Phoenix ingests gen_ai.* attributes)
+- [Cohere Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/cohere/cohere-tracing): Auto-instrument Cohere v2 Python client (chat and chat_stream) with openinference-instrumentation-cohere
 - [Groq Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/groq/groq-tracing): Auto-instrument Groq SDK
 - [LiteLLM Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/litellm/litellm-tracing): Auto-instrument LiteLLM unified API calls
 - [MistralAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai/mistralai-tracing): Auto-instrument MistralAI SDK


### PR DESCRIPTION
Adds a Cohere integration page to the Phoenix docs, covering the new `openinference-instrumentation-cohere` Python instrumentor.

Closes #15192

## Changes

- New `Cohere` provider pages: overview + tracing (install, `CO_API_KEY`, `register` + `CohereInstrumentor`, `cohere >= 5.13.0`)
- Documents coverage: v2 `chat` / `chat_stream`; excludes v1 client and embed/rerank/classify
- Wired into `docs.json` nav, `integrations.mdx` provider grid, and `llms.txt`