### PR TITLE
docs: add Together AI tracing integration page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -585,6 +585,13 @@
                 ]
               },
               {
+                "group": "Together AI",
+                "pages": [
+                  "docs/phoenix/integrations/llm-providers/together",
+                  "docs/phoenix/integrations/llm-providers/together/together-tracing"
+                ]
+              },
+              {
                 "group": "VertexAI",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/vertexai",

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -148,6 +148,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="LiteLLM" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/a22c16d3-image.avif" href="/docs/phoenix/integrations/llm-providers/litellm" />
   <Card title="OpenRouter" img="https://storage.googleapis.com/arize-assets/gitbook_openrouter.png" href="/docs/phoenix/integrations/llm-providers/openrouter" />
   <Card title="OrcaRouter" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
+  <Card title="Together AI" href="/docs/phoenix/integrations/llm-providers/together" icon="robot" />
 </CardGroup>
 
 ### Platforms

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -148,7 +148,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="LiteLLM" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/a22c16d3-image.avif" href="/docs/phoenix/integrations/llm-providers/litellm" />
   <Card title="OpenRouter" img="https://storage.googleapis.com/arize-assets/gitbook_openrouter.png" href="/docs/phoenix/integrations/llm-providers/openrouter" />
   <Card title="OrcaRouter" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
-  <Card title="Together AI" href="/docs/phoenix/integrations/llm-providers/together" icon="robot" />
+  <Card title="Together AI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/together-card.png" href="/docs/phoenix/integrations/llm-providers/together" />
 </CardGroup>
 
 ### Platforms

--- a/docs/phoenix/integrations/llm-providers/together.mdx
+++ b/docs/phoenix/integrations/llm-providers/together.mdx
@@ -4,10 +4,12 @@ sidebarTitle: "Overview"
 description: Together AI provides fast, cost-effective inference for a wide range of open-source models through a unified API.
 ---
 
+<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/together-card.png" />
+
 <Card title="Website" href="https://www.together.ai/" icon="globe" horizontal>
   [](https://www.together.ai/)
 </Card>
 
 <Columns cols={2}>
-  <Card title="Together AI Tracing" icon="robot" href="/docs/phoenix/integrations/llm-providers/together/together-tracing"/>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/together-card.png" title="Together AI Tracing" href="/docs/phoenix/integrations/llm-providers/together/together-tracing"/>
 </Columns>

--- a/docs/phoenix/integrations/llm-providers/together.mdx
+++ b/docs/phoenix/integrations/llm-providers/together.mdx
@@ -1,0 +1,13 @@
+---
+title: "Together AI"
+sidebarTitle: "Overview"
+description: Together AI provides fast, cost-effective inference for a wide range of open-source models through a unified API.
+---
+
+<Card title="Website" href="https://www.together.ai/" icon="globe" horizontal>
+  [](https://www.together.ai/)
+</Card>
+
+<Columns cols={2}>
+  <Card title="Together AI Tracing" icon="robot" href="/docs/phoenix/integrations/llm-providers/together/together-tracing"/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/together/together-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/together/together-tracing.mdx
@@ -1,0 +1,111 @@
+---
+title: "Together AI Tracing"
+description: Instrument LLM calls made using the Together AI SDK via the TogetherInstrumentor
+---
+
+import RegisterTracerPython from "../../../../snippets/register-tracer-python.mdx";
+
+[Together AI](https://www.together.ai/) provides fast inference for a wide range of open-source models. The `Together` and `AsyncTogether` chat completions clients can be instrumented using the [`openinference-instrumentation-together`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-together) package, which traces calls as OpenInference LLM spans.
+
+<Note>
+This integration requires `together >= 2.0.0`.
+</Note>
+
+## Install
+
+```bash
+pip install openinference-instrumentation-together "together>=2.0.0"
+```
+
+## Setup
+
+Set the `TOGETHER_API_KEY` environment variable to authenticate calls made using the SDK.
+
+```bash
+export TOGETHER_API_KEY=[your_key_here]
+```
+
+<RegisterTracerPython projectName="my-llm-app" />
+
+`auto_instrument=True` picks up the installed `openinference-instrumentation-together` package automatically. To instrument explicitly instead, call `TogetherInstrumentor().instrument(tracer_provider=tracer_provider)`.
+
+## Run Together AI
+
+A simple chat completion that is now instrumented:
+
+```python
+from together import Together
+
+client = Together()
+response = client.chat.completions.create(
+    model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    messages=[{"role": "user", "content": "Why is the sky blue?"}],
+)
+print(response.choices[0].message.content)
+```
+
+### Streaming
+
+When `stream=True`, the span stays open until the stream is fully consumed, then records the accumulated output, tool calls, and token counts from the chunks.
+
+```python
+stream = client.chat.completions.create(
+    model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    messages=[{"role": "user", "content": "Write a haiku about observability."}],
+    stream=True,
+)
+for chunk in stream:
+    if chunk.choices and chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+### Tool calls
+
+Tools passed on the request (`llm.tools.*`) and any tool calls returned on the response (`message.tool_calls.*`) are captured on the span.
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "The city, e.g. Paris"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+response = client.chat.completions.create(
+    model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    messages=[{"role": "user", "content": "What is the weather in Paris right now?"}],
+    tools=tools,
+)
+message = response.choices[0].message
+if message.tool_calls:
+    for tool_call in message.tool_calls:
+        print(f"tool call: {tool_call.function.name}({tool_call.function.arguments})")
+else:
+    print(message.content)
+```
+
+## Observe
+
+Now that you have tracing setup, all invocations of Together AI chat completions (sync and async, streaming and non-streaming) will be streamed to your running Phoenix for observability and evaluation.
+
+## Resources
+
+* [Example Chat Completions](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-together/examples/chat.py)
+
+* [Example Streaming](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-together/examples/chat_stream.py)
+
+* [Example Tool Calls](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-together/examples/tool_call.py)
+
+* [OpenInference package](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-together)
+
+* [Working examples](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-together/examples)

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -265,6 +265,7 @@
 - [MistralAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai/mistralai-tracing): Auto-instrument MistralAI SDK
 - [OpenRouter Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter/openai-tracing): Trace OpenRouter API calls
 - [OrcaRouter Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing): Auto-instrument OrcaRouter via its OpenAI-compatible endpoint with openinference-instrumentation-openai
+- [Together AI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/together/together-tracing): Auto-instrument the Together AI Python SDK with openinference-instrumentation-together
 - [VertexAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai/vertexai-tracing): Auto-instrument VertexAI SDK
 
 ### Python Frameworks
@@ -390,6 +391,7 @@
 - [OpenAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/openai): Pick an OpenAI tracing or evals path across Python, Node.js, Go, and Agents SDK
 - [OpenRouter Integration](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter): Trace calls routed through OpenRouter's unified multi-model API
 - [OrcaRouter Integration](https://arize.com/docs/phoenix/integrations/llm-providers/orcarouter): Trace calls through OrcaRouter's OpenAI-compatible gateway to 200+ models
+- [Together AI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/together): Trace Together AI's fast open-source model inference calls in Phoenix
 - [VertexAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai): Trace and evaluate Google Cloud Vertex AI model calls in Phoenix
 
 ## Settings


### PR DESCRIPTION
Adds a Phoenix docs page for the Together AI tracing integration (`openinference-instrumentation-together`).

- Overview + tracing page under `integrations/llm-providers/together/`
- Install, quickstart, streaming, and tool-call examples (`together >= 2.0.0`)
- Nav (`docs.json`), provider card (`integrations.mdx`), and `llms.txt` wiring

Closes #15186