### PR TITLE
refactor(agents): remove SYSTEM_INTERRUPT_ERROR in favor of USER_INTERRUPT_ERROR

### DIFF
--- a/app/src/agent/chat/__tests__/shouldSendAutomatically.test.ts
+++ b/app/src/agent/chat/__tests__/shouldSendAutomatically.test.ts
@@ -3,7 +3,6 @@ import type { UIMessage } from "ai";
 import {
   shouldKeepTurnOpenForPendingToolOutput,
   shouldSendAutomaticallyAfterToolOutput,
-  SYSTEM_INTERRUPT_ERROR,
   USER_INTERRUPT_ERROR,
 } from "@phoenix/agent/chat/shouldSendAutomatically";
 import {
@@ -75,26 +74,6 @@ describe("shouldSendAutomaticallyAfterToolOutput", () => {
             state: "output-error",
             input: {},
             errorText: USER_INTERRUPT_ERROR,
-          },
-        ],
-      }),
-    ];
-
-    expect(shouldSendAutomaticallyAfterToolOutput({ messages })).toBe(false);
-  });
-
-  it("does not continue after system-interrupted tool errors", () => {
-    const messages = [
-      createMessage({
-        id: "assistant-1",
-        role: "assistant",
-        parts: [
-          {
-            type: `tool-${READ_PROMPT_TOOL_NAME}`,
-            toolCallId: "tool-call-1",
-            state: "output-error",
-            input: {},
-            errorText: SYSTEM_INTERRUPT_ERROR,
           },
         ],
       }),

--- a/app/src/agent/chat/shouldSendAutomatically.ts
+++ b/app/src/agent/chat/shouldSendAutomatically.ts
@@ -23,8 +23,6 @@ import {
 import { getUnresolvedToolCalls } from "./interruptToolCalls";
 
 export const USER_INTERRUPT_ERROR = "The user has interrupted this tool call.";
-export const SYSTEM_INTERRUPT_ERROR =
-  "This tool call has been interrupted by unexpected system conditions.";
 
 // The AI SDK auto-continues after completed tool calls; suppress that when the last result is a local lifecycle cleanup, not model input.
 export function shouldSendAutomaticallyAfterToolOutput({
@@ -35,9 +33,6 @@ export function shouldSendAutomaticallyAfterToolOutput({
   // If tool calls were marked interrupted on message send or stream stop, do not
   // trigger another message send event.
   if (hasInterruptedToolCall({ messages, errorText: USER_INTERRUPT_ERROR })) {
-    return false;
-  }
-  if (hasInterruptedToolCall({ messages, errorText: SYSTEM_INTERRUPT_ERROR })) {
     return false;
   }
   if (hasApprovalNavigationCancel(messages)) {

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -19,10 +19,7 @@ import {
 } from "@phoenix/agent/chat/createAgentSessionChat";
 import { getUnresolvedToolCalls } from "@phoenix/agent/chat/interruptToolCalls";
 import { cleanupPendingToolState } from "@phoenix/agent/chat/pendingToolStateCleanup";
-import {
-  SYSTEM_INTERRUPT_ERROR,
-  USER_INTERRUPT_ERROR,
-} from "@phoenix/agent/chat/shouldSendAutomatically";
+import { USER_INTERRUPT_ERROR } from "@phoenix/agent/chat/shouldSendAutomatically";
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { buildUserMessageMetadata } from "@phoenix/agent/chat/userMessageMetadata";
 import type {
@@ -290,7 +287,7 @@ export function useAgentChat({
     const latestMessages = chatInstance?.messages ?? messages;
     await addInterruptedToolOutputs({
       messages: latestMessages,
-      errorText: SYSTEM_INTERRUPT_ERROR,
+      errorText: USER_INTERRUPT_ERROR,
     });
     setMessages(removeInterruptedToolInputParts);
 


### PR DESCRIPTION
Interrupted tool calls during lifecycle cleanup now reuse the user interrupt error text, so the separate system-interrupt constant and its auto-send suppression branch are no longer needed.

Stacked on #15202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)