### PR TITLE
refactor(agents): move agent identity from the URL to the chat body

### DIFF
--- a/app/src/agent/chat/agentChatApi.ts
+++ b/app/src/agent/chat/agentChatApi.ts
@@ -2,10 +2,9 @@ import type { components, paths } from "@phoenix/api/__generated__/v1";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
 const CHAT_PATH_TEMPLATE =
-  "/v1/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof paths;
+  "/v1/agent_sessions/{session_id}/chat" satisfies keyof paths;
 const COMPACT_PATH_TEMPLATE =
-  "/v1/agents/{agent_id}/sessions/{session_id}/compact" satisfies keyof paths;
-const ASSISTANT_AGENT_ID = "assistant";
+  "/v1/agent_sessions/{session_id}/compact" satisfies keyof paths;
 
 /**
  * The `code` discriminator of every HTTP 409 the agent session routes return,
@@ -74,18 +73,12 @@ export function parseAgentSessionConflictCode(
 
 export function buildAgentChatApiUrl(sessionId: string): string {
   return prependBasename(
-    CHAT_PATH_TEMPLATE.replace("{agent_id}", ASSISTANT_AGENT_ID).replace(
-      "{session_id}",
-      encodeURIComponent(sessionId)
-    )
+    CHAT_PATH_TEMPLATE.replace("{session_id}", encodeURIComponent(sessionId))
   );
 }
 
 export function buildAgentCompactApiUrl(sessionId: string): string {
   return prependBasename(
-    COMPACT_PATH_TEMPLATE.replace("{agent_id}", ASSISTANT_AGENT_ID).replace(
-      "{session_id}",
-      encodeURIComponent(sessionId)
-    )
+    COMPACT_PATH_TEMPLATE.replace("{session_id}", encodeURIComponent(sessionId))
   );
 }

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -167,6 +167,7 @@ export function buildAgentChatRequestBody({
   const base = {
     ...body,
     id,
+    userAgent: "web" as const,
     ingestTraces: traceRecording.ingestTraces,
     exportRemoteTraces: traceRecording.exportRemoteTraces,
     attachUserId: getEffectiveAttachUserId({ agentsConfig, observability }),

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -167,7 +167,7 @@ export function buildAgentChatRequestBody({
   const base = {
     ...body,
     id,
-    userAgent: "web" as const,
+    userAgentType: "web" as const,
     ingestTraces: traceRecording.ingestTraces,
     exportRemoteTraces: traceRecording.exportRemoteTraces,
     attachUserId: getEffectiveAttachUserId({ agentsConfig, observability }),

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1591,7 +1591,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions": {
+    "/v1/agent_sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -1615,7 +1615,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agent_sessions/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1639,7 +1639,7 @@ export interface paths {
         patch: operations["patchAgentSession"];
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agent_sessions/{session_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -1659,7 +1659,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agent_sessions/{session_id}/compact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1676,7 +1676,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agent_sessions/{session_id}/chat": {
         parameters: {
             query?: never;
             header?: never;
@@ -2191,6 +2191,12 @@ export interface components {
              * @default false
              */
             attachUserId?: boolean;
+            /**
+             * Useragent
+             * @description Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
+             * @enum {string}
+             */
+            userAgent: "web" | "headless";
             /** Contexts */
             contexts?: components["schemas"]["ChatContext"][];
             /**
@@ -2204,7 +2210,7 @@ export interface components {
              * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
              */
             requestedSkills?: string[];
-            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. */
+            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../agent_sessions/{session_id}``. */
             model: components["schemas"]["AgentModelSelection"];
             /**
              * Trigger
@@ -11851,9 +11857,7 @@ export interface operations {
                 limit?: number;
             };
             header?: never;
-            path: {
-                agent_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -11909,9 +11913,7 @@ export interface operations {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                agent_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody: {
@@ -11990,7 +11992,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12049,7 +12050,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12143,7 +12143,6 @@ export interface operations {
             };
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12202,7 +12201,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12301,7 +12299,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -2192,11 +2192,11 @@ export interface components {
              */
             attachUserId?: boolean;
             /**
-             * Useragent
-             * @description Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
+             * Useragenttype
+             * @description Which Phoenix user agent type is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
              * @enum {string}
              */
-            userAgent: "web" | "headless";
+            userAgentType: "web" | "headless";
             /** Contexts */
             contexts?: components["schemas"]["ChatContext"][];
             /**

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -93,8 +93,9 @@ pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
 ```
 
 <Note>
-The terminal client talks to the same `/agents/server` endpoint as the browser
-agent, so it requires a running Phoenix server with a configured model provider.
+The terminal client talks to the same `/agent_sessions` endpoints as the
+browser agent (sending `userAgent: "headless"` on its chat turns), so it
+requires a running Phoenix server with a configured model provider.
 On launch it runs a preflight check against the server's model catalog and
 credentials, surfacing configuration problems as a clean error before the chat
 opens.

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -94,7 +94,7 @@ pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
 
 <Note>
 The terminal client talks to the same `/agent_sessions` endpoints as the
-browser agent (sending `userAgent: "headless"` on its chat turns), so it
+browser agent (sending `userAgentType: "headless"` on its chat turns), so it
 requires a running Phoenix server with a configured model provider.
 On launch it runs a preflight check against the server's model catalog and
 credentials, surfacing configuration problems as a clean error before the chat

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -29,8 +29,9 @@ import type {
 } from "./types";
 
 const AGENT_SESSION_CHAT_PATH =
-  "/v1/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof pathsV1;
-const SERVER_AGENT_ID = "server";
+  "/v1/agent_sessions/{session_id}/chat" satisfies keyof pathsV1;
+/** The CLI drives the headless agent; sent as the chat body's `userAgent`. */
+const HEADLESS_USER_AGENT = "headless" as const;
 const AGENT_SESSION_PAGE_LIMIT = 100;
 /**
  * The `code` discriminator of every HTTP 409 the agent session routes return.
@@ -139,9 +140,9 @@ export function buildAgentSessionChatUrl({
   agentSessionId: string;
 }): string {
   const path = AGENT_SESSION_CHAT_PATH.replace(
-    "{agent_id}",
-    SERVER_AGENT_ID
-  ).replace("{session_id}", encodeURIComponent(agentSessionId));
+    "{session_id}",
+    encodeURIComponent(agentSessionId)
+  );
   return `${trimTrailingSlash(endpoint)}${path}`;
 }
 
@@ -173,13 +174,9 @@ export async function createAgentSession({
   const client = createPhoenixClient({ config, fetch: fetchImpl });
   let agentSessionId: string | undefined;
   try {
-    const { data: payload } = await client.POST(
-      "/v1/agents/{agent_id}/sessions",
-      {
-        params: { path: { agent_id: SERVER_AGENT_ID } },
-        body: { title: "", is_ephemeral: temporary, model },
-      }
-    );
+    const { data: payload } = await client.POST("/v1/agent_sessions", {
+      body: { title: "", is_ephemeral: temporary, model },
+    });
     agentSessionId = payload?.data.id;
   } catch (error) {
     if (error instanceof HttpError) {
@@ -218,10 +215,10 @@ async function fetchAgentSessionMessagesPage({
   cursor: string | null;
 }): Promise<{ messages: PxiMessage[]; nextCursor: string | null }> {
   const { data: payload } = await client.GET(
-    "/v1/agents/{agent_id}/sessions/{session_id}/messages",
+    "/v1/agent_sessions/{session_id}/messages",
     {
       params: {
-        path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+        path: { session_id: sessionId },
         query: cursor === null ? {} : { cursor },
       },
     }
@@ -258,15 +255,11 @@ export function createPxiSessionClient({
       const sessions: PxiSessionSummary[] = [];
       let cursor: string | undefined;
       do {
-        const { data: payload } = await client.GET(
-          "/v1/agents/{agent_id}/sessions",
-          {
-            params: {
-              path: { agent_id: SERVER_AGENT_ID },
-              query: { cursor, limit: AGENT_SESSION_PAGE_LIMIT },
-            },
-          }
-        );
+        const { data: payload } = await client.GET("/v1/agent_sessions", {
+          params: {
+            query: { cursor, limit: AGENT_SESSION_PAGE_LIMIT },
+          },
+        });
         if (!payload) {
           throw new Error(
             "Could not load PXI sessions because Phoenix returned no data."
@@ -289,10 +282,10 @@ export function createPxiSessionClient({
     async getSession({ sessionId }) {
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       const { data: payload } = await client.GET(
-        "/v1/agents/{agent_id}/sessions/{session_id}",
+        "/v1/agent_sessions/{session_id}",
         {
           params: {
-            path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+            path: { session_id: sessionId },
           },
         }
       );
@@ -330,10 +323,10 @@ export function createPxiSessionClient({
     async getSessionSyncState({ sessionId }): Promise<PxiSessionSyncState> {
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       const { data: payload } = await client.GET(
-        "/v1/agents/{agent_id}/sessions/{session_id}",
+        "/v1/agent_sessions/{session_id}",
         {
           params: {
-            path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+            path: { session_id: sessionId },
           },
         }
       );
@@ -354,10 +347,10 @@ export function createPxiSessionClient({
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       try {
         const { data: payload } = await client.PATCH(
-          "/v1/agents/{agent_id}/sessions/{session_id}",
+          "/v1/agent_sessions/{session_id}",
           {
             params: {
-              path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+              path: { session_id: sessionId },
             },
             body: { model },
           }
@@ -382,10 +375,10 @@ export function createPxiSessionClient({
       const client = createPhoenixClient({ config, fetch: fetchImpl });
       try {
         const { data: payload } = await client.POST(
-          "/v1/agents/{agent_id}/sessions/{session_id}/compact",
+          "/v1/agent_sessions/{session_id}/compact",
           {
             params: {
-              path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+              path: { session_id: sessionId },
             },
             body: { model },
           }
@@ -533,6 +526,7 @@ function buildPxiRequestBase({ options }: { options: PxiRuntimeOptions }) {
   return {
     id: options.sessionId,
     trigger: "submit-message" as const,
+    userAgent: HEADLESS_USER_AGENT,
     ingestTraces: options.ingestTraces,
     exportRemoteTraces: options.exportRemoteTraces,
     attachUserId: options.attachUserId,

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -30,8 +30,8 @@ import type {
 
 const AGENT_SESSION_CHAT_PATH =
   "/v1/agent_sessions/{session_id}/chat" satisfies keyof pathsV1;
-/** The CLI drives the headless agent; sent as the chat body's `userAgent`. */
-const HEADLESS_USER_AGENT = "headless" as const;
+/** The CLI drives the headless agent; sent as the chat body's `userAgentType`. */
+const HEADLESS_USER_AGENT_TYPE = "headless" as const;
 const AGENT_SESSION_PAGE_LIMIT = 100;
 /**
  * The `code` discriminator of every HTTP 409 the agent session routes return.
@@ -526,7 +526,7 @@ function buildPxiRequestBase({ options }: { options: PxiRuntimeOptions }) {
   return {
     id: options.sessionId,
     trigger: "submit-message" as const,
-    userAgent: HEADLESS_USER_AGENT,
+    userAgentType: HEADLESS_USER_AGENT_TYPE,
     ingestTraces: options.ingestTraces,
     exportRemoteTraces: options.exportRemoteTraces,
     attachUserId: options.attachUserId,

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -193,7 +193,7 @@ describe("PXI client", () => {
         agentSessionId: "QWdlbnRTZXNzaW9uOjE=",
       })
     ).toBe(
-      "http://localhost:6006/v1/agents/server/sessions/QWdlbnRTZXNzaW9uOjE%3D/chat"
+      "http://localhost:6006/v1/agent_sessions/QWdlbnRTZXNzaW9uOjE%3D/chat"
     );
   });
 
@@ -332,7 +332,7 @@ describe("PXI client", () => {
     });
     expect(session.lastMessageId).toBe("user-1");
     expect(requestUrl(fetchImpl.mock.calls[2])).toBe(
-      "http://localhost:6006/v1/agents/server/sessions/session-1/messages"
+      "http://localhost:6006/v1/agent_sessions/session-1/messages"
     );
   });
 
@@ -454,10 +454,10 @@ describe("PXI client", () => {
     ]);
     expect(session.lastMessageId).toBe("assistant-1");
     expect(requestUrl(fetchImpl.mock.calls[1])).toBe(
-      "http://localhost:6006/v1/agents/server/sessions/session-1/messages"
+      "http://localhost:6006/v1/agent_sessions/session-1/messages"
     );
     expect(requestUrl(fetchImpl.mock.calls[2])).toBe(
-      "http://localhost:6006/v1/agents/server/sessions/session-1/messages?cursor=cursor-1"
+      "http://localhost:6006/v1/agent_sessions/session-1/messages?cursor=cursor-1"
     );
   });
 
@@ -473,7 +473,7 @@ describe("PXI client", () => {
         const request =
           _input instanceof Request ? _input : new Request(_input, init);
         expect(request.url).toBe(
-          "http://localhost:6006/v1/agents/server/sessions/session-1/compact"
+          "http://localhost:6006/v1/agent_sessions/session-1/compact"
         );
         expect(request.method).toBe("POST");
         expect(await request.json()).toEqual({

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1591,7 +1591,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions": {
+    "/v1/agent_sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -1615,7 +1615,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agent_sessions/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1639,7 +1639,7 @@ export interface paths {
         patch: operations["patchAgentSession"];
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agent_sessions/{session_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -1659,7 +1659,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agent_sessions/{session_id}/compact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1676,7 +1676,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agent_sessions/{session_id}/chat": {
         parameters: {
             query?: never;
             header?: never;
@@ -2191,6 +2191,12 @@ export interface components {
              * @default false
              */
             attachUserId?: boolean;
+            /**
+             * Useragent
+             * @description Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
+             * @enum {string}
+             */
+            userAgent: "web" | "headless";
             /** Contexts */
             contexts?: components["schemas"]["ChatContext"][];
             /**
@@ -2204,7 +2210,7 @@ export interface components {
              * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
              */
             requestedSkills?: string[];
-            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. */
+            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../agent_sessions/{session_id}``. */
             model: components["schemas"]["AgentModelSelection"];
             /**
              * Trigger
@@ -11851,9 +11857,7 @@ export interface operations {
                 limit?: number;
             };
             header?: never;
-            path: {
-                agent_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -11909,9 +11913,7 @@ export interface operations {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                agent_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody: {
@@ -11990,7 +11992,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12049,7 +12050,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12143,7 +12143,6 @@ export interface operations {
             };
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12202,7 +12201,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12301,7 +12299,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2192,11 +2192,11 @@ export interface components {
              */
             attachUserId?: boolean;
             /**
-             * Useragent
-             * @description Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
+             * Useragenttype
+             * @description Which Phoenix user agent type is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
              * @enum {string}
              */
-            userAgent: "web" | "headless";
+            userAgentType: "web" | "headless";
             /** Contexts */
             contexts?: components["schemas"]["ChatContext"][];
             /**

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -141,21 +141,21 @@ export const ADD_SESSION_NOTE_IDENTIFIER: ParameterRequirement = {
 export const AGENT_SESSION_CREATE: RouteRequirement = {
   kind: "route",
   method: "POST",
-  path: "/v1/agents/{agent_id}/sessions",
+  path: "/v1/agent_sessions",
   minServerVersion: [20, 0, 0],
 };
 
 export const AGENT_SESSION_CHAT: RouteRequirement = {
   kind: "route",
   method: "POST",
-  path: "/v1/agents/{agent_id}/sessions/{session_id}/chat",
+  path: "/v1/agent_sessions/{session_id}/chat",
   minServerVersion: [20, 0, 0],
 };
 
 export const AGENT_SESSION_MESSAGES: RouteRequirement = {
   kind: "route",
   method: "GET",
-  path: "/v1/agents/{agent_id}/sessions/{session_id}/messages",
+  path: "/v1/agent_sessions/{session_id}/messages",
   minServerVersion: [20, 0, 0],
 };
 

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1591,7 +1591,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions": {
+    "/v1/agent_sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -1615,7 +1615,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agent_sessions/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1639,7 +1639,7 @@ export interface paths {
         patch: operations["patchAgentSession"];
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agent_sessions/{session_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -1659,7 +1659,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agent_sessions/{session_id}/compact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1676,7 +1676,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agent_sessions/{session_id}/chat": {
         parameters: {
             query?: never;
             header?: never;
@@ -2191,6 +2191,12 @@ export interface components {
              * @default false
              */
             attachUserId?: boolean;
+            /**
+             * Useragent
+             * @description Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
+             * @enum {string}
+             */
+            userAgent: "web" | "headless";
             /** Contexts */
             contexts?: components["schemas"]["ChatContext"][];
             /**
@@ -2204,7 +2210,7 @@ export interface components {
              * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
              */
             requestedSkills?: string[];
-            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``. */
+            /** @description The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on — or switching to — an unexpected model. Change the session's model with ``PATCH .../agent_sessions/{session_id}``. */
             model: components["schemas"]["AgentModelSelection"];
             /**
              * Trigger
@@ -11851,9 +11857,7 @@ export interface operations {
                 limit?: number;
             };
             header?: never;
-            path: {
-                agent_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -11909,9 +11913,7 @@ export interface operations {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                agent_id: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody: {
@@ -11990,7 +11992,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12049,7 +12050,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12143,7 +12143,6 @@ export interface operations {
             };
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12202,7 +12201,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;
@@ -12301,7 +12299,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_id: string;
                 session_id: string;
             };
             cookie?: never;

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -2192,11 +2192,11 @@ export interface components {
              */
             attachUserId?: boolean;
             /**
-             * Useragent
-             * @description Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
+             * Useragenttype
+             * @description Which Phoenix user agent type is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on.
              * @enum {string}
              */
-            userAgent: "web" | "headless";
+            userAgentType: "web" | "headless";
             /** Contexts */
             contexts?: components["schemas"]["ChatContext"][];
             /**

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -2047,6 +2047,7 @@ class PromptMessage(TypedDict):
 
 
 class ChatRequest(TypedDict):
+    userAgent: Literal["web", "headless"]
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
     id: str
     ingestTraces: NotRequired[bool]

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -2047,7 +2047,7 @@ class PromptMessage(TypedDict):
 
 
 class ChatRequest(TypedDict):
-    userAgent: Literal["web", "headless"]
+    userAgentType: Literal["web", "headless"]
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
     id: str
     ingestTraces: NotRequired[bool]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   # Code-mode sandbox. Direct, not via fastmcp's `code-mode` extra, whose ==0.0.17 pin conflicts and would ship in wheel metadata.
   "pydantic-monty==0.0.19",
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
-  "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.17.0,<3",
+  "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.26.0,<3",
   "bashkit>=0.10.0,!=0.14.2",  # 0.14.2 shipped no sdist and only cp310/cp311 wheels, breaking installs on 3.14; see https://pypi.org/project/bashkit/0.14.2/
   "authlib>=1.7.0",
   "joserfc",

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -10067,14 +10067,14 @@
             "description": "When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.",
             "default": false
           },
-          "userAgent": {
+          "userAgentType": {
             "type": "string",
             "enum": [
               "web",
               "headless"
             ],
-            "title": "Useragent",
-            "description": "Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on."
+            "title": "Useragenttype",
+            "description": "Which Phoenix user agent type is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on."
           },
           "contexts": {
             "items": {
@@ -10161,7 +10161,7 @@
         },
         "type": "object",
         "required": [
-          "userAgent",
+          "userAgentType",
           "model",
           "id"
         ],

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8242,7 +8242,7 @@
         }
       }
     },
-    "/v1/agents/{agent_id}/sessions": {
+    "/v1/agent_sessions": {
       "post": {
         "tags": [
           "chat"
@@ -8250,17 +8250,6 @@
         "summary": "Create Session",
         "description": "Create a persisted agent session owned by the requesting user.",
         "operationId": "createAgentSession",
-        "parameters": [
-          {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          }
-        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -8353,15 +8342,6 @@
         "operationId": "listAgentSessions",
         "parameters": [
           {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          },
-          {
             "name": "cursor",
             "in": "query",
             "required": false,
@@ -8446,7 +8426,7 @@
         }
       }
     },
-    "/v1/agents/{agent_id}/sessions/{session_id}": {
+    "/v1/agent_sessions/{session_id}": {
       "patch": {
         "tags": [
           "chat"
@@ -8455,15 +8435,6 @@
         "description": "Update a persisted session's mutable fields.",
         "operationId": "patchAgentSession",
         "parameters": [
-          {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -8576,15 +8547,6 @@
         "operationId": "getAgentSession",
         "parameters": [
           {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          },
-          {
             "name": "session_id",
             "in": "path",
             "required": true,
@@ -8648,7 +8610,7 @@
         }
       }
     },
-    "/v1/agents/{agent_id}/sessions/{session_id}/messages": {
+    "/v1/agent_sessions/{session_id}/messages": {
       "get": {
         "tags": [
           "chat"
@@ -8657,15 +8619,6 @@
         "description": "Page through an owned session's persisted transcript, oldest first.",
         "operationId": "listAgentSessionMessages",
         "parameters": [
-          {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -8760,7 +8713,7 @@
         }
       }
     },
-    "/v1/agents/{agent_id}/sessions/{session_id}/compact": {
+    "/v1/agent_sessions/{session_id}/compact": {
       "post": {
         "tags": [
           "chat"
@@ -8768,15 +8721,6 @@
         "summary": "Compact Agent Session",
         "operationId": "compactAgentSession",
         "parameters": [
-          {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -8891,7 +8835,7 @@
         }
       }
     },
-    "/v1/agents/{agent_id}/sessions/{session_id}/chat": {
+    "/v1/agent_sessions/{session_id}/chat": {
       "post": {
         "tags": [
           "chat"
@@ -8899,15 +8843,6 @@
         "summary": "Chat",
         "operationId": "agentSessionChat",
         "parameters": [
-          {
-            "name": "agent_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -10132,6 +10067,15 @@
             "description": "When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.",
             "default": false
           },
+          "userAgent": {
+            "type": "string",
+            "enum": [
+              "web",
+              "headless"
+            ],
+            "title": "Useragent",
+            "description": "Which Phoenix user agent is driving the turn: ``web`` for the browser assistant, ``headless`` for terminal and scripted clients. Selects the agent configuration the turn runs on."
+          },
           "contexts": {
             "items": {
               "$ref": "#/components/schemas/ChatContext"
@@ -10158,7 +10102,7 @@
           },
           "model": {
             "$ref": "#/components/schemas/AgentModelSelection",
-            "description": "The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on \u2014 or switching to \u2014 an unexpected model. Change the session's model with ``PATCH .../sessions/{session_id}``."
+            "description": "The model the client believes the session is set to. This is a precondition, not an instruction: the turn always runs on the session's persisted selection, and a mismatch is rejected with HTTP 409 and code ``agent_session_model_stale`` rather than silently running on \u2014 or switching to \u2014 an unexpected model. Change the session's model with ``PATCH .../agent_sessions/{session_id}``."
           },
           "trigger": {
             "type": "string",
@@ -10217,6 +10161,7 @@
         },
         "type": "object",
         "required": [
+          "userAgent",
           "model",
           "id"
         ],

--- a/src/phoenix/db/types/data_stream_protocol/_models.py
+++ b/src/phoenix/db/types/data_stream_protocol/_models.py
@@ -1,5 +1,5 @@
-# Vendored from pydantic-ai v2.17.0:
-# https://github.com/pydantic/pydantic-ai/tree/v2.17.0/pydantic_ai_slim/pydantic_ai/ui/vercel_ai
+# Vendored from pydantic-ai v2.26.0:
+# https://github.com/pydantic/pydantic-ai/tree/v2.26.0/pydantic_ai_slim/pydantic_ai/ui/vercel_ai
 # Copyright (c) Pydantic Services Inc. 2024 to present
 # SPDX-License-Identifier: MIT
 

--- a/src/phoenix/db/types/data_stream_protocol/request_types.py
+++ b/src/phoenix/db/types/data_stream_protocol/request_types.py
@@ -1,10 +1,10 @@
-# Vendored from pydantic-ai v2.17.0:
-# https://github.com/pydantic/pydantic-ai/tree/v2.17.0/pydantic_ai_slim/pydantic_ai/ui/vercel_ai
+# Vendored from pydantic-ai v2.26.0:
+# https://github.com/pydantic/pydantic-ai/tree/v2.26.0/pydantic_ai_slim/pydantic_ai/ui/vercel_ai
 # Copyright (c) Pydantic Services Inc. 2024 to present
 # SPDX-License-Identifier: MIT
 #
 # Kept byte-identical to upstream except for the `result_provider_metadata` field on the four
-# tool output parts, which AI SDK v7 defines but pydantic-ai v2.17.0 does not yet carry. The
+# tool output parts, which AI SDK v7 defines but pydantic-ai v2.26.0 does not yet carry. The
 # divergence is allowlisted in
 # tests/unit/db/types/test_data_stream_protocol_compatibility.py; drop it there once upstream
 # catches up.
@@ -20,7 +20,7 @@ Tool approval types (`ToolApprovalRequested`, `ToolApprovalResponded`) require A
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import Discriminator, Field
+from pydantic import Discriminator, Field, StrictBool
 
 from ._models import CamelBaseModel
 
@@ -136,8 +136,19 @@ class ToolApprovalResponded(CamelBaseModel):
     id: str
     """The approval request ID."""
 
-    approved: bool
-    """Whether the user approved the tool call."""
+    approved: StrictBool
+    """Whether the user approved the tool call.
+
+    Deliberately strict: in Pydantic's default lax mode `{'approved': 1}` or `{'approved': 'true'}`
+    would coerce to an approval, and this field is the client-controlled gate on tools declared
+    `requires_approval=True`. A non-boolean value fails validation — and so rejects the whole
+    request — instead of silently executing the call
+    ([#6922](https://github.com/pydantic/pydantic-ai/issues/6922)).
+
+    `ToolApproval` is an undiscriminated union, so rejecting here only denies because
+    `CamelBaseModel`'s `extra='forbid'` stops the part re-matching `ToolApprovalRequested`
+    (which upstream declares `approved?: never`). Relaxing either would reopen the gate.
+    """
 
     reason: str | None = None
     """Optional reason for the approval or denial."""

--- a/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_agent_wrapper.py
@@ -39,6 +39,7 @@ from pydantic_ai.messages import (
     TextContent,
     TextPart,
     ThinkingPart,
+    ToolAvailabilityDeltaPart,
     ToolCallPart,
     ToolReturnPart,
     UploadedFile,
@@ -236,7 +237,16 @@ def _get_single_text_content(parts: Sequence[ModelRequestPart | ModelResponsePar
     (part,) = parts
     if isinstance(part, TextPart):
         return part.content
-    if isinstance(part, (SystemPromptPart, UserPromptPart, ToolReturnPart, RetryPromptPart)):
+    if isinstance(
+        part,
+        (
+            SystemPromptPart,
+            UserPromptPart,
+            ToolReturnPart,
+            RetryPromptPart,
+            ToolAvailabilityDeltaPart,
+        ),
+    ):
         return _get_text_content_from_model_request_part(part)
     if isinstance(
         part,
@@ -269,7 +279,7 @@ def _get_text_content_from_model_request_part(part: ModelRequestPart) -> str | N
                 return None
             texts.append(text)
         return "\n".join(texts)
-    if isinstance(part, (ToolReturnPart, RetryPromptPart)):
+    if isinstance(part, (ToolReturnPart, RetryPromptPart, ToolAvailabilityDeltaPart)):
         return None
     assert_never(part)
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -258,7 +258,7 @@ def _get_updated_provider_metadata(
 class _CamelBaseModel(BaseModel):
     """Base model with camelCase aliases.
 
-    The wire casing under ``/agents`` is deliberately split: the chat route's
+    The wire casing under ``/agent_sessions`` is deliberately split: the chat route's
     request body and stream chunks extend this class because they follow the
     Vercel AI SDK data stream protocol, which dictates camelCase, while the
     session CRUD payloads extend ``V1RoutesBaseModel`` and keep the REST API's
@@ -331,6 +331,11 @@ class _ObservabilityMixin(_CamelBaseModel):
     )
 
 
+UserAgent = Literal["web", "headless"]
+"""Which Phoenix user agent is driving a chat turn: ``web`` for the browser
+assistant, ``headless`` for terminal and scripted clients."""
+
+
 class _ChatRequestMixin(_ObservabilityMixin):
     """Phoenix-specific extensions added to Vercel AI request messages."""
 
@@ -338,6 +343,13 @@ class _ChatRequestMixin(_ObservabilityMixin):
         protected_namespaces=(),  # allow ``model`` field; pydantic reserves ``model_*``
     )
 
+    user_agent: UserAgent = Field(
+        description=(
+            "Which Phoenix user agent is driving the turn: ``web`` for the "
+            "browser assistant, ``headless`` for terminal and scripted "
+            "clients. Selects the agent configuration the turn runs on."
+        ),
+    )
     contexts: list[ChatContext] = Field(default_factory=list)
     edit_permission: Literal["manual", "bypass"] = "manual"
     requested_skills: list[str] = Field(
@@ -357,7 +369,7 @@ class _ChatRequestMixin(_ObservabilityMixin):
             "HTTP 409 and code ``agent_session_model_stale`` rather than "
             "silently running on — or switching to — an unexpected model. "
             "Change the session's model with "
-            "``PATCH .../sessions/{session_id}``."
+            "``PATCH .../agent_sessions/{session_id}``."
         ),
     )
 
@@ -660,9 +672,6 @@ def _to_pydantic_ai_messages(messages: Sequence[PhoenixUIMessage]) -> list[Model
 
 
 logger = logging.getLogger(__name__)
-
-_ASSISTANT_AGENT_ID = "assistant"
-_SERVER_AGENT_ID = "server"
 
 
 _AsyncGeneratorType = TypeVar("_AsyncGeneratorType")
@@ -2254,7 +2263,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
     router = APIRouter(prefix="/v1", tags=["chat"], dependencies=dependencies)
 
     @router.post(
-        "/agents/{agent_id}/sessions",
+        "/agent_sessions",
         operation_id="createAgentSession",
         status_code=201,
         response_model_by_alias=True,
@@ -2262,15 +2271,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         responses=add_errors_to_responses([400, 401, 403, 404, 422, 507]),
     )
     async def create_session(
-        agent_id: str,
         request: Request,
         request_body: CreateAgentSessionRequestBody,
     ) -> CreateAgentSessionResponseBody:
         """Create a persisted agent session owned by the requesting user."""
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
         try:
             title = validate_agent_session_title(request_body.title, allow_empty=True)
         except ValueError as exc:
@@ -2301,7 +2305,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         )
 
     @router.patch(
-        "/agents/{agent_id}/sessions/{session_id}",
+        "/agent_sessions/{session_id}",
         operation_id="patchAgentSession",
         response_model=PatchAgentSessionResponseBody,
         response_model_by_alias=True,
@@ -2312,16 +2316,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         ),
     )
     async def patch_session(
-        agent_id: str,
         session_id: str,
         request: Request,
         request_body: PatchAgentSessionRequestBody,
     ) -> PatchAgentSessionResponseBody:
         """Update a persisted session's mutable fields."""
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
         if request_body.title is UNDEFINED and request_body.model is UNDEFINED:
             raise HTTPException(status_code=422, detail="No fields to update")
         title: str | None = None
@@ -2364,7 +2363,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         return PatchAgentSessionResponseBody(data=data)
 
     @router.get(
-        "/agents/{agent_id}/sessions",
+        "/agent_sessions",
         operation_id="listAgentSessions",
         response_model_by_alias=True,
         response_model_exclude_unset=True,
@@ -2372,16 +2371,11 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         responses=add_errors_to_responses([401, 403, 404, 422]),
     )
     async def list_sessions(
-        agent_id: str,
         request: Request,
         cursor: str | None = Query(default=None, description="Opaque pagination cursor."),
         limit: int = Query(default=20, gt=0, le=100),
     ) -> ListAgentSessionsResponseBody:
         """List the viewer's persisted sessions, most recently active first."""
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
         statement = select(models.AgentSession).where(models.AgentSession.is_ephemeral.is_(False))
         if (user_id := _get_request_user_id(request)) is not None:
             statement = statement.where(models.AgentSession.user_id == user_id)
@@ -2419,22 +2413,17 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         )
 
     @router.get(
-        "/agents/{agent_id}/sessions/{session_id}",
+        "/agent_sessions/{session_id}",
         operation_id="getAgentSession",
         response_model_by_alias=True,
         response_model_exclude_unset=True,
         responses=add_errors_to_responses([401, 403, 404]),
     )
     async def get_session(
-        agent_id: str,
         session_id: str,
         request: Request,
     ) -> GetAgentSessionResponseBody:
         """Retrieve an owned session's metadata."""
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
         try:
             session_rowid = from_global_id_with_expected_type(
                 GlobalID.from_id(session_id), models.AgentSession.__name__
@@ -2470,7 +2459,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         )
 
     @router.get(
-        "/agents/{agent_id}/sessions/{session_id}/messages",
+        "/agent_sessions/{session_id}/messages",
         operation_id="listAgentSessionMessages",
         response_model_by_alias=True,
         response_model_exclude_unset=True,
@@ -2479,17 +2468,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         responses=add_errors_to_responses([401, 403, 404, 422]),
     )
     async def list_session_messages(
-        agent_id: str,
         session_id: str,
         request: Request,
         cursor: str | None = Query(default=None, description="Opaque pagination cursor."),
         limit: int = Query(default=100, gt=0, le=1000),
     ) -> ListAgentSessionMessagesResponseBody:
         """Page through an owned session's persisted transcript, oldest first."""
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
         try:
             session_rowid = from_global_id_with_expected_type(
                 GlobalID.from_id(session_id), models.AgentSession.__name__
@@ -2525,7 +2509,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         )
 
     @router.post(
-        "/agents/{agent_id}/sessions/{session_id}/compact",
+        "/agent_sessions/{session_id}/compact",
         operation_id="compactAgentSession",
         response_model=CompactAgentSessionResponseBody,
         response_model_exclude_none=True,
@@ -2535,15 +2519,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         ),
     )
     async def compact_agent_session(
-        agent_id: str,
         session_id: str,
         request: Request,
         request_body: CompactAgentSessionRequestBody,
     ) -> CompactAgentSessionResponseBody:
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
         user = request.user if "user" in request.scope else None
         phoenix_user = user if isinstance(user, PhoenixUser) else None
         request_user_id = int(phoenix_user.identity) if phoenix_user is not None else None
@@ -2661,7 +2640,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             )
 
     @router.post(
-        "/agents/{agent_id}/sessions/{session_id}/chat",
+        "/agent_sessions/{session_id}/chat",
         operation_id="agentSessionChat",
         responses=add_errors_to_responses(
             [400, 401, 403, 404, 507],
@@ -2669,15 +2648,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         ),
     )
     async def chat(
-        agent_id: str,
         session_id: str,
         request: Request,
         request_body: ChatRequest,
     ) -> Response:
-        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
-            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
-        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
-            raise HTTPException(status_code=403, detail="Server agent is disabled")
+        if request_body.user_agent == "headless" and get_env_phoenix_agents_disable_bash():
+            raise HTTPException(status_code=403, detail="Headless agent is disabled")
         body = request_body
         db_session_factory: DbSessionFactory = request.app.state.db
         request_received_at = datetime.now(timezone.utc)
@@ -2759,7 +2735,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 tracer_provider = tracer.tracer_provider if tracer is not None else None
                 sandbox_availability = SandboxAvailability()
                 model_provider_availability = ModelProviderAvailability()
-                agent_supports_availability_gate = agent_id == _ASSISTANT_AGENT_ID
+                agent_supports_availability_gate = body.user_agent == "web"
                 async with request.app.state.db() as session:
                     if agent_supports_availability_gate:
                         if _contexts_need_sandbox_availability(resolved_contexts):
@@ -2827,7 +2803,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 [Callable[[AgentRunResult[Any]], AsyncIterator[BaseChunk]]],
                 AsyncIterator[BaseChunk],
             ]
-            if agent_id == _SERVER_AGENT_ID:
+            if body.user_agent == "headless":
                 server_agent = build_server_agent(
                     model=model,
                     schema=request.app.state.graphql_schema,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -331,9 +331,9 @@ class _ObservabilityMixin(_CamelBaseModel):
     )
 
 
-UserAgent = Literal["web", "headless"]
-"""Which Phoenix user agent is driving a chat turn: ``web`` for the browser
-assistant, ``headless`` for terminal and scripted clients."""
+UserAgentType = Literal["web", "headless"]
+"""Which Phoenix user agent type is driving a chat turn: ``web`` for the
+browser assistant, ``headless`` for terminal and scripted clients."""
 
 
 class _ChatRequestMixin(_ObservabilityMixin):
@@ -343,9 +343,9 @@ class _ChatRequestMixin(_ObservabilityMixin):
         protected_namespaces=(),  # allow ``model`` field; pydantic reserves ``model_*``
     )
 
-    user_agent: UserAgent = Field(
+    user_agent_type: UserAgentType = Field(
         description=(
-            "Which Phoenix user agent is driving the turn: ``web`` for the "
+            "Which Phoenix user agent type is driving the turn: ``web`` for the "
             "browser assistant, ``headless`` for terminal and scripted "
             "clients. Selects the agent configuration the turn runs on."
         ),
@@ -2652,7 +2652,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         request: Request,
         request_body: ChatRequest,
     ) -> Response:
-        if request_body.user_agent == "headless" and get_env_phoenix_agents_disable_bash():
+        if request_body.user_agent_type == "headless" and get_env_phoenix_agents_disable_bash():
             raise HTTPException(status_code=403, detail="Headless agent is disabled")
         body = request_body
         db_session_factory: DbSessionFactory = request.app.state.db
@@ -2735,7 +2735,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 tracer_provider = tracer.tracer_provider if tracer is not None else None
                 sandbox_availability = SandboxAvailability()
                 model_provider_availability = ModelProviderAvailability()
-                agent_supports_availability_gate = body.user_agent == "web"
+                agent_supports_availability_gate = body.user_agent_type == "web"
                 async with request.app.state.db() as session:
                     if agent_supports_availability_gate:
                         if _contexts_need_sandbox_availability(resolved_contexts):
@@ -2803,7 +2803,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 [Callable[[AgentRunResult[Any]], AsyncIterator[BaseChunk]]],
                 AsyncIterator[BaseChunk],
             ]
-            if body.user_agent == "headless":
+            if body.user_agent_type == "headless":
                 server_agent = build_server_agent(
                     model=model,
                     schema=request.app.state.graphql_schema,

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -1990,7 +1990,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_client = _httpx_client(_app, member.tokens)
         admin_client = _httpx_client(_app, admin.tokens)
         member_session_response = member_client.post(
-            "v1/agents/assistant/sessions",
+            "v1/agent_sessions",
             json={
                 "title": "Member session",
                 "is_ephemeral": False,
@@ -2004,7 +2004,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_session_response.raise_for_status()
         member_session_id = member_session_response.json()["data"]["id"]
         admin_session_response = admin_client.post(
-            "v1/agents/assistant/sessions",
+            "v1/agent_sessions",
             json={
                 "title": "Admin session",
                 "is_ephemeral": False,
@@ -2019,30 +2019,20 @@ class TestApiAccessViaCookiesOrApiKeys:
         admin_session_id = admin_session_response.json()["data"]["id"]
 
         member_api_client = _httpx_client(_app, member.create_api_key(_app))
-        list_response = member_api_client.get("v1/agents/assistant/sessions")
+        list_response = member_api_client.get("v1/agent_sessions")
 
         assert list_response.status_code == 200
         session_ids = {session["id"] for session in list_response.json()["data"]}
         assert member_session_id in session_ids
         assert admin_session_id not in session_ids
+        assert member_api_client.get(f"v1/agent_sessions/{member_session_id}").status_code == 200
+        assert member_api_client.get(f"v1/agent_sessions/{admin_session_id}").status_code == 404
         assert (
-            member_api_client.get(f"v1/agents/assistant/sessions/{member_session_id}").status_code
+            member_api_client.get(f"v1/agent_sessions/{member_session_id}/messages").status_code
             == 200
         )
         assert (
-            member_api_client.get(f"v1/agents/assistant/sessions/{admin_session_id}").status_code
-            == 404
-        )
-        assert (
-            member_api_client.get(
-                f"v1/agents/assistant/sessions/{member_session_id}/messages"
-            ).status_code
-            == 200
-        )
-        assert (
-            member_api_client.get(
-                f"v1/agents/assistant/sessions/{admin_session_id}/messages"
-            ).status_code
+            member_api_client.get(f"v1/agent_sessions/{admin_session_id}/messages").status_code
             == 404
         )
 
@@ -2056,7 +2046,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_client = _httpx_client(_app, member.tokens)
         admin_client = _httpx_client(_app, admin.tokens)
         member_session_response = member_client.post(
-            "v1/agents/assistant/sessions",
+            "v1/agent_sessions",
             json={
                 "title": "Member session",
                 "is_ephemeral": False,
@@ -2070,7 +2060,7 @@ class TestApiAccessViaCookiesOrApiKeys:
         member_session_response.raise_for_status()
         member_session_id = member_session_response.json()["data"]["id"]
         admin_session_response = admin_client.post(
-            "v1/agents/assistant/sessions",
+            "v1/agent_sessions",
             json={
                 "title": "Admin session",
                 "is_ephemeral": False,
@@ -2241,6 +2231,7 @@ class TestVercelChatStreamRouterAuth:
         return {
             "trigger": "submit-message",
             "id": "test-msg-id",
+            "userAgent": "web",
             "message": {
                 "id": "msg-1",
                 "role": "user",
@@ -2255,7 +2246,7 @@ class TestVercelChatStreamRouterAuth:
 
     @pytest.fixture
     def _path(self) -> str:
-        return "/v1/agents/assistant/sessions/test-session-id/chat"
+        return "/v1/agent_sessions/test-session-id/chat"
 
     def test_unauthenticated_request_is_rejected(
         self,

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -2231,7 +2231,7 @@ class TestVercelChatStreamRouterAuth:
         return {
             "trigger": "submit-message",
             "id": "test-msg-id",
-            "userAgent": "web",
+            "userAgentType": "web",
             "message": {
                 "id": "msg-1",
                 "role": "user",

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -59,7 +59,7 @@ class TestListAgentSessions:
             is_ephemeral=True,
         )
 
-        response = await httpx_client.get("/v1/agents/assistant/sessions")
+        response = await httpx_client.get("/v1/agent_sessions")
 
         assert response.status_code == 200
         assert response.json() == {
@@ -97,14 +97,14 @@ class TestListAgentSessions:
             for offset in range(3)
         ]
 
-        first_response = await httpx_client.get("/v1/agents/assistant/sessions?limit=2")
+        first_response = await httpx_client.get("/v1/agent_sessions?limit=2")
         assert first_response.status_code == 200
         first_page = first_response.json()
         assert [item["title"] for item in first_page["data"]] == ["Session 0", "Session 1"]
         assert first_page["next_cursor"]
 
         second_response = await httpx_client.get(
-            "/v1/agents/assistant/sessions",
+            "/v1/agent_sessions",
             params={"limit": 2, "cursor": first_page["next_cursor"]},
         )
         assert second_response.status_code == 200
@@ -114,7 +114,7 @@ class TestListAgentSessions:
         assert second_response.json()["next_cursor"] is None
 
     async def test_rejects_invalid_cursor(self, httpx_client: httpx.AsyncClient) -> None:
-        response = await httpx_client.get("/v1/agents/assistant/sessions?cursor=invalid")
+        response = await httpx_client.get("/v1/agent_sessions?cursor=invalid")
         assert response.status_code == 422
 
 
@@ -145,7 +145,7 @@ class TestGetAgentSession:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}")
 
         assert response.status_code == 200
         data = response.json()["data"]
@@ -170,7 +170,7 @@ class TestGetAgentSession:
         agent_session = await _insert_agent_session(db, title="Empty", updated_at=now)
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}")
 
         assert response.status_code == 200
         data = response.json()["data"]
@@ -191,7 +191,7 @@ class TestGetAgentSession:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}")
 
         assert response.status_code == 200
         assert response.json()["data"]["is_ephemeral"] is True
@@ -217,13 +217,13 @@ class TestGetAgentSession:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}")
 
         assert response.status_code == 200
         assert response.json()["data"]["is_ephemeral"] is True
 
     async def test_rejects_invalid_id(self, httpx_client: httpx.AsyncClient) -> None:
-        response = await httpx_client.get("/v1/agents/assistant/sessions/invalid")
+        response = await httpx_client.get("/v1/agent_sessions/invalid")
         assert response.status_code == 404
 
 
@@ -252,7 +252,7 @@ class TestListAgentSessionMessages:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}/messages")
 
         assert response.status_code == 200
         payload = response.json()
@@ -292,7 +292,7 @@ class TestListAgentSessionMessages:
             if cursor is not None:
                 params["cursor"] = cursor
             response = await httpx_client.get(
-                f"/v1/agents/assistant/sessions/{session_id}/messages",
+                f"/v1/agent_sessions/{session_id}/messages",
                 params=params,
             )
             assert response.status_code == 200
@@ -314,13 +314,13 @@ class TestListAgentSessionMessages:
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}/messages")
 
         assert response.status_code == 200
         assert response.json() == {"data": [], "next_cursor": None}
 
     async def test_rejects_invalid_session_id(self, httpx_client: httpx.AsyncClient) -> None:
-        response = await httpx_client.get("/v1/agents/assistant/sessions/invalid/messages")
+        response = await httpx_client.get("/v1/agent_sessions/invalid/messages")
         assert response.status_code == 404
 
     async def test_rejects_invalid_cursor(
@@ -334,25 +334,11 @@ class TestListAgentSessionMessages:
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
         response = await httpx_client.get(
-            f"/v1/agents/assistant/sessions/{session_id}/messages",
+            f"/v1/agent_sessions/{session_id}/messages",
             params={"cursor": "invalid"},
         )
 
         assert response.status_code == 422
-
-    async def test_rejects_unknown_agent(
-        self,
-        httpx_client: httpx.AsyncClient,
-        db: DbSessionFactory,
-    ) -> None:
-        agent_session = await _insert_agent_session(
-            db, title="Conversation", updated_at=datetime.now(timezone.utc)
-        )
-        session_id = str(GlobalID("AgentSession", str(agent_session.id)))
-
-        response = await httpx_client.get(f"/v1/agents/nonexistent/sessions/{session_id}/messages")
-
-        assert response.status_code == 404
 
     async def test_returns_not_found_for_nonexistent_session(
         self,
@@ -360,6 +346,6 @@ class TestListAgentSessionMessages:
     ) -> None:
         session_id = str(GlobalID("AgentSession", "1000000"))
 
-        response = await httpx_client.get(f"/v1/agents/assistant/sessions/{session_id}/messages")
+        response = await httpx_client.get(f"/v1/agent_sessions/{session_id}/messages")
 
         assert response.status_code == 404

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -135,7 +135,7 @@ def _chat_body(
     body: dict[str, Any] = {
         "trigger": "submit-message",
         "id": session_id,
-        "userAgent": "web",
+        "userAgentType": "web",
         "model": {
             "providerType": "builtin",
             "provider": "OPENAI",
@@ -153,7 +153,7 @@ def _headless_chat_body(
     message: dict[str, Any] | None,
     **overrides: Any,
 ) -> dict[str, Any]:
-    return _chat_body(session_id, message, userAgent="headless", **overrides)
+    return _chat_body(session_id, message, userAgentType="headless", **overrides)
 
 
 def _stream_chunks(response_text: str) -> list[dict[str, Any]]:
@@ -2437,7 +2437,7 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Mirror of ``test_bash_shell_state_persists_across_chat_turns`` for
-    ``userAgent="headless"``: pins the snapshot wiring ``build_server_agent``
+    ``userAgentType="headless"``: pins the snapshot wiring ``build_server_agent``
     gained for the session route."""
     session_id = "57575757-5757-4757-8757-575757575757"
     agent_session_id = await _create_agent_session_row(db)
@@ -2920,7 +2920,7 @@ async def test_chat_rejects_a_turn_asserting_a_model_the_session_is_not_on(
         assert agent_session.heartbeat_at is None
 
 
-async def test_chat_rejects_unknown_user_agents(
+async def test_chat_rejects_unknown_user_agent_types(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
 ) -> None:
@@ -2930,7 +2930,7 @@ async def test_chat_rejects_unknown_user_agents(
         json=_chat_body(
             "11111111-1111-4111-8111-111111111111",
             _user_message("hello"),
-            userAgent="nonexistent",
+            userAgentType="nonexistent",
         ),
     )
     assert response.status_code == 422

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -95,23 +95,15 @@ def _user_message(text: str, *, message_id: str = _DEFAULT_USER_MESSAGE_ID) -> d
 
 
 def _chat_url(agent_session_id: str) -> str:
-    return f"/v1/agents/assistant/sessions/{agent_session_id}/chat"
-
-
-def _server_agent_chat_url(agent_session_id: str) -> str:
-    return f"/v1/agents/server/sessions/{agent_session_id}/chat"
+    return f"/v1/agent_sessions/{agent_session_id}/chat"
 
 
 def _compact_url(agent_session_id: str) -> str:
-    return f"/v1/agents/assistant/sessions/{agent_session_id}/compact"
-
-
-def _server_agent_compact_url(agent_session_id: str) -> str:
-    return f"/v1/agents/server/sessions/{agent_session_id}/compact"
+    return f"/v1/agent_sessions/{agent_session_id}/compact"
 
 
 def _patch_session_url(agent_session_id: str) -> str:
-    return f"/v1/agents/assistant/sessions/{agent_session_id}"
+    return f"/v1/agent_sessions/{agent_session_id}"
 
 
 def _compact_body() -> dict[str, Any]:
@@ -143,6 +135,7 @@ def _chat_body(
     body: dict[str, Any] = {
         "trigger": "submit-message",
         "id": session_id,
+        "userAgent": "web",
         "model": {
             "providerType": "builtin",
             "provider": "OPENAI",
@@ -153,6 +146,14 @@ def _chat_body(
     if message is not None:
         body["message"] = message
     return body
+
+
+def _headless_chat_body(
+    session_id: str,
+    message: dict[str, Any] | None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    return _chat_body(session_id, message, userAgent="headless", **overrides)
 
 
 def _stream_chunks(response_text: str) -> list[dict[str, Any]]:
@@ -808,14 +809,14 @@ async def test_compact_is_rejected_as_already_compact_when_a_concurrent_checkpoi
     assert compaction_message_ids == [_message_uuid("foreign-compaction-1")]
 
 
-async def test_server_agent_compact_route_matches_chat_route_gating(
+async def test_compact_route_is_not_gated_by_bash_disablement(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The compact route serves the same agents as chat: the server agent can
-    compact its sessions, unknown agents are 404, and disabling bash turns the
-    route off for the server agent only."""
+    """Compaction is agent-agnostic: it summarizes the transcript with the
+    session's persisted model, so disabling bash does not turn the route
+    off even for sessions driven by the headless agent."""
     checkpoint = {
         "objectives": ["Compact a server session"],
         "constraints_and_preferences": [],
@@ -846,26 +847,13 @@ async def test_server_agent_compact_route_matches_chat_route_gating(
         ],
     )
 
-    unknown_agent_response = await httpx_client.post(
-        f"/v1/agents/nonexistent/sessions/{agent_session_id}/compact",
-        json=_compact_body(),
-    )
-    assert unknown_agent_response.status_code == 404
-
-    server_response = await httpx_client.post(
-        _server_agent_compact_url(agent_session_id),
-        json=_compact_body(),
-    )
-    assert server_response.status_code == 200
-    assert server_response.json()["data"]["metadata"]["phoenix"]["isCompactionMessage"] is True
-
     monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
-    disabled_response = await httpx_client.post(
-        _server_agent_compact_url(agent_session_id),
+    response = await httpx_client.post(
+        _compact_url(agent_session_id),
         json=_compact_body(),
     )
-    assert disabled_response.status_code == 403
-    assert "Server agent is disabled" in disabled_response.text
+    assert response.status_code == 200
+    assert response.json()["data"]["metadata"]["phoenix"]["isCompactionMessage"] is True
 
 
 async def test_chat_turn_persists_session_transcript(
@@ -2404,8 +2392,8 @@ async def test_server_agent_chat_turn_persists_session_transcript(
     agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
-        _server_agent_chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("What datasets exist?")),
+        _chat_url(agent_session_id),
+        json=_headless_chat_body(session_id, _user_message("What datasets exist?")),
     )
     assert response.status_code == 200
     # The persisted-session contract is not the deprecated one, even though
@@ -2426,8 +2414,8 @@ async def test_server_agent_chat_turn_persists_session_transcript(
     assert messages[-1] == await _accumulate_streamed_assistant_message(chunks)
 
     second_response = await httpx_client.post(
-        _server_agent_chat_url(agent_session_id),
-        json=_chat_body(
+        _chat_url(agent_session_id),
+        json=_headless_chat_body(
             session_id,
             _user_message("And experiments?", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
@@ -2449,7 +2437,7 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Mirror of ``test_bash_shell_state_persists_across_chat_turns`` for
-    ``agent_id="server"``: pins the snapshot wiring ``build_server_agent``
+    ``userAgent="headless"``: pins the snapshot wiring ``build_server_agent``
     gained for the session route."""
     session_id = "57575757-5757-4757-8757-575757575757"
     agent_session_id = await _create_agent_session_row(db)
@@ -2461,8 +2449,8 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
     )
 
     first_response = await httpx_client.post(
-        _server_agent_chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("write a note")),
+        _chat_url(agent_session_id),
+        json=_headless_chat_body(session_id, _user_message("write a note")),
     )
     assert first_response.status_code == 200
     async with db() as session:
@@ -2471,8 +2459,8 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
         assert snapshots[0].bashkit_snapshot
 
     second_response = await httpx_client.post(
-        _server_agent_chat_url(agent_session_id),
-        json=_chat_body(
+        _chat_url(agent_session_id),
+        json=_headless_chat_body(
             session_id,
             _user_message("read it back", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
@@ -2489,13 +2477,13 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
     assert any(output.get("stdout") == "hello\n" for output in bash_outputs)
 
 
-async def test_server_agent_chat_is_forbidden_when_bash_is_disabled(
+async def test_headless_chat_is_forbidden_when_bash_is_disabled(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``PHOENIX_AGENTS_DISABLE_BASH`` turns off the server agent on the
-    session chat route while leaving the assistant agent available."""
+    """``PHOENIX_AGENTS_DISABLE_BASH`` turns off the headless user agent on
+    the chat route while leaving the web user agent available."""
     monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
 
     async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
@@ -2505,18 +2493,18 @@ async def test_server_agent_chat_is_forbidden_when_bash_is_disabled(
     session_id = "58585858-5858-4858-8858-585858585858"
     agent_session_id = await _create_agent_session_row(db)
 
-    server_response = await httpx_client.post(
-        _server_agent_chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("hello")),
+    headless_response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_headless_chat_body(session_id, _user_message("hello")),
     )
-    assert server_response.status_code == 403
-    assert "Server agent is disabled" in server_response.text
+    assert headless_response.status_code == 403
+    assert "Headless agent is disabled" in headless_response.text
 
-    assistant_response = await httpx_client.post(
+    web_response = await httpx_client.post(
         _chat_url(agent_session_id),
         json=_chat_body(session_id, _user_message("hello")),
     )
-    assert assistant_response.status_code == 200
+    assert web_response.status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -2529,7 +2517,7 @@ async def test_create_session_route_creates_a_temporary_session(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/v1/agents/server/sessions",
+        "/v1/agent_sessions",
         json=_create_session_body(title=" CLI session ", is_ephemeral=True),
     )
     assert response.status_code == 201
@@ -2553,7 +2541,7 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/v1/agents/assistant/sessions",
+        "/v1/agent_sessions",
         json=_create_session_body(),
     )
     assert response.status_code == 201
@@ -2569,7 +2557,7 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
 async def test_create_session_route_requires_a_model(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    response = await httpx_client.post("/v1/agents/assistant/sessions", json={})
+    response = await httpx_client.post("/v1/agent_sessions", json={})
 
     assert response.status_code == 422
 
@@ -2578,7 +2566,7 @@ async def test_create_session_route_rejects_long_title(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     response = await httpx_client.post(
-        "/v1/agents/assistant/sessions",
+        "/v1/agent_sessions",
         json=_create_session_body(title="x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 1)),
     )
 
@@ -2597,14 +2585,14 @@ async def test_create_session_route_yields_a_chattable_session(
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
 
     created = await httpx_client.post(
-        "/v1/agents/server/sessions",
+        "/v1/agent_sessions",
         json=_create_session_body(is_ephemeral=True),
     )
     assert created.status_code == 201
 
     response = await httpx_client.post(
-        _server_agent_chat_url(created.json()["data"]["id"]),
-        json=_chat_body("11111111-1111-4111-8111-111111111111", _user_message("hello")),
+        _chat_url(created.json()["data"]["id"]),
+        json=_headless_chat_body("11111111-1111-4111-8111-111111111111", _user_message("hello")),
     )
     assert response.status_code == 200
 
@@ -2785,24 +2773,6 @@ async def test_patch_session_route_ignores_a_stale_session_lock(
         assert stored.model_name == "claude-opus-4-6"
 
 
-async def test_patch_session_route_rejects_unknown_agents(
-    db: DbSessionFactory,
-    httpx_client: httpx.AsyncClient,
-) -> None:
-    agent_session_id = await _create_agent_session_row(db)
-    response = await httpx_client.patch(
-        f"/v1/agents/unknown/sessions/{agent_session_id}",
-        json={
-            "model": {
-                "providerType": "builtin",
-                "provider": "OPENAI",
-                "modelName": "gpt-test",
-            }
-        },
-    )
-    assert response.status_code == 404
-
-
 async def test_patch_session_route_updates_the_title(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
@@ -2950,14 +2920,20 @@ async def test_chat_rejects_a_turn_asserting_a_model_the_session_is_not_on(
         assert agent_session.heartbeat_at is None
 
 
-async def test_create_session_route_rejects_unknown_agents(
+async def test_chat_rejects_unknown_user_agents(
+    db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
 ) -> None:
+    agent_session_id = await _create_agent_session_row(db)
     response = await httpx_client.post(
-        "/v1/agents/unknown/sessions",
-        json=_create_session_body(),
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            "11111111-1111-4111-8111-111111111111",
+            _user_message("hello"),
+            userAgent="nonexistent",
+        ),
     )
-    assert response.status_code == 404
+    assert response.status_code == 422
 
 
 async def test_create_session_route_is_forbidden_when_agents_are_disabled(
@@ -2969,31 +2945,26 @@ async def test_create_session_route_is_forbidden_when_agents_are_disabled(
     )
 
     response = await httpx_client.post(
-        "/v1/agents/server/sessions",
+        "/v1/agent_sessions",
         json=_create_session_body(),
     )
     assert response.status_code == 403
     assert "Agents are disabled" in response.text
 
 
-async def test_create_session_route_forbids_the_server_agent_when_bash_is_disabled(
+async def test_create_session_route_is_not_gated_by_bash_disablement(
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Sessions are agent-agnostic: only the chat route's headless user agent
+    is turned off by ``PHOENIX_AGENTS_DISABLE_BASH``."""
     monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
 
-    server_response = await httpx_client.post(
-        "/v1/agents/server/sessions",
+    response = await httpx_client.post(
+        "/v1/agent_sessions",
         json=_create_session_body(),
     )
-    assert server_response.status_code == 403
-    assert "Server agent is disabled" in server_response.text
-
-    assistant_response = await httpx_client.post(
-        "/v1/agents/assistant/sessions",
-        json=_create_session_body(),
-    )
-    assert assistant_response.status_code == 201
+    assert response.status_code == 201
 
 
 async def test_agents_router_is_forbidden_in_read_only_mode(
@@ -3007,7 +2978,7 @@ async def test_agents_router_is_forbidden_in_read_only_mode(
     app.state.read_only = True
 
     create_response = await httpx_client.post(
-        "/v1/agents/server/sessions",
+        "/v1/agent_sessions",
         json=_create_session_body(),
     )
     assert create_response.status_code == 403

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -221,10 +221,11 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
         agent_session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
     response = await httpx_client.post(
-        f"/v1/agents/assistant/sessions/{agent_session_id}/chat",
+        f"/v1/agent_sessions/{agent_session_id}/chat",
         json={
             "trigger": "submit-message",
             "id": session_id,
+            "userAgent": "web",
             "message": _user_message("hello"),
             "model": {
                 "providerType": "builtin",
@@ -243,7 +244,7 @@ async def test_new_contract_body_on_the_legacy_url_is_rejected(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     """The legacy route only speaks the full-transcript shape; the session
-    routes' single-``message`` body belongs to /v1/agents/... instead."""
+    routes' single-``message`` body belongs to /v1/agent_sessions/... instead."""
     response = await httpx_client.post(
         f"/agents/server/sessions/{_CLIENT_MINTED_SESSION_ID}/chat",
         json={

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -225,7 +225,7 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
         json={
             "trigger": "submit-message",
             "id": session_id,
-            "userAgent": "web",
+            "userAgentType": "web",
             "message": _user_message("hello"),
             "model": {
                 "providerType": "builtin",

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ requires-dist = [
     { name = "py-grpc-prometheus", marker = "extra == 'container'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.1.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=2.17.0,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=2.26.0,<3" },
     { name = "pydantic-monty", specifier = "==0.0.19" },
     { name = "pystache" },
     { name = "python-dateutil" },
@@ -5926,9 +5926,10 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.21.0"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "genai-prices" },
     { name = "griffelib" },
@@ -5938,9 +5939,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/c0/c699651a74cac2ac5e4bf19f568edf75fae529e456e2fee00ce94fe18f99/pydantic_ai_slim-2.21.0.tar.gz", hash = "sha256:dbcd6566ca1d05541f098aab42bb3464a1e39dfca6fe1af4d8e16f808e79a56c", size = 912884, upload-time = "2026-07-30T02:10:44.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/51/dc39f52dd38c8bf7d8ad6601a936d22064c935505a897c1bf5060e278c95/pydantic_ai_slim-2.26.0.tar.gz", hash = "sha256:d41a40a976885d5f9c6848552fcd6732d5daa8294faf4d3e0138fb28118b6734", size = 1004525, upload-time = "2026-08-07T03:34:19.129Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/01/05606613365f19d317eddbf5f2aaea0f947af9175c4ada5a4b577124583e/pydantic_ai_slim-2.21.0-py3-none-any.whl", hash = "sha256:25c34084808b944c000ad520553d8ac50c4d992972662a0e63f700009afb9bad", size = 1102191, upload-time = "2026-07-30T02:10:37.357Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ac/e09eb468ccec3180f73828b1e0c59b891cc9ee442be2d28410b02c1d09a3/pydantic_ai_slim-2.26.0-py3-none-any.whl", hash = "sha256:855a23f120328e7a12e8f4371db597d74f65925e20ce335d3a6db81203238f58", size = 1201143, upload-time = "2026-08-07T03:34:11.305Z" },
 ]
 
 [package.optional-dependencies]
@@ -6082,17 +6083,18 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.21.0"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/d5/d3aa91f4e8dbae1bc863e02bce282b407f9499c6c40f92cada2be7ce5fc6/pydantic_graph-2.21.0.tar.gz", hash = "sha256:65b65134904cd13a7f153f042c41f65ee79cde1759e2f2291008976b18e73c38", size = 44150, upload-time = "2026-07-30T02:10:46.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/64/05bf73d982dd778b5613ad224a58ca510aaccf622644d97af93e6006a680/pydantic_graph-2.26.0.tar.gz", hash = "sha256:12d9da6c5a0e2634d89f2795ca15783ee37250fdc295b33b5c14232576dafdac", size = 45181, upload-time = "2026-08-07T03:34:22.049Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/52/f9d1a615464b550a3335a754d8f554768acdbbaf4163093ef57e81da868b/pydantic_graph-2.21.0-py3-none-any.whl", hash = "sha256:28e68554a6b9df8c9b12cc337d492f4c00156a4d67f041a866af2913c73a2b99", size = 51661, upload-time = "2026-07-30T02:10:40.502Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/54302729598308ba437e250473c99ef51625e86997f7ae2ba6b61a2ad00f/pydantic_graph-2.26.0-py3-none-any.whl", hash = "sha256:4599a980747588faf17ac56cfa9c10b2a79723a5a20c3c7ee479e8366653097c", size = 52662, upload-time = "2026-08-07T03:34:14.831Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
| Before | After |
|---|---|
| `POST /v1/agents/{agent_id}/sessions` | `POST /v1/agent_sessions` |
| `GET /v1/agents/{agent_id}/sessions` | `GET /v1/agent_sessions` |
| `GET /v1/agents/{agent_id}/sessions/{session_id}` | `GET /v1/agent_sessions/{session_id}` |
| `PATCH /v1/agents/{agent_id}/sessions/{session_id}` | `PATCH /v1/agent_sessions/{session_id}` |
| `GET /v1/agents/{agent_id}/sessions/{session_id}/messages` | `GET /v1/agent_sessions/{session_id}/messages` |
| `POST /v1/agents/{agent_id}/sessions/{session_id}/compact` | `POST /v1/agent_sessions/{session_id}/compact` |
| `POST /v1/agents/{agent_id}/sessions/{session_id}/chat` | `POST /v1/agent_sessions/{session_id}/chat` |
