### PR TITLE
chore(ddl): generate SQLite schema assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ help: ## Show this help message
 	@echo -e "$(GREEN)Utilities:$(NC)"
 	@echo -e "  codegen-prompts        - Compile YAML prompts to Python and TypeScript"
 	@echo -e "  sync-models            - Sync model cost manifest from remote sources"
-	@echo -e "  schema-ddl             - Compile DDL schema from PostgreSQL (use ARGS= for arguments)"
+	@echo -e "  schema-ddl             - Compile DDL schema from PostgreSQL and SQLite (use ARGS=/SQLITE_ARGS= for arguments)"
 	@echo -e "  gen-otel-models        - Generate OTel GenAI semconv Pydantic models"
 	@echo -e "  gen-session-filter-ai-query-vocabulary   - Generate the session AI query vocabulary"
 	@echo -e "  check-session-filter-ai-query-vocabulary - Check the session AI query vocabulary for drift"
@@ -396,11 +396,34 @@ sync-models: ## Sync model cost manifest from remote sources
 	@$(UV) run python .github/.scripts/sync_models.py
 	@echo -e "$(GREEN)✓ Done$(NC)"
 
-schema-ddl: ## Compile DDL schema from PostgreSQL database (use ARGS= to pass arguments)
+# ARGS=--external points the PostgreSQL extractor at a foreign database, which
+# says nothing about SQLite; regenerating sqlite_schema.sql from ephemeral
+# migrations would overwrite a checked-in file as a side effect. SQLITE_ARGS
+# requests the SQLite step outright, so it always runs.
+ifeq (,$(strip $(SQLITE_ARGS)))
+SKIP_SQLITE := $(findstring --external,$(ARGS))
+endif
+
+# The cross-dialect comparison reads the two canonical files, so it is only
+# meaningful when this run rewrote both. Either variable may have redirected a
+# generator elsewhere, leaving a fresh file compared against a stale one.
+COMPARE_DIALECTS_ARGS := $(strip $(ARGS))$(strip $(SQLITE_ARGS))
+
+schema-ddl: ## Compile DDL schema from PostgreSQL and SQLite databases (ARGS=/SQLITE_ARGS= pass per-database arguments)
 	@echo -e "$(CYAN)Compiling DDL schema...$(NC)"
 	@$(UV) pip install --strict psycopg[binary] testing.postgresql pglast ty
 	@$(UV) pip install --no-sources --strict --reinstall-package arize-phoenix .
 	@cd scripts/ddl && $(UV) run ty check generate_ddl_postgresql.py && $(UV) run python generate_ddl_postgresql.py $(ARGS)
+ifeq (,$(SKIP_SQLITE))
+	@cd scripts/ddl && $(UV) run ty check generate_ddl_sqlite.py && $(UV) run python generate_ddl_sqlite.py $(SQLITE_ARGS)
+else
+	@echo -e "$(YELLOW)Skipping SQLite: ARGS targets an external PostgreSQL database (pass SQLITE_ARGS= to run it too)$(NC)"
+endif
+ifeq (,$(COMPARE_DIALECTS_ARGS))
+	@cd scripts/ddl && $(UV) run ty check compare_schemas.py && $(UV) run python compare_schemas.py
+else
+	@echo -e "$(YELLOW)Skipping cross-dialect comparison: ARGS/SQLITE_ARGS may not have written the canonical files$(NC)"
+endif
 
 check-graphql-permissions: ## Ensure GraphQL mutations and subscriptions have permission classes
 	@echo -e "$(CYAN)Checking GraphQL permissions...$(NC)"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,9 @@ Data wrangling and corpus building (LangChain / LlamaIndex / HaluEval / MS MARCO
 ### `ddl/`
 - `generate_ddl_postgresql.py` — extract DDL from a PostgreSQL Phoenix DB into a deterministic `postgresql_schema.sql`, validated with `pglast`. PEP 723 script.
 - `postgresql_schema.sql` — checked-in canonical schema.
+- `generate_ddl_sqlite.py` — extract DDL from a SQLite Phoenix DB into a deterministic `sqlite_schema.sql`, validated by replaying it into a fresh in-memory database and re-rendering it. PEP 723 script.
+- `sqlite_schema.sql` — checked-in canonical schema.
+- `compare_schemas.py` — assert both dialects describe the same tables, columns, explicitly created indexes, and CHECK/UNIQUE/FOREIGN KEY constraint names; each generator only validates against its own database, so nothing else catches the two files drifting apart. Names are normalized for PostgreSQL's 63-byte identifier cap, which SQLite does not share. Constraint-backed indexes and PRIMARY KEY names are excluded because the dialects legitimately differ there. PEP 723 script.
 
 ### `docker/devops/`
 Local docker-compose stack for development: Phoenix, OIDC, LDAP, SMTP, Grafana, Prometheus, Toxiproxy, Vite dev server, k8s manifests. See `docker/devops/README.md`.
@@ -105,6 +108,7 @@ uv run python scripts/<path>/<script>.py
 
 # PEP 723 scripts (declare their own deps inline) work standalone
 uv run scripts/ddl/generate_ddl_postgresql.py
+uv run scripts/ddl/generate_ddl_sqlite.py
 uv run scripts/generate_spans/generate_spans_for_time_series.py
 uv run scripts/perf/postgres/postgres_explain_analyze.py
 ```

--- a/scripts/ddl/compare_schemas.py
+++ b/scripts/ddl/compare_schemas.py
@@ -1,0 +1,287 @@
+# /// script
+# dependencies = []
+# ///
+"""Cross-dialect schema comparison.
+
+Both checked-in schema files materialize one logical schema: the same models and
+migration sequence rendered for PostgreSQL and for SQLite. Each generator
+validates only against its own database, so a migration that creates a table or
+column under one dialect and not the other yields two internally consistent
+files that disagree with each other.
+
+Compared: the set of tables, the name and position of every column, the names of
+explicitly created indexes, and the names of CHECK, UNIQUE, and FOREIGN KEY
+constraints.
+
+Names are normalized for identifier length before comparison. PostgreSQL caps
+identifiers at 63 bytes and SQLite does not, so SQLAlchemy shortens long
+generated names for PostgreSQL only; comparing raw names would report that as
+drift. See truncate_identifier.
+
+Constraints are compared by name rather than by expression, since each dialect
+deparses the same constraint differently: SQLite keeps "kind IN ('A', 'B')"
+where PostgreSQL returns
+"((kind)::text = ANY ((ARRAY['A'::character varying, ...])::text[]))".
+
+Not compared, because the dialects are entitled to differ:
+
+- Constraint-backed indexes. PostgreSQL backs every PRIMARY KEY and UNIQUE
+  constraint with an index; SQLite creates none for an INTEGER PRIMARY KEY,
+  which aliases the rowid the table is already stored by. Neither generator
+  emits them, since the implying constraint is already inside CREATE TABLE.
+- PRIMARY KEY names. SQLite must render a rowid primary key inline as
+  "id INTEGER PRIMARY KEY AUTOINCREMENT", which carries no constraint name.
+- Column types (serial vs INTEGER, JSONB vs JSON), defaults (now() vs
+  CURRENT_TIMESTAMP), enum types versus CHECK constraints, and index definitions
+  (btree operator classes versus SQLite expressions).
+
+Usage:
+    python compare_schemas.py
+    python compare_schemas.py --postgresql other_pg.sql --sqlite other_sqlite.sql
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+# NAMEDATALEN - 1. SQLite has no equivalent cap.
+POSTGRESQL_MAX_IDENTIFIER_LENGTH = 63
+
+# A definition starts at exactly four spaces. The PostgreSQL generator wraps
+# long constraints onto continuation lines indented further, and those carry
+# fragments like "REFERENCES public.users (id)" that must not read as columns.
+DEFINITION_PATTERN = re.compile(r"^ {4}\S")
+CREATE_TABLE_PATTERN = re.compile(r'^CREATE TABLE (?:public\.)?"?([A-Za-z_][A-Za-z0-9_]*)"? \($')
+CREATE_INDEX_PATTERN = re.compile(r"^CREATE (?:UNIQUE )?INDEX (\w+) ON")
+IDENTIFIER_PATTERN = re.compile(r'"?([A-Za-z_][A-Za-z0-9_]*)"?$')
+
+# Keywords that open a table-level constraint rather than a column.
+CONSTRAINT_KEYWORDS = frozenset({"CONSTRAINT", "PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "EXCLUDE"})
+
+# Named constraints by kind. The name is quoted when the naming convention
+# embeds backticks and bare otherwise; \s+ spans the newline the PostgreSQL
+# generator inserts when wrapping a long constraint, which puts the name and the
+# keyword on separate lines. PRIMARY KEY is absent because SQLite renders a
+# rowid primary key inline, with no constraint name to match against.
+CONSTRAINT_PATTERNS = {
+    "CHECK": re.compile(r'CONSTRAINT\s+("[^"]+"|\w+)\s+CHECK\b'),
+    "UNIQUE": re.compile(r'CONSTRAINT\s+("[^"]+"|\w+)\s+UNIQUE\b'),
+    "FOREIGN KEY": re.compile(r'CONSTRAINT\s+("[^"]+"|\w+)\s+FOREIGN KEY\b'),
+}
+
+
+def truncate_identifier(name: str, max_length: int = POSTGRESQL_MAX_IDENTIFIER_LENGTH) -> str:
+    """Shorten a name the way SQLAlchemy does when a dialect caps identifiers.
+
+    Mirrors _truncate_and_render_maxlen_name in sqlalchemy/sql/compiler.py: keep
+    the first max_length - 8 characters, then append an underscore and the last
+    four hex digits of the name's MD5. A no-op for names within the cap.
+
+    Reimplemented rather than imported to keep this script dependency-free. A
+    future change to SQLAlchemy's rule surfaces as a reported difference, which
+    is the safe direction to fail in.
+    """
+    if len(name) <= max_length:
+        return name
+    digest = hashlib.md5(name.encode("utf-8")).hexdigest()[-4:]
+    return f"{name[0 : max_length - 8]}_{digest}"
+
+
+def parse_schema(
+    path: Path,
+) -> tuple[dict[str, list[str]], set[str], dict[str, dict[str, set[str]]]]:
+    """Return each table's ordered columns, the explicit index names, and constraint names.
+
+    Every name is passed through truncate_identifier so the two dialects are
+    compared on equal terms.
+    """
+    tables: dict[str, list[str]] = {}
+    indexes: set[str] = set()
+    constraints: dict[str, dict[str, set[str]]] = {}
+    current_table: str | None = None
+    block: list[str] = []
+
+    def close_table() -> None:
+        """Extract the finished table's constraint names, by kind.
+
+        Scans the whole block rather than line by line, since a wrapped
+        PostgreSQL constraint puts its name and keyword on different lines.
+        """
+        if current_table is None:
+            return
+        body = "\n".join(block)
+        constraints[current_table] = {
+            kind: {truncate_identifier(name.strip('"')) for name in pattern.findall(body)}
+            for kind, pattern in CONSTRAINT_PATTERNS.items()
+        }
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        table_match = CREATE_TABLE_PATTERN.match(line)
+        if table_match is not None:
+            close_table()
+            current_table = str(table_match.group(1))
+            tables[current_table] = []
+            block = []
+            continue
+
+        index_match = CREATE_INDEX_PATTERN.match(line)
+        if index_match:
+            indexes.add(truncate_identifier(index_match.group(1)))
+            continue
+
+        if current_table is None:
+            continue
+        block.append(line)
+        if line.startswith(")"):
+            close_table()
+            current_table = None
+            continue
+        if not DEFINITION_PATTERN.match(line):
+            continue
+
+        token = line.strip().rstrip(",").split(None, 1)[0]
+        if token.upper() in CONSTRAINT_KEYWORDS:
+            continue
+        # Skips stray closers from the PostgreSQL generator's multi-line ARRAY
+        # formatting, which sit at four spaces but are not identifiers.
+        identifier = IDENTIFIER_PATTERN.fullmatch(token)
+        if identifier is None:
+            continue
+        tables[current_table].append(identifier.group(1))
+
+    close_table()  # a file whose last table is not followed by another
+    return tables, indexes, constraints
+
+
+def verify_parse(path: Path, tables: dict[str, list[str]]) -> list[str]:
+    """Reject an implausible parse, so a broken reader cannot report agreement.
+
+    Two empty parses compare equal; without this the check would report success
+    precisely when it had stopped working.
+    """
+    problems: list[str] = []
+    if not tables:
+        problems.append(f"{path.name}: no CREATE TABLE statements found")
+    empty = sorted(name for name, columns in tables.items() if not columns)
+    if empty:
+        problems.append(f"{path.name}: tables parsed with no columns: {empty}")
+    return problems
+
+
+def main() -> int:
+    script_dir = Path(__file__).parent
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify the PostgreSQL and SQLite schema files describe the same"
+            " tables, columns, and indexes"
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--postgresql",
+        type=Path,
+        default=script_dir / "postgresql_schema.sql",
+        help="PostgreSQL schema file",
+    )
+    parser.add_argument(
+        "--sqlite", type=Path, default=script_dir / "sqlite_schema.sql", help="SQLite schema file"
+    )
+    args = parser.parse_args()
+
+    for path in (args.postgresql, args.sqlite):
+        if not path.is_file():
+            print(f"Error: schema file not found: {path}", file=sys.stderr)
+            return 1
+
+    postgresql_tables, postgresql_indexes, postgresql_constraints = parse_schema(args.postgresql)
+    sqlite_tables, sqlite_indexes, sqlite_constraints = parse_schema(args.sqlite)
+
+    parse_problems = verify_parse(args.postgresql, postgresql_tables) + verify_parse(
+        args.sqlite, sqlite_tables
+    )
+    if parse_problems:
+        for problem in parse_problems:
+            print(f"Error: {problem}", file=sys.stderr)
+        return 1
+
+    postgresql_columns = sum(len(columns) for columns in postgresql_tables.values())
+    sqlite_columns = sum(len(columns) for columns in sqlite_tables.values())
+
+    def constraint_count(parsed: dict[str, dict[str, set[str]]]) -> int:
+        return sum(len(names) for kinds in parsed.values() for names in kinds.values())
+
+    print(
+        f"PostgreSQL: {len(postgresql_tables)} tables, {postgresql_columns} columns, "
+        f"{len(postgresql_indexes)} explicit indexes, "
+        f"{constraint_count(postgresql_constraints)} named constraints"
+    )
+    print(
+        f"SQLite:     {len(sqlite_tables)} tables, {sqlite_columns} columns, "
+        f"{len(sqlite_indexes)} explicit indexes, "
+        f"{constraint_count(sqlite_constraints)} named constraints"
+    )
+
+    differences: list[str] = []
+
+    only_postgresql = sorted(set(postgresql_tables) - set(sqlite_tables))
+    only_sqlite = sorted(set(sqlite_tables) - set(postgresql_tables))
+    if only_postgresql:
+        differences.append(f"tables only in PostgreSQL: {only_postgresql}")
+    if only_sqlite:
+        differences.append(f"tables only in SQLite: {only_sqlite}")
+
+    for table in sorted(set(postgresql_tables) & set(sqlite_tables)):
+        postgresql_column_names = postgresql_tables[table]
+        sqlite_column_names = sqlite_tables[table]
+        if postgresql_column_names == sqlite_column_names:
+            continue
+        missing = [c for c in postgresql_column_names if c not in sqlite_column_names]
+        extra = [c for c in sqlite_column_names if c not in postgresql_column_names]
+        if missing or extra:
+            differences.append(
+                f"{table}: columns only in PostgreSQL {missing}, only in SQLite {extra}"
+            )
+        else:
+            differences.append(
+                f"{table}: same columns in a different order "
+                f"(PostgreSQL {postgresql_column_names}, SQLite {sqlite_column_names})"
+            )
+
+    for table in sorted(set(postgresql_constraints) & set(sqlite_constraints)):
+        for kind in CONSTRAINT_PATTERNS:
+            postgresql_names = postgresql_constraints[table][kind]
+            sqlite_names = sqlite_constraints[table][kind]
+            missing = sorted(postgresql_names - sqlite_names)
+            extra = sorted(sqlite_names - postgresql_names)
+            if missing or extra:
+                differences.append(
+                    f"{table}: {kind} constraints only in PostgreSQL {missing}, "
+                    f"only in SQLite {extra}"
+                )
+
+    only_postgresql_indexes = sorted(postgresql_indexes - sqlite_indexes)
+    only_sqlite_indexes = sorted(sqlite_indexes - postgresql_indexes)
+    if only_postgresql_indexes:
+        differences.append(f"indexes only in PostgreSQL: {only_postgresql_indexes}")
+    if only_sqlite_indexes:
+        differences.append(f"indexes only in SQLite: {only_sqlite_indexes}")
+
+    if differences:
+        print("\n❌ The dialects describe different schemas", file=sys.stderr)
+        for difference in differences:
+            print(f"  {difference}", file=sys.stderr)
+        return 1
+
+    print(
+        "✅ Both dialects describe the same tables, columns, explicit indexes,"
+        " and CHECK/UNIQUE/FOREIGN KEY constraints"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ddl/generate_ddl_postgresql.py
+++ b/scripts/ddl/generate_ddl_postgresql.py
@@ -608,40 +608,28 @@ class PostgreSQLDDLExtractor:
         return line
 
     def _wrap_foreign_key_constraint(self, line: str) -> str:
-        """Format foreign key constraints with consistent line breaks."""
-        parts = []
-        remaining = line
+        """Render a foreign key with one clause per line.
 
-        if " FOREIGN KEY " in remaining:
-            fk_split = remaining.split(" FOREIGN KEY ", 1)
-            constraint_part = fk_split[0] + " FOREIGN KEY"
+        The column list stays attached to FOREIGN KEY rather than being
+        orphaned on a line of its own, and the constraint name always gets its
+        own line so every foreign key has the same shape regardless of name
+        length. This matches how the SQLite schema renders the same constraint.
+        """
+        if " FOREIGN KEY " not in line or " REFERENCES " not in line:
+            return line
 
-            # Always break long constraint names
-            if len(constraint_part) > 70 and "CONSTRAINT " in constraint_part:
-                constraint_name_split = constraint_part.split(" FOREIGN KEY", 1)
-                parts.append(constraint_name_split[0])
-                parts.append("    FOREIGN KEY")
-            else:
-                parts.append(constraint_part)
+        name_part, remaining = line.split(" FOREIGN KEY ", 1)
+        columns_part, remaining = remaining.split(" REFERENCES ", 1)
+        parts = [name_part, f"    FOREIGN KEY {columns_part.strip()}"]
 
-            remaining = fk_split[1]
-
-        if " REFERENCES " in remaining:
-            ref_split = remaining.split(" REFERENCES ", 1)
-            column_part = ref_split[0].strip()
-            parts.append(f"    {column_part}")
-            remaining = ref_split[1]
-
-            # Handle the REFERENCES clause and any ON DELETE/UPDATE
-            if " ON " in remaining:
-                # Split on first ON keyword
-                on_split = remaining.split(" ON ", 1)
-                parts.append(f"    REFERENCES {on_split[0].strip()}")
-
-                # Add the ON clause
-                parts.append(f"    ON {on_split[1]}")
-            else:
-                parts.append(f"    REFERENCES {remaining}")
+        # Referential actions follow the referenced table; splitting on the
+        # first " ON " keeps ON UPDATE and ON DELETE together on one line.
+        if " ON " in remaining:
+            referenced_table, actions = remaining.split(" ON ", 1)
+            parts.append(f"    REFERENCES {referenced_table.strip()}")
+            parts.append(f"    ON {actions}")
+        else:
+            parts.append(f"    REFERENCES {remaining}")
 
         return "\n".join(parts)
 
@@ -974,7 +962,12 @@ class PostgreSQLDDLExtractor:
         elif constraint_type == "CHECK":
             constraint_def = constraint.get("constraint_definition")
             if constraint_def:
-                return self._wrap_line(constraint_def)
+                # pg_get_constraintdef returns a bare "CHECK (...)". Emitting it
+                # as-is lets PostgreSQL invent a name on replay, so a migration
+                # dropping the constraint by name would not find it. Quoting is
+                # required because the naming convention embeds backticks.
+                quoted_name = self._quote_identifier_if_needed(constraint_name)
+                return self._wrap_line(f"CONSTRAINT {quoted_name} {constraint_def}")
             return None
 
         return None

--- a/scripts/ddl/generate_ddl_sqlite.py
+++ b/scripts/ddl/generate_ddl_sqlite.py
@@ -1,0 +1,1484 @@
+# /// script
+# dependencies = [
+#   "arize-phoenix",
+# ]
+# ///
+# ruff: noqa: E501
+"""SQLite DDL Extractor.
+
+Extracts DDL from a SQLite database and outputs it to a file, grouped by table
+and sorted deterministically. The generated schema is automatically validated by
+replaying it into a fresh in-memory database and re-rendering it.
+
+Supports both ephemeral and external SQLite databases:
+- Ephemeral mode: Creates a temporary SQLite database with migrations (default)
+- External mode: Reads an existing SQLite database file (no migrations)
+
+DDL is reformatted from the CREATE text sqlite_master stores, not rebuilt from
+catalog queries. SQLite exposes no catalog for CHECK constraints, and
+PRAGMA index_list() flags a partial index without exposing its WHERE clause, so
+reconstruction would silently drop both.
+
+Usage:
+    # Create ephemeral SQLite database, run migrations, extract DDL (default behavior)
+    python generate_ddl_sqlite.py
+
+    # Read an existing SQLite database (no migrations run)
+    python generate_ddl_sqlite.py --external --database /path/to/phoenix.db
+
+    # Specify custom output file with ephemeral mode (default)
+    python generate_ddl_sqlite.py --output /path/to/schema.sql
+
+Requirements:
+    pip install arize-phoenix
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from io import StringIO
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Any, Iterator
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import URL, create_engine
+
+import phoenix.db
+
+TABLE_INDENT = "    "
+CONTINUATION_INDENT = "    "  # added to TABLE_INDENT on wrapped lines
+MAX_LINE_LENGTH = 88
+STATEMENT_PREVIEW_LENGTH = 200  # caps statement text quoted in error messages
+EPHEMERAL_DATABASE_NAME = "phoenix.db"
+
+# Clause keywords a long definition is broken before, giving one clause per
+# line. Wrapping is driven only by the normalized text, so a definition re-read
+# from a replayed database wraps identically and rendering stays idempotent.
+# CONSTRAINT and the constraint-type keywords are ignored at position 0, where
+# they open the definition rather than a following clause.
+CLAUSE_KEYWORDS = (
+    "CONSTRAINT",
+    "PRIMARY KEY",
+    "FOREIGN KEY",
+    "UNIQUE",
+    "CHECK",
+    "REFERENCES",
+    "ON DELETE",
+    "ON UPDATE",
+    "DEFERRABLE",
+    "NOT DEFERRABLE",
+)
+
+# SQLite's bookkeeping objects (sqlite_sequence, sqlite_stat1, ...) are recreated
+# on demand and are not part of the application schema. ESCAPE is required
+# because '_' is a LIKE wildcard, which would also match e.g. "sqlitexschema".
+SCHEMA_OBJECTS_QUERY = r"""
+    SELECT type, name, tbl_name, sql
+    FROM sqlite_master
+    WHERE sql IS NOT NULL          -- implicit indexes (sqlite_autoindex_*) have no DDL text
+      AND name NOT LIKE 'sqlite\_%' ESCAPE '\'
+      AND tbl_name NOT LIKE 'sqlite\_%' ESCAPE '\'
+    ORDER BY name
+"""
+
+# Matches the CREATE statement of a virtual table, whose backing shadow tables
+# appear in sqlite_master as ordinary tables.
+VIRTUAL_TABLE_PATTERN = re.compile(r"CREATE\s+VIRTUAL\s+TABLE\b", re.IGNORECASE)
+
+# A bare identifier in the output must re-parse as the same identifier: ASCII
+# word characters only, not starting with a digit, and not a keyword.
+PLAIN_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# SQLAlchemy emits FOREIGN KEY(cols) with no space while writing every other
+# constraint keyword with one. Normalizing keeps the rendered file internally
+# consistent, and matching the PostgreSQL schema makes the two diffable.
+CLAUSE_SPACING_PATTERN = re.compile(r"\b(FOREIGN KEY|PRIMARY KEY|UNIQUE|CHECK|REFERENCES)\(")
+
+# Opening -> closing delimiter for string literals and quoted identifiers.
+# Scanners skip these regions wholesale: a ',', '(' or '--' inside one is data,
+# not syntax.
+LITERAL_DELIMITERS = {"'": "'", '"': '"', "`": "`", "[": "]"}
+
+# Emission order for table-level constraints, keyed by their opening keyword.
+# Constraints are order-independent in SQLite, and a table rebuilt during a
+# migration re-emits them in a run-dependent order; sorting keeps a regenerated
+# file from churning without a schema change.
+CONSTRAINT_TYPE_ORDER = {"PRIMARY": 0, "UNIQUE": 1, "CHECK": 2, "FOREIGN": 3}
+
+
+@dataclass
+class TableInfo:
+    """Complete table DDL information, as stored by SQLite."""
+
+    table_name: str
+    create_sql: str
+    indexes: list[str] = field(default_factory=list)
+    triggers: list[str] = field(default_factory=list)
+    referenced_tables: set[str] = field(default_factory=set)
+
+
+@dataclass
+class SchemaInfo:
+    """Every schema object extracted from one database."""
+
+    tables: list[TableInfo] = field(default_factory=list)
+    views: list[str] = field(default_factory=list)
+
+
+def _skip_literal(sql: str, start: int) -> int:
+    """Return the index just past the literal or quoted identifier at `start`."""
+    closing_delimiter = LITERAL_DELIMITERS[sql[start]]
+    index = start + 1
+    while index < len(sql):
+        if sql[index] != closing_delimiter:
+            index += 1
+            continue
+        # SQLite escapes a delimiter inside '', "", and `` by doubling it.
+        # Bracket quoting has no escape mechanism at all.
+        if (
+            closing_delimiter != "]"
+            and index + 1 < len(sql)
+            and sql[index + 1] == closing_delimiter
+        ):
+            index += 2
+            continue
+        return index + 1
+    raise ValueError(f"Unterminated {sql[start]!r} literal in: {_preview(sql[start:])}")
+
+
+def normalize_sql(sql: str) -> str:
+    """Collapse a statement onto one line, dropping comments and runs of whitespace.
+
+    Every rendering decision is made from this canonical form and never from the
+    original layout, which is what makes rendering idempotent: a statement
+    re-read from a replayed database normalizes to the string it was rendered
+    from.
+
+    Comments are dropped rather than preserved because joining lines around a
+    surviving '--' would comment out the rest of the statement.
+    """
+    normalized: list[str] = []
+    index, length = 0, len(sql)
+    space_pending = False
+
+    while index < length:
+        character = sql[index]
+
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index)
+            index = length if newline == -1 else newline
+            space_pending = True
+            continue
+
+        if sql.startswith("/*", index):
+            comment_end = sql.find("*/", index + 2)
+            if comment_end == -1:
+                raise ValueError(f"Unterminated block comment in: {_preview(sql[index:])}")
+            index = comment_end + 2
+            space_pending = True
+            continue
+
+        if character.isspace():
+            space_pending = True
+            index += 1
+            continue
+
+        if space_pending and normalized:
+            normalized.append(" ")
+        space_pending = False
+
+        if character in LITERAL_DELIMITERS:
+            literal_end = _skip_literal(sql, index)
+            normalized.append(sql[index:literal_end])
+            index = literal_end
+            continue
+
+        normalized.append(character)
+        index += 1
+
+    return "".join(normalized)
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split on commas that sit outside every parenthesis and literal.
+
+    Definitions are comma-separated at the top level, but so are CHECK
+    expression arguments and REFERENCES column lists, which are nested.
+    """
+    parts: list[str] = []
+    start, depth = 0, 0
+    index, length = 0, len(text)
+
+    while index < length:
+        character = text[index]
+        if character in LITERAL_DELIMITERS:
+            index = _skip_literal(text, index)
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+        elif character == "," and depth == 0:
+            parts.append(text[start:index].strip())
+            start = index + 1
+        index += 1
+
+    parts.append(text[start:].strip())
+    return [part for part in parts if part]
+
+
+def _find_matching_parenthesis(text: str, opening_index: int) -> int:
+    """Return the index of the ')' that closes the '(' at `opening_index`."""
+    depth = 0
+    index, length = opening_index, len(text)
+
+    while index < length:
+        character = text[index]
+        if character in LITERAL_DELIMITERS:
+            index = _skip_literal(text, index)
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+
+    raise ValueError(f"Unbalanced parentheses in: {_preview(text)}")
+
+
+def _is_identifier_character(character: str) -> bool:
+    """Report whether a character can appear inside a bare SQL identifier."""
+    return character.isalnum() or character in "_$"
+
+
+def _find_top_level_keyword(text: str, keyword: str) -> int | None:
+    """Locate a keyword outside every parenthesis and literal, or return None.
+
+    Finds a partial index's WHERE without matching one nested in a subquery, or
+    the same letters inside an identifier or string literal.
+    """
+    lowered_text, lowered_keyword = text.lower(), keyword.lower()
+    depth = 0
+    index, length = 0, len(text)
+
+    while index < length:
+        character = text[index]
+        if character in LITERAL_DELIMITERS:
+            index = _skip_literal(text, index)
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+        elif depth == 0 and lowered_text.startswith(lowered_keyword, index):
+            end = index + len(keyword)
+            before_is_boundary = index == 0 or not _is_identifier_character(text[index - 1])
+            after_is_boundary = end >= length or not _is_identifier_character(text[end])
+            if before_is_boundary and after_is_boundary:
+                return index
+        index += 1
+
+    return None
+
+
+def _last_identifier_span(text: str) -> tuple[int, int]:
+    """Return the span of the final identifier token in `text`.
+
+    The object name is the last identifier in a CREATE header regardless of
+    form (quoted, IF NOT EXISTS, schema-qualified), so keeping the most recent
+    token avoids parsing the prefix.
+    """
+    span: tuple[int, int] | None = None
+    index, length = 0, len(text)
+
+    while index < length:
+        character = text[index]
+        if character in LITERAL_DELIMITERS:
+            literal_end = _skip_literal(text, index)
+            span = (index, literal_end)
+            index = literal_end
+            continue
+        if _is_identifier_character(character):
+            end = index
+            while end < length and _is_identifier_character(text[end]):
+                end += 1
+            span = (index, end)
+            index = end
+            continue
+        index += 1
+
+    if span is None:
+        raise ValueError(f"No identifier found in: {_preview(text)}")
+    return span
+
+
+def _iter_tokens(text: str) -> Iterator[tuple[str, bool]]:
+    """Yield each identifier or literal in `text` as (token, is_quoted)."""
+    index, length = 0, len(text)
+
+    while index < length:
+        character = text[index]
+        if character in LITERAL_DELIMITERS:
+            literal_end = _skip_literal(text, index)
+            yield text[index:literal_end], True
+            index = literal_end
+            continue
+        if _is_identifier_character(character):
+            end = index
+            while end < length and _is_identifier_character(text[end]):
+                end += 1
+            yield text[index:end], False
+            index = end
+            continue
+        index += 1
+
+
+def _constraint_sort_key(definition: str) -> tuple[int, str] | None:
+    """Rank a table-level constraint, or return None for a column definition.
+
+    SQLite distinguishes the two by the opening keyword: a bare CONSTRAINT,
+    PRIMARY, UNIQUE, CHECK, or FOREIGN opens a table constraint, while anything
+    else -- including those same words quoted -- is a column name. A
+    column-level CHECK follows its column name rather than opening the
+    definition, so it cannot be mistaken for a table constraint.
+    """
+    tokens = [token for _, token in zip(range(3), _iter_tokens(definition))]
+    if not tokens:
+        raise ValueError(f"Empty table definition in: {_preview(definition)}")
+
+    first_token, first_is_quoted = tokens[0]
+    if first_is_quoted:
+        return None
+
+    if first_token.upper() != "CONSTRAINT":
+        order = CONSTRAINT_TYPE_ORDER.get(first_token.upper())
+        return None if order is None else (order, "")
+
+    if len(tokens) < 3:
+        raise ValueError(f"Named constraint has no type: {_preview(definition)}")
+    name_token, _ = tokens[1]
+    type_token, type_is_quoted = tokens[2]
+    order = None if type_is_quoted else CONSTRAINT_TYPE_ORDER.get(type_token.upper())
+    if order is None:
+        raise ValueError(f"Unrecognized constraint type in: {_preview(definition)}")
+
+    return (order, _decode_identifier(name_token))
+
+
+def _order_definitions(definitions: list[str]) -> list[str]:
+    """Keep columns in declaration order and sort table constraints after them.
+
+    Column order is part of the schema, since it determines what SELECT *
+    returns; constraint order carries no meaning. Pairing each constraint with
+    its sort key makes the definition text the final tiebreak, so constraints
+    sharing a key still land in a fixed order.
+    """
+    columns: list[str] = []
+    constraints: list[tuple[tuple[int, str], str]] = []
+
+    for definition in definitions:
+        sort_key = _constraint_sort_key(definition)
+        if sort_key is None:
+            columns.append(definition)
+        else:
+            constraints.append((sort_key, definition))
+
+    return columns + [definition for _, definition in sorted(constraints)]
+
+
+def _normalize_clause_spacing(definition: str) -> str:
+    """Put a space between a constraint keyword and its parenthesized list.
+
+    Literal-aware, so the same characters inside a string default or a quoted
+    identifier are left alone.
+    """
+    normalized: list[str] = []
+    index, length = 0, len(definition)
+
+    while index < length:
+        if definition[index] in LITERAL_DELIMITERS:
+            literal_end = _skip_literal(definition, index)
+            normalized.append(definition[index:literal_end])
+            index = literal_end
+            continue
+        matched = CLAUSE_SPACING_PATTERN.match(definition, index)
+        if matched is not None:
+            normalized.append(f"{matched.group(1)} (")
+            index = matched.end()
+            continue
+        normalized.append(definition[index])
+        index += 1
+
+    return "".join(normalized)
+
+
+def _find_clause_breaks(definition: str) -> list[int]:
+    """Return the offsets of clause keywords that may start a wrapped line."""
+    breaks: set[int] = set()
+    for keyword in CLAUSE_KEYWORDS:
+        search_from = 0
+        while True:
+            offset = _find_top_level_keyword(definition[search_from:], keyword)
+            if offset is None:
+                break
+            absolute = search_from + offset
+            if absolute > 0:
+                breaks.add(absolute)
+            search_from = absolute + len(keyword)
+    return sorted(breaks)
+
+
+def _split_boolean_operands(expression: str) -> list[tuple[str, str]]:
+    """Split at top-level AND/OR into (leading operator, operand) pairs."""
+    breaks: list[tuple[int, str]] = []
+    for keyword in ("AND", "OR"):
+        search_from = 0
+        while True:
+            offset = _find_top_level_keyword(expression[search_from:], keyword)
+            if offset is None:
+                break
+            breaks.append((search_from + offset, keyword))
+            search_from += offset + len(keyword)
+    breaks.sort()
+
+    if not breaks:
+        return [("", expression)]
+
+    operands = [("", expression[: breaks[0][0]].strip())]
+    for position, (offset, keyword) in enumerate(breaks):
+        end = breaks[position + 1][0] if position + 1 < len(breaks) else len(expression)
+        operands.append((keyword, expression[offset + len(keyword) : end].strip()))
+    return operands
+
+
+def _is_parenthesized(text: str) -> bool:
+    """Report whether the whole of `text` sits inside one pair of parentheses."""
+    return (
+        text.startswith("(")
+        and text.endswith(")")
+        and _find_matching_parenthesis(text, 0) == len(text) - 1
+    )
+
+
+def _wrap_boolean_expression(expression: str, indent: str) -> list[str]:
+    """Lay out a boolean expression one operand per line, recursing into groups.
+
+    Operators lead their line so the structure of a long predicate is visible
+    down the left margin rather than buried mid-line.
+    """
+    if len(indent) + len(expression) <= MAX_LINE_LENGTH:
+        return [f"{indent}{expression}"]
+
+    operands = _split_boolean_operands(expression)
+    if len(operands) < 2:
+        if _is_parenthesized(expression):
+            inner = _wrap_boolean_expression(expression[1:-1].strip(), indent + CONTINUATION_INDENT)
+            return [f"{indent}(", *inner, f"{indent})"]
+        return [f"{indent}{expression}"]
+
+    lines: list[str] = []
+    for operator, operand in operands:
+        prefix = f"{operator} " if operator else ""
+        candidate = f"{indent}{prefix}{operand}"
+        if len(candidate) <= MAX_LINE_LENGTH or not _is_parenthesized(operand):
+            lines.append(candidate)
+            continue
+        inner = _wrap_boolean_expression(operand[1:-1].strip(), indent + CONTINUATION_INDENT)
+        lines.append(f"{indent}{prefix}(")
+        lines.extend(inner)
+        lines.append(f"{indent})")
+    return lines
+
+
+def _expand_check_expression(segment: str, indent: str) -> list[str] | None:
+    """Break a CHECK across lines by laying out its predicate, or return None."""
+    if not segment.upper().startswith("CHECK "):
+        return None
+    opening = segment.find("(")
+    if opening == -1 or _find_matching_parenthesis(segment, opening) != len(segment) - 1:
+        return None
+
+    predicate = segment[opening + 1 : -1].strip()
+    body = _wrap_boolean_expression(predicate, indent + CONTINUATION_INDENT)
+    if len(body) < 2:
+        return None
+    return [f"{indent}CHECK (", *body, f"{indent})"]
+
+
+def _expand_value_list(line: str, indent: str) -> list[str] | None:
+    """Put each element of an IN list on its own line, or return None.
+
+    Mirrors the array formatting in the PostgreSQL schema: a diff then shows
+    which enum values changed rather than one rewritten line.
+    """
+    # The list sits inside the CHECK parentheses, so this scans at any depth and
+    # only skips literals, where "IN" would be data.
+    keyword = None
+    index, length = 0, len(line)
+    while index < length:
+        if line[index] in LITERAL_DELIMITERS:
+            index = _skip_literal(line, index)
+            continue
+        if line.upper().startswith("IN", index):
+            before = index == 0 or not _is_identifier_character(line[index - 1])
+            after = index + 2 >= length or not _is_identifier_character(line[index + 2])
+            if before and after:
+                keyword = index
+                break
+        index += 1
+    if keyword is None:
+        return None
+
+    opening = line.find("(", keyword)
+    if opening == -1:
+        return None
+    closing = _find_matching_parenthesis(line, opening)
+    values = _split_top_level(line[opening + 1 : closing])
+    if len(values) < 2:
+        return None
+
+    element_indent = indent + CONTINUATION_INDENT
+    return [
+        f"{line[: opening + 1].rstrip()}",
+        *[f"{element_indent}{value}," for value in values[:-1]],
+        f"{element_indent}{values[-1]}",
+        f"{indent}{line[closing:]}",
+    ]
+
+
+def wrap_definition(definition: str, indent: str) -> list[str]:
+    """Break a long column or constraint definition into indented lines.
+
+    A definition that fits is left alone. One that does not is split before
+    every clause keyword it contains, and any resulting line still over the
+    limit has its IN list expanded.
+    """
+    if len(indent) + len(definition) <= MAX_LINE_LENGTH:
+        return [f"{indent}{definition}"]
+
+    breaks = _find_clause_breaks(definition)
+    bounds = [0, *breaks, len(definition)]
+    segments = [definition[start:end].strip() for start, end in zip(bounds, bounds[1:])]
+    segments = [segment for segment in segments if segment]
+
+    continuation = indent + CONTINUATION_INDENT
+    lines: list[str] = []
+    for position, segment in enumerate(segments):
+        line_indent = indent if position == 0 else continuation
+        line = f"{line_indent}{segment}"
+        if len(line) <= MAX_LINE_LENGTH:
+            lines.append(line)
+            continue
+        expanded = _expand_check_expression(segment, line_indent) or _expand_value_list(
+            segment, line_indent
+        )
+        lines.extend(expanded if expanded else [line])
+    return lines
+
+
+def _decode_identifier(token: str) -> str:
+    """Strip quoting from an identifier token, undoing any delimiter doubling."""
+    if token and token[0] in LITERAL_DELIMITERS:
+        closing_delimiter = LITERAL_DELIMITERS[token[0]]
+        inner = token[1:-1]
+        if closing_delimiter == "]":
+            return inner
+        return inner.replace(closing_delimiter * 2, closing_delimiter)
+    return token
+
+
+def quote_identifier_if_needed(identifier: str) -> str:
+    """Quote a SQLite identifier only when bare use would change its meaning.
+
+    Alembic's batch migrations rewrite a table with its name quoted while plain
+    CREATE TABLE emits it bare, so a table's rendered name would otherwise
+    depend on which migration last touched it.
+    """
+    if PLAIN_IDENTIFIER_PATTERN.fullmatch(identifier) and identifier.lower() not in SQLITE_KEYWORDS:
+        return identifier
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _preview(text: str) -> str:
+    """Truncate a statement for inclusion in an error message."""
+    if len(text) <= STATEMENT_PREVIEW_LENGTH:
+        return text
+    return text[:STATEMENT_PREVIEW_LENGTH] + "..."
+
+
+def _terminate(statement: str) -> str:
+    """Append a statement terminator, which sqlite_master.sql never stores."""
+    return statement if statement.endswith(";") else f"{statement};"
+
+
+def render_create_table(create_sql: str) -> str:
+    """Reformat a CREATE TABLE with one column or constraint per line.
+
+    SQLite stores the statement as issued, so a column appended by a later
+    ALTER TABLE shares a line with the column before it. Re-splitting on
+    top-level commas keeps a schema diff limited to what actually changed.
+    """
+    normalized = normalize_sql(create_sql)
+    header, body, trailer = _split_create_table(normalized)
+
+    name_start, name_end = _last_identifier_span(header)
+    table_name = _decode_identifier(header[name_start:name_end])
+    header = header[:name_start] + quote_identifier_if_needed(table_name)
+
+    definitions = [
+        _normalize_clause_spacing(definition)
+        for definition in _order_definitions(_split_top_level(body))
+    ]
+    if not definitions:
+        raise ValueError(f"CREATE TABLE has no column definitions: {_preview(normalized)}")
+
+    rendered = ["\n".join(wrap_definition(definition, TABLE_INDENT)) for definition in definitions]
+    lines = [f"{header} ("]
+    lines.append(",\n".join(rendered))
+    lines.append(f"){' ' + trailer if trailer else ''};")
+    return "\n".join(lines)
+
+
+def _split_create_table(normalized_sql: str) -> tuple[str, str, str]:
+    """Split a normalized CREATE TABLE into header, definition body, and trailer.
+
+    The trailer carries table options such as WITHOUT ROWID and STRICT, which
+    follow the closing parenthesis and must be preserved verbatim.
+    """
+    index, length = 0, len(normalized_sql)
+
+    while index < length:
+        character = normalized_sql[index]
+        if character in LITERAL_DELIMITERS:
+            index = _skip_literal(normalized_sql, index)
+            continue
+        if character == "(":
+            closing_index = _find_matching_parenthesis(normalized_sql, index)
+            return (
+                normalized_sql[:index].strip(),
+                normalized_sql[index + 1 : closing_index].strip(),
+                normalized_sql[closing_index + 1 :].strip(),
+            )
+        index += 1
+
+    raise ValueError(f"CREATE TABLE has no column list: {_preview(normalized_sql)}")
+
+
+def render_index(index_sql: str) -> str:
+    """Render a CREATE INDEX, one clause per line.
+
+    A partial index always breaks before WHERE, and a long definition also
+    breaks before the indexed column list -- the same split point the
+    PostgreSQL schema uses for its USING clause.
+    """
+    normalized = normalize_sql(index_sql)
+    where_index = _find_top_level_keyword(normalized, "WHERE")
+    head = normalized if where_index is None else normalized[:where_index].rstrip()
+
+    # The terminator lands on the head only when no WHERE clause follows it.
+    head_width = len(head) + (1 if where_index is None else 0)
+    lines = [head]
+    if head_width > MAX_LINE_LENGTH:
+        columns_index = _find_first_top_level_parenthesis(head)
+        if columns_index is not None:
+            lines = [head[:columns_index].rstrip(), f"{TABLE_INDENT}{head[columns_index:]}"]
+
+    if where_index is not None:
+        lines.append(f"{TABLE_INDENT}{normalized[where_index:]}")
+    return _terminate("\n".join(lines))
+
+
+def _find_first_top_level_parenthesis(text: str) -> int | None:
+    """Return the offset of the first '(' outside any literal or nested group."""
+    index, length = 0, len(text)
+    while index < length:
+        character = text[index]
+        if character in LITERAL_DELIMITERS:
+            index = _skip_literal(text, index)
+            continue
+        if character == "(":
+            return index
+        index += 1
+    return None
+
+
+def render_statement(statement_sql: str) -> str:
+    """Render a statement that is emitted as-is (views, triggers)."""
+    return _terminate(normalize_sql(statement_sql))
+
+
+class SQLiteDDLExtractor:
+    """Extract DDL from SQLite databases."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.conn = connection
+        self.conn.row_factory = sqlite3.Row
+
+    def _execute_query(
+        self, query: str, params: tuple[Any, ...], operation_name: str
+    ) -> list[sqlite3.Row]:
+        """Execute a catalog query, letting database errors fail the run.
+
+        Converting an error into an empty result would silently omit schema
+        objects from the reference DDL while the run still exits 0.
+        """
+        try:
+            cursor = self.conn.execute(query, params)
+            try:
+                return cursor.fetchall()
+            finally:
+                cursor.close()
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Error {operation_name}: {e}") from e
+
+    def extract_schema(self) -> SchemaInfo:
+        """Extract every schema object, with indexes and triggers grouped by table."""
+        rows = self._execute_query(SCHEMA_OBJECTS_QUERY, (), "listing schema objects")
+
+        create_statements: dict[str, str] = {}
+        indexes: dict[str, list[tuple[str, str]]] = {}
+        triggers: dict[str, list[tuple[str, str]]] = {}
+        views: list[str] = []
+
+        for row in rows:
+            object_type, name, table_name, sql = (
+                row["type"],
+                row["name"],
+                row["tbl_name"],
+                row["sql"],
+            )
+            if object_type == "table":
+                if VIRTUAL_TABLE_PATTERN.match(normalize_sql(sql)):
+                    raise NotImplementedError(
+                        f"Table {name} is a virtual table, which this generator cannot render. "
+                        "Its backing shadow tables are indistinguishable from ordinary tables in "
+                        "sqlite_master, so replaying the output would create them twice."
+                    )
+                create_statements[name] = sql
+            elif object_type == "index":
+                indexes.setdefault(table_name, []).append((name, sql))
+            elif object_type == "trigger":
+                triggers.setdefault(table_name, []).append((name, sql))
+            elif object_type == "view":
+                views.append(sql)
+            else:
+                raise NotImplementedError(
+                    f"Unsupported sqlite_master object type {object_type!r} for {name}"
+                )
+
+        # An index or trigger attached to a view has no table to group under and
+        # would otherwise be dropped from the output silently.
+        for owner in sorted(set(indexes) | set(triggers)):
+            if owner not in create_statements:
+                raise NotImplementedError(
+                    f"Schema objects are attached to {owner}, which is not a table. "
+                    "This generator groups indexes and triggers under their table."
+                )
+
+        table_ddls = [
+            TableInfo(
+                table_name=name,
+                create_sql=sql,
+                indexes=[index_sql for _, index_sql in sorted(indexes.get(name, []))],
+                triggers=[trigger_sql for _, trigger_sql in sorted(triggers.get(name, []))],
+                referenced_tables=self._get_referenced_tables(name),
+            )
+            for name, sql in sorted(create_statements.items())
+        ]
+
+        # Sort tables based on foreign key dependencies (topological sort). Views
+        # keep the query's name ordering.
+        return SchemaInfo(tables=self._topological_sort_tables(table_ddls), views=views)
+
+    def _get_referenced_tables(self, table_name: str) -> set[str]:
+        """Get the tables a table's foreign keys point at."""
+        rows = self._execute_query(
+            'SELECT "table" AS referenced_table FROM pragma_foreign_key_list(?)',
+            (table_name,),
+            f"getting foreign keys for {table_name}",
+        )
+        return {row["referenced_table"] for row in rows}
+
+    def _topological_sort_tables(self, table_ddls: list[TableInfo]) -> list[TableInfo]:
+        """Order tables so a referenced table precedes the tables referencing it.
+
+        Kahn's algorithm. SQLite resolves foreign keys at DML time, not DDL
+        time, so replay does not depend on this order; it exists so the schema
+        reads top to bottom without forward references.
+        """
+        dependencies: dict[str, set[str]] = {}
+        table_map: dict[str, TableInfo] = {}
+        known_tables = {table_info.table_name for table_info in table_ddls}
+
+        for table_info in table_ddls:
+            table_name = table_info.table_name
+            table_map[table_name] = table_info
+            # Self-references and references outside this schema impose no order.
+            dependencies[table_name] = {
+                referenced_table
+                for referenced_table in table_info.referenced_tables
+                if referenced_table != table_name and referenced_table in known_tables
+            }
+
+        sorted_tables: list[TableInfo] = []
+        in_degree = {table: len(deps) for table, deps in dependencies.items()}
+        queue = [table for table, degree in in_degree.items() if degree == 0]
+
+        while queue:
+            queue.sort()  # a fixed order among ready tables keeps output stable
+            current_table = queue.pop(0)
+            sorted_tables.append(table_map[current_table])
+
+            for table_name, deps in dependencies.items():
+                if current_table in deps:
+                    in_degree[table_name] -= 1
+                    if in_degree[table_name] == 0:
+                        queue.append(table_name)
+
+        # A cycle leaves tables unplaced. Emit them alphabetically rather than
+        # failing: the order is unsatisfiable, but the DDL is still correct.
+        if len(sorted_tables) != len(table_ddls):
+            placed = {table_info.table_name for table_info in sorted_tables}
+            remaining_tables = [table_map[name] for name in dependencies if name not in placed]
+            print(
+                "Warning: Circular dependencies detected, adding remaining tables in alphabetical order",
+                file=sys.stderr,
+            )
+            remaining_tables.sort(key=lambda t: t.table_name)
+            sorted_tables.extend(remaining_tables)
+
+        return sorted_tables
+
+    def generate_ddl(self, table_info: TableInfo) -> str:
+        """Generate DDL string for a single table."""
+        ddl_parts: list[str] = []
+
+        header_line = f"Table: {quote_identifier_if_needed(table_info.table_name)}"
+        ddl_parts.append(f"-- {header_line}")
+        ddl_parts.append(f"-- {'-' * len(header_line)}")
+        ddl_parts.append(render_create_table(table_info.create_sql))
+
+        if table_info.indexes:
+            ddl_parts.append("")
+            ddl_parts.extend(render_index(index_sql) for index_sql in table_info.indexes)
+
+        if table_info.triggers:
+            ddl_parts.append("")
+            ddl_parts.extend(render_statement(trigger_sql) for trigger_sql in table_info.triggers)
+
+        return "\n".join(ddl_parts)
+
+    def generate_schema(self, schema_info: SchemaInfo) -> str:
+        """Render the complete schema artifact."""
+        output = StringIO()
+        for i, table_info in enumerate(schema_info.tables):
+            if i > 0:
+                output.write("\n\n")
+            output.write(self.generate_ddl(table_info))
+            output.write("\n")
+
+        if schema_info.views:
+            if schema_info.tables:
+                output.write("\n\n")
+            output.write("-- Views\n")
+            output.write("-- " + "=" * 30 + "\n\n")
+            for i, view_sql in enumerate(schema_info.views):
+                if i > 0:
+                    output.write("\n")
+                output.write(render_statement(view_sql))
+                output.write("\n")
+
+        return output.getvalue()
+
+
+def _tuple_rows(
+    connection: sqlite3.Connection, query: str, params: tuple[Any, ...] = ()
+) -> list[tuple[Any, ...]]:
+    """Run a query returning plain tuples, whatever row_factory the caller set.
+
+    The extractor installs sqlite3.Row on its connection, and Row has no
+    ordering, so fingerprint rows must be plain tuples to be sorted and
+    compared.
+    """
+    cursor = connection.cursor()
+    cursor.row_factory = None
+    try:
+        return cursor.execute(query, params).fetchall()
+    finally:
+        cursor.close()
+
+
+def schema_fingerprint(connection: sqlite3.Connection) -> dict[str, Any]:
+    """Summarize a schema the way SQLite itself reads it.
+
+    PRAGMAs report SQLite's parse of the stored CREATE text rather than the text
+    itself: a dropped ON DELETE CASCADE surfaces as on_delete='NO ACTION', and a
+    UNIQUE constraint surfaces as an index object appearing nowhere in the text.
+    Nothing here reuses the rendering code, so a rendering bug cannot make the
+    comparison agree with itself.
+
+    index_list.seq and foreign_key_list.id number objects in creation order and
+    are dropped, since this generator reorders constraints and indexes by name;
+    keeping them would report intended behavior as corruption. Position within a
+    composite foreign key is meaning rather than ordering, and is kept.
+    """
+    fingerprint: dict[str, Any] = {}
+
+    fingerprint["tables"] = sorted(
+        _tuple_rows(
+            connection,
+            "SELECT name, wr, strict, ncol FROM pragma_table_list"
+            " WHERE type = 'table' AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\'",
+        )
+    )
+
+    per_table: dict[str, Any] = {}
+    for table_name, *_ in fingerprint["tables"]:
+        columns = _tuple_rows(
+            connection, "SELECT * FROM pragma_table_xinfo(?) ORDER BY cid", (table_name,)
+        )
+
+        foreign_keys: dict[int, tuple[Any, list[Any]]] = {}
+        for (
+            key_id,
+            seq,
+            target,
+            source_col,
+            target_col,
+            on_update,
+            on_delete,
+            match,
+        ) in _tuple_rows(connection, "SELECT * FROM pragma_foreign_key_list(?)", (table_name,)):
+            entry = foreign_keys.setdefault(key_id, ((target, on_update, on_delete, match), []))
+            entry[1].append((seq, source_col, target_col))
+
+        indexes = sorted(
+            _tuple_rows(
+                connection,
+                'SELECT name, "unique", origin, partial FROM pragma_index_list(?)',
+                (table_name,),
+            )
+        )
+
+        per_table[table_name] = {
+            "columns": columns,
+            "foreign_keys": sorted(
+                (meta, tuple(sorted(cols))) for meta, cols in foreign_keys.values()
+            ),
+            "indexes": indexes,
+        }
+    fingerprint["per_table"] = per_table
+
+    fingerprint["index_columns"] = {
+        name: _tuple_rows(connection, "SELECT * FROM pragma_index_xinfo(?) ORDER BY seqno", (name,))
+        for (name,) in _tuple_rows(
+            connection, "SELECT name FROM sqlite_master WHERE type = 'index' AND sql IS NOT NULL"
+        )
+    }
+
+    fingerprint["checks"] = _check_expressions(connection)
+    return fingerprint
+
+
+def _canonical_expression(text: str) -> str:
+    """Normalize an expression so layout cannot register as a content change.
+
+    The renderer may break a long predicate across lines, which leaves a space
+    just inside the parentheses it wrapped. Dropping spaces adjacent to
+    parentheses -- outside literals, where they are data -- keeps the
+    fingerprint comparing what the constraint says rather than how it is set.
+    """
+    normalized = normalize_sql(text)
+    canonical: list[str] = []
+    index, length = 0, len(normalized)
+
+    while index < length:
+        character = normalized[index]
+        if character in LITERAL_DELIMITERS:
+            literal_end = _skip_literal(normalized, index)
+            canonical.append(normalized[index:literal_end])
+            index = literal_end
+            continue
+        if character == " ":
+            previous = canonical[-1][-1] if canonical else ""
+            following = normalized[index + 1] if index + 1 < length else ""
+            if previous == "(" or following == ")":
+                index += 1
+                continue
+        canonical.append(character)
+        index += 1
+
+    return "".join(canonical)
+
+
+def _check_expressions(connection: sqlite3.Connection) -> list[tuple[str, str]]:
+    """Collect every CHECK expression, paired with the object that declares it.
+
+    No PRAGMA reports CHECK constraints, so they exist only in the stored text
+    and this is the one part of the fingerprint that must read it. The scan is
+    kept minimal -- locate the keyword, take the balanced parentheses after it
+    -- so it shares none of the splitting, reordering, or requoting logic whose
+    output it checks.
+    """
+    expressions: list[tuple[str, str]] = []
+
+    for name, sql in _tuple_rows(
+        connection, "SELECT name, sql FROM sqlite_master WHERE sql IS NOT NULL"
+    ):
+        index, length = 0, len(sql)
+        while index < length:
+            character = sql[index]
+            if character in LITERAL_DELIMITERS:
+                index = _skip_literal(sql, index)
+                continue
+            if not sql[index:].upper().startswith("CHECK") or _is_identifier_character(
+                sql[index - 1] if index else " "
+            ):
+                index += 1
+                continue
+            opening = sql.find("(", index)
+            if opening == -1:
+                break
+            closing = _find_matching_parenthesis(sql, opening)
+            expressions.append((name, _canonical_expression(sql[opening + 1 : closing])))
+            index = closing + 1
+
+    return sorted(expressions)
+
+
+def validate_schema(schema_sql: str, source_connection: sqlite3.Connection) -> bool:
+    """Validate the generated schema against the database it was extracted from.
+
+    Two checks, both required because they fail in different ways:
+
+    1. Round trip. Re-extracting and re-rendering the replayed schema must
+       reproduce the input byte for byte, proving the output executes and that
+       rendering is a fixed point.
+    2. Fidelity. SQLite's reading of the replayed schema must match its reading
+       of the source. The round trip is blind to this: both its sides pass
+       through the same renderer, so a clause dropped uniformly is absent from
+       the replay too and still compares equal.
+
+    Returns True only if both pass.
+    """
+    if not schema_sql.strip():
+        print("Warning: Schema is empty", file=sys.stderr)
+        return True
+
+    print("Replaying schema into an in-memory database...")
+    connection = sqlite3.connect(":memory:")
+    try:
+        try:
+            connection.executescript(schema_sql)
+        except sqlite3.Error as e:
+            print(f"ERROR: Generated schema failed to execute: {e}", file=sys.stderr)
+            return False
+
+        extractor = SQLiteDDLExtractor(connection)
+        replayed_sql = extractor.generate_schema(extractor.extract_schema())
+        replayed_fingerprint = schema_fingerprint(connection)
+    finally:
+        connection.close()
+
+    if replayed_sql != schema_sql:
+        print("\n❌ Schema validation failed - the replayed schema differs", file=sys.stderr)
+        _report_first_difference(schema_sql, replayed_sql)
+        return False
+
+    source_fingerprint = schema_fingerprint(source_connection)
+    if replayed_fingerprint != source_fingerprint:
+        print(
+            "\n❌ Schema validation failed - the rebuilt database differs from the source",
+            file=sys.stderr,
+        )
+        _report_fingerprint_difference(source_fingerprint, replayed_fingerprint)
+        return False
+
+    check_count = len(source_fingerprint["checks"])
+    print(
+        f"✅ Schema validation passed - replay matches exactly and rebuilds an identical "
+        f"schema ({len(source_fingerprint['tables'])} tables, "
+        f"{len(source_fingerprint['index_columns'])} indexes, {check_count} CHECK constraints)"
+    )
+    return True
+
+
+def _report_fingerprint_difference(
+    source_fingerprint: dict[str, Any], replayed_fingerprint: dict[str, Any]
+) -> None:
+    """Print the first schema aspect where source and rebuilt database disagree."""
+    for aspect in ("tables", "per_table", "index_columns", "checks"):
+        source_value = source_fingerprint[aspect]
+        replayed_value = replayed_fingerprint[aspect]
+        if source_value == replayed_value:
+            continue
+
+        if isinstance(source_value, dict):
+            # Keyed aspects (per_table, index_columns) name the object that
+            # differs; the annotations keep the key type sortable.
+            source_map: dict[str, Any] = source_value
+            replayed_map: dict[str, Any] = replayed_value
+            for key in sorted(set(source_map) | set(replayed_map)):
+                if source_map.get(key) != replayed_map.get(key):
+                    print(f"{aspect}[{key}]:", file=sys.stderr)
+                    print(f"  source: {_preview(str(source_map.get(key)))}", file=sys.stderr)
+                    print(f"  rebuilt: {_preview(str(replayed_map.get(key)))}", file=sys.stderr)
+                    return
+        else:
+            source_only = [item for item in source_value if item not in replayed_value]
+            replayed_only = [item for item in replayed_value if item not in source_value]
+            print(f"{aspect}:", file=sys.stderr)
+            for item in source_only[:5]:
+                print(f"  only in source: {_preview(str(item))}", file=sys.stderr)
+            for item in replayed_only[:5]:
+                print(f"  only in rebuilt: {_preview(str(item))}", file=sys.stderr)
+            return
+
+
+def _report_first_difference(generated_sql: str, replayed_sql: str) -> None:
+    """Print the first line where the generated and replayed schemas diverge."""
+    generated_lines = generated_sql.split("\n")
+    replayed_lines = replayed_sql.split("\n")
+
+    for line_number, (generated_line, replayed_line) in enumerate(
+        zip(generated_lines, replayed_lines), start=1
+    ):
+        if generated_line != replayed_line:
+            print(f"First difference at line {line_number}:", file=sys.stderr)
+            print(f"  generated: {_preview(generated_line)}", file=sys.stderr)
+            print(f"  replayed:  {_preview(replayed_line)}", file=sys.stderr)
+            return
+
+    print(
+        f"Schemas share a common prefix but differ in length "
+        f"({len(generated_lines)} vs {len(replayed_lines)} lines)",
+        file=sys.stderr,
+    )
+
+
+@contextmanager
+def ephemeral_sqlite() -> Iterator[Path]:
+    """Yield a database path inside a temporary directory removed on exit."""
+    with TemporaryDirectory() as temporary_directory:
+        yield Path(temporary_directory) / EPHEMERAL_DATABASE_NAME
+
+
+@contextmanager
+def connect_read_only(database: Path) -> Iterator[sqlite3.Connection]:
+    """Open a SQLite database read-only, so extraction cannot modify it."""
+    if not database.is_file():
+        raise FileNotFoundError(f"SQLite database not found: {database}")
+
+    connection = sqlite3.connect(f"{database.resolve().as_uri()}?mode=ro", uri=True)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def run_alembic_migrations(database: Path, skip_if_failed: bool = False) -> bool:
+    """Upgrade the database to head, returning whether it succeeded.
+
+    The engine's connection is handed to Alembic through config.attributes so
+    it migrates this database rather than whatever URL alembic.ini names.
+    Set skip_if_failed to suppress the warnings on failure.
+    """
+    try:
+        phoenix_db_path = Path(phoenix.db.__path__[0])
+        alembic_ini = phoenix_db_path / "alembic.ini"
+
+        if not alembic_ini.exists():
+            if not skip_if_failed:
+                print(
+                    f"Warning: Alembic config not found at {alembic_ini}, skipping migrations",
+                    file=sys.stderr,
+                )
+            return False
+
+        config = Config(str(alembic_ini))
+        config.set_main_option("script_location", str(phoenix_db_path / "migrations"))
+
+        engine = create_engine(URL.create(drivername="sqlite", database=str(database)))
+
+        print("Running Alembic migrations...")
+        with engine.connect() as conn:
+            config.attributes["connection"] = conn
+            command.upgrade(config, "head")
+        engine.dispose()
+        print("Migrations completed successfully")
+        return True
+
+    except Exception as e:
+        if not skip_if_failed:
+            print(f"Error: Failed to run migrations: {e}", file=sys.stderr)
+        return False
+
+
+def main() -> int:
+    """Main entry point."""
+    script_dir = Path(__file__).parent
+    default_output = script_dir / "sqlite_schema.sql"
+
+    parser = argparse.ArgumentParser(
+        description="Extract DDL from SQLite database (ephemeral by default, --external for existing database)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--external",
+        action="store_true",
+        help="Read an existing SQLite database (default: create ephemeral database)",
+    )
+    parser.add_argument(
+        "--database", type=Path, help="Path to the SQLite database file (external mode)"
+    )
+    parser.add_argument("--output", type=Path, default=default_output, help="Output file path")
+
+    args = parser.parse_args()
+
+    if args.external and args.database is None:
+        print("Error: External mode requires --database", file=sys.stderr)
+        return 1
+    if not args.external and args.database is not None:
+        print("Error: --database is only valid with --external", file=sys.stderr)
+        return 1
+
+    try:
+        if args.external:
+            return _extract_ddl_external(args)
+        else:
+            return _extract_ddl_ephemeral(args)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+def _extract_ddl_ephemeral(args: argparse.Namespace) -> int:
+    """Extract DDL using an ephemeral SQLite database."""
+    print("Creating ephemeral SQLite database...")
+
+    with ephemeral_sqlite() as database:
+        print(f"Database: {database}")
+        if not run_alembic_migrations(database):
+            return 1
+        return _extract_ddl_from_database(database, args)
+
+
+def _extract_ddl_external(args: argparse.Namespace) -> int:
+    """Extract DDL from an existing SQLite database, leaving its schema untouched."""
+    print(f"Reading external SQLite database: {args.database}")
+    return _extract_ddl_from_database(args.database, args)
+
+
+def _extract_ddl_from_database(database: Path, args: argparse.Namespace) -> int:
+    """Extract DDL from the SQLite database at the given path."""
+    with connect_read_only(database) as connection:
+        print("Extracting DDL...")
+        extractor = SQLiteDDLExtractor(connection)
+
+        # Render in full before touching the destination: generation can fail on
+        # unsupported schema features, and must not truncate the checked-in DDL.
+        schema_info = extractor.extract_schema()
+        schema_sql = extractor.generate_schema(schema_info)
+
+        # Validate while the source is open; the fidelity check compares against
+        # this schema, not just the rendered text.
+        print("\nValidating schema...")
+        if not validate_schema(schema_sql, connection):
+            print("Error: Schema failed validation - destination was not changed", file=sys.stderr)
+            return 1
+
+    # Stage in the destination directory so the final rename is atomic and a
+    # crash mid-write cannot leave a truncated schema file behind.
+    temporary_output: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=args.output.parent,
+            prefix=f".{args.output.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_file.write(schema_sql)
+            temporary_output = Path(temporary_file.name)
+
+        temporary_output.replace(args.output)
+        temporary_output = None
+    except OSError as e:
+        print(f"Error writing to {args.output}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        if temporary_output is not None:
+            temporary_output.unlink(missing_ok=True)
+
+    print(f"DDL exported to: {args.output}")
+    print(f"Processed {len(schema_info.tables)} tables and {len(schema_info.views)} views")
+
+    return 0
+
+
+SQLITE_KEYWORDS = frozenset(
+    {
+        "abort",
+        "action",
+        "add",
+        "after",
+        "all",
+        "alter",
+        "always",
+        "analyze",
+        "and",
+        "as",
+        "asc",
+        "attach",
+        "autoincrement",
+        "before",
+        "begin",
+        "between",
+        "by",
+        "cascade",
+        "case",
+        "cast",
+        "check",
+        "collate",
+        "column",
+        "commit",
+        "conflict",
+        "constraint",
+        "create",
+        "cross",
+        "current",
+        "current_date",
+        "current_time",
+        "current_timestamp",
+        "database",
+        "default",
+        "deferrable",
+        "deferred",
+        "delete",
+        "desc",
+        "detach",
+        "distinct",
+        "do",
+        "drop",
+        "each",
+        "else",
+        "end",
+        "escape",
+        "except",
+        "exclude",
+        "exclusive",
+        "exists",
+        "explain",
+        "fail",
+        "filter",
+        "first",
+        "following",
+        "for",
+        "foreign",
+        "from",
+        "full",
+        "generated",
+        "glob",
+        "group",
+        "groups",
+        "having",
+        "if",
+        "ignore",
+        "immediate",
+        "in",
+        "index",
+        "indexed",
+        "initially",
+        "inner",
+        "insert",
+        "instead",
+        "intersect",
+        "into",
+        "is",
+        "isnull",
+        "join",
+        "key",
+        "last",
+        "left",
+        "like",
+        "limit",
+        "match",
+        "materialized",
+        "natural",
+        "no",
+        "not",
+        "nothing",
+        "notnull",
+        "null",
+        "nulls",
+        "of",
+        "offset",
+        "on",
+        "or",
+        "order",
+        "others",
+        "outer",
+        "over",
+        "partition",
+        "plan",
+        "pragma",
+        "preceding",
+        "primary",
+        "query",
+        "raise",
+        "range",
+        "recursive",
+        "references",
+        "regexp",
+        "reindex",
+        "release",
+        "rename",
+        "replace",
+        "restrict",
+        "returning",
+        "right",
+        "rollback",
+        "row",
+        "rows",
+        "savepoint",
+        "select",
+        "set",
+        "table",
+        "temp",
+        "temporary",
+        "then",
+        "ties",
+        "to",
+        "transaction",
+        "trigger",
+        "unbounded",
+        "union",
+        "unique",
+        "update",
+        "using",
+        "vacuum",
+        "values",
+        "view",
+        "virtual",
+        "when",
+        "where",
+        "window",
+        "with",
+        "without",
+    }
+)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -99,8 +99,7 @@ CREATE TABLE public.projects (
     CONSTRAINT uq_projects_name
         UNIQUE (name),
     CONSTRAINT fk_projects_trace_retention_policy_id_project_trace_ret_aa47
-        FOREIGN KEY
-        (trace_retention_policy_id)
+        FOREIGN KEY (trace_retention_policy_id)
         REFERENCES public.project_trace_retention_policies (id)
         ON DELETE SET NULL
 );
@@ -119,13 +118,11 @@ CREATE TABLE public.project_annotation_configs (
     CONSTRAINT uq_project_annotation_configs_project_id_annotation_config_id
         UNIQUE (project_id, annotation_config_id),
     CONSTRAINT fk_project_annotation_configs_annotation_config_id_anno_98f5
-        FOREIGN KEY
-        (annotation_config_id)
+        FOREIGN KEY (annotation_config_id)
         REFERENCES public.annotation_configs (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_project_annotation_configs_project_id_projects
-        FOREIGN KEY
-        (project_id)
+        FOREIGN KEY (project_id)
         REFERENCES public.projects (id)
         ON DELETE CASCADE
 );
@@ -145,8 +142,8 @@ CREATE TABLE public.project_sessions (
     CONSTRAINT pk_project_sessions PRIMARY KEY (id),
     CONSTRAINT uq_project_sessions_session_id
         UNIQUE (session_id),
-    CONSTRAINT fk_project_sessions_project_id_projects FOREIGN KEY
-        (project_id)
+    CONSTRAINT fk_project_sessions_project_id_projects
+        FOREIGN KEY (project_id)
         REFERENCES public.projects (id)
         ON DELETE CASCADE
 );
@@ -182,8 +179,8 @@ CREATE TABLE public.prompts (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_prompts PRIMARY KEY (id),
-    CONSTRAINT fk_prompts_source_prompt_id_prompts FOREIGN KEY
-        (source_prompt_id)
+    CONSTRAINT fk_prompts_source_prompt_id_prompts
+        FOREIGN KEY (source_prompt_id)
         REFERENCES public.prompts (id)
         ON DELETE SET NULL
 );
@@ -203,13 +200,12 @@ CREATE TABLE public.prompts_prompt_labels (
     CONSTRAINT pk_prompts_prompt_labels PRIMARY KEY (id),
     CONSTRAINT uq_prompts_prompt_labels_prompt_label_id_prompt_id
         UNIQUE (prompt_label_id, prompt_id),
-    CONSTRAINT fk_prompts_prompt_labels_prompt_id_prompts FOREIGN KEY
-        (prompt_id)
+    CONSTRAINT fk_prompts_prompt_labels_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
         REFERENCES public.prompts (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_prompts_prompt_labels_prompt_label_id_prompt_labels
-        FOREIGN KEY
-        (prompt_label_id)
+        FOREIGN KEY (prompt_label_id)
         REFERENCES public.prompt_labels (id)
         ON DELETE CASCADE
 );
@@ -230,8 +226,8 @@ CREATE TABLE public.token_prices (
     CONSTRAINT pk_token_prices PRIMARY KEY (id),
     CONSTRAINT uq_token_prices_model_id_token_type_is_prompt
         UNIQUE (model_id, token_type, is_prompt),
-    CONSTRAINT fk_token_prices_model_id_generative_models FOREIGN KEY
-        (model_id)
+    CONSTRAINT fk_token_prices_model_id_generative_models
+        FOREIGN KEY (model_id)
         REFERENCES public.generative_models (id)
         ON DELETE CASCADE
 );
@@ -249,13 +245,12 @@ CREATE TABLE public.traces (
     CONSTRAINT pk_traces PRIMARY KEY (id),
     CONSTRAINT uq_traces_trace_id
         UNIQUE (trace_id),
-    CONSTRAINT fk_traces_project_rowid_projects FOREIGN KEY
-        (project_rowid)
+    CONSTRAINT fk_traces_project_rowid_projects
+        FOREIGN KEY (project_rowid)
         REFERENCES public.projects (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_traces_project_session_rowid_project_sessions
-        FOREIGN KEY
-        (project_session_rowid)
+        FOREIGN KEY (project_session_rowid)
         REFERENCES public.project_sessions (id)
         ON DELETE CASCADE
 );
@@ -289,13 +284,14 @@ CREATE TABLE public.spans (
     CONSTRAINT pk_spans PRIMARY KEY (id),
     CONSTRAINT uq_spans_span_id
         UNIQUE (span_id),
-    CHECK (((status_code)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_spans_`valid_status`"
+        CHECK (((status_code)::text = ANY ((ARRAY[
             'OK'::character varying,
             'ERROR'::character varying,
             'UNSET'::character varying
         ])::text[]))),
-    CONSTRAINT fk_spans_trace_rowid_traces FOREIGN KEY
-        (trace_rowid)
+    CONSTRAINT fk_spans_trace_rowid_traces
+        FOREIGN KEY (trace_rowid)
         REFERENCES public.traces (id)
         ON DELETE CASCADE
 );
@@ -331,16 +327,16 @@ CREATE TABLE public.span_costs (
     completion_cost DOUBLE PRECISION,
     completion_tokens DOUBLE PRECISION,
     CONSTRAINT pk_span_costs PRIMARY KEY (id),
-    CONSTRAINT fk_span_costs_model_id_generative_models FOREIGN KEY
-        (model_id)
+    CONSTRAINT fk_span_costs_model_id_generative_models
+        FOREIGN KEY (model_id)
         REFERENCES public.generative_models (id)
         ON DELETE RESTRICT,
-    CONSTRAINT fk_span_costs_span_rowid_spans FOREIGN KEY
-        (span_rowid)
+    CONSTRAINT fk_span_costs_span_rowid_spans
+        FOREIGN KEY (span_rowid)
         REFERENCES public.spans (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_span_costs_trace_rowid_traces FOREIGN KEY
-        (trace_rowid)
+    CONSTRAINT fk_span_costs_trace_rowid_traces
+        FOREIGN KEY (trace_rowid)
         REFERENCES public.traces (id)
         ON DELETE CASCADE
 );
@@ -368,8 +364,8 @@ CREATE TABLE public.span_cost_details (
     CONSTRAINT pk_span_cost_details PRIMARY KEY (id),
     CONSTRAINT uq_span_cost_details_span_cost_id_token_type_is_prompt
         UNIQUE (span_cost_id, token_type, is_prompt),
-    CONSTRAINT fk_span_cost_details_span_cost_id_span_costs FOREIGN KEY
-        (span_cost_id)
+    CONSTRAINT fk_span_cost_details_span_cost_id_span_costs
+        FOREIGN KEY (span_cost_id)
         REFERENCES public.span_costs (id)
         ON DELETE CASCADE
 );
@@ -408,18 +404,19 @@ CREATE TABLE public.users (
     auth_method VARCHAR NOT NULL,
     ldap_unique_id VARCHAR,
     CONSTRAINT pk_users PRIMARY KEY (id),
-    CHECK ((((auth_method)::text <> 'LDAP'::text) OR ((oauth2_client_id IS NULL) AND (oauth2_user_id IS NULL) AND ((email IS NOT NULL) OR (ldap_unique_id IS NOT NULL))))),
-    CHECK ((((auth_method)::text <> 'LOCAL'::text) OR ((password_hash IS NOT NULL) AND (password_salt IS NOT NULL) AND (oauth2_client_id IS NULL) AND (oauth2_user_id IS NULL) AND (ldap_unique_id IS NULL)))),
-    CHECK ((((auth_method)::text = 'LDAP'::text) OR (email IS NOT NULL))),
-    CHECK ((((auth_method)::text = 'LOCAL'::text) OR ((password_hash IS NULL) AND (password_salt IS NULL)))),
-    CHECK ((((auth_method)::text <> 'OAUTH2'::text) OR (ldap_unique_id IS NULL))),
-    CHECK (((auth_method)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_users_`ldap_auth_valid`" CHECK ((((auth_method)::text <> 'LDAP'::text) OR ((oauth2_client_id IS NULL) AND (oauth2_user_id IS NULL) AND ((email IS NOT NULL) OR (ldap_unique_id IS NOT NULL))))),
+    CONSTRAINT "ck_users_`local_auth_has_password_no_oauth`" CHECK ((((auth_method)::text <> 'LOCAL'::text) OR ((password_hash IS NOT NULL) AND (password_salt IS NOT NULL) AND (oauth2_client_id IS NULL) AND (oauth2_user_id IS NULL) AND (ldap_unique_id IS NULL)))),
+    CONSTRAINT "ck_users_`non_ldap_auth_has_email`" CHECK ((((auth_method)::text = 'LDAP'::text) OR (email IS NOT NULL))),
+    CONSTRAINT "ck_users_`non_local_auth_has_no_password`" CHECK ((((auth_method)::text = 'LOCAL'::text) OR ((password_hash IS NULL) AND (password_salt IS NULL)))),
+    CONSTRAINT "ck_users_`oauth2_auth_no_ldap_fields`" CHECK ((((auth_method)::text <> 'OAUTH2'::text) OR (ldap_unique_id IS NULL))),
+    CONSTRAINT "ck_users_`valid_auth_method`"
+        CHECK (((auth_method)::text = ANY ((ARRAY[
             'LOCAL'::character varying,
             'OAUTH2'::character varying,
             'LDAP'::character varying
         ])::text[]))),
-    CONSTRAINT fk_users_user_role_id_user_roles FOREIGN KEY
-        (user_role_id)
+    CONSTRAINT fk_users_user_role_id_user_roles
+        FOREIGN KEY (user_role_id)
         REFERENCES public.user_roles (id)
         ON DELETE CASCADE
 );
@@ -448,8 +445,8 @@ CREATE TABLE public.api_keys (
     scopes JSONB,
     audience JSONB,
     CONSTRAINT pk_api_keys PRIMARY KEY (id),
-    CONSTRAINT fk_api_keys_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_api_keys_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -471,8 +468,8 @@ CREATE TABLE public.dataset_labels (
     CONSTRAINT pk_dataset_labels PRIMARY KEY (id),
     CONSTRAINT uq_dataset_labels_name
         UNIQUE (name),
-    CONSTRAINT fk_dataset_labels_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_dataset_labels_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -495,8 +492,8 @@ CREATE TABLE public.dataset_splits (
     CONSTRAINT pk_dataset_splits PRIMARY KEY (id),
     CONSTRAINT uq_dataset_splits_name
         UNIQUE (name),
-    CONSTRAINT fk_dataset_splits_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_dataset_splits_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -518,8 +515,8 @@ CREATE TABLE public.datasets (
     CONSTRAINT pk_datasets PRIMARY KEY (id),
     CONSTRAINT uq_datasets_name
         UNIQUE (name),
-    CONSTRAINT fk_datasets_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_datasets_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -539,12 +536,12 @@ CREATE TABLE public.dataset_examples (
     CONSTRAINT pk_dataset_examples PRIMARY KEY (id),
     CONSTRAINT uq_dataset_examples_dataset_id_external_id
         UNIQUE (dataset_id, external_id),
-    CONSTRAINT fk_dataset_examples_dataset_id_datasets FOREIGN KEY
-        (dataset_id)
+    CONSTRAINT fk_dataset_examples_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
         REFERENCES public.datasets (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_dataset_examples_span_rowid_spans FOREIGN KEY
-        (span_rowid)
+    CONSTRAINT fk_dataset_examples_span_rowid_spans
+        FOREIGN KEY (span_rowid)
         REFERENCES public.spans (id)
         ON DELETE SET NULL
 );
@@ -560,13 +557,11 @@ CREATE TABLE public.dataset_splits_dataset_examples (
     dataset_example_id BIGINT NOT NULL,
     CONSTRAINT pk_dataset_splits_dataset_examples PRIMARY KEY (dataset_split_id, dataset_example_id),
     CONSTRAINT fk_dataset_splits_dataset_examples_dataset_example_id_d_63b2
-        FOREIGN KEY
-        (dataset_example_id)
+        FOREIGN KEY (dataset_example_id)
         REFERENCES public.dataset_examples (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_dataset_splits_dataset_examples_dataset_split_id_dat_a90c
-        FOREIGN KEY
-        (dataset_split_id)
+        FOREIGN KEY (dataset_split_id)
         REFERENCES public.dataset_splits (id)
         ON DELETE CASCADE
 );
@@ -585,12 +580,12 @@ CREATE TABLE public.dataset_versions (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     user_id BIGINT,
     CONSTRAINT pk_dataset_versions PRIMARY KEY (id),
-    CONSTRAINT fk_dataset_versions_dataset_id_datasets FOREIGN KEY
-        (dataset_id)
+    CONSTRAINT fk_dataset_versions_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
         REFERENCES public.datasets (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_dataset_versions_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_dataset_versions_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -616,19 +611,18 @@ CREATE TABLE public.dataset_example_revisions (
     CONSTRAINT pk_dataset_example_revisions PRIMARY KEY (id),
     CONSTRAINT uq_dataset_example_revisions_dataset_example_id_dataset_bbf2
         UNIQUE (dataset_example_id, dataset_version_id),
-    CHECK (((revision_kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_dataset_example_revisions_`valid_revision_kind`"
+        CHECK (((revision_kind)::text = ANY ((ARRAY[
             'CREATE'::character varying,
             'PATCH'::character varying,
             'DELETE'::character varying
         ])::text[]))),
     CONSTRAINT fk_dataset_example_revisions_dataset_example_id_dataset_c72a
-        FOREIGN KEY
-        (dataset_example_id)
+        FOREIGN KEY (dataset_example_id)
         REFERENCES public.dataset_examples (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_dataset_example_revisions_dataset_version_id_dataset_3a56
-        FOREIGN KEY
-        (dataset_version_id)
+        FOREIGN KEY (dataset_version_id)
         REFERENCES public.dataset_versions (id)
         ON DELETE CASCADE
 );
@@ -645,13 +639,12 @@ CREATE TABLE public.datasets_dataset_labels (
     dataset_id BIGINT NOT NULL,
     dataset_label_id BIGINT NOT NULL,
     CONSTRAINT pk_datasets_dataset_labels PRIMARY KEY (dataset_id, dataset_label_id),
-    CONSTRAINT fk_datasets_dataset_labels_dataset_id_datasets FOREIGN KEY
-        (dataset_id)
+    CONSTRAINT fk_datasets_dataset_labels_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
         REFERENCES public.datasets (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_datasets_dataset_labels_dataset_label_id_dataset_labels
-        FOREIGN KEY
-        (dataset_label_id)
+        FOREIGN KEY (dataset_label_id)
         REFERENCES public.dataset_labels (id)
         ON DELETE CASCADE
 );
@@ -680,21 +673,23 @@ CREATE TABLE public.document_annotations (
     CONSTRAINT pk_document_annotations PRIMARY KEY (id),
     CONSTRAINT uq_document_annotations_name_span_rowid_document_pos_identifier
         UNIQUE (name, span_rowid, document_position, identifier),
-    CHECK (((annotator_kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_document_annotations_`valid_annotator_kind`"
+        CHECK (((annotator_kind)::text = ANY ((ARRAY[
             'LLM'::character varying,
             'CODE'::character varying,
             'HUMAN'::character varying
         ])::text[]))),
-    CHECK (((source)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_document_annotations_`valid_source`"
+        CHECK (((source)::text = ANY ((ARRAY[
             'API'::character varying,
             'APP'::character varying
         ])::text[]))),
-    CONSTRAINT fk_document_annotations_span_rowid_spans FOREIGN KEY
-        (span_rowid)
+    CONSTRAINT fk_document_annotations_span_rowid_spans
+        FOREIGN KEY (span_rowid)
         REFERENCES public.spans (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_document_annotations_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_document_annotations_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -720,13 +715,14 @@ CREATE TABLE public.evaluators (
         UNIQUE (kind, id),
     CONSTRAINT uq_evaluators_name
         UNIQUE (name),
-    CHECK (((kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_evaluators_`valid_evaluator_kind`"
+        CHECK (((kind)::text = ANY ((ARRAY[
             'LLM'::character varying,
             'CODE'::character varying,
             'BUILTIN'::character varying
         ])::text[]))),
-    CONSTRAINT fk_evaluators_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_evaluators_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -747,9 +743,9 @@ CREATE TABLE public.builtin_evaluators (
     CONSTRAINT pk_builtin_evaluators PRIMARY KEY (id),
     CONSTRAINT uq_builtin_evaluators_key
         UNIQUE (key),
-    CHECK (((kind)::text = 'BUILTIN'::text)),
-    CONSTRAINT fk_builtin_evaluators_kind_evaluators FOREIGN KEY
-        (kind, id)
+    CONSTRAINT "ck_builtin_evaluators_`valid_evaluator_kind`" CHECK (((kind)::text = 'BUILTIN'::text)),
+    CONSTRAINT fk_builtin_evaluators_kind_evaluators
+        FOREIGN KEY (kind, id)
         REFERENCES public.evaluators (kind, id)
         ON DELETE CASCADE
 );
@@ -772,20 +768,20 @@ CREATE TABLE public.dataset_evaluators (
     CONSTRAINT pk_dataset_evaluators PRIMARY KEY (id),
     CONSTRAINT uq_dataset_evaluators_dataset_id_name
         UNIQUE (dataset_id, name),
-    CONSTRAINT fk_dataset_evaluators_dataset_id_datasets FOREIGN KEY
-        (dataset_id)
+    CONSTRAINT fk_dataset_evaluators_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
         REFERENCES public.datasets (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_dataset_evaluators_evaluator_id_evaluators FOREIGN KEY
-        (evaluator_id)
+    CONSTRAINT fk_dataset_evaluators_evaluator_id_evaluators
+        FOREIGN KEY (evaluator_id)
         REFERENCES public.evaluators (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_dataset_evaluators_project_id_projects FOREIGN KEY
-        (project_id)
+    CONSTRAINT fk_dataset_evaluators_project_id_projects
+        FOREIGN KEY (project_id)
         REFERENCES public.projects (id)
         ON DELETE RESTRICT,
-    CONSTRAINT fk_dataset_evaluators_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_dataset_evaluators_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -812,17 +808,16 @@ CREATE TABLE public.experiments (
     user_id BIGINT,
     is_ephemeral BOOLEAN NOT NULL DEFAULT false,
     CONSTRAINT pk_experiments PRIMARY KEY (id),
-    CONSTRAINT fk_experiments_dataset_id_datasets FOREIGN KEY
-        (dataset_id)
+    CONSTRAINT fk_experiments_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
         REFERENCES public.datasets (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiments_dataset_version_id_dataset_versions
-        FOREIGN KEY
-        (dataset_version_id)
+        FOREIGN KEY (dataset_version_id)
         REFERENCES public.dataset_versions (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiments_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_experiments_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -853,18 +848,20 @@ CREATE TABLE public.experiment_jobs (
     CONSTRAINT pk_experiment_jobs PRIMARY KEY (id),
     CONSTRAINT uq_experiment_jobs_type_id
         UNIQUE (type, id),
-    CHECK (((status)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_experiment_jobs_`valid_experiment_status`"
+        CHECK (((status)::text = ANY ((ARRAY[
             'RUNNING'::character varying,
             'COMPLETED'::character varying,
             'STOPPED'::character varying,
             'ERROR'::character varying
         ])::text[]))),
-    CHECK (((type)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_experiment_jobs_`valid_type`"
+        CHECK (((type)::text = ANY ((ARRAY[
             'PROMPT'::character varying,
             'EVAL_ONLY'::character varying
         ])::text[]))),
-    CONSTRAINT fk_experiment_jobs_id_experiments FOREIGN KEY
-        (id)
+    CONSTRAINT fk_experiment_jobs_id_experiments
+        FOREIGN KEY (id)
         REFERENCES public.experiments (id)
         ON DELETE CASCADE
 );
@@ -877,13 +874,11 @@ CREATE TABLE public.experiment_dataset_evaluators (
     dataset_evaluator_id BIGINT NOT NULL,
     CONSTRAINT pk_experiment_dataset_evaluators PRIMARY KEY (experiment_id, dataset_evaluator_id),
     CONSTRAINT fk_experiment_dataset_evaluators_dataset_evaluator_id_d_138b
-        FOREIGN KEY
-        (dataset_evaluator_id)
+        FOREIGN KEY (dataset_evaluator_id)
         REFERENCES public.dataset_evaluators (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiment_dataset_evaluators_experiment_id_experiment_jobs
-        FOREIGN KEY
-        (experiment_id)
+        FOREIGN KEY (experiment_id)
         REFERENCES public.experiment_jobs (id)
         ON DELETE CASCADE
 );
@@ -905,19 +900,20 @@ CREATE TABLE public.experiment_logs (
     CONSTRAINT pk_experiment_logs PRIMARY KEY (id),
     CONSTRAINT uq_experiment_logs_category_id
         UNIQUE (category, id),
-    CHECK (((category)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_experiment_logs_`valid_event_category`"
+        CHECK (((category)::text = ANY ((ARRAY[
             'TASK'::character varying,
             'EVAL'::character varying,
             'EXPERIMENT'::character varying
         ])::text[]))),
-    CHECK (((level)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_experiment_logs_`valid_event_level`"
+        CHECK (((level)::text = ANY ((ARRAY[
             'ERROR'::character varying,
             'WARN'::character varying,
             'INFO'::character varying
         ])::text[]))),
     CONSTRAINT fk_experiment_logs_experiment_id_experiment_jobs
-        FOREIGN KEY
-        (experiment_id)
+        FOREIGN KEY (experiment_id)
         REFERENCES public.experiment_jobs (id)
         ON DELETE CASCADE
 );
@@ -946,12 +942,11 @@ CREATE TABLE public.experiment_runs (
     CONSTRAINT uq_experiment_runs_experiment_id_dataset_example_id_rep_81e7
         UNIQUE (experiment_id, dataset_example_id, repetition_number),
     CONSTRAINT fk_experiment_runs_dataset_example_id_dataset_examples
-        FOREIGN KEY
-        (dataset_example_id)
+        FOREIGN KEY (dataset_example_id)
         REFERENCES public.dataset_examples (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiment_runs_experiment_id_experiments FOREIGN KEY
-        (experiment_id)
+    CONSTRAINT fk_experiment_runs_experiment_id_experiments
+        FOREIGN KEY (experiment_id)
         REFERENCES public.experiments (id)
         ON DELETE CASCADE
 );
@@ -968,20 +963,17 @@ CREATE TABLE public.experiment_eval_logs (
     experiment_run_id BIGINT NOT NULL,
     dataset_evaluator_id BIGINT NOT NULL,
     CONSTRAINT pk_experiment_eval_logs PRIMARY KEY (id),
-    CHECK (((category)::text = 'EVAL'::text)),
+    CONSTRAINT "ck_experiment_eval_logs_`valid_category`" CHECK (((category)::text = 'EVAL'::text)),
     CONSTRAINT fk_experiment_eval_logs_category_experiment_logs
-        FOREIGN KEY
-        (category, id)
+        FOREIGN KEY (category, id)
         REFERENCES public.experiment_logs (category, id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiment_eval_logs_dataset_evaluator_id_dataset_evaluators
-        FOREIGN KEY
-        (dataset_evaluator_id)
+        FOREIGN KEY (dataset_evaluator_id)
         REFERENCES public.dataset_evaluators (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiment_eval_logs_experiment_run_id_experiment_runs
-        FOREIGN KEY
-        (experiment_run_id)
+        FOREIGN KEY (experiment_run_id)
         REFERENCES public.experiment_runs (id)
         ON DELETE CASCADE
 );
@@ -1010,14 +1002,14 @@ CREATE TABLE public.experiment_run_annotations (
     CONSTRAINT pk_experiment_run_annotations PRIMARY KEY (id),
     CONSTRAINT uq_experiment_run_annotations_experiment_run_id_name
         UNIQUE (experiment_run_id, name),
-    CHECK (((annotator_kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_experiment_run_annotations_`valid_annotator_kind`"
+        CHECK (((annotator_kind)::text = ANY ((ARRAY[
             'LLM'::character varying,
             'CODE'::character varying,
             'HUMAN'::character varying
         ])::text[]))),
     CONSTRAINT fk_experiment_run_annotations_experiment_run_id_experiment_runs
-        FOREIGN KEY
-        (experiment_run_id)
+        FOREIGN KEY (experiment_run_id)
         REFERENCES public.experiment_runs (id)
         ON DELETE CASCADE
 );
@@ -1035,16 +1027,16 @@ CREATE TABLE public.experiment_tags (
     CONSTRAINT pk_experiment_tags PRIMARY KEY (id),
     CONSTRAINT uq_experiment_tags_dataset_id_name
         UNIQUE (dataset_id, name),
-    CONSTRAINT fk_experiment_tags_dataset_id_datasets FOREIGN KEY
-        (dataset_id)
+    CONSTRAINT fk_experiment_tags_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
         REFERENCES public.datasets (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiment_tags_experiment_id_experiments FOREIGN KEY
-        (experiment_id)
+    CONSTRAINT fk_experiment_tags_experiment_id_experiments
+        FOREIGN KEY (experiment_id)
         REFERENCES public.experiments (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiment_tags_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_experiment_tags_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1063,15 +1055,13 @@ CREATE TABLE public.experiment_task_logs (
     dataset_example_id BIGINT NOT NULL,
     repetition_number INTEGER NOT NULL,
     CONSTRAINT pk_experiment_task_logs PRIMARY KEY (id),
-    CHECK (((category)::text = 'TASK'::text)),
+    CONSTRAINT "ck_experiment_task_logs_`valid_category`" CHECK (((category)::text = 'TASK'::text)),
     CONSTRAINT fk_experiment_task_logs_category_experiment_logs
-        FOREIGN KEY
-        (category, id)
+        FOREIGN KEY (category, id)
         REFERENCES public.experiment_logs (category, id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiment_task_logs_dataset_example_id_dataset_examples
-        FOREIGN KEY
-        (dataset_example_id)
+        FOREIGN KEY (dataset_example_id)
         REFERENCES public.dataset_examples (id)
         ON DELETE CASCADE
 );
@@ -1088,18 +1078,15 @@ CREATE TABLE public.experiments_dataset_examples (
     dataset_example_revision_id BIGINT NOT NULL,
     CONSTRAINT pk_experiments_dataset_examples PRIMARY KEY (experiment_id, dataset_example_id),
     CONSTRAINT fk_experiments_dataset_examples_dataset_example_id_data_7c5c
-        FOREIGN KEY
-        (dataset_example_id)
+        FOREIGN KEY (dataset_example_id)
         REFERENCES public.dataset_examples (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiments_dataset_examples_dataset_example_revisio_7f42
-        FOREIGN KEY
-        (dataset_example_revision_id)
+        FOREIGN KEY (dataset_example_revision_id)
         REFERENCES public.dataset_example_revisions (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiments_dataset_examples_experiment_id_experiments
-        FOREIGN KEY
-        (experiment_id)
+        FOREIGN KEY (experiment_id)
         REFERENCES public.experiments (id)
         ON DELETE CASCADE
 );
@@ -1117,13 +1104,11 @@ CREATE TABLE public.experiments_dataset_splits (
     dataset_split_id BIGINT NOT NULL,
     CONSTRAINT pk_experiments_dataset_splits PRIMARY KEY (experiment_id, dataset_split_id),
     CONSTRAINT fk_experiments_dataset_splits_dataset_split_id_dataset_splits
-        FOREIGN KEY
-        (dataset_split_id)
+        FOREIGN KEY (dataset_split_id)
         REFERENCES public.dataset_splits (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_experiments_dataset_splits_experiment_id_experiments
-        FOREIGN KEY
-        (experiment_id)
+        FOREIGN KEY (experiment_id)
         REFERENCES public.experiments (id)
         ON DELETE CASCADE
 );
@@ -1148,8 +1133,7 @@ CREATE TABLE public.generative_model_custom_providers (
     CONSTRAINT uq_generative_model_custom_providers_name
         UNIQUE (name),
     CONSTRAINT fk_generative_model_custom_providers_user_id_users
-        FOREIGN KEY
-        (user_id)
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1172,12 +1156,11 @@ CREATE TABLE public.oauth2_authorization_codes (
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
     CONSTRAINT pk_oauth2_authorization_codes PRIMARY KEY (id),
     CONSTRAINT fk_oauth2_authorization_codes_oauth2_client_id_oauth2_clients
-        FOREIGN KEY
-        (oauth2_client_id)
+        FOREIGN KEY (oauth2_client_id)
         REFERENCES public.oauth2_clients (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_oauth2_authorization_codes_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_oauth2_authorization_codes_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1202,12 +1185,11 @@ CREATE TABLE public.oauth2_grants (
     revoked_at TIMESTAMP WITH TIME ZONE,
     CONSTRAINT pk_oauth2_grants PRIMARY KEY (id),
     CONSTRAINT fk_oauth2_grants_oauth2_client_id_oauth2_clients
-        FOREIGN KEY
-        (oauth2_client_id)
+        FOREIGN KEY (oauth2_client_id)
         REFERENCES public.oauth2_clients (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_oauth2_grants_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_oauth2_grants_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1226,8 +1208,8 @@ CREATE TABLE public.password_reset_tokens (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
     CONSTRAINT pk_password_reset_tokens PRIMARY KEY (id),
-    CONSTRAINT fk_password_reset_tokens_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_password_reset_tokens_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1257,22 +1239,23 @@ CREATE TABLE public.project_session_annotations (
     CONSTRAINT pk_project_session_annotations PRIMARY KEY (id),
     CONSTRAINT uq_project_session_annotations_name_project_session_id__6b58
         UNIQUE (name, project_session_id, identifier),
-    CHECK (((annotator_kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_project_session_annotations_`valid_annotator_kind`"
+        CHECK (((annotator_kind)::text = ANY ((ARRAY[
             'LLM'::character varying,
             'CODE'::character varying,
             'HUMAN'::character varying
         ])::text[]))),
-    CHECK (((source)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_project_session_annotations_`valid_source`"
+        CHECK (((source)::text = ANY ((ARRAY[
             'API'::character varying,
             'APP'::character varying
         ])::text[]))),
     CONSTRAINT fk_project_session_annotations_project_session_id_proje_ea96
-        FOREIGN KEY
-        (project_session_id)
+        FOREIGN KEY (project_session_id)
         REFERENCES public.project_sessions (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_project_session_annotations_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_project_session_annotations_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1302,26 +1285,27 @@ CREATE TABLE public.prompt_versions (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     custom_provider_id BIGINT,
     CONSTRAINT pk_prompt_versions PRIMARY KEY (id),
-    CHECK (((template_format)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_prompt_versions_`template_format`"
+        CHECK (((template_format)::text = ANY ((ARRAY[
             'F_STRING'::character varying,
             'MUSTACHE'::character varying,
             'NONE'::character varying
         ])::text[]))),
-    CHECK (((template_type)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_prompt_versions_`template_type`"
+        CHECK (((template_type)::text = ANY ((ARRAY[
             'CHAT'::character varying,
             'STR'::character varying
         ])::text[]))),
     CONSTRAINT fk_prompt_versions_custom_provider_id_generative_model__f97f
-        FOREIGN KEY
-        (custom_provider_id)
+        FOREIGN KEY (custom_provider_id)
         REFERENCES public.generative_model_custom_providers (id)
         ON DELETE SET NULL,
-    CONSTRAINT fk_prompt_versions_prompt_id_prompts FOREIGN KEY
-        (prompt_id)
+    CONSTRAINT fk_prompt_versions_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
         REFERENCES public.prompts (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_prompt_versions_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_prompt_versions_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1353,20 +1337,18 @@ CREATE TABLE public.experiment_prompt_tasks (
     playground_config JSONB,
     stream_model_output BOOLEAN NOT NULL DEFAULT true,
     CONSTRAINT pk_experiment_prompt_tasks PRIMARY KEY (id),
-    CHECK ((NOT ((custom_provider_id IS NOT NULL) AND (connection IS NOT NULL)))),
-    CHECK (((type)::text = 'PROMPT'::text)),
+    CONSTRAINT "ck_experiment_prompt_tasks_`custom_provider_or_connection`" CHECK ((NOT ((custom_provider_id IS NOT NULL) AND (connection IS NOT NULL)))),
+    CONSTRAINT "ck_experiment_prompt_tasks_`valid_type`" CHECK (((type)::text = 'PROMPT'::text)),
     CONSTRAINT fk_experiment_prompt_tasks_custom_provider_id_generativ_44e2
-        FOREIGN KEY
-        (custom_provider_id)
+        FOREIGN KEY (custom_provider_id)
         REFERENCES public.generative_model_custom_providers (id)
         ON DELETE SET NULL,
     CONSTRAINT fk_experiment_prompt_tasks_prompt_version_id_prompt_versions
-        FOREIGN KEY
-        (prompt_version_id)
+        FOREIGN KEY (prompt_version_id)
         REFERENCES public.prompt_versions (id)
         ON DELETE SET NULL,
-    CONSTRAINT fk_experiment_prompt_tasks_type_experiment_jobs FOREIGN KEY
-        (type, id)
+    CONSTRAINT fk_experiment_prompt_tasks_type_experiment_jobs
+        FOREIGN KEY (type, id)
         REFERENCES public.experiment_jobs (type, id)
         ON DELETE CASCADE
 );
@@ -1384,17 +1366,16 @@ CREATE TABLE public.prompt_version_tags (
     CONSTRAINT pk_prompt_version_tags PRIMARY KEY (id),
     CONSTRAINT uq_prompt_version_tags_name_prompt_id
         UNIQUE (name, prompt_id),
-    CONSTRAINT fk_prompt_version_tags_prompt_id_prompts FOREIGN KEY
-        (prompt_id)
+    CONSTRAINT fk_prompt_version_tags_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
         REFERENCES public.prompts (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_prompt_version_tags_prompt_version_id_prompt_versions
-        FOREIGN KEY
-        (prompt_version_id)
+        FOREIGN KEY (prompt_version_id)
         REFERENCES public.prompt_versions (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_prompt_version_tags_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_prompt_version_tags_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1417,18 +1398,17 @@ CREATE TABLE public.llm_evaluators (
     output_configs JSONB NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_llm_evaluators PRIMARY KEY (id),
-    CHECK (((kind)::text = 'LLM'::text)),
-    CONSTRAINT fk_llm_evaluators_kind_evaluators FOREIGN KEY
-        (kind, id)
+    CONSTRAINT "ck_llm_evaluators_`valid_evaluator_kind`" CHECK (((kind)::text = 'LLM'::text)),
+    CONSTRAINT fk_llm_evaluators_kind_evaluators
+        FOREIGN KEY (kind, id)
         REFERENCES public.evaluators (kind, id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_llm_evaluators_prompt_id_prompts FOREIGN KEY
-        (prompt_id)
+    CONSTRAINT fk_llm_evaluators_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
         REFERENCES public.prompts (id)
         ON DELETE RESTRICT,
     CONSTRAINT fk_llm_evaluators_prompt_version_tag_id_prompt_version_tags
-        FOREIGN KEY
-        (prompt_version_tag_id)
+        FOREIGN KEY (prompt_version_tag_id)
         REFERENCES public.prompt_version_tags (id)
         ON DELETE SET NULL
 );
@@ -1451,12 +1431,12 @@ CREATE TABLE public.refresh_tokens (
     audience JSONB,
     consumed_at TIMESTAMP WITH TIME ZONE,
     CONSTRAINT pk_refresh_tokens PRIMARY KEY (id),
-    CONSTRAINT fk_refresh_tokens_oauth2_grant_id_oauth2_grants FOREIGN KEY
-        (oauth2_grant_id)
+    CONSTRAINT fk_refresh_tokens_oauth2_grant_id_oauth2_grants
+        FOREIGN KEY (oauth2_grant_id)
         REFERENCES public.oauth2_grants (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_refresh_tokens_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_refresh_tokens_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1481,12 +1461,11 @@ CREATE TABLE public.access_tokens (
     audience JSONB,
     CONSTRAINT pk_access_tokens PRIMARY KEY (id),
     CONSTRAINT fk_access_tokens_refresh_token_id_refresh_tokens
-        FOREIGN KEY
-        (refresh_token_id)
+        FOREIGN KEY (refresh_token_id)
         REFERENCES public.refresh_tokens (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_access_tokens_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_access_tokens_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1508,8 +1487,8 @@ CREATE TABLE public.sandbox_providers (
     user_id BIGINT,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_sandbox_providers PRIMARY KEY (backend_type),
-    CONSTRAINT fk_sandbox_providers_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_sandbox_providers_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1538,16 +1517,15 @@ CREATE TABLE public.sandbox_configs (
     CONSTRAINT uq_sandbox_configs_language_id
         UNIQUE (language, id),
     CONSTRAINT fk_sandbox_configs_backend_type_sandbox_providers
-        FOREIGN KEY
-        (backend_type)
+        FOREIGN KEY (backend_type)
         REFERENCES public.sandbox_providers (backend_type)
         ON DELETE RESTRICT,
-    CONSTRAINT fk_sandbox_configs_language_languages FOREIGN KEY
-        (language)
+    CONSTRAINT fk_sandbox_configs_language_languages
+        FOREIGN KEY (language)
         REFERENCES public.languages (name)
         ON DELETE RESTRICT,
-    CONSTRAINT fk_sandbox_configs_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_sandbox_configs_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1567,22 +1545,21 @@ CREATE TABLE public.code_evaluators (
     output_configs JSONB NOT NULL DEFAULT '[]'::jsonb,
     sandbox_config_id BIGINT,
     CONSTRAINT pk_code_evaluators PRIMARY KEY (id),
-    CHECK (((kind)::text = 'CODE'::text)),
-    CONSTRAINT fk_code_evaluators_kind_evaluators FOREIGN KEY
-        (kind, id)
+    CONSTRAINT "ck_code_evaluators_`valid_evaluator_kind`" CHECK (((kind)::text = 'CODE'::text)),
+    CONSTRAINT fk_code_evaluators_kind_evaluators
+        FOREIGN KEY (kind, id)
         REFERENCES public.evaluators (kind, id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_code_evaluators_language_languages FOREIGN KEY
-        (language)
+    CONSTRAINT fk_code_evaluators_language_languages
+        FOREIGN KEY (language)
         REFERENCES public.languages (name)
         ON DELETE RESTRICT,
     CONSTRAINT fk_code_evaluators_sandbox_config_id_sandbox_configs
-        FOREIGN KEY
-        (sandbox_config_id)
+        FOREIGN KEY (sandbox_config_id)
         REFERENCES public.sandbox_configs (id)
         ON DELETE SET NULL,
-    CONSTRAINT fk_code_evaluators_sandbox_config_language FOREIGN KEY
-        (sandbox_config_id, language)
+    CONSTRAINT fk_code_evaluators_sandbox_config_language
+        FOREIGN KEY (sandbox_config_id, language)
         REFERENCES public.sandbox_configs (id, language)
 );
 
@@ -1602,12 +1579,11 @@ CREATE TABLE public.code_evaluator_code_versions (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_code_evaluator_code_versions PRIMARY KEY (id),
     CONSTRAINT fk_code_evaluator_code_versions_code_evaluator_id_code__3f57
-        FOREIGN KEY
-        (code_evaluator_id)
+        FOREIGN KEY (code_evaluator_id)
         REFERENCES public.code_evaluators (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_code_evaluator_code_versions_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_code_evaluator_code_versions_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1626,8 +1602,8 @@ CREATE TABLE public.secrets (
     user_id BIGINT,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_secrets PRIMARY KEY (key),
-    CONSTRAINT fk_secrets_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_secrets_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1652,21 +1628,23 @@ CREATE TABLE public.span_annotations (
     CONSTRAINT pk_span_annotations PRIMARY KEY (id),
     CONSTRAINT uq_span_annotations_name_span_rowid_identifier
         UNIQUE (name, span_rowid, identifier),
-    CHECK (((annotator_kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_span_annotations_`valid_annotator_kind`"
+        CHECK (((annotator_kind)::text = ANY ((ARRAY[
             'LLM'::character varying,
             'CODE'::character varying,
             'HUMAN'::character varying
         ])::text[]))),
-    CHECK (((source)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_span_annotations_`valid_source`"
+        CHECK (((source)::text = ANY ((ARRAY[
             'API'::character varying,
             'APP'::character varying
         ])::text[]))),
-    CONSTRAINT fk_span_annotations_span_rowid_spans FOREIGN KEY
-        (span_rowid)
+    CONSTRAINT fk_span_annotations_span_rowid_spans
+        FOREIGN KEY (span_rowid)
         REFERENCES public.spans (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_span_annotations_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_span_annotations_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1685,8 +1663,8 @@ CREATE TABLE public.system_settings (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_by BIGINT,
     CONSTRAINT pk_system_settings PRIMARY KEY (key),
-    CONSTRAINT fk_system_settings_updated_by_users FOREIGN KEY
-        (updated_by)
+    CONSTRAINT fk_system_settings_updated_by_users
+        FOREIGN KEY (updated_by)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );
@@ -1714,21 +1692,23 @@ CREATE TABLE public.trace_annotations (
     CONSTRAINT pk_trace_annotations PRIMARY KEY (id),
     CONSTRAINT uq_trace_annotations_name_trace_rowid_identifier
         UNIQUE (name, trace_rowid, identifier),
-    CHECK (((annotator_kind)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_trace_annotations_`valid_annotator_kind`"
+        CHECK (((annotator_kind)::text = ANY ((ARRAY[
             'LLM'::character varying,
             'CODE'::character varying,
             'HUMAN'::character varying
         ])::text[]))),
-    CHECK (((source)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_trace_annotations_`valid_source`"
+        CHECK (((source)::text = ANY ((ARRAY[
             'API'::character varying,
             'APP'::character varying
         ])::text[]))),
-    CONSTRAINT fk_trace_annotations_trace_rowid_traces FOREIGN KEY
-        (trace_rowid)
+    CONSTRAINT fk_trace_annotations_trace_rowid_traces
+        FOREIGN KEY (trace_rowid)
         REFERENCES public.traces (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_trace_annotations_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_trace_annotations_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE SET NULL
 );

--- a/scripts/ddl/sqlite_schema.sql
+++ b/scripts/ddl/sqlite_schema.sql
@@ -1,0 +1,1589 @@
+-- Table: alembic_version
+-- ----------------------
+CREATE TABLE alembic_version (
+    version_num VARCHAR(32) NOT NULL,
+    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+);
+
+
+-- Table: annotation_configs
+-- -------------------------
+CREATE TABLE annotation_configs (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    config JSONB NOT NULL,
+    CONSTRAINT pk_annotation_configs PRIMARY KEY (id),
+    CONSTRAINT uq_annotation_configs_name UNIQUE (name)
+);
+
+
+-- Table: generative_models
+-- ------------------------
+CREATE TABLE generative_models (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    provider VARCHAR NOT NULL,
+    name_pattern VARCHAR NOT NULL,
+    is_built_in BOOLEAN NOT NULL,
+    start_time TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP,
+    CONSTRAINT pk_generative_models PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX ix_generative_models_match_criteria ON generative_models
+    (name_pattern, provider, is_built_in)
+    WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX ix_generative_models_name_is_built_in ON generative_models
+    (name, is_built_in)
+    WHERE deleted_at IS NULL;
+CREATE INDEX ix_generative_models_updated_at ON generative_models (updated_at);
+
+
+-- Table: languages
+-- ----------------
+CREATE TABLE languages (
+    name VARCHAR NOT NULL,
+    CONSTRAINT pk_languages PRIMARY KEY (name)
+);
+
+
+-- Table: oauth2_clients
+-- ---------------------
+CREATE TABLE oauth2_clients (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    client_id VARCHAR NOT NULL,
+    name VARCHAR NOT NULL,
+    logo_uri VARCHAR,
+    redirect_uris JSONB NOT NULL,
+    grant_types JSONB NOT NULL,
+    token_endpoint_auth_method VARCHAR NOT NULL,
+    is_first_party BOOLEAN DEFAULT 0 NOT NULL,
+    metadata JSONB,
+    registration_client_ip VARCHAR,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX ix_oauth2_clients_client_id ON oauth2_clients (client_id);
+CREATE INDEX ix_oauth2_clients_registration_client_ip ON oauth2_clients
+    (registration_client_ip, created_at);
+
+
+-- Table: project_trace_retention_policies
+-- ---------------------------------------
+CREATE TABLE project_trace_retention_policies (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    cron_expression VARCHAR NOT NULL,
+    rule JSONB NOT NULL,
+    CONSTRAINT pk_project_trace_retention_policies PRIMARY KEY (id)
+);
+
+
+-- Table: projects
+-- ---------------
+CREATE TABLE projects (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    gradient_start_color VARCHAR DEFAULT '#5bdbff' NOT NULL,
+    gradient_end_color VARCHAR DEFAULT '#1c76fc' NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    trace_retention_policy_id INTEGER,
+    CONSTRAINT pk_projects PRIMARY KEY (id),
+    CONSTRAINT uq_projects_name UNIQUE (name),
+    CONSTRAINT fk_projects_trace_retention_policy_id_project_trace_retention_policies
+        FOREIGN KEY (trace_retention_policy_id)
+        REFERENCES project_trace_retention_policies (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_projects_trace_retention_policy_id ON projects
+    (trace_retention_policy_id);
+
+
+-- Table: project_annotation_configs
+-- ---------------------------------
+CREATE TABLE project_annotation_configs (
+    id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    annotation_config_id INTEGER NOT NULL,
+    CONSTRAINT pk_project_annotation_configs PRIMARY KEY (id),
+    CONSTRAINT uq_project_annotation_configs_project_id_annotation_config_id
+        UNIQUE (project_id, annotation_config_id),
+    CONSTRAINT fk_project_annotation_configs_annotation_config_id_annotation_configs
+        FOREIGN KEY (annotation_config_id)
+        REFERENCES annotation_configs (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_project_annotation_configs_project_id_projects
+        FOREIGN KEY (project_id)
+        REFERENCES projects (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_project_annotation_configs_annotation_config_id ON project_annotation_configs
+    (annotation_config_id);
+
+
+-- Table: project_sessions
+-- -----------------------
+CREATE TABLE project_sessions (
+    id INTEGER NOT NULL,
+    session_id VARCHAR NOT NULL,
+    project_id INTEGER NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL,
+    CONSTRAINT pk_project_sessions PRIMARY KEY (id),
+    CONSTRAINT uq_project_sessions_session_id UNIQUE (session_id),
+    CONSTRAINT fk_project_sessions_project_id_projects
+        FOREIGN KEY (project_id)
+        REFERENCES projects (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_project_sessions_project_id_end_time ON project_sessions
+    (project_id, end_time DESC);
+CREATE INDEX ix_project_sessions_project_id_start_time ON project_sessions
+    (project_id, start_time DESC);
+
+
+-- Table: prompt_labels
+-- --------------------
+CREATE TABLE prompt_labels (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    color VARCHAR,
+    CONSTRAINT pk_prompt_labels PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX ix_prompt_labels_name ON prompt_labels (name);
+
+
+-- Table: prompts
+-- --------------
+CREATE TABLE prompts (
+    id INTEGER NOT NULL,
+    source_prompt_id INTEGER,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_prompts PRIMARY KEY (id),
+    CONSTRAINT fk_prompts_source_prompt_id_prompts
+        FOREIGN KEY (source_prompt_id)
+        REFERENCES prompts (id)
+        ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX ix_prompts_name ON prompts (name);
+CREATE INDEX ix_prompts_source_prompt_id ON prompts (source_prompt_id);
+
+
+-- Table: prompts_prompt_labels
+-- ----------------------------
+CREATE TABLE prompts_prompt_labels (
+    id INTEGER NOT NULL,
+    prompt_label_id INTEGER NOT NULL,
+    prompt_id INTEGER NOT NULL,
+    CONSTRAINT pk_prompts_prompt_labels PRIMARY KEY (id),
+    CONSTRAINT uq_prompts_prompt_labels_prompt_label_id_prompt_id
+        UNIQUE (prompt_label_id, prompt_id),
+    CONSTRAINT fk_prompts_prompt_labels_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
+        REFERENCES prompts (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_prompts_prompt_labels_prompt_label_id_prompt_labels
+        FOREIGN KEY (prompt_label_id)
+        REFERENCES prompt_labels (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_prompts_prompt_labels_prompt_id ON prompts_prompt_labels (prompt_id);
+
+
+-- Table: token_prices
+-- -------------------
+CREATE TABLE token_prices (
+    id INTEGER NOT NULL,
+    model_id INTEGER NOT NULL,
+    token_type VARCHAR NOT NULL,
+    is_prompt BOOLEAN NOT NULL,
+    base_rate FLOAT NOT NULL,
+    customization JSON,
+    CONSTRAINT pk_token_prices PRIMARY KEY (id),
+    CONSTRAINT uq_token_prices_model_id_token_type_is_prompt
+        UNIQUE (model_id, token_type, is_prompt),
+    CONSTRAINT fk_token_prices_model_id_generative_models
+        FOREIGN KEY (model_id)
+        REFERENCES generative_models (id)
+        ON DELETE CASCADE
+);
+
+
+-- Table: traces
+-- -------------
+CREATE TABLE traces (
+    id INTEGER NOT NULL,
+    project_rowid INTEGER NOT NULL,
+    trace_id VARCHAR NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL,
+    project_session_rowid INTEGER,
+    CONSTRAINT pk_traces PRIMARY KEY (id),
+    CONSTRAINT uq_traces_trace_id UNIQUE (trace_id),
+    CONSTRAINT fk_traces_project_rowid_projects
+        FOREIGN KEY (project_rowid)
+        REFERENCES projects (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_traces_project_session_rowid_project_sessions
+        FOREIGN KEY (project_session_rowid)
+        REFERENCES project_sessions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_traces_project_rowid_start_time ON traces
+    (project_rowid, start_time DESC);
+CREATE INDEX ix_traces_project_session_rowid ON traces (project_session_rowid);
+
+
+-- Table: spans
+-- ------------
+CREATE TABLE spans (
+    id INTEGER NOT NULL,
+    trace_rowid INTEGER NOT NULL,
+    span_id VARCHAR NOT NULL,
+    parent_id VARCHAR,
+    name VARCHAR NOT NULL,
+    span_kind VARCHAR NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL,
+    attributes JSONB NOT NULL,
+    events JSONB NOT NULL,
+    status_code VARCHAR DEFAULT 'UNSET' NOT NULL
+        CONSTRAINT "ck_spans_`valid_status`"
+        CHECK (status_code IN ('OK', 'ERROR', 'UNSET')),
+    status_message VARCHAR NOT NULL,
+    cumulative_error_count INTEGER NOT NULL,
+    cumulative_llm_token_count_prompt INTEGER NOT NULL,
+    cumulative_llm_token_count_completion INTEGER NOT NULL,
+    llm_token_count_prompt INTEGER,
+    llm_token_count_completion INTEGER,
+    CONSTRAINT pk_spans PRIMARY KEY (id),
+    CONSTRAINT uq_spans_span_id UNIQUE (span_id),
+    CONSTRAINT fk_spans_trace_rowid_traces
+        FOREIGN KEY (trace_rowid)
+        REFERENCES traces (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_cumulative_llm_token_count_total ON spans
+    ((cumulative_llm_token_count_prompt + cumulative_llm_token_count_completion));
+CREATE INDEX ix_latency ON spans ((end_time - start_time));
+CREATE INDEX ix_spans_parent_id ON spans (parent_id);
+CREATE INDEX ix_spans_session_id ON spans (JSON_EXTRACT(attributes, '$."session"."id"'))
+    WHERE JSON_EXTRACT(attributes, '$."session"."id"') IS NOT NULL;
+CREATE INDEX ix_spans_start_time ON spans (start_time);
+CREATE INDEX ix_spans_trace_rowid ON spans (trace_rowid);
+CREATE INDEX ix_spans_user_id ON spans (JSON_EXTRACT(attributes, '$."user"."id"'))
+    WHERE JSON_EXTRACT(attributes, '$."user"."id"') IS NOT NULL;
+
+
+-- Table: span_costs
+-- -----------------
+CREATE TABLE span_costs (
+    id INTEGER NOT NULL,
+    span_rowid INTEGER NOT NULL,
+    trace_rowid INTEGER NOT NULL,
+    model_id INTEGER,
+    span_start_time TIMESTAMP NOT NULL,
+    total_cost FLOAT,
+    total_tokens FLOAT,
+    prompt_cost FLOAT,
+    prompt_tokens FLOAT,
+    completion_cost FLOAT,
+    completion_tokens FLOAT,
+    CONSTRAINT pk_span_costs PRIMARY KEY (id),
+    CONSTRAINT fk_span_costs_model_id_generative_models
+        FOREIGN KEY (model_id)
+        REFERENCES generative_models (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_span_costs_span_rowid_spans
+        FOREIGN KEY (span_rowid)
+        REFERENCES spans (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_span_costs_trace_rowid_traces
+        FOREIGN KEY (trace_rowid)
+        REFERENCES traces (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_span_costs_model_id_span_start_time ON span_costs
+    (model_id, span_start_time);
+CREATE INDEX ix_span_costs_span_rowid ON span_costs (span_rowid);
+CREATE INDEX ix_span_costs_span_start_time ON span_costs (span_start_time);
+CREATE INDEX ix_span_costs_trace_rowid ON span_costs (trace_rowid);
+
+
+-- Table: span_cost_details
+-- ------------------------
+CREATE TABLE span_cost_details (
+    id INTEGER NOT NULL,
+    span_cost_id INTEGER NOT NULL,
+    token_type VARCHAR NOT NULL,
+    is_prompt BOOLEAN NOT NULL,
+    cost FLOAT,
+    tokens FLOAT,
+    cost_per_token FLOAT,
+    CONSTRAINT pk_span_cost_details PRIMARY KEY (id),
+    CONSTRAINT uq_span_cost_details_span_cost_id_token_type_is_prompt
+        UNIQUE (span_cost_id, token_type, is_prompt),
+    CONSTRAINT fk_span_cost_details_span_cost_id_span_costs
+        FOREIGN KEY (span_cost_id)
+        REFERENCES span_costs (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_span_cost_details_token_type ON span_cost_details (token_type);
+
+
+-- Table: user_roles
+-- -----------------
+CREATE TABLE user_roles (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    CONSTRAINT pk_user_roles PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX ix_user_roles_name ON user_roles (name);
+
+
+-- Table: users
+-- ------------
+CREATE TABLE users (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    user_role_id INTEGER NOT NULL,
+    username VARCHAR NOT NULL,
+    email VARCHAR,
+    profile_picture_url VARCHAR,
+    password_hash BLOB,
+    password_salt BLOB,
+    reset_password BOOLEAN NOT NULL,
+    oauth2_client_id VARCHAR,
+    oauth2_user_id VARCHAR,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    auth_method VARCHAR NOT NULL,
+    ldap_unique_id VARCHAR,
+    CONSTRAINT "ck_users_`ldap_auth_valid`"
+        CHECK (
+            auth_method != 'LDAP'
+            OR (
+                oauth2_client_id IS NULL
+                AND oauth2_user_id IS NULL
+                AND (email IS NOT NULL OR ldap_unique_id IS NOT NULL)
+            )
+        ),
+    CONSTRAINT "ck_users_`local_auth_has_password_no_oauth`"
+        CHECK (
+            auth_method != 'LOCAL'
+            OR (
+                password_hash IS NOT NULL
+                AND password_salt IS NOT NULL
+                AND oauth2_client_id IS NULL
+                AND oauth2_user_id IS NULL
+                AND ldap_unique_id IS NULL
+            )
+        ),
+    CONSTRAINT "ck_users_`non_ldap_auth_has_email`"
+        CHECK (auth_method = 'LDAP' OR email IS NOT NULL),
+    CONSTRAINT "ck_users_`non_local_auth_has_no_password`"
+        CHECK (auth_method = 'LOCAL' OR (password_hash IS NULL AND password_salt IS NULL)),
+    CONSTRAINT "ck_users_`oauth2_auth_no_ldap_fields`"
+        CHECK (auth_method != 'OAUTH2' OR ldap_unique_id IS NULL),
+    CONSTRAINT "ck_users_`valid_auth_method`"
+        CHECK (auth_method IN ('LOCAL', 'OAUTH2', 'LDAP')),
+    CONSTRAINT fk_users_user_role_id_user_roles
+        FOREIGN KEY (user_role_id)
+        REFERENCES user_roles (id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ix_users_email ON users (email);
+CREATE UNIQUE INDEX ix_users_ldap_unique_id ON users (ldap_unique_id)
+    WHERE auth_method = 'LDAP' AND ldap_unique_id IS NOT NULL;
+CREATE UNIQUE INDEX ix_users_oauth2_unique ON users (oauth2_client_id, oauth2_user_id)
+    WHERE auth_method = 'OAUTH2';
+CREATE INDEX ix_users_user_role_id ON users (user_role_id);
+CREATE UNIQUE INDEX ix_users_username ON users (username);
+
+
+-- Table: api_keys
+-- ---------------
+CREATE TABLE api_keys (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP,
+    scopes JSONB,
+    audience JSONB,
+    CONSTRAINT fk_api_keys_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_api_keys_expires_at ON api_keys (expires_at);
+CREATE INDEX ix_api_keys_user_id ON api_keys (user_id);
+
+
+-- Table: dataset_labels
+-- ---------------------
+CREATE TABLE dataset_labels (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    color VARCHAR NOT NULL,
+    user_id INTEGER,
+    CONSTRAINT pk_dataset_labels PRIMARY KEY (id),
+    CONSTRAINT uq_dataset_labels_name UNIQUE (name),
+    CONSTRAINT fk_dataset_labels_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_dataset_labels_user_id ON dataset_labels (user_id);
+
+
+-- Table: dataset_splits
+-- ---------------------
+CREATE TABLE dataset_splits (
+    id INTEGER NOT NULL,
+    user_id INTEGER,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    color VARCHAR NOT NULL,
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_dataset_splits PRIMARY KEY (id),
+    CONSTRAINT uq_dataset_splits_name UNIQUE (name),
+    CONSTRAINT fk_dataset_splits_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_dataset_splits_user_id ON dataset_splits (user_id);
+
+
+-- Table: datasets
+-- ---------------
+CREATE TABLE datasets (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id INTEGER,
+    CONSTRAINT pk_datasets PRIMARY KEY (id),
+    CONSTRAINT uq_datasets_name UNIQUE (name),
+    CONSTRAINT fk_datasets_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_datasets_user_id ON datasets (user_id);
+
+
+-- Table: dataset_examples
+-- -----------------------
+CREATE TABLE dataset_examples (
+    id INTEGER NOT NULL,
+    dataset_id INTEGER NOT NULL,
+    span_rowid INTEGER,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    external_id VARCHAR,
+    CONSTRAINT pk_dataset_examples PRIMARY KEY (id),
+    CONSTRAINT uq_dataset_examples_dataset_id_external_id
+        UNIQUE (dataset_id, external_id),
+    CONSTRAINT fk_dataset_examples_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
+        REFERENCES datasets (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_dataset_examples_span_rowid_spans
+        FOREIGN KEY (span_rowid)
+        REFERENCES spans (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_dataset_examples_span_rowid ON dataset_examples (span_rowid);
+
+
+-- Table: dataset_splits_dataset_examples
+-- --------------------------------------
+CREATE TABLE dataset_splits_dataset_examples (
+    dataset_split_id INTEGER NOT NULL,
+    dataset_example_id INTEGER NOT NULL,
+    CONSTRAINT pk_dataset_splits_dataset_examples
+        PRIMARY KEY (dataset_split_id, dataset_example_id),
+    CONSTRAINT fk_dataset_splits_dataset_examples_dataset_example_id_dataset_examples
+        FOREIGN KEY (dataset_example_id)
+        REFERENCES dataset_examples (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_dataset_splits_dataset_examples_dataset_split_id_dataset_splits
+        FOREIGN KEY (dataset_split_id)
+        REFERENCES dataset_splits (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_dataset_splits_dataset_examples_dataset_example_id ON dataset_splits_dataset_examples
+    (dataset_example_id);
+
+
+-- Table: dataset_versions
+-- -----------------------
+CREATE TABLE dataset_versions (
+    id INTEGER NOT NULL,
+    dataset_id INTEGER NOT NULL,
+    description VARCHAR,
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id INTEGER,
+    CONSTRAINT pk_dataset_versions PRIMARY KEY (id),
+    CONSTRAINT fk_dataset_versions_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
+        REFERENCES datasets (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_dataset_versions_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_dataset_versions_dataset_id ON dataset_versions (dataset_id);
+CREATE INDEX ix_dataset_versions_user_id ON dataset_versions (user_id);
+
+
+-- Table: dataset_example_revisions
+-- --------------------------------
+CREATE TABLE dataset_example_revisions (
+    id INTEGER NOT NULL,
+    dataset_example_id INTEGER NOT NULL,
+    dataset_version_id INTEGER NOT NULL,
+    input JSONB NOT NULL,
+    output JSONB NOT NULL,
+    metadata JSONB NOT NULL,
+    revision_kind VARCHAR NOT NULL
+        CONSTRAINT "ck_dataset_example_revisions_`valid_revision_kind`"
+        CHECK (revision_kind IN ('CREATE', 'PATCH', 'DELETE')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    content_hash BLOB,
+    CONSTRAINT pk_dataset_example_revisions PRIMARY KEY (id),
+    CONSTRAINT uq_dataset_example_revisions_dataset_example_id_dataset_version_id
+        UNIQUE (dataset_example_id, dataset_version_id),
+    CONSTRAINT fk_dataset_example_revisions_dataset_example_id_dataset_examples
+        FOREIGN KEY (dataset_example_id)
+        REFERENCES dataset_examples (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_dataset_example_revisions_dataset_version_id_dataset_versions
+        FOREIGN KEY (dataset_version_id)
+        REFERENCES dataset_versions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_dataset_example_revisions_content_hash ON dataset_example_revisions
+    (content_hash);
+CREATE INDEX ix_dataset_example_revisions_dataset_version_id ON dataset_example_revisions
+    (dataset_version_id);
+
+
+-- Table: datasets_dataset_labels
+-- ------------------------------
+CREATE TABLE datasets_dataset_labels (
+    dataset_id INTEGER NOT NULL,
+    dataset_label_id INTEGER NOT NULL,
+    CONSTRAINT pk_datasets_dataset_labels PRIMARY KEY (dataset_id, dataset_label_id),
+    CONSTRAINT fk_datasets_dataset_labels_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
+        REFERENCES datasets (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_datasets_dataset_labels_dataset_label_id_dataset_labels
+        FOREIGN KEY (dataset_label_id)
+        REFERENCES dataset_labels (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_datasets_dataset_labels_dataset_label_id ON datasets_dataset_labels
+    (dataset_label_id);
+
+
+-- Table: document_annotations
+-- ---------------------------
+CREATE TABLE document_annotations (
+    id INTEGER NOT NULL,
+    span_rowid INTEGER NOT NULL,
+    document_position INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    label VARCHAR,
+    score FLOAT,
+    explanation VARCHAR,
+    metadata JSONB NOT NULL,
+    annotator_kind VARCHAR NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id INTEGER,
+    identifier VARCHAR DEFAULT ('') NOT NULL,
+    source VARCHAR NOT NULL,
+    CONSTRAINT pk_document_annotations PRIMARY KEY (id),
+    CONSTRAINT uq_document_annotations_name_span_rowid_document_pos_identifier
+        UNIQUE (name, span_rowid, document_position, identifier),
+    CONSTRAINT "ck_document_annotations_`valid_annotator_kind`"
+        CHECK (annotator_kind IN ('LLM', 'CODE', 'HUMAN')),
+    CONSTRAINT "ck_document_annotations_`valid_source`" CHECK (source IN ('API', 'APP')),
+    CONSTRAINT fk_document_annotations_span_rowid_spans
+        FOREIGN KEY (span_rowid)
+        REFERENCES spans (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_document_annotations_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_document_annotations_span_rowid ON document_annotations (span_rowid);
+CREATE INDEX ix_document_annotations_user_id ON document_annotations (user_id);
+
+
+-- Table: evaluators
+-- -----------------
+CREATE TABLE evaluators (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    metadata JSONB NOT NULL,
+    kind VARCHAR NOT NULL
+        CONSTRAINT "ck_evaluators_`valid_evaluator_kind`"
+        CHECK (kind IN ('LLM', 'CODE', 'BUILTIN')),
+    user_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_evaluators PRIMARY KEY (id),
+    CONSTRAINT uq_evaluators_kind_id UNIQUE (kind, id),
+    CONSTRAINT uq_evaluators_name UNIQUE (name),
+    CONSTRAINT fk_evaluators_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_evaluators_user_id ON evaluators (user_id);
+
+
+-- Table: builtin_evaluators
+-- -------------------------
+CREATE TABLE builtin_evaluators (
+    id INTEGER NOT NULL,
+    kind VARCHAR DEFAULT 'BUILTIN' NOT NULL
+        CONSTRAINT "ck_builtin_evaluators_`valid_evaluator_kind`"
+        CHECK (kind = 'BUILTIN'),
+    "key" VARCHAR NOT NULL,
+    input_schema JSONB NOT NULL,
+    output_configs JSONB NOT NULL,
+    synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_builtin_evaluators PRIMARY KEY (id),
+    CONSTRAINT uq_builtin_evaluators_key UNIQUE ("key"),
+    CONSTRAINT fk_builtin_evaluators_kind_evaluators
+        FOREIGN KEY (kind, id)
+        REFERENCES evaluators (kind, id)
+        ON DELETE CASCADE
+);
+
+
+-- Table: dataset_evaluators
+-- -------------------------
+CREATE TABLE dataset_evaluators (
+    id INTEGER NOT NULL,
+    dataset_id INTEGER NOT NULL,
+    evaluator_id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    output_configs JSONB NOT NULL,
+    input_mapping JSONB NOT NULL,
+    user_id INTEGER,
+    project_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_dataset_evaluators PRIMARY KEY (id),
+    CONSTRAINT uq_dataset_evaluators_dataset_id_name UNIQUE (dataset_id, name),
+    CONSTRAINT fk_dataset_evaluators_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
+        REFERENCES datasets (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_dataset_evaluators_evaluator_id_evaluators
+        FOREIGN KEY (evaluator_id)
+        REFERENCES evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_dataset_evaluators_project_id_projects
+        FOREIGN KEY (project_id)
+        REFERENCES projects (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_dataset_evaluators_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_dataset_evaluators_evaluator_id ON dataset_evaluators (evaluator_id);
+CREATE INDEX ix_dataset_evaluators_project_id ON dataset_evaluators (project_id);
+
+
+-- Table: experiments
+-- ------------------
+CREATE TABLE experiments (
+    id INTEGER NOT NULL,
+    dataset_id INTEGER NOT NULL,
+    dataset_version_id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    repetitions INTEGER NOT NULL,
+    metadata JSONB NOT NULL,
+    project_name VARCHAR,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id INTEGER,
+    is_ephemeral BOOLEAN DEFAULT 0 NOT NULL,
+    CONSTRAINT pk_experiments PRIMARY KEY (id),
+    CONSTRAINT fk_experiments_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
+        REFERENCES datasets (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_dataset_version_id_dataset_versions
+        FOREIGN KEY (dataset_version_id)
+        REFERENCES dataset_versions (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_experiments_dataset_id ON experiments (dataset_id);
+CREATE INDEX ix_experiments_dataset_version_id ON experiments (dataset_version_id);
+CREATE INDEX ix_experiments_ephemeral_updated_at ON experiments (updated_at)
+    WHERE is_ephemeral IS TRUE;
+CREATE INDEX ix_experiments_project_name ON experiments (project_name);
+CREATE INDEX ix_experiments_user_id ON experiments (user_id);
+
+
+-- Table: experiment_jobs
+-- ----------------------
+CREATE TABLE experiment_jobs (
+    id INTEGER NOT NULL,
+    type VARCHAR NOT NULL
+        CONSTRAINT "ck_experiment_jobs_`valid_type`"
+        CHECK (type IN ('PROMPT', 'EVAL_ONLY')),
+    status VARCHAR DEFAULT 'STOPPED' NOT NULL
+        CONSTRAINT "ck_experiment_jobs_`valid_experiment_status`"
+        CHECK (status IN ('RUNNING', 'COMPLETED', 'STOPPED', 'ERROR')),
+    claimed_at TIMESTAMP,
+    claimed_by VARCHAR,
+    cooldown_until TIMESTAMP,
+    max_concurrency INTEGER DEFAULT '10' NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_experiment_jobs PRIMARY KEY (id),
+    CONSTRAINT uq_experiment_jobs_type_id UNIQUE (type, id),
+    CONSTRAINT fk_experiment_jobs_id_experiments
+        FOREIGN KEY (id)
+        REFERENCES experiments (id)
+        ON DELETE CASCADE
+);
+
+
+-- Table: experiment_dataset_evaluators
+-- ------------------------------------
+CREATE TABLE experiment_dataset_evaluators (
+    experiment_id INTEGER NOT NULL,
+    dataset_evaluator_id INTEGER NOT NULL,
+    CONSTRAINT pk_experiment_dataset_evaluators
+        PRIMARY KEY (experiment_id, dataset_evaluator_id),
+    CONSTRAINT fk_experiment_dataset_evaluators_dataset_evaluator_id_dataset_evaluators
+        FOREIGN KEY (dataset_evaluator_id)
+        REFERENCES dataset_evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_dataset_evaluators_experiment_id_experiment_jobs
+        FOREIGN KEY (experiment_id)
+        REFERENCES experiment_jobs (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiment_dataset_evaluators_dataset_evaluator_id ON experiment_dataset_evaluators
+    (dataset_evaluator_id);
+
+
+-- Table: experiment_logs
+-- ----------------------
+CREATE TABLE experiment_logs (
+    id INTEGER NOT NULL,
+    experiment_id INTEGER NOT NULL,
+    occurred_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    category VARCHAR NOT NULL
+        CONSTRAINT "ck_experiment_logs_`valid_event_category`"
+        CHECK (category IN ('TASK', 'EVAL', 'EXPERIMENT')),
+    level VARCHAR NOT NULL
+        CONSTRAINT "ck_experiment_logs_`valid_event_level`"
+        CHECK (level IN ('ERROR', 'WARN', 'INFO')),
+    message VARCHAR NOT NULL,
+    detail JSONB,
+    CONSTRAINT pk_experiment_logs PRIMARY KEY (id),
+    CONSTRAINT uq_experiment_logs_category_id UNIQUE (category, id),
+    CONSTRAINT fk_experiment_logs_experiment_id_experiment_jobs
+        FOREIGN KEY (experiment_id)
+        REFERENCES experiment_jobs (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiment_logs_experiment_id ON experiment_logs (experiment_id);
+CREATE INDEX ix_experiment_logs_experiment_id_occurred_at_errors ON experiment_logs
+    (experiment_id, occurred_at DESC)
+    WHERE level = 'ERROR';
+
+
+-- Table: experiment_runs
+-- ----------------------
+CREATE TABLE experiment_runs (
+    id INTEGER NOT NULL,
+    experiment_id INTEGER NOT NULL,
+    dataset_example_id INTEGER NOT NULL,
+    repetition_number INTEGER NOT NULL,
+    trace_id VARCHAR,
+    output JSONB NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL,
+    prompt_token_count INTEGER,
+    completion_token_count INTEGER,
+    error VARCHAR,
+    CONSTRAINT pk_experiment_runs PRIMARY KEY (id),
+    CONSTRAINT uq_experiment_runs_experiment_id_dataset_example_id_repetition_number
+        UNIQUE (experiment_id, dataset_example_id, repetition_number),
+    CONSTRAINT fk_experiment_runs_dataset_example_id_dataset_examples
+        FOREIGN KEY (dataset_example_id)
+        REFERENCES dataset_examples (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_runs_experiment_id_experiments
+        FOREIGN KEY (experiment_id)
+        REFERENCES experiments (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiment_runs_dataset_example_id ON experiment_runs
+    (dataset_example_id);
+
+
+-- Table: experiment_eval_logs
+-- ---------------------------
+CREATE TABLE experiment_eval_logs (
+    id INTEGER NOT NULL,
+    category VARCHAR DEFAULT 'EVAL' NOT NULL
+        CONSTRAINT "ck_experiment_eval_logs_`valid_category`"
+        CHECK (category = 'EVAL'),
+    experiment_run_id INTEGER NOT NULL,
+    dataset_evaluator_id INTEGER NOT NULL,
+    CONSTRAINT pk_experiment_eval_logs PRIMARY KEY (id),
+    CONSTRAINT fk_experiment_eval_logs_category_experiment_logs
+        FOREIGN KEY (category, id)
+        REFERENCES experiment_logs (category, id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_eval_logs_dataset_evaluator_id_dataset_evaluators
+        FOREIGN KEY (dataset_evaluator_id)
+        REFERENCES dataset_evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_eval_logs_experiment_run_id_experiment_runs
+        FOREIGN KEY (experiment_run_id)
+        REFERENCES experiment_runs (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiment_eval_logs_dataset_evaluator_id ON experiment_eval_logs
+    (dataset_evaluator_id);
+CREATE INDEX ix_experiment_eval_logs_experiment_run_id ON experiment_eval_logs
+    (experiment_run_id);
+
+
+-- Table: experiment_run_annotations
+-- ---------------------------------
+CREATE TABLE experiment_run_annotations (
+    id INTEGER NOT NULL,
+    experiment_run_id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    annotator_kind VARCHAR NOT NULL
+        CONSTRAINT "ck_experiment_run_annotations_`valid_annotator_kind`"
+        CHECK (annotator_kind IN ('LLM', 'CODE', 'HUMAN')),
+    label VARCHAR,
+    score FLOAT,
+    explanation VARCHAR,
+    trace_id VARCHAR,
+    error VARCHAR,
+    metadata JSONB NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL,
+    CONSTRAINT pk_experiment_run_annotations PRIMARY KEY (id),
+    CONSTRAINT uq_experiment_run_annotations_experiment_run_id_name
+        UNIQUE (experiment_run_id, name),
+    CONSTRAINT fk_experiment_run_annotations_experiment_run_id_experiment_runs
+        FOREIGN KEY (experiment_run_id)
+        REFERENCES experiment_runs (id)
+        ON DELETE CASCADE
+);
+
+
+-- Table: experiment_tags
+-- ----------------------
+CREATE TABLE experiment_tags (
+    id INTEGER NOT NULL,
+    experiment_id INTEGER NOT NULL,
+    dataset_id INTEGER NOT NULL,
+    user_id INTEGER,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    CONSTRAINT pk_experiment_tags PRIMARY KEY (id),
+    CONSTRAINT uq_experiment_tags_dataset_id_name UNIQUE (dataset_id, name),
+    CONSTRAINT fk_experiment_tags_dataset_id_datasets
+        FOREIGN KEY (dataset_id)
+        REFERENCES datasets (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_tags_experiment_id_experiments
+        FOREIGN KEY (experiment_id)
+        REFERENCES experiments (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_tags_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_experiment_tags_experiment_id ON experiment_tags (experiment_id);
+CREATE INDEX ix_experiment_tags_user_id ON experiment_tags (user_id);
+
+
+-- Table: experiment_task_logs
+-- ---------------------------
+CREATE TABLE experiment_task_logs (
+    id INTEGER NOT NULL,
+    category VARCHAR DEFAULT 'TASK' NOT NULL
+        CONSTRAINT "ck_experiment_task_logs_`valid_category`"
+        CHECK (category = 'TASK'),
+    dataset_example_id INTEGER NOT NULL,
+    repetition_number INTEGER NOT NULL,
+    CONSTRAINT pk_experiment_task_logs PRIMARY KEY (id),
+    CONSTRAINT fk_experiment_task_logs_category_experiment_logs
+        FOREIGN KEY (category, id)
+        REFERENCES experiment_logs (category, id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiment_task_logs_dataset_example_id_dataset_examples
+        FOREIGN KEY (dataset_example_id)
+        REFERENCES dataset_examples (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiment_task_logs_dataset_example_id ON experiment_task_logs
+    (dataset_example_id);
+
+
+-- Table: experiments_dataset_examples
+-- -----------------------------------
+CREATE TABLE experiments_dataset_examples (
+    experiment_id INTEGER NOT NULL,
+    dataset_example_id INTEGER NOT NULL,
+    dataset_example_revision_id INTEGER NOT NULL,
+    CONSTRAINT pk_experiments_dataset_examples
+        PRIMARY KEY (experiment_id, dataset_example_id),
+    CONSTRAINT fk_experiments_dataset_examples_dataset_example_id_dataset_examples
+        FOREIGN KEY (dataset_example_id)
+        REFERENCES dataset_examples (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_dataset_examples_dataset_example_revision_id_dataset_example_revisions
+        FOREIGN KEY (dataset_example_revision_id)
+        REFERENCES dataset_example_revisions (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_dataset_examples_experiment_id_experiments
+        FOREIGN KEY (experiment_id)
+        REFERENCES experiments (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiments_dataset_examples_dataset_example_id ON experiments_dataset_examples
+    (dataset_example_id);
+CREATE INDEX ix_experiments_dataset_examples_dataset_example_revision_id ON experiments_dataset_examples
+    (dataset_example_revision_id);
+
+
+-- Table: experiments_dataset_splits
+-- ---------------------------------
+CREATE TABLE experiments_dataset_splits (
+    experiment_id INTEGER NOT NULL,
+    dataset_split_id INTEGER NOT NULL,
+    CONSTRAINT pk_experiments_dataset_splits
+        PRIMARY KEY (experiment_id, dataset_split_id),
+    CONSTRAINT fk_experiments_dataset_splits_dataset_split_id_dataset_splits
+        FOREIGN KEY (dataset_split_id)
+        REFERENCES dataset_splits (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_dataset_splits_experiment_id_experiments
+        FOREIGN KEY (experiment_id)
+        REFERENCES experiments (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiments_dataset_splits_dataset_split_id ON experiments_dataset_splits
+    (dataset_split_id);
+
+
+-- Table: generative_model_custom_providers
+-- ----------------------------------------
+CREATE TABLE generative_model_custom_providers (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    provider VARCHAR NOT NULL,
+    sdk VARCHAR NOT NULL,
+    config BLOB NOT NULL,
+    user_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_generative_model_custom_providers PRIMARY KEY (id),
+    CONSTRAINT uq_generative_model_custom_providers_name UNIQUE (name),
+    CONSTRAINT fk_generative_model_custom_providers_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+
+-- Table: oauth2_authorization_codes
+-- ---------------------------------
+CREATE TABLE oauth2_authorization_codes (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    code_hash VARCHAR NOT NULL,
+    user_id INTEGER NOT NULL,
+    oauth2_client_id INTEGER NOT NULL,
+    redirect_uri VARCHAR NOT NULL,
+    code_challenge VARCHAR NOT NULL,
+    code_challenge_method VARCHAR NOT NULL,
+    scopes JSONB,
+    resource VARCHAR,
+    audience JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_oauth2_authorization_codes_oauth2_client_id_oauth2_clients
+        FOREIGN KEY (oauth2_client_id)
+        REFERENCES oauth2_clients (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_oauth2_authorization_codes_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ix_oauth2_authorization_codes_code_hash ON oauth2_authorization_codes
+    (code_hash);
+CREATE INDEX ix_oauth2_authorization_codes_expires_at ON oauth2_authorization_codes
+    (expires_at);
+
+
+-- Table: oauth2_grants
+-- --------------------
+CREATE TABLE oauth2_grants (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    oauth2_client_id INTEGER NOT NULL,
+    scopes JSONB,
+    audience JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP,
+    last_used_at TIMESTAMP,
+    revoked_at TIMESTAMP,
+    CONSTRAINT fk_oauth2_grants_oauth2_client_id_oauth2_clients
+        FOREIGN KEY (oauth2_client_id)
+        REFERENCES oauth2_clients (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_oauth2_grants_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_oauth2_grants_oauth2_client_id ON oauth2_grants (oauth2_client_id);
+CREATE INDEX ix_oauth2_grants_user_id ON oauth2_grants (user_id);
+
+
+-- Table: password_reset_tokens
+-- ----------------------------
+CREATE TABLE password_reset_tokens (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_password_reset_tokens_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_password_reset_tokens_expires_at ON password_reset_tokens (expires_at);
+CREATE UNIQUE INDEX ix_password_reset_tokens_user_id ON password_reset_tokens (user_id);
+
+
+-- Table: project_session_annotations
+-- ----------------------------------
+CREATE TABLE project_session_annotations (
+    id INTEGER NOT NULL,
+    project_session_id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    label VARCHAR,
+    score FLOAT,
+    explanation VARCHAR,
+    metadata JSONB NOT NULL,
+    annotator_kind VARCHAR NOT NULL
+        CONSTRAINT "ck_project_session_annotations_`valid_annotator_kind`"
+        CHECK (annotator_kind IN ('LLM', 'CODE', 'HUMAN')),
+    user_id INTEGER,
+    identifier VARCHAR DEFAULT '' NOT NULL,
+    source VARCHAR NOT NULL
+        CONSTRAINT "ck_project_session_annotations_`valid_source`"
+        CHECK (source IN ('API', 'APP')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_project_session_annotations PRIMARY KEY (id),
+    CONSTRAINT uq_project_session_annotations_name_project_session_id_identifier
+        UNIQUE (name, project_session_id, identifier),
+    CONSTRAINT fk_project_session_annotations_project_session_id_project_sessions
+        FOREIGN KEY (project_session_id)
+        REFERENCES project_sessions (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_project_session_annotations_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_project_session_annotations_project_session_id ON project_session_annotations
+    (project_session_id);
+CREATE INDEX ix_project_session_annotations_user_id ON project_session_annotations
+    (user_id);
+
+
+-- Table: prompt_versions
+-- ----------------------
+CREATE TABLE prompt_versions (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    prompt_id INTEGER NOT NULL,
+    description VARCHAR,
+    user_id INTEGER,
+    template_type VARCHAR NOT NULL,
+    template_format VARCHAR NOT NULL,
+    template JSONB NOT NULL,
+    invocation_parameters JSONB NOT NULL,
+    tools JSON,
+    response_format JSON,
+    model_provider VARCHAR NOT NULL,
+    model_name VARCHAR NOT NULL,
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    custom_provider_id INTEGER,
+    CONSTRAINT "ck_prompt_versions_`template_format`"
+        CHECK (template_format IN ('F_STRING', 'MUSTACHE', 'NONE')),
+    CONSTRAINT "ck_prompt_versions_`template_type`"
+        CHECK (template_type IN ('CHAT', 'STR')),
+    CONSTRAINT fk_prompt_versions_custom_provider_id_generative_model_custom_providers
+        FOREIGN KEY (custom_provider_id)
+        REFERENCES generative_model_custom_providers (id)
+        ON DELETE SET NULL,
+    CONSTRAINT fk_prompt_versions_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
+        REFERENCES prompts (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_prompt_versions_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_prompt_versions_custom_provider_id ON prompt_versions
+    (custom_provider_id);
+CREATE INDEX ix_prompt_versions_prompt_id ON prompt_versions (prompt_id);
+CREATE INDEX ix_prompt_versions_user_id ON prompt_versions (user_id);
+
+
+-- Table: experiment_prompt_tasks
+-- ------------------------------
+CREATE TABLE experiment_prompt_tasks (
+    id INTEGER NOT NULL,
+    type VARCHAR DEFAULT 'PROMPT' NOT NULL
+        CONSTRAINT "ck_experiment_prompt_tasks_`valid_type`"
+        CHECK (type = 'PROMPT'),
+    prompt_version_id INTEGER,
+    model_provider VARCHAR NOT NULL,
+    model_name VARCHAR NOT NULL,
+    custom_provider_id INTEGER,
+    template_type VARCHAR NOT NULL,
+    template_format VARCHAR NOT NULL,
+    template JSONB NOT NULL,
+    tools JSONB,
+    response_format JSONB,
+    invocation_parameters JSONB DEFAULT '{}' NOT NULL,
+    connection JSONB,
+    playground_config JSONB,
+    stream_model_output BOOLEAN DEFAULT '1' NOT NULL,
+    CONSTRAINT pk_experiment_prompt_tasks PRIMARY KEY (id),
+    CONSTRAINT "ck_experiment_prompt_tasks_`custom_provider_or_connection`"
+        CHECK (NOT (custom_provider_id IS NOT NULL AND connection IS NOT NULL)),
+    CONSTRAINT fk_experiment_prompt_tasks_custom_provider_id_generative_model_custom_providers
+        FOREIGN KEY (custom_provider_id)
+        REFERENCES generative_model_custom_providers (id)
+        ON DELETE SET NULL,
+    CONSTRAINT fk_experiment_prompt_tasks_prompt_version_id_prompt_versions
+        FOREIGN KEY (prompt_version_id)
+        REFERENCES prompt_versions (id)
+        ON DELETE SET NULL,
+    CONSTRAINT fk_experiment_prompt_tasks_type_experiment_jobs
+        FOREIGN KEY (type, id)
+        REFERENCES experiment_jobs (type, id)
+        ON DELETE CASCADE
+);
+
+
+-- Table: prompt_version_tags
+-- --------------------------
+CREATE TABLE prompt_version_tags (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    prompt_id INTEGER NOT NULL,
+    prompt_version_id INTEGER NOT NULL,
+    user_id INTEGER,
+    CONSTRAINT pk_prompt_version_tags PRIMARY KEY (id),
+    CONSTRAINT uq_prompt_version_tags_name_prompt_id UNIQUE (name, prompt_id),
+    CONSTRAINT fk_prompt_version_tags_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
+        REFERENCES prompts (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_prompt_version_tags_prompt_version_id_prompt_versions
+        FOREIGN KEY (prompt_version_id)
+        REFERENCES prompt_versions (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_prompt_version_tags_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_prompt_version_tags_prompt_id ON prompt_version_tags (prompt_id);
+CREATE INDEX ix_prompt_version_tags_prompt_version_id ON prompt_version_tags
+    (prompt_version_id);
+CREATE INDEX ix_prompt_version_tags_user_id ON prompt_version_tags (user_id);
+
+
+-- Table: llm_evaluators
+-- ---------------------
+CREATE TABLE llm_evaluators (
+    id INTEGER NOT NULL,
+    kind VARCHAR DEFAULT 'LLM' NOT NULL
+        CONSTRAINT "ck_llm_evaluators_`valid_evaluator_kind`"
+        CHECK (kind = 'LLM'),
+    prompt_id INTEGER NOT NULL,
+    prompt_version_tag_id INTEGER,
+    output_configs JSONB NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_llm_evaluators PRIMARY KEY (id),
+    CONSTRAINT fk_llm_evaluators_kind_evaluators
+        FOREIGN KEY (kind, id)
+        REFERENCES evaluators (kind, id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_llm_evaluators_prompt_id_prompts
+        FOREIGN KEY (prompt_id)
+        REFERENCES prompts (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_llm_evaluators_prompt_version_tag_id_prompt_version_tags
+        FOREIGN KEY (prompt_version_tag_id)
+        REFERENCES prompt_version_tags (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_llm_evaluators_prompt_id ON llm_evaluators (prompt_id);
+CREATE INDEX ix_llm_evaluators_prompt_version_tag_id ON llm_evaluators
+    (prompt_version_tag_id);
+
+
+-- Table: refresh_tokens
+-- ---------------------
+CREATE TABLE refresh_tokens (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    oauth2_grant_id INTEGER,
+    scopes JSONB,
+    audience JSONB,
+    consumed_at TIMESTAMP,
+    CONSTRAINT fk_refresh_tokens_oauth2_grant_id_oauth2_grants
+        FOREIGN KEY (oauth2_grant_id)
+        REFERENCES oauth2_grants (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_refresh_tokens_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_refresh_tokens_expires_at ON refresh_tokens (expires_at);
+CREATE INDEX ix_refresh_tokens_oauth2_grant_id ON refresh_tokens (oauth2_grant_id);
+CREATE INDEX ix_refresh_tokens_user_id ON refresh_tokens (user_id);
+
+
+-- Table: access_tokens
+-- --------------------
+CREATE TABLE access_tokens (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    refresh_token_id INTEGER NOT NULL,
+    scopes JSONB,
+    audience JSONB,
+    CONSTRAINT fk_access_tokens_refresh_token_id_refresh_tokens
+        FOREIGN KEY (refresh_token_id)
+        REFERENCES refresh_tokens (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_access_tokens_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_access_tokens_expires_at ON access_tokens (expires_at);
+CREATE UNIQUE INDEX ix_access_tokens_refresh_token_id ON access_tokens
+    (refresh_token_id);
+CREATE INDEX ix_access_tokens_user_id ON access_tokens (user_id);
+
+
+-- Table: sandbox_providers
+-- ------------------------
+CREATE TABLE sandbox_providers (
+    backend_type VARCHAR NOT NULL,
+    enabled BOOLEAN NOT NULL,
+    config JSONB DEFAULT '{}' NOT NULL,
+    user_id INTEGER,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_sandbox_providers PRIMARY KEY (backend_type),
+    CONSTRAINT fk_sandbox_providers_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_sandbox_providers_user_id ON sandbox_providers (user_id);
+
+
+-- Table: sandbox_configs
+-- ----------------------
+CREATE TABLE sandbox_configs (
+    id INTEGER NOT NULL,
+    backend_type VARCHAR NOT NULL,
+    language VARCHAR NOT NULL,
+    name VARCHAR NOT NULL,
+    description VARCHAR,
+    config JSONB DEFAULT '{}' NOT NULL,
+    timeout INTEGER NOT NULL,
+    enabled BOOLEAN DEFAULT true NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    user_id INTEGER,
+    CONSTRAINT pk_sandbox_configs PRIMARY KEY (id),
+    CONSTRAINT uq_sandbox_configs_backend_type_name UNIQUE (backend_type, name),
+    CONSTRAINT uq_sandbox_configs_language_id UNIQUE (language, id),
+    CONSTRAINT fk_sandbox_configs_backend_type_sandbox_providers
+        FOREIGN KEY (backend_type)
+        REFERENCES sandbox_providers (backend_type)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_sandbox_configs_language_languages
+        FOREIGN KEY (language)
+        REFERENCES languages (name)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_sandbox_configs_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_sandbox_configs_user_id ON sandbox_configs (user_id);
+
+
+-- Table: code_evaluators
+-- ----------------------
+CREATE TABLE code_evaluators (
+    id INTEGER NOT NULL,
+    kind VARCHAR DEFAULT 'CODE' NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    language VARCHAR NOT NULL,
+    input_mapping JSONB DEFAULT '{"literal_mapping": {}, "path_mapping": {}}' NOT NULL,
+    output_configs JSONB DEFAULT '[]' NOT NULL,
+    sandbox_config_id INTEGER,
+    CONSTRAINT pk_code_evaluators PRIMARY KEY (id),
+    CONSTRAINT "ck_code_evaluators_`valid_evaluator_kind`" CHECK (kind = 'CODE'),
+    CONSTRAINT fk_code_evaluators_kind_evaluators
+        FOREIGN KEY (kind, id)
+        REFERENCES evaluators (kind, id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_code_evaluators_language_languages
+        FOREIGN KEY (language)
+        REFERENCES languages (name)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_code_evaluators_sandbox_config_id_sandbox_configs
+        FOREIGN KEY (sandbox_config_id)
+        REFERENCES sandbox_configs (id)
+        ON DELETE SET NULL,
+    CONSTRAINT fk_code_evaluators_sandbox_config_language
+        FOREIGN KEY (sandbox_config_id, language)
+        REFERENCES sandbox_configs (id, language)
+);
+
+CREATE INDEX ix_code_evaluators_language ON code_evaluators (language);
+CREATE INDEX ix_code_evaluators_sandbox_config_id ON code_evaluators
+    (sandbox_config_id);
+
+
+-- Table: code_evaluator_code_versions
+-- -----------------------------------
+CREATE TABLE code_evaluator_code_versions (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    code_evaluator_id INTEGER NOT NULL,
+    user_id INTEGER,
+    source_code VARCHAR DEFAULT '' NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT fk_code_evaluator_code_versions_code_evaluator_id_code_evaluators
+        FOREIGN KEY (code_evaluator_id)
+        REFERENCES code_evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_code_evaluator_code_versions_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_code_evaluator_code_versions_code_evaluator_id_id ON code_evaluator_code_versions
+    (code_evaluator_id, id);
+CREATE INDEX ix_code_evaluator_code_versions_user_id ON code_evaluator_code_versions
+    (user_id);
+
+
+-- Table: secrets
+-- --------------
+CREATE TABLE secrets (
+    "key" VARCHAR NOT NULL,
+    value BLOB NOT NULL,
+    user_id INTEGER,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_secrets PRIMARY KEY ("key"),
+    CONSTRAINT fk_secrets_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+
+-- Table: span_annotations
+-- -----------------------
+CREATE TABLE span_annotations (
+    id INTEGER NOT NULL,
+    span_rowid INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    label VARCHAR,
+    score FLOAT,
+    explanation VARCHAR,
+    metadata JSONB NOT NULL,
+    annotator_kind VARCHAR NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id INTEGER,
+    identifier VARCHAR DEFAULT ('') NOT NULL,
+    source VARCHAR NOT NULL,
+    CONSTRAINT pk_span_annotations PRIMARY KEY (id),
+    CONSTRAINT uq_span_annotations_name_span_rowid_identifier
+        UNIQUE (name, span_rowid, identifier),
+    CONSTRAINT "ck_span_annotations_`valid_annotator_kind`"
+        CHECK (annotator_kind IN ('LLM', 'CODE', 'HUMAN')),
+    CONSTRAINT "ck_span_annotations_`valid_source`" CHECK (source IN ('API', 'APP')),
+    CONSTRAINT fk_span_annotations_span_rowid_spans
+        FOREIGN KEY (span_rowid)
+        REFERENCES spans (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_span_annotations_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_span_annotations_span_rowid ON span_annotations (span_rowid);
+CREATE INDEX ix_span_annotations_user_id ON span_annotations (user_id);
+
+
+-- Table: system_settings
+-- ----------------------
+CREATE TABLE system_settings (
+    "key" VARCHAR NOT NULL,
+    value JSONB NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by INTEGER,
+    CONSTRAINT pk_system_settings PRIMARY KEY ("key"),
+    CONSTRAINT fk_system_settings_updated_by_users
+        FOREIGN KEY (updated_by)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_system_settings_updated_at ON system_settings (updated_at);
+
+
+-- Table: trace_annotations
+-- ------------------------
+CREATE TABLE trace_annotations (
+    id INTEGER NOT NULL,
+    trace_rowid INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    label VARCHAR,
+    score FLOAT,
+    explanation VARCHAR,
+    metadata JSONB NOT NULL,
+    annotator_kind VARCHAR NOT NULL,
+    created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id INTEGER,
+    identifier VARCHAR DEFAULT ('') NOT NULL,
+    source VARCHAR NOT NULL,
+    CONSTRAINT pk_trace_annotations PRIMARY KEY (id),
+    CONSTRAINT uq_trace_annotations_name_trace_rowid_identifier
+        UNIQUE (name, trace_rowid, identifier),
+    CONSTRAINT "ck_trace_annotations_`valid_annotator_kind`"
+        CHECK (annotator_kind IN ('LLM', 'CODE', 'HUMAN')),
+    CONSTRAINT "ck_trace_annotations_`valid_source`" CHECK (source IN ('API', 'APP')),
+    CONSTRAINT fk_trace_annotations_trace_rowid_traces
+        FOREIGN KEY (trace_rowid)
+        REFERENCES traces (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_trace_annotations_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE SET NULL
+);
+
+CREATE INDEX ix_trace_annotations_trace_rowid ON trace_annotations (trace_rowid);
+CREATE INDEX ix_trace_annotations_user_id ON trace_annotations (user_id);


### PR DESCRIPTION
## Summary
- Add a deterministic SQLite schema generator alongside the PostgreSQL generator.
- Compare the two generated schemas so table, column, index, and constraint drift fails generation.
- Preserve PostgreSQL CHECK-constraint names when regenerating the existing asset.

## Validation
- `make schema-ddl`
- SQLite replay and fidelity checks
- Cross-dialect schema comparison