### PR TITLE
docs: replace app.phoenix.arize.com with generic placeholder in package docs

### DIFF
--- a/js/packages/phoenix-otel/README.md
+++ b/js/packages/phoenix-otel/README.md
@@ -68,14 +68,14 @@ await provider.shutdown();
 
 ### Production Setup
 
-For production use with Phoenix Cloud:
+For production use with a remote Phoenix instance:
 
 ```typescript
 import { register } from "@arizeai/phoenix-otel";
 
 register({
   projectName: "my-app",
-  url: "https://app.phoenix.arize.com",
+  url: "https://your-phoenix-instance.com",
   apiKey: process.env.PHOENIX_API_KEY,
 });
 ```
@@ -90,8 +90,8 @@ The `register` function automatically reads from environment variables:
 # For local Phoenix server (default)
 export PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
 
-# For Phoenix Cloud
-export PHOENIX_COLLECTOR_ENDPOINT="https://app.phoenix.arize.com"
+# For a remote Phoenix instance
+export PHOENIX_COLLECTOR_ENDPOINT="https://your-phoenix-instance.com"
 export PHOENIX_API_KEY="your-api-key"
 ```
 
@@ -579,7 +579,7 @@ import { register } from "@arizeai/phoenix-otel";
 
 register({
   projectName: "my-app-prod",
-  url: "https://app.phoenix.arize.com",
+  url: "https://your-phoenix-instance.com",
   apiKey: process.env.PHOENIX_API_KEY,
   batch: true, // Batch processing for better performance
 });
@@ -594,7 +594,7 @@ import { register } from "@arizeai/phoenix-otel";
 
 register({
   projectName: "my-app",
-  url: "https://app.phoenix.arize.com",
+  url: "https://your-phoenix-instance.com",
   headers: {
     "X-Custom-Header": "custom-value",
     "X-Environment": process.env.NODE_ENV || "development",

--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -105,8 +105,8 @@ client = Client()
 
 client = Client(base_url="http://localhost:6006")  # Local Phoenix server
 
-# Cloud instance with API key
-client = Client(base_url="https://app.phoenix.arize.com/s/your-space", api_key="your-api-key")
+# Remote instance with API key
+client = Client(base_url="https://your-phoenix-instance.com", api_key="your-api-key")
 
 # Custom authentication headers
 client = Client(
@@ -117,7 +117,7 @@ client = Client(
 async_client = AsyncClient()
 async_client = AsyncClient(base_url="http://localhost:6006")
 async_client = AsyncClient(
-    base_url="https://app.phoenix.arize.com/s/your-space", api_key="your-api-key"
+    base_url="https://your-phoenix-instance.com", api_key="your-api-key"
 )
 ```
 

--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -116,9 +116,7 @@ client = Client(
 # Asynchronous client (same configuration options)
 async_client = AsyncClient()
 async_client = AsyncClient(base_url="http://localhost:6006")
-async_client = AsyncClient(
-    base_url="https://your-phoenix-instance.com", api_key="your-api-key"
-)
+async_client = AsyncClient(base_url="https://your-phoenix-instance.com", api_key="your-api-key")
 ```
 
 ## Resources

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -52,8 +52,8 @@ client = Client()
 
 client = Client(base_url="http://localhost:6006")  # Local Phoenix server
 
-# Cloud instance with API key
-client = Client(base_url="https://app.phoenix.arize.com/s/your-space", api_key="your-api-key")
+# Remote instance with API key
+client = Client(base_url="https://your-phoenix-instance.com", api_key="your-api-key")
 
 # Custom authentication headers
 client = Client(
@@ -64,7 +64,7 @@ client = Client(
 async_client = AsyncClient()
 async_client = AsyncClient(base_url="http://localhost:6006")
 async_client = AsyncClient(
-    base_url="https://app.phoenix.arize.com/s/your-space", api_key="your-api-key"
+    base_url="https://your-phoenix-instance.com", api_key="your-api-key"
 )
 ```
 

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -63,9 +63,7 @@ client = Client(
 # Asynchronous client (same configuration options)
 async_client = AsyncClient()
 async_client = AsyncClient(base_url="http://localhost:6006")
-async_client = AsyncClient(
-    base_url="https://your-phoenix-instance.com", api_key="your-api-key"
-)
+async_client = AsyncClient(base_url="https://your-phoenix-instance.com", api_key="your-api-key")
 ```
 
 ## Resources

--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -103,7 +103,7 @@ Configure where to send your traces:
 **Environment Variables** (Recommended):
 
 ```bash
-export PHOENIX_COLLECTOR_ENDPOINT="https://app.phoenix.arize.com/s/your-space"
+export PHOENIX_COLLECTOR_ENDPOINT="https://your-phoenix-instance.com"
 export PHOENIX_PROJECT_NAME="my-project"
 ```
 
@@ -135,7 +135,7 @@ tracer_provider = register(
     auto_instrument=True,  # Auto-trace AI/ML libraries
     batch=True,  # Background batching for performance
     api_key="your-api-key",  # Authentication
-    endpoint="https://app.phoenix.arize.com/s/your-space",
+    endpoint="https://your-phoenix-instance.com",
 )
 ```
 
@@ -177,7 +177,7 @@ def weather(location):
 
 | Variable                     | Description          | Example                                      |
 | ---------------------------- | -------------------- | -------------------------------------------- |
-| `PHOENIX_COLLECTOR_ENDPOINT` | Where to send traces | `https://app.phoenix.arize.com/s/your-space` |
+| `PHOENIX_COLLECTOR_ENDPOINT` | Where to send traces | `https://your-phoenix-instance.com`          |
 | `PHOENIX_PROJECT_NAME`       | Project name         | `my-llm-app`                                 |
 | `PHOENIX_API_KEY`            | Authentication key   | `your-api-key`                               |
 | `PHOENIX_CLIENT_HEADERS`     | Custom headers       | `Authorization=Bearer token`                 |

--- a/packages/phoenix-otel/docs/source/index.md
+++ b/packages/phoenix-otel/docs/source/index.md
@@ -250,9 +250,9 @@ The package recognizes these Phoenix-specific environment variables for automati
 # Local Phoenix server (default)
 export PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
 
-# Phoenix Cloud instance
+# Remote Phoenix instance with API key
 export PHOENIX_API_KEY="your-api-key"
-export PHOENIX_COLLECTOR_ENDPOINT="https://app.phoenix.arize.com/s/your-space"
+export PHOENIX_COLLECTOR_ENDPOINT="https://your-phoenix-instance.com"
 export PHOENIX_PROJECT_NAME="production-app"
 
 # Custom Phoenix instance with authentication


### PR DESCRIPTION
resolves #<issue-number>

## Summary

Removes all `app.phoenix.arize.com` references from the user-facing package docs, replacing them with the generic placeholder host `https://your-phoenix-instance.com`.

Worth noting up front: **the Mintlify docs site (`docs/`, 769 files) already had zero `app.phoenix.arize.com` references** — it was migrated to `https://your-phoenix-instance.com` previously. The package READMEs and Sphinx docs were the stragglers, so this change aligns them with the placeholder convention already established at:

- `docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx:72`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx:49`

## Changes

12 URL references across 5 files:

| File | Refs |
| --- | --- |
| `js/packages/phoenix-otel/README.md` | 4 |
| `packages/phoenix-otel/README.md` | 3 |
| `packages/phoenix-client/README.md` | 2 |
| `packages/phoenix-client/docs/source/index.md` | 2 |
| `packages/phoenix-otel/docs/source/index.md` | 1 |

The examples are kept intact rather than deleted, so remote/authenticated setup stays documented.

Three accompanying label changes were needed because the surrounding text specifically described these snippets as *Phoenix Cloud*, which would have been inaccurate once the URL became a generic host:

- `For production use with Phoenix Cloud:` → `For production use with a remote Phoenix instance:`
- `# For Phoenix Cloud` → `# For a remote Phoenix instance`
- `# Cloud instance with API key` → `# Remote instance with API key`
- `# Phoenix Cloud instance` → `# Remote Phoenix instance with API key`

## Intentionally out of scope

The remaining 120 occurrences elsewhere in the repo were left alone, as they are not docs:

- Source code and tests (`js/packages/phoenix-otel/src/register.ts`, `phoenix-cli/src/`, `app/src/components/project/hosting.ts`, `packages/phoenix-otel/src/phoenix/otel/otel.py`) — changing these would alter behavior, not documentation.
- Tutorial notebooks and example `.env.example` files under `tutorials/` and `js/examples/`.
- Agent skill references under `.agents/skills/`.

One non-URL mention of the product name remains at `packages/phoenix-otel/README.md:41` (*"Seamless integration with Phoenix Cloud and self-hosted instances"*). This is a factual statement about supported deployments rather than an endpoint reference, so it was left as-is — happy to drop it if preferred.

## Verification

- `grep` confirms zero `app.phoenix.arize.com` references remain in the five touched files.
- `prettier --check` passes on `js/packages/phoenix-otel/README.md`.
- Markdown table alignment in `packages/phoenix-otel/README.md` was preserved by re-padding the shortened cell. (The `PHOENIX_DISCOVER_CONFIG` row is misaligned, but that predates this change and was not touched.)

Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzpq7hKJ5CaHbujP7EH634


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tzpq7hKJ5CaHbujP7EH634)_