### PR TITLE
feat(agents): make the tool_outputs route the only path for client tool outputs

### DIFF
--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -335,7 +335,7 @@ describe("buildAgentChatRequestBody", () => {
     expect(body.lastMessageId).toBe("compaction-1");
   });
 
-  it("sends resolved client tool outputs instead of the assistant message on continuations", () => {
+  it("sends a bare continuation for a trailing assistant message", () => {
     const continuationAssistant: AgentUIMessage = {
       id: "assistant-1",
       role: "assistant",
@@ -388,17 +388,15 @@ describe("buildAgentChatRequestBody", () => {
       },
     });
 
-    // The server owns the assistant message; only the client-executed tool
-    // outputs travel, and the message field is omitted entirely.
+    // The server owns the assistant message, and its outputs already arrived
+    // via the tool_outputs route — the continuation carries no payload.
     expect(body.message).toBeUndefined();
-    expect(body.toolOutputs?.map((part) => part.toolCallId)).toEqual([
-      "call-1",
-    ]);
+    expect("toolOutputs" in body).toBe(false);
     // The continued assistant message is itself the persisted transcript tail.
     expect(body.lastMessageId).toBe("assistant-1");
   });
 
-  it("attaches interrupted client tool outputs to a superseding user message", () => {
+  it("sends only the user message when superseding an interrupted turn", () => {
     const interruptedAssistant: AgentUIMessage = {
       id: "assistant-1",
       role: "assistant",
@@ -445,10 +443,10 @@ describe("buildAgentChatRequestBody", () => {
       },
     });
 
+    // Outputs travel only via the tool_outputs route; anything unresolved
+    // server-side is repaired as interrupted when the new turn starts.
     expect(body.message?.id).toBe("user-2");
-    expect(body.toolOutputs?.map((part) => part.toolCallId)).toEqual([
-      "call-1",
-    ]);
+    expect("toolOutputs" in body).toBe(false);
     expect(body.lastMessageId).toBe("assistant-1");
   });
 });

--- a/app/src/agent/chat/__tests__/pendingToolStateCleanup.test.ts
+++ b/app/src/agent/chat/__tests__/pendingToolStateCleanup.test.ts
@@ -86,7 +86,7 @@ describe("cleanupResolvedPendingToolState", () => {
               "The tool call was interrupted before a result was produced.",
           }
         : {}),
-    }) as AgentUIMessage["parts"][number];
+    } as AgentUIMessage["parts"][number]);
 
   it("clears pending state for tool calls the transcript shows as resolved", () => {
     const state = createStateStub();

--- a/app/src/agent/chat/__tests__/shouldSendAutomatically.test.ts
+++ b/app/src/agent/chat/__tests__/shouldSendAutomatically.test.ts
@@ -196,7 +196,7 @@ describe("getFlushableClientToolOutputs", () => {
     expect(outputs).toEqual([]);
   });
 
-  it("returns nothing once every call has resolved", () => {
+  it("returns the final output once every call has resolved", () => {
     const messages = [
       createMessage({
         id: "assistant-1",
@@ -214,10 +214,15 @@ describe("getFlushableClientToolOutputs", () => {
       }),
     ];
 
-    // The normal chat continuation carries the outputs instead.
-    expect(
-      getFlushableClientToolOutputs({ messages, isFlushed: () => false })
-    ).toEqual([]);
+    // The bare chat continuation carries no outputs, so the last one must
+    // flush before the turn resumes.
+    const outputs = getFlushableClientToolOutputs({
+      messages,
+      isFlushed: () => false,
+    });
+    expect(outputs.map((output) => output.toolCallId)).toEqual([
+      "tool-call-resolved",
+    ]);
   });
 
   it("returns nothing when the tail holds a user-interrupted output", () => {

--- a/app/src/agent/chat/__tests__/toolOutputFlush.test.ts
+++ b/app/src/agent/chat/__tests__/toolOutputFlush.test.ts
@@ -106,13 +106,15 @@ describe("createToolOutputFlusher", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not flush when every tool call has resolved", async () => {
+  it("flushes the final output once every tool call has resolved", async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse());
     const flusher = createToolOutputFlusher({
       flushUrl: FLUSH_URL,
       fetch: fetchMock,
     });
 
+    // The bare chat continuation carries no outputs, so even a fully
+    // resolved tail must flush.
     flusher.maybeFlush([
       userMessage(),
       assistantMessage([
@@ -122,7 +124,75 @@ describe("createToolOutputFlusher", () => {
     ]);
     await settle();
 
-    // The normal chat continuation carries the outputs instead.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.toolOutputs).toHaveLength(2);
+  });
+
+  it("flushAndWait resolves true once every output has landed", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    const flusher = createToolOutputFlusher({
+      flushUrl: FLUSH_URL,
+      fetch: fetchMock,
+    });
+
+    const flushed = await flusher.flushAndWait([
+      userMessage(),
+      assistantMessage([
+        resolvedToolPart("call-1"),
+        resolvedToolPart("call-2"),
+      ]),
+    ]);
+
+    expect(flushed).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushAndWait retries a failed pass once before giving up", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse())
+      .mockResolvedValue(okResponse());
+    const flusher = createToolOutputFlusher({
+      flushUrl: FLUSH_URL,
+      fetch: fetchMock,
+    });
+
+    const flushed = await flusher.flushAndWait([
+      userMessage(),
+      assistantMessage([resolvedToolPart("call-1")]),
+    ]);
+
+    expect(flushed).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("flushAndWait resolves false when outputs cannot land", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse());
+    const flusher = createToolOutputFlusher({
+      flushUrl: FLUSH_URL,
+      fetch: fetchMock,
+    });
+
+    const flushed = await flusher.flushAndWait([
+      userMessage(),
+      assistantMessage([resolvedToolPart("call-1")]),
+    ]);
+
+    expect(flushed).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("flushAndWait is a no-op when nothing needs flushing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    const flusher = createToolOutputFlusher({
+      flushUrl: FLUSH_URL,
+      fetch: fetchMock,
+    });
+
+    const flushed = await flusher.flushAndWait([userMessage()]);
+
+    expect(flushed).toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/app/src/agent/chat/agentChatApi.ts
+++ b/app/src/agent/chat/agentChatApi.ts
@@ -48,6 +48,7 @@ const AGENT_SESSION_CONFLICT_CODES = [
   "agent_session_model_stale",
   "agent_session_messages_stale",
   "agent_session_tool_outputs_conflict",
+  "agent_session_tool_outputs_pending",
   "agent_session_already_compact",
   "agent_session_compaction_conflict",
 ] as const satisfies readonly AgentSessionConflictCode[];

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -11,7 +11,6 @@ import {
   type AgentServerConfig,
 } from "@phoenix/store/agentStore";
 
-import { isResolvedClientToolOutputPart } from "./chatUtils";
 import type { ClientToolTimingRecorder } from "./clientToolTimings";
 import { toServerSafeUIMessages } from "./serverSafeMessages";
 import type { AgentUIMessage } from "./types";
@@ -56,29 +55,6 @@ type ClientToolTimingMetadata = Pick<
   components["schemas"]["PhoenixToolCallCallbackProviderMetadata"],
   "clientStartedAt" | "clientEndedAt"
 >;
-
-/**
- * A tool part in a terminal AI SDK output state (`output-available` /
- * `output-error`), as the chat endpoint's `toolOutputs` field models it.
- */
-type ChatToolOutput = NonNullable<
-  BuildAgentChatRequestBodyResult["toolOutputs"]
->[number];
-
-/**
- * Extract the assistant message's resolved client-executed tool parts — the
- * `toolOutputs` a send may carry. The server matches them by `toolCallId`,
- * applies them to its persisted copy of the message, and ignores outputs for
- * tool calls it has already resolved, so resending is idempotent.
- */
-function getClientToolOutputs(message: AgentUIMessage): ChatToolOutput[] {
-  const resolvedClientToolParts = message.parts.filter((part) =>
-    isResolvedClientToolOutputPart(part)
-  );
-  // The AI SDK's tool UI parts and the generated wire schema describe the
-  // same Vercel data-stream shapes but spell optionality differently.
-  return resolvedClientToolParts as unknown as ChatToolOutput[];
-}
 
 export type AgentChatRequestBodyPatch = Pick<
   BuildAgentChatRequestBodyResult,
@@ -163,24 +139,12 @@ export function buildAgentChatRequestBody({
     throw new Error("A chat submit request requires a message to send");
   }
   if (trailingMessage.role === "assistant") {
-    // Client-tool continuation: the server owns the assistant message, so
-    // only the resolved client tool outputs are sent, not the message itself.
-    const [enrichedAssistant] = enrichMessagesWithClientToolTimings({
-      messages: [trailingMessage],
-      toolTimings,
-    });
-    const toolOutputs = getClientToolOutputs(
-      enrichedAssistant ?? trailingMessage
-    );
-    if (toolOutputs.length === 0) {
-      throw new Error(
-        "A chat continuation requires resolved client tool outputs to send"
-      );
-    }
+    // Bare client-tool continuation: the resolved outputs already reached the
+    // server via the tool_outputs route, so the request carries no payload —
+    // it only asks the server to resume the turn it owns.
     return {
       ...base,
       trigger: "submit-message",
-      toolOutputs,
       lastMessageId: getLastPersistedMessageId(messages),
     };
   }
@@ -193,26 +157,14 @@ export function buildAgentChatRequestBody({
   if (!message) {
     throw new Error("A chat submit request requires a message to send");
   }
-  // A new user message supersedes the previous assistant turn. Any of its
-  // client tool results that never reached the server (e.g. tools marked as
-  // interrupted after Stop) ride along as toolOutputs so the persisted
-  // transcript resolves them; the server ignores already-resolved calls and
-  // authoritatively marks anything still unresolved as interrupted.
-  const precedingMessage = messages.at(-2);
-  const toolOutputs =
-    precedingMessage?.role === "assistant"
-      ? getClientToolOutputs(
-          enrichMessagesWithClientToolTimings({
-            messages: [precedingMessage],
-            toolTimings,
-          })[0] ?? precedingMessage
-        )
-      : [];
+  // A new user message supersedes the previous assistant turn. Client tool
+  // results reach the server only via the tool_outputs route; anything still
+  // unresolved server-side is authoritatively repaired as interrupted when
+  // the new turn starts.
   return {
     ...base,
     trigger: "submit-message",
     message,
-    ...(toolOutputs.length > 0 ? { toolOutputs } : {}),
     lastMessageId: getLastPersistedMessageId(messages),
   };
 }

--- a/app/src/agent/chat/createAgentSessionChat.ts
+++ b/app/src/agent/chat/createAgentSessionChat.ts
@@ -217,8 +217,8 @@ export function createAgentSessionChat({
       const shouldSendAutomatically =
         await turnCompletionGate.handleSendAutomaticallyWhen({ messages });
       if (!shouldSendAutomatically) {
-        // The turn is not continuing yet; eagerly persist any newly resolved
-        // client tool outputs while their siblings stay pending.
+        // The turn is not continuing yet; persist any newly resolved client
+        // tool outputs while their siblings stay pending.
         toolOutputFlusher.maybeFlush(messages);
         return false;
       }
@@ -226,9 +226,19 @@ export function createAgentSessionChat({
       if (assistantMessage?.role !== "assistant") {
         return false;
       }
-      return transcriptPersistence.waitForMessage({
+      const transcriptPersisted = await transcriptPersistence.waitForMessage({
         messageId: assistantMessage.id,
       });
+      if (!transcriptPersisted) {
+        return false;
+      }
+      // The continuation carries no outputs of its own, so every resolved
+      // output must land on the tool_outputs route first. On persistent flush
+      // failure the continuation still fires: the server rejects it with a
+      // visible agent_session_tool_outputs_pending conflict instead of the
+      // turn stalling silently.
+      await toolOutputFlusher.flushAndWait(messages);
+      return true;
     },
     onError: (error) => {
       transcriptPersistence.cancelPendingWaiters();

--- a/app/src/agent/chat/shouldSendAutomatically.ts
+++ b/app/src/agent/chat/shouldSendAutomatically.ts
@@ -45,13 +45,14 @@ export function shouldSendAutomaticallyAfterToolOutput({
 }
 
 /**
- * The trailing assistant message's resolved client tool outputs that are
- * eligible for an eager flush to the tool-outputs endpoint — outputs the
- * server has not yet persisted, on a turn that stays open because sibling
- * tool calls are still pending. Empty when every call has resolved (the
- * normal chat continuation carries the outputs instead) or when the tail
- * holds interrupted or navigation-cancel outputs, which follow the
- * new-user-message path rather than continuing this turn.
+ * The trailing assistant message's resolved client tool outputs that must be
+ * flushed to the tool-outputs endpoint — outputs the server has not yet
+ * persisted. The endpoint is the only path outputs take to the server: each
+ * one flushes as it resolves while sibling calls stay pending, and the last
+ * one flushes before the bare chat continuation resumes the turn. Empty when
+ * the tail holds interrupted or navigation-cancel outputs, which follow the
+ * new-user-message path (where the server repairs unresolved calls as
+ * interrupted) rather than continuing this turn.
  */
 export function getFlushableClientToolOutputs({
   messages,
@@ -69,9 +70,6 @@ export function getFlushableClientToolOutputs({
     return [];
   }
   if (hasApprovalNavigationCancel(messages)) {
-    return [];
-  }
-  if (getUnresolvedToolCalls(messages).length === 0) {
     return [];
   }
   return message.parts.filter(

--- a/app/src/agent/chat/toolOutputFlush.ts
+++ b/app/src/agent/chat/toolOutputFlush.ts
@@ -9,19 +9,23 @@ type SubmitToolOutputsRequestBody =
   components["schemas"]["SubmitAgentSessionToolOutputsRequestBody"];
 
 /**
- * Eagerly persists resolved client tool outputs while sibling tool calls on
- * the trailing assistant message are still pending.
+ * Persists resolved client tool outputs to the session's tool-outputs
+ * endpoint — the only path outputs take to the server.
  *
- * A turn that stops on several client tool approvals stays open until every
- * call resolves, so without flushing, the first Accept/Reject would sit on
- * its result client-side and the persisted transcript would not reflect it.
- * Each newly resolved output is posted to the session's tool-outputs
- * endpoint, which applies it under the turn lock without running the model.
+ * A turn that stops on client tool calls stays open until every call
+ * resolves. Each newly resolved output is posted as it lands, so the
+ * persisted transcript reflects it while sibling calls are still pending,
+ * and the bare chat continuation that finally resumes the turn carries no
+ * outputs of its own — it requires every flush to have landed first
+ * ({@link ToolOutputFlusher.flushAndWait}).
  *
- * Flushing is best-effort: the endpoint ignores outputs for calls it has
- * already resolved, and the final chat continuation re-carries every resolved
- * output, so a failed or skipped flush loses nothing. Failed flushes are
- * simply retried on the next resolution event.
+ * Mid-approval flushes are still failure-tolerant: the endpoint ignores
+ * outputs for calls it has already resolved, so a failed flush is simply
+ * retried on the next resolution event, and `flushAndWait` retries once more
+ * before the continuation. If outputs still cannot land, the continuation
+ * proceeds and the server rejects it with a visible
+ * `agent_session_tool_outputs_pending` conflict rather than stalling
+ * silently.
  */
 export function createToolOutputFlusher({
   flushUrl,
@@ -109,6 +113,16 @@ export function createToolOutputFlusher({
     }
   };
 
+  const startFlush = (): Promise<void> => {
+    const flush = runFlushLoop().finally(() => {
+      if (activeFlush === flush) {
+        activeFlush = null;
+      }
+    });
+    activeFlush = flush;
+    return flush;
+  };
+
   return {
     /**
      * Flush any newly resolved client tool outputs in the trailing assistant
@@ -120,12 +134,23 @@ export function createToolOutputFlusher({
       if (activeFlush !== null) {
         return;
       }
-      const flush = runFlushLoop().finally(() => {
-        if (activeFlush === flush) {
-          activeFlush = null;
+      startFlush();
+    },
+    /**
+     * Flush and wait until every flushable output has reached the server —
+     * the gate a bare chat continuation passes before resuming the turn.
+     * Retries a failed pass once; returns whether all outputs landed.
+     */
+    flushAndWait: async (messages: AgentUIMessage[]): Promise<boolean> => {
+      latestMessages = messages;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const flush = activeFlush ?? startFlush();
+        await flush;
+        if (collectFlushableOutputs().toolOutputs.length === 0) {
+          return true;
         }
-      });
-      activeFlush = flush;
+      }
+      return false;
     },
     /** Reset all tracking when the logical turn completes. */
     clear: (): void => {

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1798,6 +1798,10 @@ export interface components {
          *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
          *       concurrent-writer race but an inconsistent request; fix the client
          *       rather than retrying.
+         *     - ``agent_session_tool_outputs_pending``: a bare continuation asked the
+         *       turn to resume while the trailing assistant message still has pending
+         *       tool calls. Submit the missing outputs via the ``tool_outputs`` route,
+         *       then retry the continuation.
          *     - ``agent_session_already_compact``: there are no complete turns to
          *       compact — either nothing new has finished since the transcript's latest
          *       checkpoint, or a concurrent request's checkpoint already covers them.
@@ -1811,7 +1815,7 @@ export interface components {
              * @description Machine-readable reason the request conflicted.
              * @enum {string}
              */
-            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_already_compact" | "agent_session_compaction_conflict";
+            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_tool_outputs_pending" | "agent_session_already_compact" | "agent_session_compaction_conflict";
             /**
              * Message
              * @description Optional human-readable elaboration on the conflict.
@@ -2243,13 +2247,8 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            /** @description The turn's new user message to append. May be omitted for a bare client-tool continuation: once every pending tool call on the trailing assistant message has been resolved via the ``tool_outputs`` route, a message-less request resumes the turn and runs the model. A continuation whose tail still has pending calls is rejected with HTTP 409 and code ``agent_session_tool_outputs_pending``. */
             message?: components["schemas"]["PhoenixUIMessage"] | null;
-            /**
-             * Tooloutputs
-             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs.
-             */
-            toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**
              * Lastmessageid
              * @description The id of the last transcript message the client has rendered, used for optimistic concurrency. Omit when the session has no messages; required (and validated against the persisted transcript) once it does. On mismatch the server rejects the send with HTTP 409 and code ``agent_session_messages_stale`` — the client should refetch the session before retrying.

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -111,15 +111,13 @@ export function useAgentChat({
   const [compactionStatus, setCompactionStatus] = useState<string | null>(null);
   const isDraft = sessionId == null || sessionId === DRAFT_SESSION_ID;
   const isCompacting = useAgentContext((state) =>
-    sessionId
-      ? (state.isCompactionPendingBySessionId[sessionId] ?? false)
-      : false
+    sessionId ? state.isCompactionPendingBySessionId[sessionId] ?? false : false
   );
   const pendingElicitation = useAgentContext((state) =>
-    sessionId ? (state.pendingElicitationBySessionId[sessionId] ?? null) : null
+    sessionId ? state.pendingElicitationBySessionId[sessionId] ?? null : null
   );
   const isBusyElsewhere = useAgentContext((state) =>
-    sessionId ? (state.isBusyElsewhereBySessionId[sessionId] ?? false) : false
+    sessionId ? state.isBusyElsewhereBySessionId[sessionId] ?? false : false
   );
 
   /**
@@ -215,10 +213,9 @@ export function useAgentChat({
   });
 
   // Local lifecycle cleanup for interrupted client tools: pending calls are
-  // resolved as output-error so the UI settles, pending dialogs are cleared,
-  // and the next send carries the errors to the server as toolOutputs so the
-  // persisted transcript resolves them too. Anything the client can't report
-  // (e.g. a killed tab) is repaired authoritatively server-side at merge time.
+  // resolved as output-error so the UI settles and pending dialogs are
+  // cleared. The errors stay client-side — the server repairs the still-
+  // pending calls authoritatively as interrupted when the next turn starts.
   const addInterruptedToolOutputs = async ({
     messages,
     errorText,

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1798,6 +1798,10 @@ export interface components {
          *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
          *       concurrent-writer race but an inconsistent request; fix the client
          *       rather than retrying.
+         *     - ``agent_session_tool_outputs_pending``: a bare continuation asked the
+         *       turn to resume while the trailing assistant message still has pending
+         *       tool calls. Submit the missing outputs via the ``tool_outputs`` route,
+         *       then retry the continuation.
          *     - ``agent_session_already_compact``: there are no complete turns to
          *       compact — either nothing new has finished since the transcript's latest
          *       checkpoint, or a concurrent request's checkpoint already covers them.
@@ -1811,7 +1815,7 @@ export interface components {
              * @description Machine-readable reason the request conflicted.
              * @enum {string}
              */
-            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_already_compact" | "agent_session_compaction_conflict";
+            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_tool_outputs_pending" | "agent_session_already_compact" | "agent_session_compaction_conflict";
             /**
              * Message
              * @description Optional human-readable elaboration on the conflict.
@@ -2243,13 +2247,8 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            /** @description The turn's new user message to append. May be omitted for a bare client-tool continuation: once every pending tool call on the trailing assistant message has been resolved via the ``tool_outputs`` route, a message-less request resumes the turn and runs the model. A continuation whose tail still has pending calls is rejected with HTTP 409 and code ``agent_session_tool_outputs_pending``. */
             message?: components["schemas"]["PhoenixUIMessage"] | null;
-            /**
-             * Tooloutputs
-             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs.
-             */
-            toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**
              * Lastmessageid
              * @description The id of the last transcript message the client has rendered, used for optimistic concurrency. Omit when the session has no messages; required (and validated against the persisted transcript) once it does. On mismatch the server rejects the send with HTTP 409 and code ``agent_session_messages_stale`` — the client should refetch the session before retrying.

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1798,6 +1798,10 @@ export interface components {
          *       mismatch). Unlike ``agent_session_messages_stale`` this is not a
          *       concurrent-writer race but an inconsistent request; fix the client
          *       rather than retrying.
+         *     - ``agent_session_tool_outputs_pending``: a bare continuation asked the
+         *       turn to resume while the trailing assistant message still has pending
+         *       tool calls. Submit the missing outputs via the ``tool_outputs`` route,
+         *       then retry the continuation.
          *     - ``agent_session_already_compact``: there are no complete turns to
          *       compact — either nothing new has finished since the transcript's latest
          *       checkpoint, or a concurrent request's checkpoint already covers them.
@@ -1811,7 +1815,7 @@ export interface components {
              * @description Machine-readable reason the request conflicted.
              * @enum {string}
              */
-            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_already_compact" | "agent_session_compaction_conflict";
+            code: "agent_session_busy" | "agent_session_model_stale" | "agent_session_messages_stale" | "agent_session_tool_outputs_conflict" | "agent_session_tool_outputs_pending" | "agent_session_already_compact" | "agent_session_compaction_conflict";
             /**
              * Message
              * @description Optional human-readable elaboration on the conflict.
@@ -2243,13 +2247,8 @@ export interface components {
             trigger?: "submit-message";
             /** Id */
             id: string;
-            /** @description The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead. */
+            /** @description The turn's new user message to append. May be omitted for a bare client-tool continuation: once every pending tool call on the trailing assistant message has been resolved via the ``tool_outputs`` route, a message-less request resumes the turn and runs the model. A continuation whose tail still has pending calls is rejected with HTTP 409 and code ``agent_session_tool_outputs_pending``. */
             message?: components["schemas"]["PhoenixUIMessage"] | null;
-            /**
-             * Tooloutputs
-             * @description Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs.
-             */
-            toolOutputs?: (components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"] | components["schemas"]["phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"])[];
             /**
              * Lastmessageid
              * @description The id of the last transcript message the client has rendered, used for optimistic concurrency. Omit when the session has no messages; required (and validated against the persisted transcript) once it does. On mismatch the server rejects the send with HTTP 409 and code ``agent_session_messages_stale`` — the client should refetch the session before retrying.

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -14,6 +14,7 @@ class AgentSessionConflictError(TypedDict):
         "agent_session_model_stale",
         "agent_session_messages_stale",
         "agent_session_tool_outputs_conflict",
+        "agent_session_tool_outputs_pending",
         "agent_session_already_compact",
         "agent_session_compaction_conflict",
     ]
@@ -2092,16 +2093,6 @@ class ChatRequest(TypedDict):
     requestedSkills: NotRequired[Sequence[str]]
     trigger: NotRequired[str]
     message: NotRequired[PhoenixUIMessage]
-    toolOutputs: NotRequired[
-        Sequence[
-            Union[
-                PhoenixDbTypesDataStreamProtocolRequestTypesToolOutputAvailablePart,
-                PhoenixDbTypesDataStreamProtocolRequestTypesToolOutputErrorPart,
-                PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputAvailablePart,
-                PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputErrorPart,
-            ]
-        ]
-    ]
     lastMessageId: NotRequired[str]
 
 

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9221,6 +9221,7 @@
               "agent_session_model_stale",
               "agent_session_messages_stale",
               "agent_session_tool_outputs_conflict",
+              "agent_session_tool_outputs_pending",
               "agent_session_already_compact",
               "agent_session_compaction_conflict"
             ],
@@ -9245,7 +9246,7 @@
           "code"
         ],
         "title": "AgentSessionConflictError",
-        "description": "Body of every HTTP 409 returned by the agent session routes.\n\n- ``agent_session_busy``: another turn holds the session's turn lock.\n- ``agent_session_model_stale``: the request asserted a model the session\n  is no longer set to; refetch the session before retrying.\n- ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer\n  matches the persisted transcript \u2014 another client appended; refetch the\n  transcript and retry.\n- ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do\n  not match the transcript's trailing assistant message (no trailing\n  assistant message to continue, an unknown ``toolCallId``, or a tool-name\n  mismatch). Unlike ``agent_session_messages_stale`` this is not a\n  concurrent-writer race but an inconsistent request; fix the client\n  rather than retrying.\n- ``agent_session_already_compact``: there are no complete turns to\n  compact \u2014 either nothing new has finished since the transcript's latest\n  checkpoint, or a concurrent request's checkpoint already covers them.\n  Not retryable; the conversation is as compact as it can get.\n- ``agent_session_compaction_conflict``: the conversation changed while it\n  was being compacted; retry."
+        "description": "Body of every HTTP 409 returned by the agent session routes.\n\n- ``agent_session_busy``: another turn holds the session's turn lock.\n- ``agent_session_model_stale``: the request asserted a model the session\n  is no longer set to; refetch the session before retrying.\n- ``agent_session_messages_stale``: the send's ``lastMessageId`` no longer\n  matches the persisted transcript \u2014 another client appended; refetch the\n  transcript and retry.\n- ``agent_session_tool_outputs_conflict``: the submitted ``toolOutputs`` do\n  not match the transcript's trailing assistant message (no trailing\n  assistant message to continue, an unknown ``toolCallId``, or a tool-name\n  mismatch). Unlike ``agent_session_messages_stale`` this is not a\n  concurrent-writer race but an inconsistent request; fix the client\n  rather than retrying.\n- ``agent_session_tool_outputs_pending``: a bare continuation asked the\n  turn to resume while the trailing assistant message still has pending\n  tool calls. Submit the missing outputs via the ``tool_outputs`` route,\n  then retry the continuation.\n- ``agent_session_already_compact``: there are no complete turns to\n  compact \u2014 either nothing new has finished since the transcript's latest\n  checkpoint, or a concurrent request's checkpoint already covers them.\n  Not retryable; the conversation is as compact as it can get.\n- ``agent_session_compaction_conflict``: the conversation changed while it\n  was being compacted; retry."
       },
       "AgentSessionData": {
         "properties": {
@@ -10301,28 +10302,7 @@
                 "type": "null"
               }
             ],
-            "description": "The turn's new user message to append. May be omitted for client-tool continuation, where ``toolOutputs`` resolve the trailing assistant message's pending tool calls instead."
-          },
-          "toolOutputs": {
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__ToolOutputAvailablePart"
-                },
-                {
-                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__ToolOutputErrorPart"
-                },
-                {
-                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputAvailablePart"
-                },
-                {
-                  "$ref": "#/components/schemas/phoenix__db__types__data_stream_protocol__request_types__DynamicToolOutputErrorPart"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Tooloutputs",
-            "description": "Client-executed tool results for pending tool calls on the transcript's trailing assistant message, matched by ``toolCallId``. Submitted alone they continue the assistant turn; submitted with ``message`` they resolve dangling tool calls before the new user turn runs."
+            "description": "The turn's new user message to append. May be omitted for a bare client-tool continuation: once every pending tool call on the trailing assistant message has been resolved via the ``tool_outputs`` route, a message-less request resumes the turn and runs the model. A continuation whose tail still has pending calls is rejected with HTTP 409 and code ``agent_session_tool_outputs_pending``."
           },
           "lastMessageId": {
             "anyOf": [

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -47,7 +47,7 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 from pydantic_ai import AgentRunResult
-from pydantic_ai.messages import ModelMessage
+from pydantic_ai.messages import ModelMessage, ModelRequest
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 from pydantic_ai.ui.vercel_ai.request_types import (
     SubmitMessage as PydanticAISubmitMessage,
@@ -404,19 +404,13 @@ class ChatSubmitMessage(_ChatRequestMixin):
     message: PhoenixUIMessage | None = Field(
         default=None,
         description=(
-            "The turn's new user message to append. May be omitted for client-tool "
-            "continuation, where ``toolOutputs`` resolve the trailing "
-            "assistant message's pending tool calls instead."
-        ),
-    )
-    tool_outputs: list[ToolOutputUIPart] = Field(
-        default_factory=list,
-        description=(
-            "Client-executed tool results for pending tool calls on the "
-            "transcript's trailing assistant message, matched by "
-            "``toolCallId``. Submitted alone they continue the assistant "
-            "turn; submitted with ``message`` they resolve dangling tool "
-            "calls before the new user turn runs."
+            "The turn's new user message to append. May be omitted for a bare "
+            "client-tool continuation: once every pending tool call on the "
+            "trailing assistant message has been resolved via the "
+            "``tool_outputs`` route, a message-less request resumes the turn "
+            "and runs the model. A continuation whose tail still has pending "
+            "calls is rejected with HTTP 409 and code "
+            "``agent_session_tool_outputs_pending``."
         ),
     )
     last_message_id: str | None = Field(
@@ -433,8 +427,6 @@ class ChatSubmitMessage(_ChatRequestMixin):
 
     @model_validator(mode="after")
     def _validate_turn_inputs(self) -> "ChatSubmitMessage":
-        if self.message is None and not self.tool_outputs:
-            raise ValueError("A chat submit request requires a message, toolOutputs, or both")
         if self.message is not None and self.message.role != "user":
             raise ValueError("Only user messages can be submitted")
         if (
@@ -446,7 +438,6 @@ class ChatSubmitMessage(_ChatRequestMixin):
             raise ValueError(
                 "Compaction checkpoints are created by the compact route and cannot be submitted"
             )
-        _validate_submitted_tool_outputs(self.tool_outputs)
         return self
 
 
@@ -484,6 +475,7 @@ AgentSessionConflictCode = Literal[
     "agent_session_model_stale",
     "agent_session_messages_stale",
     "agent_session_tool_outputs_conflict",
+    "agent_session_tool_outputs_pending",
     "agent_session_already_compact",
     "agent_session_compaction_conflict",
 ]
@@ -504,6 +496,10 @@ class AgentSessionConflictError(V1RoutesBaseModel):
       mismatch). Unlike ``agent_session_messages_stale`` this is not a
       concurrent-writer race but an inconsistent request; fix the client
       rather than retrying.
+    - ``agent_session_tool_outputs_pending``: a bare continuation asked the
+      turn to resume while the trailing assistant message still has pending
+      tool calls. Submit the missing outputs via the ``tool_outputs`` route,
+      then retry the continuation.
     - ``agent_session_already_compact``: there are no complete turns to
       compact — either nothing new has finished since the transcript's latest
       checkpoint, or a concurrent request's checkpoint already covers them.
@@ -1779,78 +1775,83 @@ class _MergedTranscript:
     """The model-facing transcript for this turn."""
 
     updated_messages: dict[_MessageId, PhoenixUIMessage]
-    """Persisted messages rewritten by the merge (applied ``toolOutputs`` and
-    interrupted-tool repairs); persist under the turn lock before the model runs."""
+    """Persisted messages rewritten by the merge (interrupted-tool repairs);
+    persist under the turn lock before the model runs."""
 
     continued_assistant_message: PhoenixUIMessage | None
-    """The trailing assistant message this turn continues when the request
-    carried only ``toolOutputs``; None for a new user turn."""
+    """The trailing assistant message a bare (message-less) continuation
+    resumes; None for a new user turn."""
 
     superseded_assistant_message: PhoenixUIMessage | None
     """The trailing assistant message of a turn this request superseded.
 
-    A turn that stops on unresolved client tool calls stays open: only a
-    ``toolOutputs``-only request continues it, finishing the turn and emitting
-    its deferred ``pxi.turn`` root span. A request carrying a new user message
-    starts a new turn instead, superseding the open one — its dangling calls
-    are resolved at merge time (by ``toolOutputs`` sent alongside the message,
-    or repaired as interrupted without them), but the continuation that would
-    have emitted the root span never runs. None when the request continues
-    the turn or the tail had nothing pending."""
+    A turn that stops on unresolved client tool calls stays open: its outputs
+    arrive via the ``tool_outputs`` route, and only a bare continuation
+    resumes it, finishing the turn and emitting its deferred ``pxi.turn``
+    root span. A request carrying a new user message starts a new turn
+    instead, superseding the open one — dangling calls whose outputs never
+    reached the ``tool_outputs`` route are repaired as interrupted at merge
+    time, but the continuation that would have emitted the root span never
+    runs. None when the request continues the turn or the tail had nothing
+    pending."""
 
 
 def _merge_messages(
     *,
     old_messages: Sequence[PhoenixUIMessage],
     new_message: PhoenixUIMessage | None,
-    tool_outputs: Sequence[ToolOutputUIPart] = (),
 ) -> _MergedTranscript:
     messages = list(old_messages)
     updated_messages: dict[_MessageId, PhoenixUIMessage] = {}
-    if tool_outputs:
+    if new_message is None:
+        # A bare continuation resumes the trailing assistant turn. Tool
+        # outputs reach the transcript only through the tool_outputs route,
+        # so the tail must already be fully resolved before the model runs.
         if not messages or messages[-1].role != "assistant":
             raise AgentSessionConflict(
                 "agent_session_tool_outputs_conflict",
                 (
-                    "Tool outputs were submitted but the session's latest "
+                    "A continuation was submitted but the session's latest "
                     "transcript message is not an assistant message; reload "
                     "the conversation"
                 ),
             )
-        merged_tail = _apply_tool_outputs(messages[-1], tool_outputs)
-        if merged_tail is not None:
-            updated_messages[merged_tail.id] = merged_tail
-            messages[-1] = merged_tail
+        if any(isinstance(part, _UNRESOLVED_TOOL_PART_TYPES) for part in messages[-1].parts):
+            raise AgentSessionConflict(
+                "agent_session_tool_outputs_pending",
+                (
+                    "The trailing assistant message still has pending tool "
+                    "calls; submit their outputs via the tool_outputs route, "
+                    "then retry the continuation"
+                ),
+            )
+        return _MergedTranscript(
+            messages=messages,
+            updated_messages=updated_messages,
+            continued_assistant_message=messages[-1],
+            superseded_assistant_message=None,
+        )
+    assert new_message.role == "user", "request validation rejects non-user messages"
     for index, message in enumerate(messages):
         repaired_message = _resolve_interrupted_tool_parts(message)
         if repaired_message is not None:
             updated_messages[repaired_message.id] = repaired_message
             messages[index] = repaired_message
-    if new_message is not None:
-        assert new_message.role == "user", "request validation rejects non-user messages"
-        # A rewritten assistant tail means it still had pending tool calls —
-        # a turn that ended awaiting outputs and is now superseded by the new
-        # user message instead of continued.
-        last_message = messages[-1] if messages else None
-        last_message_had_pending_tool_calls = (
-            last_message is not None
-            and last_message.role == "assistant"
-            and last_message.id in updated_messages
-        )
-        superseded_assistant_message = last_message if last_message_had_pending_tool_calls else None
-        return _MergedTranscript(
-            messages=[*messages, new_message],
-            updated_messages=updated_messages,
-            continued_assistant_message=None,
-            superseded_assistant_message=superseded_assistant_message,
-        )
-    assert tool_outputs, "request validation requires a message, toolOutputs, or both"
-    assert messages[-1].role == "assistant", "the tool-output branch guarantees an assistant tail"
+    # A rewritten assistant tail means it still had pending tool calls —
+    # a turn that ended awaiting outputs and is now superseded by the new
+    # user message instead of continued.
+    last_message = messages[-1] if messages else None
+    last_message_had_pending_tool_calls = (
+        last_message is not None
+        and last_message.role == "assistant"
+        and last_message.id in updated_messages
+    )
+    superseded_assistant_message = last_message if last_message_had_pending_tool_calls else None
     return _MergedTranscript(
-        messages=messages,
+        messages=[*messages, new_message],
         updated_messages=updated_messages,
-        continued_assistant_message=messages[-1],
-        superseded_assistant_message=None,
+        continued_assistant_message=None,
+        superseded_assistant_message=superseded_assistant_message,
     )
 
 
@@ -2848,9 +2849,23 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 merged_transcript = _merge_messages(
                     old_messages=[row.message for row in session_history],
                     new_message=body.message,
-                    tool_outputs=body.tool_outputs,
                 )
                 transcript_messages = merged_transcript.messages
+                if merged_transcript.continued_assistant_message is not None:
+                    # A resolved tail alone cannot distinguish a turn awaiting
+                    # its continuation from one that already completed; the
+                    # model-facing transcript can. A completed turn ends with
+                    # a model response, and rerunning it would double-run the
+                    # model (and violate pydantic-ai's request-last invariant).
+                    model_messages = _to_pydantic_ai_messages(transcript_messages)
+                    if not model_messages or not isinstance(model_messages[-1], ModelRequest):
+                        raise AgentSessionConflict(
+                            "agent_session_tool_outputs_conflict",
+                            (
+                                "The trailing assistant turn is already "
+                                "complete; there is nothing to continue"
+                            ),
+                        )
                 session_model = get_agent_session_model(agent_session)
                 await _claim_agent_session_turn_lock_for_model(
                     session,
@@ -3210,8 +3225,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     else:
                         # Persist the submitted user message and its generated response.
                         assert body.message is not None, (
-                            "request validation requires a message or toolOutputs, and "
-                            "the merge continues the assistant turn for toolOutputs-only"
+                            "the merge continues the assistant turn for message-less requests"
                         )
                         turn_messages = [body.message, generated_assistant_message]
                     try:

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -60,6 +60,7 @@ from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_strea
 from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, get_otel_session_id
 from phoenix.server.api.routers.agents import (
     AgentSessionConflict,
+    _apply_tool_outputs,
     _build_message_metadata_chunk,
     _emit_turn_root_span,
     _get_span_context,
@@ -1126,12 +1127,17 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
         "output": {"datasets": []},
     }
 
+    submit_response = await httpx_client.post(
+        _tool_outputs_url(agent_session_id),
+        json=_tool_outputs_body([tool_output], last_message_id=assistant_message_id),
+    )
+    assert submit_response.status_code == 200
+
     continuation_response = await httpx_client.post(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
             None,
-            toolOutputs=[tool_output],
             lastMessageId=assistant_message_id,
         ),
     )
@@ -1259,22 +1265,30 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
     # The unanswered call is untouched — still pending, not repaired.
     assert persisted_parts_by_call_id[unanswered_call["toolCallId"]] == unanswered_call
 
-    # The final chat continuation re-carries the submitted output alongside
-    # the remaining one; the server ignores the already-resolved call.
-    final_response = await httpx_client.post(
+    # A premature bare continuation is rejected while a call is still pending.
+    premature_response = await httpx_client.post(
         _chat_url(agent_session_id),
-        json=_chat_body(
-            session_id,
-            None,
-            toolOutputs=[
-                _tool_output_for(answered_call),
-                _tool_output_for(unanswered_call),
-            ],
-            lastMessageId=assistant_message_id,
+        json=_chat_body(session_id, None, lastMessageId=assistant_message_id),
+    )
+    assert premature_response.status_code == 409
+    assert premature_response.json()["code"] == "agent_session_tool_outputs_pending"
+    assert build_model_calls == 1
+
+    remaining_response = await httpx_client.post(
+        _tool_outputs_url(agent_session_id),
+        json=_tool_outputs_body(
+            [_tool_output_for(unanswered_call)],
+            last_message_id=assistant_message_id,
         ),
     )
+    assert remaining_response.status_code == 200
+
+    final_response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(session_id, None, lastMessageId=assistant_message_id),
+    )
     assert final_response.status_code == 200
-    # With every pending call resolved, the continuation runs the model.
+    # With every pending call resolved, the bare continuation runs the model.
     assert build_model_calls == 2
     final_acknowledgement = next(
         chunk
@@ -1294,6 +1308,16 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
         part["type"] == "text" and part["text"] == "done"
         for part in final_assistant_message["parts"]
     )
+
+    # A duplicate bare continuation after the turn completed is rejected
+    # instead of rerunning the model on a finished turn.
+    duplicate_response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(session_id, None, lastMessageId=assistant_message_id),
+    )
+    assert duplicate_response.status_code == 409
+    assert duplicate_response.json()["code"] == "agent_session_tool_outputs_conflict"
+    assert build_model_calls == 2
 
 
 def _pending_client_tool_output(**overrides: Any) -> dict[str, Any]:
@@ -1577,7 +1601,7 @@ async def test_user_turn_persists_interrupted_repair_for_dangling_client_tool(
     assert repaired_part["callProviderMetadata"]["pydantic_ai"]["outcome"] == "interrupted"
 
 
-async def test_user_turn_applies_submitted_tool_output_error_resolutions(
+async def test_user_turn_keeps_error_resolutions_submitted_via_the_tool_outputs_route(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -1596,12 +1620,10 @@ async def test_user_turn_applies_submitted_tool_output_error_resolutions(
         ],
     )
 
-    response = await httpx_client.post(
-        _chat_url(agent_session_id),
-        json=_chat_body(
-            session_id,
-            _user_message("never mind", message_id=_message_uuid("msg-user-2")),
-            toolOutputs=[
+    submit_response = await httpx_client.post(
+        _tool_outputs_url(agent_session_id),
+        json=_tool_outputs_body(
+            [
                 {
                     "type": "tool-edit_prompt_instance",
                     "toolCallId": "tool-call-pending",
@@ -1616,11 +1638,23 @@ async def test_user_turn_applies_submitted_tool_output_error_resolutions(
                     },
                 }
             ],
+            last_message_id=_message_uuid("assistant-1"),
+        ),
+    )
+    assert submit_response.status_code == 200
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            _user_message("never mind", message_id=_message_uuid("msg-user-2")),
             lastMessageId=_message_uuid("assistant-1"),
         ),
     )
     assert response.status_code == 200
 
+    # The client's error resolution survives the new user turn — the call was
+    # already resolved, so the supersede repair leaves it untouched.
     resolved_part = await _load_pending_tool_part(db)
     assert resolved_part["state"] == "output-error"
     assert resolved_part["errorText"] == "The user has interrupted this tool call."
@@ -2073,12 +2107,10 @@ async def test_chat_stream_metadata_reuses_the_persisted_turn_trace_context(
         messages=[_user_message("edit the prompt"), assistant_tail],
     )
 
-    response = await httpx_client.post(
-        _chat_url(agent_session_id),
-        json=_chat_body(
-            session_id,
-            None,
-            toolOutputs=[
+    submit_response = await httpx_client.post(
+        _tool_outputs_url(agent_session_id),
+        json=_tool_outputs_body(
+            [
                 {
                     "type": "tool-edit_prompt_instance",
                     "toolCallId": "tool-call-pending",
@@ -2087,8 +2119,14 @@ async def test_chat_stream_metadata_reuses_the_persisted_turn_trace_context(
                     "output": {"ok": True},
                 }
             ],
-            lastMessageId=assistant_tail["id"],
+            last_message_id=assistant_tail["id"],
         ),
+    )
+    assert submit_response.status_code == 200
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(session_id, None, lastMessageId=assistant_tail["id"]),
     )
     assert response.status_code == 200
 
@@ -2114,11 +2152,11 @@ async def test_chat_stream_metadata_reuses_the_persisted_turn_trace_context(
     assert persisted_turn_trace_context["rootSpanId"] == root_span_id
 
 
-async def test_chat_turn_without_a_message_is_rejected(
+async def test_bare_continuation_on_an_empty_session_is_rejected(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    """A submit request must carry the turn's new message."""
+    """A message-less request is a continuation, which needs an assistant tail."""
     session_id = "22222222-2222-4222-8222-222222222222"
     agent_session_id = await _create_agent_session_row(db)
 
@@ -2126,7 +2164,8 @@ async def test_chat_turn_without_a_message_is_rejected(
         _chat_url(agent_session_id),
         json=_chat_body(session_id, None),
     )
-    assert response.status_code == 422
+    assert response.status_code == 409
+    assert response.json()["code"] == "agent_session_tool_outputs_conflict"
 
     async with db() as session:
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
@@ -2397,41 +2436,30 @@ def test_repaired_interrupted_tools_load_with_interrupted_outcome() -> None:
     assert tool_returns["tool-call-done"].outcome == "success"
 
 
-def test_merge_applies_tool_outputs_to_the_trailing_assistant_message() -> None:
-    persisted = _validated_messages(
-        [_user_message("run a command"), _assistant_message_with_tool_states()]
+def test_apply_tool_outputs_resolves_pending_calls_and_leaves_others_untouched() -> None:
+    message = PhoenixUIMessage.model_validate(_assistant_message_with_tool_states())
+
+    applied = _apply_tool_outputs(
+        message,
+        [ToolOutputAvailablePart.model_validate(_tool_output())],
     )
 
-    merged = _merge_messages(
-        old_messages=persisted,
-        new_message=None,
-        tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
-    )
-
-    continued = merged.continued_assistant_message
-    assert continued is not None
-    assert continued.id == _message_uuid("assistant-1")
-    assert merged.messages[-1] is continued
-    assert set(merged.updated_messages) == {_message_uuid("assistant-1")}
-    parts = _parts_by_tool_call_id(continued)
+    assert applied is not None
+    parts = _parts_by_tool_call_id(applied)
     assert parts["tool-call-unresolved"].state == "output-available"
     assert parts["tool-call-unresolved"].output == {"stdout": "README.md"}
-    # The streaming call the outputs did not cover can never be resolved, so
-    # it is authoritatively closed out as interrupted before the turn continues.
-    assert parts["tool-call-streaming"].state == "output-available"
-    streaming_metadata = parts["tool-call-streaming"].call_provider_metadata
-    assert streaming_metadata["pydantic_ai"]["outcome"] == "interrupted"
+    # Calls the outputs did not cover keep their pending states — partial
+    # application never repairs them.
+    assert parts["tool-call-streaming"].state == "input-streaming"
+    assert parts["tool-call-done"].output == {"stdout": "/"}
 
 
-def test_merge_ignores_tool_outputs_for_already_resolved_tool_calls() -> None:
-    persisted = _validated_messages(
-        [_user_message("run a command"), _assistant_message_with_tool_states()]
-    )
+def test_apply_tool_outputs_ignores_outputs_for_already_resolved_tool_calls() -> None:
+    message = PhoenixUIMessage.model_validate(_assistant_message_with_tool_states())
 
-    merged = _merge_messages(
-        old_messages=persisted,
-        new_message=None,
-        tool_outputs=[
+    applied = _apply_tool_outputs(
+        message,
+        [
             ToolOutputAvailablePart.model_validate(_tool_output()),
             ToolOutputAvailablePart.model_validate(
                 _tool_output(toolCallId="tool-call-done", output={"stdout": "overwritten"})
@@ -2439,52 +2467,77 @@ def test_merge_ignores_tool_outputs_for_already_resolved_tool_calls() -> None:
         ],
     )
 
-    continued = merged.continued_assistant_message
-    assert continued is not None
-    parts = _parts_by_tool_call_id(continued)
+    assert applied is not None
+    parts = _parts_by_tool_call_id(applied)
     assert parts["tool-call-done"].output == {"stdout": "/"}
 
 
-def test_merge_rejects_tool_outputs_that_match_no_tool_call() -> None:
-    persisted = _validated_messages(
-        [_user_message("run a command"), _assistant_message_with_tool_states()]
-    )
+def test_apply_tool_outputs_rejects_outputs_that_match_no_tool_call() -> None:
+    message = PhoenixUIMessage.model_validate(_assistant_message_with_tool_states())
 
     with pytest.raises(AgentSessionConflict) as exc_info:
-        _merge_messages(
-            old_messages=persisted,
-            new_message=None,
-            tool_outputs=[
-                ToolOutputAvailablePart.model_validate(_tool_output(toolCallId="tool-call-missing"))
-            ],
+        _apply_tool_outputs(
+            message,
+            [ToolOutputAvailablePart.model_validate(_tool_output(toolCallId="tool-call-missing"))],
         )
     assert exc_info.value.code == "agent_session_tool_outputs_conflict"
 
 
-def test_merge_rejects_tool_outputs_that_rename_the_tool() -> None:
-    persisted = _validated_messages(
-        [_user_message("run a command"), _assistant_message_with_tool_states()]
-    )
+def test_apply_tool_outputs_rejects_outputs_that_rename_the_tool() -> None:
+    message = PhoenixUIMessage.model_validate(_assistant_message_with_tool_states())
 
     with pytest.raises(AgentSessionConflict) as exc_info:
-        _merge_messages(
-            old_messages=persisted,
-            new_message=None,
-            tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output(type="tool-python"))],
+        _apply_tool_outputs(
+            message,
+            [ToolOutputAvailablePart.model_validate(_tool_output(type="tool-python"))],
         )
     assert exc_info.value.code == "agent_session_tool_outputs_conflict"
 
 
-def test_merge_rejects_tool_outputs_without_a_trailing_assistant_message() -> None:
+def test_merge_rejects_a_bare_continuation_without_a_trailing_assistant_message() -> None:
     persisted = _validated_messages([_user_message("hello")])
 
     with pytest.raises(AgentSessionConflict) as exc_info:
-        _merge_messages(
-            old_messages=persisted,
-            new_message=None,
-            tool_outputs=[ToolOutputAvailablePart.model_validate(_tool_output())],
-        )
+        _merge_messages(old_messages=persisted, new_message=None)
     assert exc_info.value.code == "agent_session_tool_outputs_conflict"
+
+
+def test_merge_rejects_a_bare_continuation_while_tool_calls_are_pending() -> None:
+    persisted = _validated_messages(
+        [_user_message("run a command"), _assistant_message_with_tool_states()]
+    )
+
+    with pytest.raises(AgentSessionConflict) as exc_info:
+        _merge_messages(old_messages=persisted, new_message=None)
+    assert exc_info.value.code == "agent_session_tool_outputs_pending"
+
+
+def test_merge_continues_a_fully_resolved_assistant_tail() -> None:
+    resolved_tail = _apply_tool_outputs(
+        PhoenixUIMessage.model_validate(_assistant_message_with_tool_states()),
+        [
+            ToolOutputAvailablePart.model_validate(_tool_output()),
+            ToolOutputAvailablePart.model_validate(
+                _tool_output(toolCallId="tool-call-streaming", output={"stdout": "streamed"})
+            ),
+        ],
+    )
+    assert resolved_tail is not None
+    persisted = [
+        PhoenixUIMessage.model_validate(_user_message("run a command")),
+        resolved_tail,
+    ]
+
+    merged = _merge_messages(old_messages=persisted, new_message=None)
+
+    continued = merged.continued_assistant_message
+    assert continued is not None
+    assert continued.id == _message_uuid("assistant-1")
+    assert merged.messages[-1] is continued
+    # Nothing to rewrite: outputs were applied by the tool_outputs route, and
+    # a bare continuation never repairs.
+    assert merged.updated_messages == {}
+    assert merged.superseded_assistant_message is None
 
 
 async def test_chat_endpoint_rejects_assistant_message_submissions(
@@ -2533,32 +2586,30 @@ async def test_chat_endpoint_rejects_compaction_message_submissions(
     assert response.status_code == 422
 
 
-async def test_chat_endpoint_rejects_phoenix_namespace_in_tool_output_result_metadata(
+async def test_tool_outputs_endpoint_rejects_phoenix_namespace_in_result_metadata(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
     response = await httpx_client.post(
-        _chat_url(str(GlobalID("AgentSession", "999999"))),
-        json=_chat_body(
-            session_id,
-            None,
-            toolOutputs=[
-                _tool_output(resultProviderMetadata={"phoenix": {"anything": True}}),
-            ],
+        _tool_outputs_url(str(GlobalID("AgentSession", "999999"))),
+        json=_tool_outputs_body(
+            [_tool_output(resultProviderMetadata={"phoenix": {"anything": True}})],
+            last_message_id=_message_uuid("assistant-1"),
         ),
     )
     assert response.status_code == 422
 
 
-async def test_chat_endpoint_requires_a_message_or_tool_outputs(
+async def test_chat_endpoint_accepts_message_less_requests_as_continuations(
     httpx_client: httpx.AsyncClient,
 ) -> None:
+    # A bare (message-less) request is a continuation, not a validation error;
+    # against an unknown session it fails on the session lookup instead.
     session_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
     response = await httpx_client.post(
         _chat_url(str(GlobalID("AgentSession", "999999"))),
         json=_chat_body(session_id, None),
     )
-    assert response.status_code == 422
+    assert response.status_code == 404
 
 
 async def test_chat_endpoint_rejects_regenerate_requests(
@@ -3479,13 +3530,10 @@ async def _post_traced_continuation_turn(
     *,
     last_message_id: str,
 ) -> httpx.Response:
-    return await httpx_client.post(
-        _chat_url(agent_session_id),
-        json=_chat_body(
-            session_id,
-            None,
-            ingestTraces=True,
-            toolOutputs=[
+    submit_response = await httpx_client.post(
+        _tool_outputs_url(agent_session_id),
+        json=_tool_outputs_body(
+            [
                 {
                     "type": "tool-edit_prompt_instance",
                     "toolCallId": "tool-call-pending",
@@ -3510,6 +3558,16 @@ async def _post_traced_continuation_turn(
                     },
                 }
             ],
+            last_message_id=last_message_id,
+        ),
+    )
+    assert submit_response.status_code == 200
+    return await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(
+            session_id,
+            None,
+            ingestTraces=True,
             lastMessageId=last_message_id,
         ),
     )


### PR DESCRIPTION
## Summary

Stacked on #15249. Completes the migration that PR started: `toolOutputs` is removed from the chat request contract entirely, making the `tool_outputs` route the **only** path client tool outputs take to the server. The chat route's client-tool continuation becomes a bare, message-less request that just asks the server to resume the turn it owns.

### Server

- `ChatSubmitMessage` loses `tool_outputs`; a message-less request is now a valid bare continuation rather than a 422.
- A bare continuation requires a fully resolved assistant tail. Unanswered calls reject with the new **`agent_session_tool_outputs_pending`** conflict code, directing the client to submit outputs via the `tool_outputs` route first.
- A resolved tail alone can't distinguish a turn awaiting continuation from one that already completed, so the route checks the model-facing transcript: a duplicate continuation whose history already ends in a model response is rejected with a 409 instead of double-running the model.
- User-message sends no longer carry outputs. Calls still pending server-side are repaired as interrupted at merge time — same repair semantics as before, now the only path for dangling calls.

### Client

- The flusher is promoted from optimization to the delivery mechanism: every resolved output flushes, including the final one (the "still-pending siblings" guard is gone).
- The send decision awaits `flushAndWait` (one retry) after the transcript-persisted acknowledgement, before firing the bare continuation. If outputs still can't land, the continuation fires anyway and surfaces the server's pending conflict — a visible failure instead of a silent stall.
- Interrupted and navigation-cancel outputs stay client-side by design; the server's interrupted repair covers them when the next turn starts. This narrows the previous behavior where such outputs rode along on the next user message — a fidelity trade-off accepted for the single-path contract.

The pxi CLI is unaffected: it executes no client tools and never produced `toolOutputs`.

## Test plan

- Backend: E2E flow updated — partial submit via endpoint → premature bare continuation rejected `tool_outputs_pending` → remaining output submitted → bare continuation runs the model → duplicate continuation rejected. `_apply_tool_outputs` unit tests (resolve/ignore/reject-unknown/reject-rename), bare-continue merge tests (empty session, pending tail, resolved tail), error-resolution submission via the endpoint surviving a superseding user turn, and the traced-continuation ingestion tests migrated to the two-request flow. Full `test_agents_router.py` suite passes.
- Frontend: request-body tests assert bare continuations and output-free user sends; flusher tests cover final-output flushing, `flushAndWait` success/retry/failure/no-op; full agent suites (85 files, 838 tests), `tsc`, `oxlint`, `prettier` pass.
- `ruff` and `mypy` clean; OpenAPI schema and all generated clients regenerated via `make openapi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)