### PR TITLE
fix(online-evals): preserve evaluator fields on update, guard clearProject session deletes, close LLM provider identity gap

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -4791,7 +4791,7 @@ input UpdateDatasetLLMEvaluatorInput {
   datasetEvaluatorId: ID!
   datasetId: ID!
   name: Identifier!
-  description: String = null
+  description: String
   promptVersionId: ID
   promptVersion: ChatPromptVersionInput!
   outputConfigs: [AnnotationConfigInput!]!
@@ -4841,7 +4841,7 @@ input UpdateProjectLLMEvaluatorInput {
   evaluationTarget: EvaluationTarget!
   filterCondition: String!
   enabled: Boolean
-  description: String = null
+  description: String
   promptVersionId: ID
 }
 

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE public.annotation_configs (
 -- ------------------------
 CREATE TABLE public.eval_work_cursors (
     id bigserial NOT NULL,
-    grain VARCHAR NOT NULL,
+    evaluation_target VARCHAR NOT NULL,
     consumer_group VARCHAR NOT NULL,
     produced_through_id BIGINT NOT NULL DEFAULT '0'::bigint,
     observed_high_water_id BIGINT,
@@ -32,9 +32,9 @@ CREATE TABLE public.eval_work_cursors (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_eval_work_cursors PRIMARY KEY (id),
-    CONSTRAINT uq_eval_work_cursors_grain_consumer_group
-        UNIQUE (grain, consumer_group),
-    CHECK (((grain)::text = ANY ((ARRAY[
+    CONSTRAINT uq_eval_work_cursors_evaluation_target_consumer_group
+        UNIQUE (evaluation_target, consumer_group),
+    CHECK (((evaluation_target)::text = ANY ((ARRAY[
             'SPAN'::character varying,
             'TRACE'::character varying,
             'SESSION'::character varying
@@ -166,6 +166,7 @@ CREATE TABLE public.project_sessions (
     project_id INTEGER NOT NULL,
     start_time TIMESTAMP WITH TIME ZONE NOT NULL,
     end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    last_span_ingested_at TIMESTAMP WITH TIME ZONE,
     CONSTRAINT pk_project_sessions PRIMARY KEY (id),
     CONSTRAINT uq_project_sessions_session_id
         UNIQUE (session_id),
@@ -177,6 +178,8 @@ CREATE TABLE public.project_sessions (
 
 CREATE INDEX ix_project_sessions_project_id_end_time ON public.project_sessions
     USING btree (project_id, end_time DESC);
+CREATE INDEX ix_project_sessions_project_id_last_span_ingested_at ON public.project_sessions
+    USING btree (project_id, last_span_ingested_at) WHERE (last_span_ingested_at IS NOT NULL);
 CREATE INDEX ix_project_sessions_project_id_start_time ON public.project_sessions
     USING btree (project_id, start_time DESC);
 

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1277,6 +1277,7 @@ CREATE TABLE public.project_evaluator_criteria (
     evaluation_target VARCHAR NOT NULL,
     input_mapping JSONB,
     enabled BOOLEAN NOT NULL DEFAULT true,
+    work_materialized_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_project_evaluator_criteria PRIMARY KEY (id),

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -39,6 +39,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # project_sessions carries raw-expression DESC indexes, so add_column/drop_column are used
+    # bare here: batch mode would rebuild the table by reflection and silently recreate those
+    # indexes as ascending. SQLite supports both statements natively on this column.
     op.add_column(
         "project_sessions",
         sa.Column(

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -139,6 +139,7 @@ def upgrade() -> None:
         ),
         sa.Column("input_mapping", JSON_, nullable=True),
         sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("work_materialized_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3303,6 +3303,10 @@ class ProjectEvaluatorCriteria(HasId):
         nullable=False,
     )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    # Stamped the first time a materializer creates evaluation work for this row, and
+    # never cleared. It records that work has ever existed, which outlives the work rows
+    # themselves — retention deletes them, so their presence cannot answer that question.
+    work_materialized_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -331,7 +331,7 @@ class UpdateDatasetLLMEvaluatorInput:
     dataset_evaluator_id: GlobalID
     dataset_id: GlobalID
     name: Identifier
-    description: Optional[str] = None
+    description: Optional[str] = UNSET
     prompt_version_id: Optional[GlobalID] = UNSET
     prompt_version: ChatPromptVersionInput
     output_configs: list[AnnotationConfigInput]
@@ -431,7 +431,7 @@ class UpdateProjectLLMEvaluatorInput:
     evaluation_target: EvaluationTarget
     filter_condition: str
     enabled: Optional[bool] = UNSET
-    description: Optional[str] = None
+    description: Optional[str] = UNSET
     prompt_version_id: Optional[GlobalID] = UNSET
 
 
@@ -727,8 +727,10 @@ class EvaluatorMutationMixin:
                 if pair is None:
                     raise NotFound(f"LLM project evaluator not found: {input.project_evaluator_id}")
                 criteria, evaluator = pair
+                shared_evaluator_changed = False
                 if criteria.name != name:
                     evaluator.name = await _generate_unique_evaluator_name(session, name)
+                    shared_evaluator_changed = True
 
                 selected_version: Optional[models.PromptVersion] = None
                 if input.prompt_version_id is not UNSET and input.prompt_version_id is not None:
@@ -763,12 +765,17 @@ class EvaluatorMutationMixin:
                     session.add(prompt_version)
                     await session.flush()
                     final_prompt_version_id = prompt_version.id
+                    shared_evaluator_changed = True
 
-                evaluator.description = input.description
-                evaluator.output_configs = output_configs
-                evaluator.user_id = user_id
-                evaluator.prompt_id = target_prompt_id
-                evaluator.updated_at = datetime.now(timezone.utc)
+                if input.description is not UNSET and evaluator.description != input.description:
+                    evaluator.description = input.description
+                    shared_evaluator_changed = True
+                if evaluator.output_configs != output_configs:
+                    evaluator.output_configs = output_configs
+                    shared_evaluator_changed = True
+                if evaluator.prompt_id != target_prompt_id:
+                    evaluator.prompt_id = target_prompt_id
+                    shared_evaluator_changed = True
                 try:
                     validate_consistent_llm_evaluator_and_prompt_version(prompt_version, evaluator)
                 except ValueError as error:
@@ -781,14 +788,24 @@ class EvaluatorMutationMixin:
                         prompt_id=target_prompt_id,
                         prompt_version_id=final_prompt_version_id,
                     )
+                    shared_evaluator_changed = True
                 else:
                     prompt_version_tag = await session.get(
                         models.PromptVersionTag, evaluator.prompt_version_tag_id
                     )
                     if prompt_version_tag is None:
                         raise NotFound("Prompt version tag was not found")
-                    prompt_version_tag.prompt_id = target_prompt_id
-                    prompt_version_tag.prompt_version_id = final_prompt_version_id
+                    if (
+                        prompt_version_tag.prompt_id != target_prompt_id
+                        or prompt_version_tag.prompt_version_id != final_prompt_version_id
+                    ):
+                        prompt_version_tag.prompt_id = target_prompt_id
+                        prompt_version_tag.prompt_version_id = final_prompt_version_id
+                        shared_evaluator_changed = True
+
+                if shared_evaluator_changed:
+                    evaluator.user_id = user_id
+                    evaluator.updated_at = datetime.now(timezone.utc)
 
                 criteria.name = name
                 criteria.filter_condition = input.filter_condition
@@ -1392,6 +1409,7 @@ class EvaluatorMutationMixin:
                     f"LLM evaluator not found for DatasetEvaluator {input.dataset_evaluator_id}"
                 )
             dataset_evaluator, llm_evaluator = dataset_evaluator_pair
+            shared_evaluator_changed = False
 
             # Handle prompt_version_id if provided
             target_prompt_id = llm_evaluator.prompt_id
@@ -1411,14 +1429,20 @@ class EvaluatorMutationMixin:
                 if provided_prompt_version.prompt_id != llm_evaluator.prompt_id:
                     target_prompt_id = provided_prompt_version.prompt_id
                     llm_evaluator.prompt_id = target_prompt_id
+                    shared_evaluator_changed = True
                 # Update the prompt_version_tag to point to the provided prompt_version
                 if llm_evaluator.prompt_version_tag_id is not None:
                     prompt_version_tag = await session.get(
                         models.PromptVersionTag, llm_evaluator.prompt_version_tag_id
                     )
                     if prompt_version_tag is not None:
-                        prompt_version_tag.prompt_id = target_prompt_id
-                        prompt_version_tag.prompt_version_id = provided_prompt_version_id
+                        if (
+                            prompt_version_tag.prompt_id != target_prompt_id
+                            or prompt_version_tag.prompt_version_id != provided_prompt_version_id
+                        ):
+                            prompt_version_tag.prompt_id = target_prompt_id
+                            prompt_version_tag.prompt_version_id = provided_prompt_version_id
+                            shared_evaluator_changed = True
                     else:
                         raise NotFound(
                             f"Prompt version tag with id {llm_evaluator.prompt_version_tag_id} "
@@ -1450,25 +1474,25 @@ class EvaluatorMutationMixin:
 
                 target_prompt_id = new_prompt.id
                 llm_evaluator.prompt_id = target_prompt_id
+                shared_evaluator_changed = True
                 # Use the newly created prompt_version for comparison (it will always be "new")
                 active_prompt_version = prompt_version
 
             dataset_evaluator.name = evaluator_name
-            dataset_evaluator.description = (
-                input.description if isinstance(input.description, str) else None
-            )
+            if input.description is not UNSET:
+                dataset_evaluator.description = input.description
             dataset_evaluator.output_configs = list(output_configs)
             if input.input_mapping is None:
                 raise BadRequest("input_mapping is required")
             dataset_evaluator.input_mapping = input.input_mapping.to_orm()
             dataset_evaluator.user_id = user_id
 
-            llm_evaluator.description = (
-                input.description if isinstance(input.description, str) else None
-            )
-            llm_evaluator.output_configs = list(output_configs)
-            llm_evaluator.updated_at = datetime.now(timezone.utc)
-            llm_evaluator.user_id = user_id
+            if input.description is not UNSET and llm_evaluator.description != input.description:
+                llm_evaluator.description = input.description
+                shared_evaluator_changed = True
+            if llm_evaluator.output_configs != list(output_configs):
+                llm_evaluator.output_configs = list(output_configs)
+                shared_evaluator_changed = True
 
             if new_prompt is not None:
                 # We already created a new prompt above
@@ -1481,6 +1505,7 @@ class EvaluatorMutationMixin:
                 if create_new_prompt_version:
                     prompt_version.prompt_id = target_prompt_id
                     session.add(prompt_version)
+                    shared_evaluator_changed = True
 
             try:
                 validate_consistent_llm_evaluator_and_prompt_version(prompt_version, llm_evaluator)
@@ -1505,9 +1530,18 @@ class EvaluatorMutationMixin:
                         models.PromptVersionTag, llm_evaluator.prompt_version_tag_id
                     )
                     if prompt_version_tag is not None:
-                        prompt_version_tag.prompt_version_id = final_prompt_version_id
-                        # Ensure prompt_id matches
-                        prompt_version_tag.prompt_id = target_prompt_id
+                        if (
+                            prompt_version_tag.prompt_version_id != final_prompt_version_id
+                            or prompt_version_tag.prompt_id != target_prompt_id
+                        ):
+                            prompt_version_tag.prompt_version_id = final_prompt_version_id
+                            # Ensure prompt_id matches
+                            prompt_version_tag.prompt_id = target_prompt_id
+                            shared_evaluator_changed = True
+
+            if shared_evaluator_changed:
+                llm_evaluator.updated_at = datetime.now(timezone.utc)
+                llm_evaluator.user_id = user_id
 
         return DatasetEvaluatorMutationPayload(
             evaluator=DatasetEvaluator(id=dataset_evaluator.id),

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -1,5 +1,5 @@
 import strawberry
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, literal, not_, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.orm import load_only
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
@@ -93,7 +93,20 @@ class ProjectMutationMixin:
             stmt = delete(models.ProjectSession)
             for i in range(0, len(session_ids_to_delete), chunk_size):
                 chunk = session_ids_to_delete[i : i + chunk_size]
-                await session.execute(stmt.where(models.ProjectSession.id.in_(chunk)))
+                await session.execute(
+                    stmt.where(
+                        and_(
+                            models.ProjectSession.id.in_(chunk),
+                            not_(
+                                select(literal(1))
+                                .where(
+                                    models.Trace.project_session_rowid == models.ProjectSession.id
+                                )
+                                .exists()
+                            ),
+                        )
+                    )
+                )
         info.context.event_queue.put(SpanDeleteEvent((project_id,)))
         return Query()
 

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -774,6 +774,9 @@ class OnlineEvalProducer(DaemonTask):
         criteria: _ActiveCriteria,
         span_ids: list[int],
     ) -> None:
+        if not span_ids:
+            return
+        await self._stamp_work_materialized(session, criteria.criteria_id)
         records = [
             {
                 "span_rowid": span_rowid,
@@ -820,3 +823,22 @@ class OnlineEvalProducer(DaemonTask):
                     on_conflict=OnConflict.DO_NOTHING,
                 )
             )
+
+    async def _stamp_work_materialized(self, session: AsyncSession, criteria_id: int) -> None:
+        """Record that this criteria has produced evaluation work, once and for good.
+
+        The stamp is what the evaluationTarget lock reads, so it must survive the work
+        rows that retention will eventually delete. updated_at is carried forward
+        explicitly: this is a producer bookkeeping write, not a configuration change.
+        """
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(
+                models.ProjectEvaluatorCriteria.id == criteria_id,
+                models.ProjectEvaluatorCriteria.work_materialized_at.is_(None),
+            )
+            .values(
+                work_materialized_at=datetime.now(timezone.utc),
+                updated_at=models.ProjectEvaluatorCriteria.updated_at,
+            )
+        )

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -138,6 +138,37 @@ async def resolve_criteria_bulk(
             .all()
         )
 
+    # A prompt version's custom provider is a mutable pointer: editing the provider's
+    # connection config changes what answers the evaluation without changing the prompt
+    # version. Resolve it to (provider id, updated_at) so the fingerprint moves with it.
+    custom_provider_refs: dict[int, tuple[int, str]] = {}
+    prompt_version_ids = set(tagged_prompt_version_ids.values()) | set(
+        latest_prompt_version_ids.values()
+    )
+    if prompt_version_ids:
+        custom_provider_refs = {
+            prompt_version_id: (custom_provider_id, updated_at.isoformat())
+            for prompt_version_id, custom_provider_id, updated_at in (
+                (
+                    await session.execute(
+                        select(
+                            models.PromptVersion.id,
+                            models.GenerativeModelCustomProvider.id,
+                            models.GenerativeModelCustomProvider.updated_at,
+                        )
+                        .join(
+                            models.GenerativeModelCustomProvider,
+                            models.PromptVersion.custom_provider_id
+                            == models.GenerativeModelCustomProvider.id,
+                        )
+                        .where(models.PromptVersion.id.in_(prompt_version_ids))
+                    )
+                )
+                .tuples()
+                .all()
+            )
+        }
+
     latest_code_versions = await latest_code_evaluator_versions_by_evaluator_id(
         list(code_evaluators),
         session,
@@ -151,6 +182,8 @@ async def resolve_criteria_bulk(
                 version_ref = tagged_prompt_version_ids.get(evaluator.prompt_version_tag_id)
             else:
                 version_ref = latest_prompt_version_ids.get(evaluator.prompt_id)
+            if (custom_provider_ref := custom_provider_refs.get(version_ref)) is not None:
+                version_ref = [version_ref, *custom_provider_ref]
         elif isinstance(evaluator, models.CodeEvaluator):
             version = latest_code_versions.get(evaluator.id)
             version_ref = version.id if version is not None else None

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -20,8 +20,7 @@ from . import (
     _verify_clean_state,
 )
 
-_DOWN = "d4e5f6a7b8c9"
-_PREVIOUS = "c9d0e1f2a3b4"
+_DOWN = "c9d0e1f2a3b4"
 _UP = "a7f1c3e9d2b4"
 _SQLITE_PROJECT_SESSION_DESC_INDEX_SQL = {
     "ix_project_sessions_project_id_end_time": (
@@ -32,6 +31,10 @@ _SQLITE_PROJECT_SESSION_DESC_INDEX_SQL = {
         "CREATE INDEX ix_project_sessions_project_id_start_time "
         "ON project_sessions (project_id, start_time DESC)"
     ),
+}
+_PG_PROJECT_SESSION_DESC_INDEX_COLUMNS = {
+    "ix_project_sessions_project_id_end_time": "(project_id, end_time DESC)",
+    "ix_project_sessions_project_id_start_time": "(project_id, start_time DESC)",
 }
 
 
@@ -47,6 +50,22 @@ def _get_sqlite_project_session_index_sql(conn: Connection) -> dict[str, str]:
         )
     ).all()
     return {name: sql for name, sql in rows if sql is not None}
+
+
+def _get_postgresql_project_session_index_def(conn: Connection, schema: str) -> dict[str, str]:
+    rows = conn.execute(
+        sa.text(
+            "SELECT indexname, indexdef FROM pg_indexes "
+            "WHERE schemaname = :schema "
+            "AND tablename = 'project_sessions' "
+            "AND indexname IN ("
+            "'ix_project_sessions_project_id_start_time', "
+            "'ix_project_sessions_project_id_end_time'"
+            ")"
+        ),
+        {"schema": schema},
+    ).all()
+    return {name: indexdef for name, indexdef in rows}
 
 
 def _constraint_name(name: str, db_backend: _DBBackend) -> str:
@@ -249,11 +268,29 @@ async def test_project_session_liveness_schema(
     _schema: str,
 ) -> None:
     await _verify_clean_state(_engine, _schema)
-    await _up(_engine, _alembic_config, _PREVIOUS, _schema)
+    await _up(_engine, _alembic_config, _DOWN, _schema)
     end_time = datetime(2026, 1, 2, tzinfo=timezone.utc)
 
     def _get(conn: Connection) -> Optional[_TableSchemaInfo]:
         return _get_table_schema_info(conn, "project_sessions", _db_backend, _schema)
+
+    async def _assert_desc_indexes() -> None:
+        """Assert both project_sessions indexes are descending, at DDL level, on either dialect."""
+        if _db_backend == "sqlite":
+            assert (
+                await _run_async(_engine, _get_sqlite_project_session_index_sql)
+                == _SQLITE_PROJECT_SESSION_DESC_INDEX_SQL
+            )
+        elif _db_backend == "postgresql":
+            index_defs = await _run_async(
+                _engine,
+                lambda conn: _get_postgresql_project_session_index_def(conn, _schema),
+            )
+            assert index_defs.keys() == _PG_PROJECT_SESSION_DESC_INDEX_COLUMNS.keys()
+            for index_name, columns in _PG_PROJECT_SESSION_DESC_INDEX_COLUMNS.items():
+                assert index_defs[index_name].endswith(columns)
+        else:
+            assert_never(_db_backend)
 
     def _seed(conn: Connection) -> None:
         metadata = sa.MetaData()
@@ -321,11 +358,10 @@ async def test_project_session_liveness_schema(
     assert last_span_ingested_at is None
     assert index_columns == ["project_id", "last_span_ingested_at"]
     assert "last_span_ingested_at IS NOT NULL" in index_where
-    if _db_backend == "sqlite":
-        assert (
-            await _run_async(_engine, _get_sqlite_project_session_index_sql)
-            == _SQLITE_PROJECT_SESSION_DESC_INDEX_SQL
-        )
+    await _assert_desc_indexes()
 
-    await _down(_engine, _alembic_config, _PREVIOUS, _schema)
+    await _down(_engine, _alembic_config, _DOWN, _schema)
     assert await _run_async(_engine, _get) == before
+    # Reflection-driven index drift is symmetric: index names and column lists survive a
+    # DESC -> ASC rebuild, so the schema comparison above cannot catch one on the way down.
+    await _assert_desc_indexes()

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -168,6 +168,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             "evaluation_target",
             "input_mapping",
             "enabled",
+            "work_materialized_at",
             "created_at",
             "updated_at",
         }
@@ -199,7 +200,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             column_names=frozenset(column_names),
             index_names=frozenset(index_names),
             constraint_names=frozenset(constraint_names),
-            nullable_column_names=frozenset(["input_mapping"]),
+            nullable_column_names=frozenset(["input_mapping", "work_materialized_at"]),
         )
 
 

--- a/tests/unit/server/api/mutations/test_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_evaluator_mutations.py
@@ -1847,6 +1847,155 @@ class TestUpdateDatasetLLMEvaluatorMutation:
             )
             assert len(prompt_versions.all()) == 1
 
+    async def test_update_preserves_description_and_owner_on_no_op_save(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        empty_dataset: models.Dataset,
+        llm_evaluator: models.LLMEvaluator,
+    ) -> None:
+        """An omitted description must not null either row, and a no-op save must not
+        re-attribute ownership of the shared LLM evaluator."""
+        dataset_id = str(GlobalID("Dataset", str(empty_dataset.id)))
+
+        async with db() as session:
+            current_prompt_version = await session.scalar(
+                select(models.PromptVersion)
+                .where(models.PromptVersion.prompt_id == llm_evaluator.prompt_id)
+                .order_by(models.PromptVersion.id.desc())
+                .limit(1)
+            )
+            assert current_prompt_version is not None
+            current_prompt_version_id = str(
+                GlobalID("PromptVersion", str(current_prompt_version.id))
+            )
+            dataset_evaluator = await session.scalar(
+                select(models.DatasetEvaluators).where(
+                    models.DatasetEvaluators.dataset_id == empty_dataset.id,
+                    models.DatasetEvaluators.evaluator_id == llm_evaluator.id,
+                )
+            )
+            assert dataset_evaluator is not None
+            dataset_evaluator_id = str(GlobalID("DatasetEvaluator", str(dataset_evaluator.id)))
+
+        # The evaluator description is constrained to equal the tool function description,
+        # so both carry the seeded value.
+        def _input(prompt_version_id: str, **overrides: Any) -> dict[str, Any]:
+            return {
+                "inputMapping": {"literalMapping": {}, "pathMapping": {}},
+                "datasetEvaluatorId": dataset_evaluator_id,
+                "datasetId": dataset_id,
+                "name": "no-op-evaluator",
+                "promptVersionId": prompt_version_id,
+                "promptVersion": dict(
+                    description=None,
+                    templateFormat="F_STRING",
+                    template=dict(
+                        messages=[
+                            dict(
+                                role="USER",
+                                content=[dict(text=dict(text="Test evaluator: {input}"))],
+                            )
+                        ]
+                    ),
+                    invocationParameters=dict(openai=dict()),
+                    tools=dict(
+                        tools=[
+                            dict(
+                                function=dict(
+                                    name="correctness",
+                                    description="seeded description",
+                                    parameters={
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "type": "string",
+                                                "enum": ["correct", "incorrect"],
+                                                "description": "correctness",
+                                            }
+                                        },
+                                        "required": ["label"],
+                                    },
+                                ),
+                            )
+                        ],
+                        toolChoice=dict(oneOrMore=True),
+                    ),
+                    responseFormat=None,
+                    modelProvider="OPENAI",
+                    modelName="gpt-4",
+                ),
+                "outputConfigs": [
+                    dict(
+                        categorical=dict(
+                            name="correctness",
+                            description="correctness description",
+                            optimizationDirection="MAXIMIZE",
+                            values=[
+                                dict(label="correct", score=1),
+                                dict(label="incorrect", score=0),
+                            ],
+                        )
+                    )
+                ],
+                **overrides,
+            }
+
+        # Seed a known description through the mutation itself, so the follow-up save is
+        # a no-op on every shared field.
+        seed_result = await gql_client.execute(
+            self._UPDATE_MUTATION,
+            {"input": _input(current_prompt_version_id, description="seeded description")},
+        )
+        assert seed_result.data and not seed_result.errors
+
+        async with db() as session:
+            seeded_prompt_version = await session.scalar(
+                select(models.PromptVersion)
+                .where(models.PromptVersion.prompt_id == llm_evaluator.prompt_id)
+                .order_by(models.PromptVersion.id.desc())
+                .limit(1)
+            )
+            assert seeded_prompt_version is not None
+            seeded_prompt_version_id = str(GlobalID("PromptVersion", str(seeded_prompt_version.id)))
+
+        async with db() as session:
+            user_role_id = await session.scalar(select(models.UserRole.id).limit(1))
+            assert user_role_id is not None
+            owner = models.User(
+                user_role_id=user_role_id,
+                username=f"dataset-evaluator-owner-{token_hex(4)}",
+                email=f"{token_hex(4)}@test.com",
+                password_hash=b"hash",
+                password_salt=b"salt",
+                reset_password=False,
+                auth_method="LOCAL",
+            )
+            session.add(owner)
+            await session.flush()
+            db_evaluator = await session.get(models.LLMEvaluator, llm_evaluator.id)
+            assert db_evaluator is not None
+            db_evaluator.user_id = owner.id
+            owner_id = owner.id
+
+        result = await gql_client.execute(
+            self._UPDATE_MUTATION, {"input": _input(seeded_prompt_version_id)}
+        )
+        assert result.data and not result.errors
+
+        async with db() as session:
+            db_evaluator = await session.get(models.LLMEvaluator, llm_evaluator.id)
+            assert db_evaluator is not None
+            assert db_evaluator.description == "seeded description"
+            assert db_evaluator.user_id == owner_id
+            db_dataset_evaluator = await session.scalar(
+                select(models.DatasetEvaluators).where(
+                    models.DatasetEvaluators.evaluator_id == llm_evaluator.id
+                )
+            )
+            assert db_dataset_evaluator is not None
+            assert db_dataset_evaluator.description == "seeded description"
+
     async def test_update_with_prompt_version_id_same_prompt(
         self,
         db: DbSessionFactory,

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -528,6 +528,68 @@ async def test_project_llm_evaluator_create_update_delete(
     assert delete_result.data and not delete_result.errors
 
 
+async def test_update_project_llm_evaluator_preserves_description_and_owner_on_no_op_save(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    project = await _add_project(db)
+
+    # The evaluator description is constrained to equal the tool function description.
+    def _described_input(**overrides: Any) -> dict[str, Any]:
+        payload = _llm_input(project, name="llm-owner", text="Evaluate {{input}}")
+        payload["description"] = "original description"
+        payload["promptVersion"]["tools"]["tools"][0]["function"]["description"] = (
+            "original description"
+        )
+        payload.update(overrides)
+        return payload
+
+    create_result = await gql_client.execute(_CREATE_LLM, {"input": _described_input()})
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectLlmEvaluator"]["evaluator"]
+
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        evaluator = await session.get(models.LLMEvaluator, criteria.evaluator_id)
+        assert evaluator is not None
+        assert evaluator.description == "original description"
+        user_role_id = await session.scalar(select(models.UserRole.id).limit(1))
+        assert user_role_id is not None
+        owner = models.User(
+            user_role_id=user_role_id,
+            username=f"llm-evaluator-owner-{token_hex(4)}",
+            email=f"{token_hex(4)}@test.com",
+            password_hash=b"hash",
+            password_salt=b"salt",
+            reset_password=False,
+            auth_method="LOCAL",
+        )
+        session.add(owner)
+        await session.flush()
+        evaluator.user_id = owner.id
+        owner_id = owner.id
+
+    # Same prompt content and output configs, no description: nothing about the shared
+    # evaluator changed, so neither its description nor its owner may be rewritten.
+    update_input = _described_input()
+    update_input.pop("projectId")
+    update_input.pop("enabled")
+    update_input.pop("description")
+    update_input["projectEvaluatorId"] = created["id"]
+    update_result = await gql_client.execute(_UPDATE_LLM, {"input": update_input})
+    assert update_result.data and not update_result.errors
+
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        evaluator = await session.get(models.LLMEvaluator, criteria.evaluator_id)
+        assert evaluator is not None
+        assert evaluator.description == "original description"
+        assert evaluator.user_id == owner_id
+
+
 @pytest.mark.parametrize("evaluator_kind", ["LLM", "CODE"])
 async def test_set_project_evaluator_enabled_toggles_only_enabled(
     gql_client: AsyncGraphQLClient,

--- a/tests/unit/server/api/mutations/test_project_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_mutations.py
@@ -132,6 +132,73 @@ class TestProjectMutations:
                     session_obj = await session.get(models.ProjectSession, project_sessions[i].id)
                     assert session_obj is None, f"Session {i} should be deleted"
 
+    async def test_clear_project_keeps_session_spanning_end_time(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        """A session with traces on both sides of end_time must keep its newer traces.
+
+        Trace.project_session_rowid cascades on delete, so deleting the session row would
+        take the retained traces with it.
+        """
+        base_start_time = datetime.now(timezone.utc)
+        end_time = base_start_time - timedelta(hours=12)
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+
+            project_session = models.ProjectSession(
+                project_id=project.id,
+                session_id=token_hex(8),
+                start_time=base_start_time - timedelta(days=1),
+                end_time=base_start_time,
+            )
+            session.add(project_session)
+            await session.flush()
+
+            old_trace = models.Trace(
+                project_rowid=project.id,
+                trace_id=token_hex(16),
+                start_time=base_start_time - timedelta(days=1),
+                end_time=base_start_time - timedelta(days=1) + timedelta(hours=1),
+                project_session_rowid=project_session.id,
+            )
+            new_trace = models.Trace(
+                project_rowid=project.id,
+                trace_id=token_hex(16),
+                start_time=base_start_time,
+                end_time=base_start_time + timedelta(hours=1),
+                project_session_rowid=project_session.id,
+            )
+            session.add_all([old_trace, new_trace])
+            await session.flush()
+            project_id, session_rowid = project.id, project_session.id
+            old_trace_id, new_trace_id = old_trace.id, new_trace.id
+
+        result = await gql_client.execute(
+            query="""
+            mutation($input: ClearProjectInput!) {
+                clearProject(input: $input) {
+                    __typename
+                }
+            }
+            """,
+            variables={
+                "input": {
+                    "id": str(GlobalID("Project", str(project_id))),
+                    "endTime": end_time.isoformat(),
+                }
+            },
+        )
+        assert not result.errors
+
+        async with db() as session:
+            assert await session.get(models.Trace, old_trace_id) is None
+            assert await session.get(models.Trace, new_trace_id) is not None
+            assert await session.get(models.ProjectSession, session_rowid) is not None
+
     async def test_create_project(
         self,
         db: DbSessionFactory,

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -3,7 +3,7 @@ from secrets import token_hex
 from typing import Any
 
 import pytest
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
@@ -207,6 +207,59 @@ async def test_tick_materializes_matching_spans_and_advances_watermark(
         )
     await producer._tick()
     assert len(await _work_unit_span_rowids(db)) == len(llm_spans)
+
+
+async def test_materialization_stamp_is_set_once_and_outlives_the_work_rows(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace, span_kind="LLM") for _ in range(2)]
+    _, criteria_id = await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(
+        db,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.work_materialized_at is None
+        updated_at_before = criteria.updated_at
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        first_stamp = criteria.work_materialized_at
+        assert first_stamp is not None
+        # Producer bookkeeping must not read as a configuration change.
+        assert criteria.updated_at == updated_at_before
+
+    # Retention eventually deletes the work rows; the record that work has ever
+    # existed must not go with them, and re-materializing must not move it.
+    async with db() as session:
+        await session.execute(delete(models.EvalWorkUnit))
+        await session.execute(
+            update(models.EvalWorkCursor)
+            .where(models.EvalWorkCursor.id == cursor_id)
+            .values(
+                produced_through_id=0,
+                observed_high_water_id=spans[-1].id,
+                observed_at=_now() - timedelta(seconds=120),
+            )
+        )
+    await producer._tick()
+
+    assert len(await _work_unit_span_rowids(db)) == len(spans)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.work_materialized_at == first_stamp
 
 
 async def test_builtin_implementation_version_changes_fingerprint(

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -6,8 +6,23 @@ import pytest
 from sqlalchemy import func, select, update
 
 from phoenix.db import models
+from phoenix.db.types.annotation_configs import (
+    CategoricalAnnotationValue,
+    CategoricalOutputConfig,
+    OptimizationDirection,
+)
 from phoenix.db.types.identifier import Identifier
+from phoenix.db.types.model_provider import ModelProvider
+from phoenix.db.types.prompts import (
+    PromptChatTemplate,
+    PromptMessage,
+    PromptOpenAIInvocationParameters,
+    PromptOpenAIInvocationParametersContent,
+    PromptTemplateFormat,
+    PromptTemplateType,
+)
 from phoenix.server.api.evaluators import ContainsEvaluator
+from phoenix.server.encryption import EncryptionService
 from phoenix.server.online_eval import producer as producer_module
 from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
 from phoenix.server.online_eval.db_coordinator import (
@@ -228,6 +243,91 @@ async def test_builtin_implementation_version_changes_fingerprint(
         assert second is not None
 
     assert config_fingerprint(first) != config_fingerprint(second)
+
+
+async def test_llm_custom_provider_edit_changes_fingerprint(
+    db: DbSessionFactory,
+) -> None:
+    """A custom provider's connection config decides what actually answers the evaluation,
+    so editing it must move the fingerprint even though the prompt version is unchanged."""
+    async with db() as session:
+        project = await _add_project(session)
+        provider = models.GenerativeModelCustomProvider(
+            name=f"provider-{token_hex(4)}",
+            provider="openai",
+            sdk="OPENAI",
+            config=EncryptionService().encrypt(b'{"base_url": "https://vendor.example"}'),
+        )
+        session.add(provider)
+        await session.flush()
+
+        prompt = models.Prompt(
+            name=Identifier(root=f"prompt-{token_hex(4)}"),
+            description=None,
+            prompt_versions=[
+                models.PromptVersion(
+                    template_type=PromptTemplateType.CHAT,
+                    template_format=PromptTemplateFormat.MUSTACHE,
+                    template=PromptChatTemplate(
+                        type="chat",
+                        messages=[PromptMessage(role="user", content="Good? {{output}}")],
+                    ),
+                    invocation_parameters=PromptOpenAIInvocationParameters(
+                        type="openai", openai=PromptOpenAIInvocationParametersContent()
+                    ),
+                    tools=None,
+                    response_format=None,
+                    model_provider=ModelProvider.OPENAI,
+                    model_name="gpt-4",
+                    metadata_={},
+                    custom_provider_id=provider.id,
+                )
+            ],
+        )
+        evaluator = models.LLMEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            description=None,
+            kind="LLM",
+            output_configs=[
+                CategoricalOutputConfig(
+                    type="CATEGORICAL",
+                    name="quality",
+                    optimization_direction=OptimizationDirection.MAXIMIZE,
+                    description=None,
+                    values=[
+                        CategoricalAnnotationValue(label="good", score=1.0),
+                        CategoricalAnnotationValue(label="bad", score=0.0),
+                    ],
+                )
+            ],
+            prompt=prompt,
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+        )
+        session.add(criteria)
+        await session.flush()
+
+        before = await resolve_criteria(session, criteria, evaluator)
+        assert before is not None
+
+        # Repoint the provider at a different endpoint. The prompt version — and so the
+        # pre-fix version_ref — is untouched.
+        provider.config = EncryptionService().encrypt(b'{"base_url": "https://self.hosted"}')
+        provider.updated_at = _now() + timedelta(minutes=1)
+        await session.flush()
+
+        after = await resolve_criteria(session, criteria, evaluator)
+        assert after is not None
+
+    assert config_fingerprint(before) != config_fingerprint(after)
 
 
 async def test_unregistered_builtin_cannot_resolve_criteria(


### PR DESCRIPTION
Four behavior fixes and two migration-test hardenings on the online-evals base.

## Behavior fixes

- **`updateProjectLlmEvaluator` and `updateDatasetLlmEvaluator` no longer erase omitted fields or reassign ownership on every save.** `description` omission previously nulled the stored value (on the dataset variant, on both the binding and the shared evaluator), and every save re-attributed the shared evaluator's `user_id` to the caller — including no-op saves. Both mutations now use `UNSET` defaults with change-guarded assignment and only re-attribute ownership when a shared field actually changed, matching the existing CODE evaluator update behavior. Explicitly sending `description: null` still clears it.
- **`clearProject` with an `endTime` no longer deletes traces newer than the cutoff.** The session-row delete now carries the same correlated `NOT EXISTS` guard `deleteTraces` uses, so a session spanning the cutoff keeps its newer traces instead of losing them to the FK cascade.
- **LLM evaluation results now include custom-provider identity in their fingerprint.** When a prompt version routes through a custom model provider, the provider id and its `updated_at` join the version reference, so editing a provider's connection produces new evaluation work instead of silently reusing results produced by a different endpoint. Mirrors the sandbox-runtime fingerprint on the CODE path.

## Migration-test hardening

- The `project_sessions` DESC-index DDL assertion now runs after downgrade as well as upgrade on SQLite, and PostgreSQL gains an equivalent `pg_indexes.indexdef` assertion — index sort order is now pinned at DDL level on both dialects in both directions.
- The schema-test baseline constant now points at the migration's actual parent revision.
- A comment records why the migration deliberately avoids `batch_alter_table` (a rebuild would silently flip the DESC indexes on SQLite).
- `scripts/ddl/postgresql_schema.sql` regenerated — it was missing the `last_span_ingested_at` column and partial index and still carried pre-rename constraint names (isolated in its own commit).

Each behavior fix carries a test that fails without it. Full mypy and the touched suites pass on SQLite and PostgreSQL.