### PR TITLE
feat(skills): add PHOENIX_ROSTER_INCLUDE to phoenix-github roster

### DIFF
--- a/.agents/skills/phoenix-github/SKILL.md
+++ b/.agents/skills/phoenix-github/SKILL.md
@@ -83,10 +83,13 @@ Every script that writes is **dry-run by default** and takes `--apply`.
 Tunable via env vars: `PHOENIX_MIN_TICKETS` (3), `PHOENIX_MAX_TICKETS` (15),
 `PHOENIX_ROSTER_TEAM` (`oss-eng`; comma-separated list of org teams),
 `PHOENIX_ROSTER_EXCLUDE` (empty; comma-separated logins to omit from all
-reporting), `PHOENIX_STANDUP_DAYS` (2), `PHOENIX_PROJECT_NUMBER` (42),
-`PHOENIX_SNAPSHOT_MAX_AGE_MIN` (120),
-`PHOENIX_ISSUE_LIMIT` (5000). Local overrides for these live in
-`.claude/settings.local.json` (`env` block), not in the scripts.
+reporting), `PHOENIX_ROSTER_INCLUDE` (empty; comma-separated logins to add to
+the roster regardless of team membership), `PHOENIX_STANDUP_DAYS` (2),
+`PHOENIX_PROJECT_NUMBER` (42), `PHOENIX_SNAPSHOT_MAX_AGE_MIN` (120),
+`PHOENIX_ISSUE_LIMIT` (5000). Team-wide values live in `.claude/settings.json`
+(`env` block); personal overrides go in `.claude/settings.local.json`. Neither
+is read by a plain shell — `export` them when running the scripts outside
+Claude Code.
 
 ---
 
@@ -188,7 +191,11 @@ carrying between **3 and 15** tickets. Under 3 means they are about to run dry;
 over 15 means they are buried and the queue is not real.
 
 Roster is the live membership of the `PHOENIX_ROSTER_TEAM` team(s) (default
-**`@Arize-ai/oss-eng`**), so it self-updates as the teams change. Logins listed
+**`@Arize-ai/oss-eng`**), so it self-updates as the teams change. Collaborators
+who carry sprint work without belonging to a roster team are added by login via
+`PHOENIX_ROSTER_INCLUDE`, and show in the roster label as `+login`. Prefer
+adding someone to the org team when that is appropriate — the include list is a
+standing override that does not self-update. Logins listed
 in `PHOENIX_ROSTER_EXCLUDE` are dropped from the roster and filtered out of
 snapshot assignee data at parse time, so they never appear in any report.
 

--- a/.agents/skills/phoenix-github/scripts/_board.py
+++ b/.agents/skills/phoenix-github/scripts/_board.py
@@ -19,10 +19,18 @@ REPO = os.environ.get("PHOENIX_REPO", "Arize-ai/phoenix")
 ROSTER_TEAMS = [
     t.strip() for t in os.environ.get("PHOENIX_ROSTER_TEAM", "oss-eng").split(",") if t.strip()
 ]
-ROSTER_LABEL = ", ".join(f"@{ORG}/{t}" for t in ROSTER_TEAMS)
 ROSTER_EXCLUDE = {
     p.strip().lower() for p in os.environ.get("PHOENIX_ROSTER_EXCLUDE", "").split(",") if p.strip()
 }
+# Collaborators who carry sprint work without belonging to a roster team —
+# contractors, cross-org contributors, anyone not yet added to the org teams.
+ROSTER_INCLUDE = [
+    p.strip() for p in os.environ.get("PHOENIX_ROSTER_INCLUDE", "").split(",") if p.strip()
+]
+ROSTER_LABEL = ", ".join(
+    [f"@{ORG}/{t}" for t in ROSTER_TEAMS]
+    + [f"+{p}" for p in ROSTER_INCLUDE if p.lower() not in ROSTER_EXCLUDE]
+)
 
 # Ticket-load guardrails: everyone should be fed, nobody should be buried.
 MIN_TICKETS = int(os.environ.get("PHOENIX_MIN_TICKETS", "3"))
@@ -276,12 +284,14 @@ def stranded(items: Iterable[Item], past: Iterable[Sprint]) -> list[Item]:
 
 
 def roster() -> list[str]:
-    """Live membership of the roster team(s), minus PHOENIX_ROSTER_EXCLUDE."""
+    """Live membership of the roster team(s), plus PHOENIX_ROSTER_INCLUDE,
+    minus PHOENIX_ROSTER_EXCLUDE. Exclude wins over include."""
     logins = {
         login
         for team in ROSTER_TEAMS
         for login in gh_json("api", f"orgs/{ORG}/teams/{team}/members", "--jq", "[.[].login]")
     }
+    logins.update(ROSTER_INCLUDE)
     return sorted((lg for lg in logins if lg.lower() not in ROSTER_EXCLUDE), key=str.lower)
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "PHOENIX_ROSTER_INCLUDE": "Nancy-Chauhan"
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary

The phoenix-github roster reads live `@Arize-ai/oss-eng` membership, so collaborators who carry sprint work without belonging to an org team were invisible to `health.py` and `standup.py`. `PHOENIX_ROSTER_INCLUDE` adds them by login.

- Exclude wins over include, in both the roster and the report label
- Included logins render in the roster label as `+login`
- Adds `Nancy-Chauhan` via `.claude/settings.json` — she has sprint work on board #42 but is not in any `oss-*` team

Prefer adding someone to the org team when that's appropriate; the include list is a standing override that does not self-update.

## Test plan

- [ ] `PHOENIX_ROSTER_INCLUDE=Nancy-Chauhan uv run .agents/skills/phoenix-github/scripts/health.py` lists Nancy in the ticket-load table
- [ ] Roster label reads `@Arize-ai/oss-eng, +Nancy-Chauhan`
- [ ] Setting `PHOENIX_ROSTER_EXCLUDE=Nancy-Chauhan` alongside the include drops her from both roster and label