### PR TITLE
feat(agents): partially apply client tool outputs on the chat route

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -48,6 +48,7 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 from pydantic_ai import AgentRunResult
 from pydantic_ai.messages import ModelMessage
+from pydantic_ai.ui import SSE_CONTENT_TYPE
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 from pydantic_ai.ui.vercel_ai.request_types import (
     SubmitMessage as PydanticAISubmitMessage,
@@ -58,6 +59,7 @@ from pydantic_ai.ui.vercel_ai.request_types import (
 from pydantic_ai.ui.vercel_ai.response_types import (
     BaseChunk,
     DataChunk,
+    DoneChunk,
     ErrorChunk,
     FinishChunk,
     MessageMetadataChunk,
@@ -71,7 +73,7 @@ from sqlalchemy.dialects.postgresql import insert as insert_postgresql
 from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from strawberry.relay import GlobalID
 from typing_extensions import TypeIs, assert_never
 
@@ -217,6 +219,9 @@ _PYDANTIC_AI_PROVIDER_METADATA_KEY = "pydantic_ai"
 recorded under it."""
 
 _PXI_INSTRUMENTATION_SCOPE = InstrumentationScope("phoenix.server.pxi")
+
+_VERCEL_AI_SDK_VERSION: Literal[7] = 7
+"""The Vercel AI SDK version the chat route targets when encoding stream chunks."""
 
 register_openapi_schema(PhoenixToolCallProviderMetadata)
 register_openapi_schema(PhoenixToolCallCallbackProviderMetadata)
@@ -1753,6 +1758,13 @@ class _MergedTranscript:
     have emitted the root span never runs. None when the request continues
     the turn or the tail had nothing pending."""
 
+    awaiting_tool_outputs: bool = False
+    """True when a ``toolOutputs``-only request resolved only some of the
+    trailing assistant message's pending tool calls. The unanswered calls keep
+    their pending states (no interrupted repair), the applied outputs are
+    persisted, and the turn yields back to the client for the remaining
+    outputs instead of running the model."""
+
 
 def _merge_messages(
     *,
@@ -1776,6 +1788,21 @@ def _merge_messages(
         if merged_tail is not None:
             updated_messages[merged_tail.id] = merged_tail
             messages[-1] = merged_tail
+        if new_message is None and any(
+            isinstance(part, _UNRESOLVED_TOOL_PART_TYPES) for part in messages[-1].parts
+        ):
+            # A partial submission: the continuation resolved only some of the
+            # tail's pending tool calls. Leave the unanswered calls in their
+            # pending states — repairing them as interrupted would discard
+            # results the client still intends to submit — and skip all
+            # repairs, since the model does not run until the tail resolves.
+            return _MergedTranscript(
+                messages=messages,
+                updated_messages=updated_messages,
+                continued_assistant_message=messages[-1],
+                superseded_assistant_message=None,
+                awaiting_tool_outputs=True,
+            )
     for index, message in enumerate(messages):
         repaired_message = _resolve_interrupted_tool_parts(message)
         if repaired_message is not None:
@@ -1806,6 +1833,64 @@ def _merge_messages(
         updated_messages=updated_messages,
         continued_assistant_message=messages[-1],
         superseded_assistant_message=None,
+    )
+
+
+_VERCEL_AI_DATA_STREAM_HEADERS = {"x-vercel-ai-ui-message-stream": "v1"}
+"""The Vercel AI data stream protocol marker header, matching the headers
+``VercelAIEventStream`` stamps on the normal turn response.
+
+See https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#data-stream-protocol
+"""
+
+
+def _awaiting_tool_outputs_response(
+    db: DbSessionFactory,
+    *,
+    agent_session_rowid: int,
+    assistant_message_id: str,
+) -> StreamingResponse:
+    """Yield the turn back to a client whose ``toolOutputs`` were partially applied.
+
+    The submitted outputs are already persisted under the turn lock, but the
+    trailing assistant message still has pending tool calls, so the model does
+    not run. The response is a minimal, well-formed message stream — ``start``
+    with the continued assistant message id (the same id a normal continuation
+    streams), the transient ``data-transcript-persisted`` acknowledgement the
+    client's transcript-persistence coordinator waits on, then
+    ``finish``/``[DONE]`` — encoded exactly like the adapter-built stream. The
+    turn lock is released when the stream closes, mirroring the normal turn's
+    cleanup, so the client can submit the remaining outputs in a follow-up
+    request.
+    """
+    chunks: tuple[BaseChunk, ...] = (
+        StartChunk(message_id=assistant_message_id),
+        TranscriptPersistedChunk(data=TranscriptPersistedData(message_id=assistant_message_id)),
+        FinishChunk(),
+        DoneChunk(),
+    )
+
+    async def _stream() -> AsyncIterator[str]:
+        stream_interrupted = False
+        try:
+            for chunk in chunks:
+                yield f"data: {chunk.encode(_VERCEL_AI_SDK_VERSION)}\n\n"
+        except (asyncio.CancelledError, GeneratorExit):
+            # Disconnect cancellation re-fires at every await; shield the
+            # release below so cleanup completes.
+            stream_interrupted = True
+            raise
+        finally:
+            with anyio.CancelScope(shield=stream_interrupted):
+                await _release_agent_session_turn_lock(
+                    db,
+                    agent_session_rowid=agent_session_rowid,
+                )
+
+    return StreamingResponse(
+        _stream(),
+        headers=_VERCEL_AI_DATA_STREAM_HEADERS,
+        media_type=SSE_CONTENT_TYPE,
     )
 
 
@@ -2746,6 +2831,20 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
         try:
+            if merged_transcript.awaiting_tool_outputs:
+                # The submitted outputs resolved only some of the tail's pending
+                # tool calls: the applied outputs are persisted above, and the
+                # model does not run until a follow-up continuation resolves the
+                # rest, so yield the turn back to the client.
+                awaiting_assistant_message = merged_transcript.continued_assistant_message
+                assert awaiting_assistant_message is not None, (
+                    "a transcript awaiting tool outputs continues its trailing assistant message"
+                )
+                return _awaiting_tool_outputs_response(
+                    db_session_factory,
+                    agent_session_rowid=agent_session_rowid,
+                    assistant_message_id=awaiting_assistant_message.id,
+                )
             try:
                 tracer = (
                     Tracer(
@@ -2855,7 +2954,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         body, messages=model_transcript_messages
                     ),
                     accept=request.headers.get("accept"),
-                    sdk_version=7,
+                    sdk_version=_VERCEL_AI_SDK_VERSION,
                     server_message_id=server_message_id,
                 )
 
@@ -2963,7 +3062,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             body, messages=model_transcript_messages
                         ),
                         accept=request.headers.get("accept"),
-                        sdk_version=7,
+                        sdk_version=_VERCEL_AI_SDK_VERSION,
                         server_message_id=server_message_id,
                     )
                 )

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -313,6 +313,36 @@ def _client_tool_model() -> FunctionModel:
     return FunctionModel(function=function, stream_function=stream_function)
 
 
+def _two_client_tool_model() -> FunctionModel:
+    """Request two client tools, then finish after both results are submitted."""
+
+    async def stream_function(
+        messages: list[ModelMessage],
+        agent_info: AgentInfo,
+    ) -> AsyncIterator[str | DeltaToolCalls]:
+        # Unlike the single-call double above, resolved calls load as
+        # alternating call/return messages, so count returns across the
+        # whole history rather than just the trailing message.
+        tool_result_count = sum(
+            1
+            for message in messages
+            for part in message.parts
+            if isinstance(part, ToolReturnPart) and part.tool_name == "list_datasets"
+        )
+        if tool_result_count >= 2:
+            yield "done"
+        else:
+            yield {
+                1: DeltaToolCall(name="list_datasets", json_args="{}"),
+                2: DeltaToolCall(name="list_datasets", json_args="{}"),
+            }
+
+    def function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[])
+
+    return FunctionModel(function=function, stream_function=stream_function)
+
+
 def _mock_turn_models(monkeypatch: pytest.MonkeyPatch, *turn_models: FunctionModel) -> None:
     """Serve one scripted model per chat turn, in order."""
     remaining_models = iter(turn_models)
@@ -1124,6 +1154,126 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
     assert any(
         isinstance(part, TextUIPart) and part.text == "done"
         for part in persisted_assistant.message.parts
+    )
+
+
+async def test_partial_tool_outputs_persist_and_yield_without_running_the_model(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = "49494949-4949-4449-8449-494949494949"
+    agent_session_id = await _create_agent_session_row(
+        db,
+        title="Already titled",
+    )
+    build_model_calls = 0
+    remaining_models = iter([_two_client_tool_model(), _two_client_tool_model()])
+
+    async def _fake_build_model(*args: object, **kwargs: object) -> FunctionModel:
+        nonlocal build_model_calls
+        build_model_calls += 1
+        return next(remaining_models)
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+
+    first_response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(session_id, _user_message("list my datasets twice")),
+    )
+    assert first_response.status_code == 200
+    first_start = next(
+        chunk for chunk in _stream_chunks(first_response.text) if chunk["type"] == "start"
+    )
+    assistant_message_id = first_start["messageId"]
+    assert build_model_calls == 1
+
+    async with db() as session:
+        agent_session_rowid = await session.scalar(select(models.AgentSession.id))
+        assert agent_session_rowid is not None
+        stored_messages = await _load_session_messages(session, agent_session_rowid)
+    pending_parts = [
+        part for part in stored_messages[-1]["parts"] if part["type"] == "tool-list_datasets"
+    ]
+    assert len(pending_parts) == 2
+    assert all(part["state"] == "input-available" for part in pending_parts)
+    answered_call, unanswered_call = pending_parts
+
+    def _tool_output_for(pending_part: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "type": "tool-list_datasets",
+            "toolCallId": pending_part["toolCallId"],
+            "state": "output-available",
+            "input": pending_part.get("input"),
+            "output": {"datasets": []},
+        }
+
+    partial_response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            None,
+            toolOutputs=[_tool_output_for(answered_call)],
+            lastMessageId=assistant_message_id,
+        ),
+    )
+    assert partial_response.status_code == 200
+    # A minimal stream: no model output, just the persistence acknowledgement
+    # bracketed by a well-formed start/finish for the continued message.
+    partial_chunks = _stream_chunks(partial_response.text)
+    assert [chunk["type"] for chunk in partial_chunks] == [
+        "start",
+        "data-transcript-persisted",
+        "finish",
+    ]
+    assert partial_chunks[0]["messageId"] == assistant_message_id
+    assert partial_chunks[1]["data"]["messageId"] == assistant_message_id
+    assert "data: [DONE]" in partial_response.text
+    assert build_model_calls == 1
+
+    async with db() as session:
+        stored_messages = await _load_session_messages(session, agent_session_rowid)
+    assert len(stored_messages) == 2
+    persisted_parts_by_call_id = {
+        part["toolCallId"]: part
+        for part in stored_messages[-1]["parts"]
+        if part["type"] == "tool-list_datasets"
+    }
+    applied_part = persisted_parts_by_call_id[answered_call["toolCallId"]]
+    assert applied_part["state"] == "output-available"
+    assert applied_part["output"] == {"datasets": []}
+    # The unanswered call is untouched — still pending, not repaired.
+    assert persisted_parts_by_call_id[unanswered_call["toolCallId"]] == unanswered_call
+
+    final_response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            None,
+            toolOutputs=[_tool_output_for(unanswered_call)],
+            lastMessageId=assistant_message_id,
+        ),
+    )
+    assert final_response.status_code == 200
+    # With every pending call resolved, the continuation runs the model.
+    assert build_model_calls == 2
+    final_acknowledgement = next(
+        chunk
+        for chunk in _stream_chunks(final_response.text)
+        if chunk["type"] == "data-transcript-persisted"
+    )
+    assert final_acknowledgement["data"]["messageId"] == assistant_message_id
+
+    async with db() as session:
+        stored_messages = await _load_session_messages(session, agent_session_rowid)
+    final_assistant_message = stored_messages[-1]
+    final_tool_parts = [
+        part for part in final_assistant_message["parts"] if part["type"] == "tool-list_datasets"
+    ]
+    assert all(part["state"] == "output-available" for part in final_tool_parts)
+    assert any(
+        part["type"] == "text" and part["text"] == "done"
+        for part in final_assistant_message["parts"]
     )
 
 
@@ -2037,9 +2187,15 @@ def test_merge_applies_tool_outputs_to_the_trailing_assistant_message() -> None:
     merged = _merge_messages(
         old_messages=persisted,
         new_message=None,
-        tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
+        tool_outputs=[
+            ToolOutputAvailablePart.model_validate(_tool_output()),
+            ToolOutputAvailablePart.model_validate(
+                _tool_output(toolCallId="tool-call-streaming", output={"stdout": "streamed"})
+            ),
+        ],
     )
 
+    assert not merged.awaiting_tool_outputs
     continued = merged.continued_assistant_message
     assert continued is not None
     assert continued.id == _message_uuid("assistant-1")
@@ -2048,8 +2204,66 @@ def test_merge_applies_tool_outputs_to_the_trailing_assistant_message() -> None:
     parts = _parts_by_tool_call_id(continued)
     assert parts["tool-call-unresolved"].state == "output-available"
     assert parts["tool-call-unresolved"].output == {"stdout": "README.md"}
-    # The streaming call the outputs did not cover can never be resolved, so
-    # it is authoritatively closed out as interrupted before the turn continues.
+    assert parts["tool-call-streaming"].state == "output-available"
+    assert parts["tool-call-streaming"].output == {"stdout": "streamed"}
+    # All pending calls were resolved by the submitted outputs, so nothing was
+    # repaired as interrupted and the turn continues into the model run.
+    for part in parts.values():
+        metadata = part.call_provider_metadata or {}
+        assert "pydantic_ai" not in metadata
+
+
+def test_merge_partially_applies_tool_outputs_and_keeps_unanswered_calls_pending() -> None:
+    persisted = _validated_messages(
+        [_user_message("run a command"), _assistant_message_with_tool_states()]
+    )
+
+    merged = _merge_messages(
+        old_messages=persisted,
+        new_message=None,
+        tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
+    )
+
+    assert merged.awaiting_tool_outputs
+    assert merged.superseded_assistant_message is None
+    continued = merged.continued_assistant_message
+    assert continued is not None
+    assert continued.id == _message_uuid("assistant-1")
+    assert merged.messages[-1] is continued
+    assert set(merged.updated_messages) == {_message_uuid("assistant-1")}
+    parts = _parts_by_tool_call_id(continued)
+    assert parts["tool-call-unresolved"].state == "output-available"
+    assert parts["tool-call-unresolved"].output == {"stdout": "README.md"}
+    # The call the outputs did not cover keeps its pending state instead of
+    # being repaired as interrupted: the client submits its output later.
+    assert parts["tool-call-streaming"].state == "input-streaming"
+    assert parts["tool-call-done"].output == {"stdout": "/"}
+
+
+def test_merge_with_a_new_user_message_repairs_calls_partial_outputs_left_pending() -> None:
+    persisted = _validated_messages(
+        [_user_message("run a command"), _assistant_message_with_tool_states()]
+    )
+
+    merged = _merge_messages(
+        old_messages=persisted,
+        new_message=PhoenixUIMessage.model_validate(
+            _user_message("never mind", message_id=_message_uuid("msg-user-2"))
+        ),
+        tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
+    )
+
+    # A new user message supersedes the open turn, so the calls the outputs
+    # did not cover are authoritatively closed out as interrupted — today's
+    # repair semantics, unchanged by partial application.
+    assert not merged.awaiting_tool_outputs
+    assert merged.continued_assistant_message is None
+    superseded = merged.superseded_assistant_message
+    assert superseded is not None
+    assert superseded.id == _message_uuid("assistant-1")
+    parts = _parts_by_tool_call_id(superseded)
+    assert parts["tool-call-unresolved"].state == "output-available"
+    assert parts["tool-call-unresolved"].output == {"stdout": "README.md"}
     assert parts["tool-call-streaming"].state == "output-available"
     streaming_metadata = parts["tool-call-streaming"].call_provider_metadata
     assert streaming_metadata["pydantic_ai"]["outcome"] == "interrupted"


### PR DESCRIPTION
## Scenario

A turn ends with the trailing assistant message holding **two pending client tool calls** (e.g. two approvals). The client POSTs a `toolOutputs`-only continuation to `POST /v1/agents/{agent_id}/sessions/{session_id}/chat` that answers **only one** of them.

## Old behavior

`_merge_messages` applied the submitted outputs and then **unconditionally repaired** every remaining unresolved tool part — rewriting the unanswered call as a neutral `output-available` with an `interrupted` outcome — and the model turn resumed immediately. The result the client still intended to submit was discarded.

## New behavior

When a `toolOutputs`-only request leaves the trailing assistant message with unresolved tool parts, the server now **partially applies** the outputs:

1. The answered calls get their outputs; the unanswered calls keep their original pending states (no interrupted repair). Repairs are skipped entirely in this branch — they exist to make the transcript model-safe, and the model does not run here; the eventual continuation that does run the model still repairs anything left dangling.
2. The partially-updated assistant message is persisted under the turn lock, exactly as before (`_MergedTranscript.updated_messages` written back before any early return; the merge result carries a new `awaiting_tool_outputs` flag).
3. The model is **not** run: the route yields back to the client with a minimal stream so the remaining outputs can be submitted in a follow-up request, which flows through the existing continuation path and completes the turn normally.

Unchanged behavior:

- A request carrying a **new user message** keeps today's repair-and-supersede semantics.
- Outputs that resolve **all** pending calls continue the turn and run the model, as today.
- `_apply_tool_outputs` semantics are untouched: already-resolved calls are ignored idempotently (so a retried partial submit is also idempotent), and unknown/renamed tool calls still 409. All optimistic-concurrency checks (`lastMessageId` staleness, tool-output conflicts, turn-lock claim, model-stale) run before the early yield.

## Early-yield stream shape

The early return happens before any model/agent/adapter is built, so the response is constructed directly rather than via `VercelAIAdapter.streaming_response`: an SSE `StreamingResponse` with the same media type and `x-vercel-ai-ui-message-stream: v1` marker header the adapter stamps, emitting a minimal well-formed message stream encoded identically to the adapter's chunks:

```
start (messageId = the continued assistant message id, same id a normal continuation streams)
data-transcript-persisted (transient; the acknowledgement the client's transcript-persistence coordinator waits on)
finish
[DONE]
```

The turn lock is released in the stream generator's `finally` (shielded against disconnect cancellation), mirroring the normal turn's cleanup; a failure before the response is returned is covered by the route's existing `except BaseException` release.

## Note on clients

The current PXI UI never sends partial submits — its auto-send gate waits for all tool outputs before continuing — so this is server-side tolerance for incremental clients that prefer to stream outputs up as they finish.

## Tests

- Merge-level: partial outputs keep unanswered calls pending and flag the transcript as awaiting outputs; full resolution continues as today with no repairs; partial outputs alongside a new user message keep the repair/supersede semantics.
- Route-level: POST one of two pending tool outputs ⇒ 200 with exactly `start` / `data-transcript-persisted` / `finish` / `[DONE]`, the persisted row contains the applied output and the untouched pending part, and `build_model` was never invoked; the follow-up POST with the second output runs the model and completes the turn.

`uv run pytest tests/unit/server/agents/test_agents_router.py`: 74 passed. `make typecheck-python`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
