### PR TITLE
fix(deps): cap vercel below 0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dev = [
   "ldap3",
   "litellm>=1.83.14; python_version < '3.14'",  # >=1.83.14 fixes CVE-2026-42208; excluded because upstream metadata does not support Python 3.14 (https://github.com/BerriAI/litellm/issues/26343)
   "modal>=1.2.0",  # type-checking only; runtime is gated by the [modal] extra
-  "vercel>=0.5.8",  # type-checking only; runtime is gated by the [vercel] extra. 0.5.8 exposes `network_policy` on AsyncSandbox.create.
+  "vercel>=0.5.8,<0.8",  # type-checking only; runtime is gated by the [vercel] extra. 0.5.8 exposes `network_policy` on AsyncSandbox.create.
   "wasmtime>=15.0",  # bundled in dev so the local WASM sandbox runs without an extra opt-in; the [wasm] extra still gates production installs
   "mypy==2.3.0",
   "mypy-boto3-bedrock-runtime",

--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,7 @@ dev = [
     { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "vcrpy" },
-    { name = "vercel", specifier = ">=0.5.8" },
+    { name = "vercel", specifier = ">=0.5.8,<0.8" },
     { name = "wasmtime", specifier = ">=15.0" },
 ]
 


### PR DESCRIPTION
## Summary
- cap the development-only Vercel SDK dependency below 0.8
- preserve compatibility with Phoenix's current `AsyncSandbox` integration while a 0.8 migration is designed

## Test plan
- [x] `uv lock --check`