### PR TITLE
fix(ci): wait for PyPI propagation before opening dependency-bump PRs

### DIFF
--- a/.github/workflows/update-phoenix-package-versions.yml
+++ b/.github/workflows/update-phoenix-package-versions.yml
@@ -64,6 +64,43 @@ jobs:
             echo "✓ Versions already match for $PACKAGE_NAME: $CURRENT_VERSION"
           fi
 
+      # This workflow is dispatched by publish.yaml the moment the PyPI upload
+      # returns, but the *simple index* that resolvers read trails the upload by
+      # up to a couple of minutes while the CDN revalidates. CI installs the
+      # root package with `uv pip install --no-sources .` (see tox.ini), which
+      # deliberately resolves the workspace siblings from PyPI, so a PR opened
+      # inside that window fails with "No solution found ... only
+      # $PACKAGE_NAME<=<previous version> is available". Hold the PR until the
+      # index actually serves the new version.
+      #
+      # Two consecutive confirmations, because the failure mode was one CI leg
+      # seeing the version and another not: the purge reaches CDN nodes
+      # unevenly, so a single lucky response is not evidence that the whole
+      # fleet is serving it.
+      - name: Wait for version to be resolvable on PyPI
+        if: steps.check-update.outputs.needs_update == 'true'
+        run: |
+          CONFIRMATIONS=0
+          for attempt in $(seq 1 40); do
+            if curl -sf -H 'Accept: application/vnd.pypi.simple.v1+json' \
+                 -H 'Cache-Control: no-cache' \
+                 "https://pypi.org/simple/$PACKAGE_NAME/" \
+                 | jq -e --arg v "$PACKAGE_VERSION" '.versions | index($v)' > /dev/null; then
+              CONFIRMATIONS=$((CONFIRMATIONS + 1))
+              if [ "$CONFIRMATIONS" -ge 2 ]; then
+                echo "✓ $PACKAGE_NAME==$PACKAGE_VERSION is in the PyPI simple index"
+                exit 0
+              fi
+              echo "· $PACKAGE_NAME==$PACKAGE_VERSION seen ($CONFIRMATIONS/2 confirmations)"
+            else
+              CONFIRMATIONS=0
+              echo "· $PACKAGE_NAME==$PACKAGE_VERSION not in the simple index yet (attempt $attempt/40)"
+            fi
+            sleep 15
+          done
+          echo "::error::$PACKAGE_NAME==$PACKAGE_VERSION never appeared in the PyPI simple index; not opening a PR that cannot resolve"
+          exit 1
+
       - name: Update pyproject.toml
         if: steps.check-update.outputs.needs_update == 'true'
         run: |

--- a/.github/workflows/update-phoenix-package-versions.yml
+++ b/.github/workflows/update-phoenix-package-versions.yml
@@ -64,19 +64,10 @@ jobs:
             echo "✓ Versions already match for $PACKAGE_NAME: $CURRENT_VERSION"
           fi
 
-      # This workflow is dispatched by publish.yaml the moment the PyPI upload
-      # returns, but the *simple index* that resolvers read trails the upload by
-      # up to a couple of minutes while the CDN revalidates. CI installs the
-      # root package with `uv pip install --no-sources .` (see tox.ini), which
-      # deliberately resolves the workspace siblings from PyPI, so a PR opened
-      # inside that window fails with "No solution found ... only
-      # $PACKAGE_NAME<=<previous version> is available". Hold the PR until the
-      # index actually serves the new version.
-      #
-      # Two consecutive confirmations, because the failure mode was one CI leg
-      # seeing the version and another not: the purge reaches CDN nodes
-      # unevenly, so a single lucky response is not evidence that the whole
-      # fleet is serving it.
+      # PyPI's simple index trails the upload by a minute or two, and tox.ini
+      # resolves the workspace siblings from PyPI (`--no-sources`), so a PR opened
+      # too early cannot resolve. Require two hits: the CDN purge reaches nodes
+      # unevenly, so one lucky response proves nothing.
       - name: Wait for version to be resolvable on PyPI
         if: steps.check-update.outputs.needs_update == 'true'
         run: |


### PR DESCRIPTION
`Unit Tests (sqlite, 3.10)` on #15277 (`fix(deps): update arize-phoenix-otel to 0.17.1`) failed in `commands_pre`:

```
uv pip install --no-sources --strict --reinstall-package arize-phoenix .
  × No solution found when resolving dependencies:
  ╰─▶ Because only arize-phoenix-otel<=0.17.0 is available and
      arize-phoenix==19.20.0 depends on arize-phoenix-otel>=0.17.1, we can
      conclude that arize-phoenix==19.20.0 cannot be used.
```

Timeline from the run:

| time (UTC) | event |
| --- | --- |
| 17:36:28 | `arize-phoenix-otel` 0.17.1 uploaded to PyPI |
| ~17:37:00 | `publish.yaml` dispatches `update-phoenix-package-versions.yml`, which bumps the floor to `>=0.17.1` and opens #15277 |
| 17:37:52 | sqlite unit-tests leg resolves against PyPI, sees only `<=0.17.0`, fails |
| 17:38+ | postgresql leg reaches the same step, sees 0.17.1, **passes** |

`tox.ini` installs the root package with `--no-sources` on purpose, so the workspace siblings resolve from PyPI exactly as a user's install would — that guard is worth keeping. The bug is that the bump PR is opened before PyPI's simple index (what resolvers read, and which trails the upload by a minute or two while the CDN revalidates) actually serves the new version. Two legs of the same matrix disagreeing is the tell: the purge reaches CDN nodes unevenly.

