### PR TITLE
fix(ui): debounce responsive chart resize updates

### DIFF
--- a/app/src/components/chart/AnnotationMetricsChart.tsx
+++ b/app/src/components/chart/AnnotationMetricsChart.tsx
@@ -10,7 +10,6 @@ import {
   CartesianGrid,
   ComposedChart,
   Line,
-  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
@@ -33,6 +32,7 @@ import {
   getAnnotationOtherFraction,
 } from "./annotationMetricsUtils";
 import { ChartEmptyStateOverlay } from "./ChartEmptyStateOverlay";
+import { ChartResponsiveContainer } from "./ChartResponsiveContainer";
 import { ChartTooltip, ChartTooltipItem } from "./ChartTooltip";
 import { getCategoryChartColor, useCategoryChartColors } from "./colors";
 import {
@@ -185,7 +185,7 @@ function AnnotationMetricsChartContent({
       message={emptyStateMessage}
       chartType={isScoreView ? "line" : "bar"}
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <ComposedChart
           data={chartData}
           margin={isScoreView ? SCORE_CHART_MARGIN : compactChartMargin}
@@ -282,7 +282,7 @@ function AnnotationMetricsChartContent({
             ]}
           />
         </ComposedChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/components/chart/ChartResponsiveContainer.tsx
+++ b/app/src/components/chart/ChartResponsiveContainer.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { ResponsiveContainer } from "recharts";
+
+/**
+ * Recharts handles a positive `debounce` value as a trailing resize throttle.
+ * Fifty milliseconds keeps compact charts responsive during a drag while
+ * preventing ResizeObserver-driven render cycles from running every frame.
+ */
+const CHART_RESIZE_DEBOUNCE_MS = 50;
+
+/**
+ * Shared responsive container for charts that fill a {@link ChartPanel}.
+ */
+export function ChartResponsiveContainer({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <ResponsiveContainer
+      width="100%"
+      height="100%"
+      debounce={CHART_RESIZE_DEBOUNCE_MS}
+    >
+      {children}
+    </ResponsiveContainer>
+  );
+}

--- a/app/src/components/chart/ChartSkeleton.tsx
+++ b/app/src/components/chart/ChartSkeleton.tsx
@@ -1,17 +1,11 @@
 import { css } from "@emotion/react";
 import type { HTMLAttributes, Ref } from "react";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { pulseAnimation } from "@phoenix/components/core/loading";
 import { classNames } from "@phoenix/utils/classNames";
 
+import { ChartResponsiveContainer } from "./ChartResponsiveContainer";
 import {
   compactChartMargin,
   compactTimeXAxisProps,
@@ -95,7 +89,7 @@ export function ChartSkeleton({
       {...props}
     >
       <div className="chart-skeleton__plot" aria-hidden>
-        <ResponsiveContainer width="100%" height="100%">
+        <ChartResponsiveContainer>
           <BarChart
             data={PLACEHOLDER_DATA}
             margin={compactChartMargin}
@@ -125,7 +119,7 @@ export function ChartSkeleton({
               isAnimationActive={false}
             />
           </BarChart>
-        </ResponsiveContainer>
+        </ChartResponsiveContainer>
       </div>
       <div className="chart-skeleton__legend" aria-hidden>
         {Array.from({ length: 2 }, (_, itemIndex) => (

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -1,6 +1,7 @@
 export * from "./ChartEmptyStateOverlay";
 export * from "./ChartPanel";
 export * from "./ChartPanelStrip";
+export * from "./ChartResponsiveContainer";
 export * from "./DeferredChartPanel";
 export * from "./ChartTypeIcon";
 export * from "./AnnotationMetricsChart";

--- a/app/src/pages/dataset/metrics/ExperimentAnnotationScoresChart.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentAnnotationScoresChart.tsx
@@ -3,7 +3,6 @@ import {
   CartesianGrid,
   Line,
   LineChart,
-  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
@@ -11,6 +10,7 @@ import {
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   ChartTooltip,
   ChartTooltipItem,
   COMPACT_CHART_ANIMATION_DURATION_MS,
@@ -131,7 +131,7 @@ export function ExperimentAnnotationScoresChart({
       message="No annotation data"
       chartType="line"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <LineChart
           data={chartData}
           margin={compactChartMargin}
@@ -165,7 +165,7 @@ export function ExperimentAnnotationScoresChart({
           />
           <Tooltip {...defaultTooltipProps} content={TooltipContent} />
         </LineChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/dataset/metrics/ExperimentCostChart.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentCostChart.tsx
@@ -1,15 +1,8 @@
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   compactChartMargin,
   compactLegendProps,
@@ -72,7 +65,7 @@ export function ExperimentCostChart({ datasetId }: ExperimentMetricViewProps) {
       message="No cost data"
       chartType="bar"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <BarChart
           data={chartData}
           margin={compactChartMargin}
@@ -115,7 +108,7 @@ export function ExperimentCostChart({ datasetId }: ExperimentMetricViewProps) {
             )}
           />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/dataset/metrics/ExperimentErrorRateChart.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentErrorRateChart.tsx
@@ -1,15 +1,8 @@
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   compactChartMargin,
   compactLegendProps,
@@ -72,7 +65,7 @@ export function ExperimentErrorRateChart({
       message={hasRuns ? "No errors" : "No data"}
       chartType="bar"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <BarChart
           data={chartData}
           margin={compactChartMargin}
@@ -107,7 +100,7 @@ export function ExperimentErrorRateChart({
             )}
           />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/dataset/metrics/ExperimentLatencyChart.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentLatencyChart.tsx
@@ -1,15 +1,8 @@
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   compactChartMargin,
   compactLegendProps,
@@ -64,7 +57,7 @@ export function ExperimentLatencyChart({
       message="No latency data"
       chartType="bar"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <BarChart
           data={chartData}
           margin={compactChartMargin}
@@ -99,7 +92,7 @@ export function ExperimentLatencyChart({
             )}
           />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/dataset/metrics/ExperimentTokensChart.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentTokensChart.tsx
@@ -1,15 +1,8 @@
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   compactChartMargin,
   compactLegendProps,
@@ -76,7 +69,7 @@ export function ExperimentTokensChart({
       message="No token data"
       chartType="bar"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <BarChart
           data={chartData}
           margin={compactChartMargin}
@@ -120,7 +113,7 @@ export function ExperimentTokensChart({
             )}
           />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
+++ b/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
@@ -4,7 +4,6 @@ import {
   CartesianGrid,
   Line,
   LineChart,
-  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
@@ -13,6 +12,7 @@ import {
 import { Text } from "@phoenix/components";
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   ChartTooltip,
   ChartTooltipItem,
   compactChartMargin,
@@ -133,7 +133,7 @@ export function AnnotationScoreTimeSeriesChart({
           message="No data in this time range"
           chartType="line"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <LineChart
               data={chartData}
               margin={compactChartMargin}
@@ -170,7 +170,7 @@ export function AnnotationScoreTimeSeriesChart({
                 onToggleDataKey={toggleDataKey}
               />
             </LineChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>

--- a/app/src/pages/project/metrics/SpanCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SpanCountTimeSeries.tsx
@@ -1,17 +1,10 @@
 import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   TimeRangeChartBrush,
   compactChartMargin,
@@ -128,7 +121,7 @@ export function SpanCountTimeSeries({
           message="No data in this time range"
           chartType="bar"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <BarChart
               data={chartData}
               margin={compactChartMargin}
@@ -178,7 +171,7 @@ export function SpanCountTimeSeries({
                 onToggleDataKey={toggleDataKey}
               />
             </BarChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>

--- a/app/src/pages/project/metrics/SpanErrorsTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SpanErrorsTimeSeries.tsx
@@ -1,16 +1,9 @@
 import { useLazyLoadQuery } from "react-relay";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   TimeRangeChartBrush,
   compactChartMargin,
@@ -99,7 +92,7 @@ export function SpanErrorsTimeSeries({
           message={hasSpans ? emptyMessage : "No data in this time range"}
           chartType="bar"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <BarChart
               data={chartData}
               margin={compactChartMargin}
@@ -138,7 +131,7 @@ export function SpanErrorsTimeSeries({
                 onToggleDataKey={toggleDataKey}
               />
             </BarChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>

--- a/app/src/pages/project/metrics/TopModelsByCost.tsx
+++ b/app/src/pages/project/metrics/TopModelsByCost.tsx
@@ -1,16 +1,9 @@
 import { graphql, useLazyLoadQuery } from "react-relay";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   compactChartMargin,
   defaultCartesianGridProps,
@@ -114,7 +107,7 @@ export function TopModelsByCost({
       message={emptyStateMessage}
       chartType="barHorizontal"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <BarChart
           data={chartData}
           margin={compactChartMargin}
@@ -175,7 +168,7 @@ export function TopModelsByCost({
             onToggleDataKey={toggleDataKey}
           />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/project/metrics/TopModelsByToken.tsx
+++ b/app/src/pages/project/metrics/TopModelsByToken.tsx
@@ -1,16 +1,9 @@
 import { graphql, useLazyLoadQuery } from "react-relay";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   compactChartMargin,
   defaultCartesianGridProps,
@@ -100,7 +93,7 @@ export function TopModelsByToken({
       message="No data in this time range"
       chartType="barHorizontal"
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartResponsiveContainer>
         <BarChart
           data={chartData}
           margin={compactChartMargin}
@@ -162,7 +155,7 @@ export function TopModelsByToken({
             onToggleDataKey={toggleDataKey}
           />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartResponsiveContainer>
     </ChartEmptyStateOverlay>
   );
 }

--- a/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
@@ -1,17 +1,10 @@
 import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   InteractiveLegend,
   TimeRangeChartBrush,
   compactChartMargin,
@@ -109,7 +102,7 @@ export function TraceCountTimeSeries({
           message="No data in this time range"
           chartType="bar"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <BarChart
               data={chartData}
               margin={compactChartMargin}
@@ -155,7 +148,7 @@ export function TraceCountTimeSeries({
                 onToggleDataKey={toggleDataKey}
               />
             </BarChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>

--- a/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
@@ -4,7 +4,6 @@ import {
   CartesianGrid,
   ComposedChart,
   Line,
-  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
@@ -13,6 +12,7 @@ import {
 import { Text } from "@phoenix/components";
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   ChartTooltip,
   ChartTooltipItem,
   compactChartMargin,
@@ -149,7 +149,7 @@ export function TraceLatencyPercentilesTimeSeries({
           message="No data in this time range"
           chartType="line"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <ComposedChart
               data={chartData}
               margin={compactChartMargin}
@@ -245,7 +245,7 @@ export function TraceLatencyPercentilesTimeSeries({
               />
               <Tooltip content={TooltipContent} {...defaultTooltipProps} />
             </ComposedChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>

--- a/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
@@ -1,18 +1,11 @@
 import { graphql, useLazyLoadQuery } from "react-relay";
 import type { TooltipContentProps } from "recharts";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import { Text } from "@phoenix/components";
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -145,7 +138,7 @@ export function TraceTokenCostTimeSeries({
           message="No data in this time range"
           chartType="bar"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <BarChart
               data={chartData}
               margin={compactChartMargin}
@@ -190,7 +183,7 @@ export function TraceTokenCostTimeSeries({
                 onToggleDataKey={toggleDataKey}
               />
             </BarChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>

--- a/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
@@ -1,18 +1,11 @@
 import { graphql, useLazyLoadQuery } from "react-relay";
 import type { TooltipContentProps } from "recharts";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 
 import { Text } from "@phoenix/components";
 import {
   ChartEmptyStateOverlay,
+  ChartResponsiveContainer,
   ChartTooltip,
   ChartTooltipItem,
   InteractiveLegend,
@@ -243,7 +236,7 @@ export function TraceTokenCountTimeSeries({
           message="No data in this time range"
           chartType="bar"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <BarChart
               data={chartData}
               margin={compactChartMargin}
@@ -289,7 +282,7 @@ export function TraceTokenCountTimeSeries({
                 onToggleDataKey={toggleDataKey}
               />
             </BarChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>
@@ -348,7 +341,7 @@ function TraceTokenDetailsTimeSeries({
           message="No data in this time range"
           chartType="bar"
         >
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartResponsiveContainer>
             <BarChart
               data={chartData}
               margin={compactChartMargin}
@@ -397,7 +390,7 @@ function TraceTokenDetailsTimeSeries({
                 onToggleDataKey={toggleDataKey}
               />
             </BarChart>
-          </ResponsiveContainer>
+          </ChartResponsiveContainer>
         </ChartEmptyStateOverlay>
       )}
     </TimeRangeChartBrush>


### PR DESCRIPTION
## Summary

- add a shared `ChartResponsiveContainer` for panel-filling charts
- throttle Recharts resize updates with a 50ms trailing delay
- apply the shared container to project metrics, experiment metrics, annotation charts, and chart loading skeletons
- leave fixed-size settings and generative UI charts unchanged

## Why

Responsive Recharts containers update their dimensions for every
`ResizeObserver` notification. During continuous resizing, those updates can
participate in a resize → render → resize cycle and produce excessive nested
React updates.

Recharts implements its `debounce` prop as a trailing resize throttle while
keeping the initial chart measurement synchronous. A 50ms delay limits resize
redraws to approximately 20 updates per second without introducing substantial
lag while dragging Phoenix's resizable chart panels.

We have not reproduced the exact failure from the issue consistently, so this
is intentionally a defensive mitigation rather than a claim that the underlying
feedback loop has been fully identified.

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm fmt:check`
- [x] targeted chart and metrics tests — 12 passed
- [x] exercised the seeded Sessions page through 30 alternating viewport sizes
- [x] verified both visible charts settled to their final dimensions with no page errors or chart ErrorBoundary

Related to #14919