### PR TITLE
fix(evals): surface PXI online eval failures

### DIFF
--- a/.github/workflows/pxi-online-evals.yml
+++ b/.github/workflows/pxi-online-evals.yml
@@ -63,4 +63,29 @@ jobs:
           if [[ "${PXI_DRY_RUN}" == "true" ]]; then
             args+=(--dry-run)
           fi
+          args+=(--summary-json "${RUNNER_TEMP}/pxi-online-evals-summary.json")
           uv run python -m evals.pxi.online_evals.run "${args[@]}"
+      - name: Upload evaluation summary
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pxi-online-evals-summary
+          path: ${{ runner.temp }}/pxi-online-evals-summary.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  slack-notification:
+    name: Slack notification
+    needs: [evaluate]
+    if: ${{ always() && needs.evaluate.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: PXI Online Evals failed for `${{ env.PHOENIX_PROJECT }}`\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -31,6 +31,12 @@ tool_count_per_turn: discovered=11 already_annotated=0 sampled_out=0 not_applica
 user_friction:       discovered=11 already_annotated=0 sampled_out=0 not_applicable=6 evaluated=5  errors=0 written=5
 ```
 
+The CLI can also write the same counters as a versioned JSON report with
+`--summary-json`. In GitHub Actions it appends a compact evaluator table to the
+job summary automatically. Not-applicable results are grouped by reason so an
+isolated incomplete trace is distinguishable from an evaluator's normal
+applicability filtering.
+
 ## Anatomy of a turn trace
 
 One trace = one conversational turn. All spans are children of the

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -146,7 +146,7 @@ rate 0.25  █████                 subset of the 0.50 selection
 | Unbounded discovery | hard cap (5,000 roots) fails the run loudly | operator shrinks the window |
 | One bad turn poisoning the run | per-turn exception isolation | logged + counted; run continues; process exits non-zero so schedules go red |
 | Bad judge config | provider/API-key validated at startup | fail fast, before any trace work |
-| Malformed topology (orphan tool span, missing ancestor, cycle) | **deliberately loud** — counts as an error | post-settle traces should be complete; an anomaly means dropped spans or a tracing regression. Downgrade to skip-with-warning if noisy in practice. |
+| Malformed topology (orphan tool span, missing ancestor, cycle) | skip as not-applicable + warning | incomplete traces cannot produce a trustworthy tool count and should not poison later scheduled runs |
 
 ## Assumptions
 

--- a/evals/pxi/online_evals/models.py
+++ b/evals/pxi/online_evals/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Optional
 
 from phoenix.client.__generated__ import v1
@@ -49,3 +49,8 @@ class RunSummary:
     evaluated: int = 0
     errors: int = 0
     annotations: int = 0
+    not_applicable_reasons: dict[str, int] = field(default_factory=dict)
+
+    def record_not_applicable(self, reason: str) -> None:
+        self.not_applicable += 1
+        self.not_applicable_reasons[reason] = self.not_applicable_reasons.get(reason, 0) + 1

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import json
 import logging
 import math
 import os
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
+from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
 
 from phoenix.client import Client
 from phoenix.client.__generated__ import v1
@@ -29,6 +33,8 @@ MAX_SPANS_PER_BATCH = 10_000
 TRACE_ID_BATCH_SIZE = 100
 ANNOTATION_WRITE_BATCH_SIZE = 100
 MAX_CONCURRENT_EVALUATIONS = 8
+EVALUATOR_NOT_APPLICABLE = "evaluator_not_applicable"
+INCOMPLETE_TOPOLOGY = "incomplete_topology"
 
 
 class OversizedTraceError(RuntimeError):
@@ -240,14 +246,14 @@ async def run_evaluators(
                 trace_id(root),
                 error,
             )
-            summaries[spec.name].not_applicable += 1
+            summaries[spec.name].record_not_applicable(INCOMPLETE_TOPOLOGY)
             continue
         except Exception:
             logger.exception("%s failed on trace %s; continuing", spec.name, trace_id(root))
             summaries[spec.name].errors += 1
             continue
         if result is None:
-            summaries[spec.name].not_applicable += 1
+            summaries[spec.name].record_not_applicable(EVALUATOR_NOT_APPLICABLE)
             continue
         summaries[spec.name].evaluated += 1
         annotation: v1.SpanAnnotationData = {
@@ -276,6 +282,51 @@ async def run_evaluators(
 
 def _default_project() -> str | None:
     return os.getenv("PHOENIX_PROJECT") or os.getenv("PHOENIX_PROJECT_NAME")
+
+
+def _build_run_report(
+    *, project: str, dry_run: bool, summaries: dict[str, RunSummary]
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "status": "failed"
+        if any(summary.errors for summary in summaries.values())
+        else "succeeded",
+        "project": project,
+        "dry_run": dry_run,
+        "evaluators": {name: asdict(summary) for name, summary in summaries.items()},
+    }
+
+
+def _write_json_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+
+def _append_github_step_summary(path: Path, report: dict[str, Any]) -> None:
+    status = report["status"]
+    lines = [
+        "## PXI Online Evals",
+        "",
+        f"**Status:** {status}  ",
+        f"**Project:** `{report['project']}`  ",
+        f"**Dry run:** `{str(report['dry_run']).lower()}`",
+        "",
+        "| Evaluator | Discovered | Existing | Evaluated | Not applicable | Errors | Annotations | Reasons |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for name, summary in report["evaluators"].items():
+        reasons = ", ".join(
+            f"`{reason}`={count}"
+            for reason, count in sorted(summary["not_applicable_reasons"].items())
+        )
+        lines.append(
+            f"| `{name}` | {summary['discovered']} | {summary['already_annotated']} | "
+            f"{summary['evaluated']} | {summary['not_applicable']} | {summary['errors']} | "
+            f"{summary['annotations']} | {reasons or '—'} |"
+        )
+    with path.open("a") as file:
+        file.write("\n".join(lines) + "\n")
 
 
 def _positive_float(value: str) -> float:
@@ -321,6 +372,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dry-run", action="store_true", help="Evaluate without writing annotations."
     )
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        help="Write a versioned, machine-readable run summary to this path.",
+    )
     return parser
 
 
@@ -353,7 +409,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"evaluated={summary.evaluated} errors={summary.errors} "
             f"{annotation_verb}={summary.annotations}"
         )
-    return 1 if any(summary.errors for summary in summaries.values()) else 0
+    report = _build_run_report(project=args.project, dry_run=args.dry_run, summaries=summaries)
+    if args.summary_json is not None:
+        _write_json_report(args.summary_json, report)
+    if github_step_summary := os.getenv("GITHUB_STEP_SUMMARY"):
+        _append_github_step_summary(Path(github_step_summary), report)
+    return 1 if report["status"] == "failed" else 0
 
 
 if __name__ == "__main__":

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -17,7 +17,7 @@ from phoenix.evals.evaluators import Score
 from evals.pxi.online_evals import judge
 from evals.pxi.online_evals.evaluators import EVALUATORS
 from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary
-from evals.pxi.online_evals.topology import span_id, trace_id
+from evals.pxi.online_evals.topology import InvalidTurnTrace, span_id, trace_id
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +233,15 @@ async def run_evaluators(
     for spec, root, task in tasks:
         try:
             result = await task
+        except InvalidTurnTrace as error:
+            logger.warning(
+                "%s: skipping trace %s because its topology is incomplete: %s",
+                spec.name,
+                trace_id(root),
+                error,
+            )
+            summaries[spec.name].not_applicable += 1
+            continue
         except Exception:
             logger.exception("%s failed on trace %s; continuing", spec.name, trace_id(root))
             summaries[spec.name].errors += 1

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import replace
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from unittest import mock
 
@@ -478,6 +480,7 @@ def test_none_result_counts_as_not_applicable() -> None:
     )["tool_count_per_turn"]
 
     assert summary.not_applicable == 1
+    assert summary.not_applicable_reasons == {"evaluator_not_applicable": 1}
     assert summary.evaluated == 0
     assert spans.writes == []
 
@@ -495,6 +498,7 @@ def test_incomplete_tool_topology_is_not_applicable() -> None:
     )["tool_count_per_turn"]
 
     assert summary.not_applicable == 1
+    assert summary.not_applicable_reasons == {"incomplete_topology": 1}
     assert summary.errors == 0
     assert summary.evaluated == 0
     assert spans.writes == []
@@ -611,6 +615,65 @@ def test_main_returns_nonzero_when_an_evaluator_errors() -> None:
         ),
     ):
         assert run_module.main(["--project", "pxi_dev", "--eval", "tool_count_per_turn"]) == 1
+
+
+def test_main_writes_structured_and_github_summaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    json_path = tmp_path / "summary.json"
+    markdown_path = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(markdown_path))
+    summary = RunSummary(
+        discovered=3,
+        already_annotated=1,
+        not_applicable=1,
+        evaluated=1,
+        annotations=1,
+        not_applicable_reasons={"incomplete_topology": 1},
+    )
+
+    with (
+        mock.patch.object(run_module, "Client"),
+        mock.patch.object(
+            run_module,
+            "run_evaluators",
+            new=mock.AsyncMock(return_value={"tool_count_per_turn": summary}),
+        ),
+    ):
+        exit_code = run_module.main(
+            [
+                "--project",
+                "pxi_dev",
+                "--eval",
+                "tool_count_per_turn",
+                "--summary-json",
+                str(json_path),
+            ]
+        )
+
+    assert exit_code == 0
+    assert json.loads(json_path.read_text()) == {
+        "schema_version": 1,
+        "status": "succeeded",
+        "project": "pxi_dev",
+        "dry_run": False,
+        "evaluators": {
+            "tool_count_per_turn": {
+                "discovered": 3,
+                "already_annotated": 1,
+                "sampled_out": 0,
+                "not_applicable": 1,
+                "evaluated": 1,
+                "errors": 0,
+                "annotations": 1,
+                "not_applicable_reasons": {"incomplete_topology": 1},
+            }
+        },
+    }
+    markdown = markdown_path.read_text()
+    assert "**Status:** succeeded" in markdown
+    assert "| `tool_count_per_turn` | 3 | 1 | 1 | 1 | 0 | 1 |" in markdown
+    assert "`incomplete_topology`=1" in markdown
 
 
 @pytest.mark.parametrize("value", ["0", "-1", "nan", "inf", "not-a-number"])

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -482,6 +482,24 @@ def test_none_result_counts_as_not_applicable() -> None:
     assert spans.writes == []
 
 
+def test_incomplete_tool_topology_is_not_applicable() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    tool = _span("tool", trace_id="trace", name="bash", kind="TOOL", parent_id="missing")
+    spans = _FakeSpans([root], {"trace": [root, tool]}, [])
+
+    summary = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[TOOL_COUNT_PER_TURN],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )["tool_count_per_turn"]
+
+    assert summary.not_applicable == 1
+    assert summary.errors == 0
+    assert summary.evaluated == 0
+    assert spans.writes == []
+
+
 def test_evaluator_failure_is_isolated_to_one_turn() -> None:
     failing_root = _span(
         "failing-root", trace_id="failing-trace", name="pxi.turn", kind="AGENT", parent_id=None


### PR DESCRIPTION
## Summary
- treat incomplete PXI trace topology as not-applicable instead of poisoning scheduled runs
- send a Slack notification when the PXI Online Evals job fails
- publish versioned JSON artifacts and GitHub job summaries with reason-coded skips

## Root cause
A persistent PXI trace contained a tool span whose parent chain referenced a missing ancestor. The batch runner treated InvalidTurnTrace as a generic evaluator error, so every overlapping 48-hour run exited nonzero without a team-owned alert.

## Verification
- 76 PXI online-evals unit tests passed
- Ruff lint and format checks passed
- focused source mypy passed
- workflow YAML syntax validated
- live read-only dry-run against pxi_dev exited 0 and produced JSON/Markdown summaries with incomplete_topology=1 and errors=0