### PR TITLE
feat(online-evals): move Add evaluator into a project evaluators search header

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2900,7 +2900,7 @@ type Project implements Node {
   id: ID!
   name: String!
   description: String
-  evaluators(first: Int = 30, last: Int = null, after: String = null, before: String = null): ProjectEvaluatorConnection!
+  evaluators(first: Int = 30, last: Int = null, after: String = null, before: String = null, filter: ProjectEvaluatorFilter): ProjectEvaluatorConnection!
   gradientStartColor: String!
   gradientEndColor: String!
   startTime: DateTime
@@ -3122,6 +3122,16 @@ type ProjectEvaluatorEdge {
 
   """The item at the end of the edge"""
   node: ProjectEvaluator!
+}
+
+"""The filter key and value for project evaluator connections"""
+input ProjectEvaluatorFilter {
+  col: ProjectEvaluatorFilterColumn!
+  value: String!
+}
+
+enum ProjectEvaluatorFilterColumn {
+  name
 }
 
 type ProjectEvaluatorMutationPayload {

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -32,11 +32,6 @@ import {
 } from "@phoenix/constants/searchParams";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
-import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
-import {
-  CreateProjectEvaluatorSlideover,
-  type ProjectEvaluatorCreationMode,
-} from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
 import {
   clearSelectionScopedParams,
   withSearchParams,
@@ -84,29 +79,6 @@ const mainCSS = css`
       }
     }
   }
-`;
-
-/**
- * Puts tab-scoped actions on the tab header row. The row grows to fit the
- * padded action button while the tabs stay anchored to the bottom border,
- * and the bottom border moves here from the TabList.
- */
-const tabBarRowCSS = css`
-  display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-  flex: none;
-  border-bottom: 1px solid var(--tab-border-color);
-  .project-tab-bar__actions {
-    flex: none;
-    padding: var(--global-dimension-size-100);
-  }
-`;
-
-/** Must go on the TabList's own css prop to win against its base styles. */
-const tabBarTabListCSS = css`
-  flex: 1 1 auto;
-  border-bottom: none;
 `;
 
 export function ProjectPage() {
@@ -209,35 +181,7 @@ function ProjectPageContentBody({
 }) {
   const navigate = useNavigate();
   const { rootPath, tab } = useProjectRootPath();
-  const [creationMode, setCreationMode] =
-    useState<ProjectEvaluatorCreationMode | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
-  const shouldOpenScratchFromUrl =
-    searchParams.get(CREATE_LLM_EVALUATOR_PARAM) === "true";
-  const shouldOpenNewCodeFromUrl =
-    searchParams.get(CREATE_CODE_EVALUATOR_PARAM) === "true";
-  const urlCreationMode: ProjectEvaluatorCreationMode | null =
-    shouldOpenScratchFromUrl
-      ? { kind: "scratch" }
-      : shouldOpenNewCodeFromUrl
-        ? { kind: "newCode" }
-        : null;
-  const activeCreationMode =
-    tab === "evaluators" ? (creationMode ?? urlCreationMode) : null;
-  const clearCreationMode = () => {
-    setCreationMode(null);
-    if (shouldOpenScratchFromUrl || shouldOpenNewCodeFromUrl) {
-      setSearchParams(
-        (previousSearchParams) => {
-          const nextSearchParams = new URLSearchParams(previousSearchParams);
-          nextSearchParams.delete(CREATE_LLM_EVALUATOR_PARAM);
-          nextSearchParams.delete(CREATE_CODE_EVALUATOR_PARAM);
-          return nextSearchParams;
-        },
-        { replace: true }
-      );
-    }
-  };
   const data = useLazyLoadQuery<ProjectPageQueryType>(
     graphql`
       query ProjectPageQuery($id: ID!, $timeRange: TimeRange!) {
@@ -433,7 +377,8 @@ function ProjectPageContentBody({
   const onTabChange = useCallback(
     (index: number) => {
       startTransition(() => {
-        setCreationMode(null);
+        // The evaluators tab owns these; drop them so a creation slideover does
+        // not reopen when the user comes back to the tab.
         const search = withSearchParams(
           clearSelectionScopedParams(location.search),
           (params) => {
@@ -477,24 +422,14 @@ function ProjectPageContentBody({
           }}
           selectedKey={tab}
         >
-          <div css={tabBarRowCSS}>
-            <TabList css={tabBarTabListCSS}>
-              <Tab id="spans">Spans</Tab>
-              <Tab id="traces">Traces</Tab>
-              <Tab id="sessions">Sessions</Tab>
-              <Tab id="metrics">Metrics</Tab>
-              <Tab id="evaluators">Evaluators</Tab>
-              <Tab id="config">Config</Tab>
-            </TabList>
-            {tab === "evaluators" ? (
-              <div className="project-tab-bar__actions">
-                <AddProjectEvaluatorMenu
-                  size="S"
-                  onSelectCreationMode={setCreationMode}
-                />
-              </div>
-            ) : null}
-          </div>
+          <TabList>
+            <Tab id="spans">Spans</Tab>
+            <Tab id="traces">Traces</Tab>
+            <Tab id="sessions">Sessions</Tab>
+            <Tab id="metrics">Metrics</Tab>
+            <Tab id="evaluators">Evaluators</Tab>
+            <Tab id="config">Config</Tab>
+          </TabList>
           <LazyTabPanel padded={false} id="spans">
             <Outlet />
           </LazyTabPanel>
@@ -514,16 +449,6 @@ function ProjectPageContentBody({
             <Outlet />
           </LazyTabPanel>
         </Tabs>
-        {activeCreationMode ? (
-          <CreateProjectEvaluatorSlideover
-            isOpen
-            onOpenChange={(isOpen) => {
-              if (!isOpen) clearCreationMode();
-            }}
-            projectId={projectId}
-            creationMode={activeCreationMode}
-          />
-        ) : null}
       </ProjectPageQueryReferenceContext.Provider>
     </main>
   );

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -377,8 +377,7 @@ function ProjectPageContentBody({
   const onTabChange = useCallback(
     (index: number) => {
       startTransition(() => {
-        // The evaluators tab owns these; drop them so a creation slideover does
-        // not reopen when the user comes back to the tab.
+        // The evaluators tab owns these; drop them so it does not reopen.
         const search = withSearchParams(
           clearSelectionScopedParams(location.search),
           (params) => {

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -20,8 +20,7 @@ export function ProjectEvaluatorsPage() {
   invariant(projectId, "projectId is required");
   const [filter, setFilter] = useState("");
   const [searchParams, setSearchParams] = useSearchParams();
-  // Two of the four creation modes are linkable today; the rest are selection
-  // driven. See #15297 for moving all of them onto routes.
+  // Only two of the four creation modes are linkable today; see #15297.
   const shouldOpenScratchFromUrl =
     searchParams.get(CREATE_LLM_EVALUATOR_PARAM) === "true";
   const shouldOpenNewCodeFromUrl =

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -1,16 +1,54 @@
 import { css } from "@emotion/react";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import { useParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import invariant from "tiny-invariant";
 
 import { Skeleton, View } from "@phoenix/components";
+import {
+  CREATE_CODE_EVALUATOR_PARAM,
+  CREATE_LLM_EVALUATOR_PARAM,
+} from "@phoenix/constants/searchParams";
 import type { ProjectEvaluatorsPageQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql";
+import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
+import { CreateProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
 import { ProjectEvaluatorsTable } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsTable";
+import { ProjectEvaluatorsToolbar } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsToolbar";
 
 export function ProjectEvaluatorsPage() {
   const { projectId } = useParams();
   invariant(projectId, "projectId is required");
+  const [filter, setFilter] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Two of the four creation modes are linkable today; the rest are selection
+  // driven. See #15297 for moving all of them onto routes.
+  const shouldOpenScratchFromUrl =
+    searchParams.get(CREATE_LLM_EVALUATOR_PARAM) === "true";
+  const shouldOpenNewCodeFromUrl =
+    searchParams.get(CREATE_CODE_EVALUATOR_PARAM) === "true";
+  const urlCreationMode: ProjectEvaluatorCreationMode | null =
+    shouldOpenScratchFromUrl
+      ? { kind: "scratch" }
+      : shouldOpenNewCodeFromUrl
+        ? { kind: "newCode" }
+        : null;
+  const [creationMode, setCreationMode] =
+    useState<ProjectEvaluatorCreationMode | null>(null);
+  const activeCreationMode = creationMode ?? urlCreationMode;
+  const clearCreationMode = () => {
+    setCreationMode(null);
+    if (shouldOpenScratchFromUrl || shouldOpenNewCodeFromUrl) {
+      setSearchParams(
+        (previousSearchParams) => {
+          const nextSearchParams = new URLSearchParams(previousSearchParams);
+          nextSearchParams.delete(CREATE_LLM_EVALUATOR_PARAM);
+          nextSearchParams.delete(CREATE_CODE_EVALUATOR_PARAM);
+          return nextSearchParams;
+        },
+        { replace: true }
+      );
+    }
+  };
   return (
     <main
       css={css`
@@ -20,14 +58,35 @@ export function ProjectEvaluatorsPage() {
         min-height: 0;
       `}
     >
+      <ProjectEvaluatorsToolbar
+        filter={filter}
+        onFilterChange={setFilter}
+        onSelectCreationMode={setCreationMode}
+      />
       <Suspense fallback={<ProjectEvaluatorsPageSkeleton />}>
-        <ProjectEvaluatorsPageContent projectId={projectId} />
+        <ProjectEvaluatorsPageContent projectId={projectId} filter={filter} />
       </Suspense>
+      {activeCreationMode ? (
+        <CreateProjectEvaluatorSlideover
+          isOpen
+          onOpenChange={(isOpen) => {
+            if (!isOpen) clearCreationMode();
+          }}
+          projectId={projectId}
+          creationMode={activeCreationMode}
+        />
+      ) : null}
     </main>
   );
 }
 
-function ProjectEvaluatorsPageContent({ projectId }: { projectId: string }) {
+function ProjectEvaluatorsPageContent({
+  projectId,
+  filter,
+}: {
+  projectId: string;
+  filter: string;
+}) {
   const data = useLazyLoadQuery<ProjectEvaluatorsPageQuery>(
     graphql`
       query ProjectEvaluatorsPageQuery($projectId: ID!) {
@@ -43,7 +102,11 @@ function ProjectEvaluatorsPageContent({ projectId }: { projectId: string }) {
   );
   invariant(data.project, "project is required");
   return (
-    <ProjectEvaluatorsTable project={data.project} projectId={projectId} />
+    <ProjectEvaluatorsTable
+      project={data.project}
+      projectId={projectId}
+      filter={filter}
+    />
   );
 }
 

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -5,11 +5,20 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { startTransition, useCallback, useEffect, useMemo } from "react";
 import { graphql, readInlineData, usePaginationFragment } from "react-relay";
 
-import { Flex, LoadMoreButton, Text, View } from "@phoenix/components";
+import {
+  Flex,
+  Icon,
+  Icons,
+  LoadMoreButton,
+  Text,
+  View,
+} from "@phoenix/components";
+import { CompactEmptyState } from "@phoenix/components/core/empty";
 import { tableCSS } from "@phoenix/components/table/styles";
+import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import type { ProjectEvaluatorsTable_project$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql";
 import type { ProjectEvaluatorsTable_row$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql";
 import { ProjectEvaluatorActionMenu } from "@phoenix/pages/project/evaluators/ProjectEvaluatorActionMenu";
@@ -42,20 +51,30 @@ type TableRow = ReturnType<typeof readRow>;
 export function ProjectEvaluatorsTable({
   project,
   projectId,
+  filter,
 }: {
   project: ProjectEvaluatorsTable_project$key;
   projectId: string;
+  /** Free-text name search from the toolbar; empty means unfiltered. */
+  filter: string;
 }) {
   "use no memo";
-  const { data, hasNext, isLoadingNext, loadNext } = usePaginationFragment(
+  const {
+    data,
+    hasNext,
+    isLoadingNext,
+    loadNext: _loadNext,
+    refetch,
+  } = usePaginationFragment(
     graphql`
       fragment ProjectEvaluatorsTable_project on Project
       @refetchable(queryName: "ProjectEvaluatorsTablePaginationQuery")
       @argumentDefinitions(
         first: { type: "Int", defaultValue: 30 }
         after: { type: "String", defaultValue: null }
+        filter: { type: "ProjectEvaluatorFilter", defaultValue: null }
       ) {
-        evaluators(first: $first, after: $after)
+        evaluators(first: $first, after: $after, filter: $filter)
           @connection(key: "ProjectEvaluatorsTable_evaluators") {
           edges {
             node {
@@ -67,6 +86,26 @@ export function ProjectEvaluatorsTable({
     `,
     project
   );
+  const trimmedFilter = filter.trim();
+  // The connection is filtered server-side so paging stays consistent with the
+  // search -- a client-side filter would only ever see the loaded page.
+  useEffect(() => {
+    startTransition(() => {
+      refetch(
+        {
+          filter: trimmedFilter ? { col: "name", value: trimmedFilter } : null,
+        },
+        { fetchPolicy: "store-and-network" }
+      );
+    });
+  }, [trimmedFilter, refetch]);
+  const loadNext = useCallback(() => {
+    _loadNext(PAGE_SIZE, {
+      UNSTABLE_extraVariables: {
+        filter: trimmedFilter ? { col: "name", value: trimmedFilter } : null,
+      },
+    });
+  }, [_loadNext, trimmedFilter]);
   const tableData = useMemo(
     () => data.evaluators.edges.map(({ node }) => readRow(node)),
     [data.evaluators.edges]
@@ -158,7 +197,17 @@ export function ProjectEvaluatorsTable({
             ))}
           </thead>
           {rows.length === 0 ? (
-            <ProjectEvaluatorsEmptyGallery projectId={projectId} />
+            trimmedFilter ? (
+              <TableEmptyWrap>
+                <CompactEmptyState
+                  icon={<Icon svg={<Icons.Scale />} />}
+                  description="No evaluators match your search"
+                  isFiltered
+                />
+              </TableEmptyWrap>
+            ) : (
+              <ProjectEvaluatorsEmptyGallery projectId={projectId} />
+            )
           ) : (
             <tbody>
               {rows.map((row) => (
@@ -181,7 +230,7 @@ export function ProjectEvaluatorsTable({
             <Flex justifyContent="center">
               <LoadMoreButton
                 isLoadingNext={isLoadingNext}
-                onLoadMore={() => loadNext(PAGE_SIZE)}
+                onLoadMore={loadNext}
               />
             </Flex>
           </View>

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -87,8 +87,7 @@ export function ProjectEvaluatorsTable({
     project
   );
   const trimmedFilter = filter.trim();
-  // The connection is filtered server-side so paging stays consistent with the
-  // search -- a client-side filter would only ever see the loaded page.
+  // Filtered server-side; a client-side filter would only see the loaded page.
   useEffect(() => {
     startTransition(() => {
       refetch(

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
@@ -18,7 +18,7 @@ export function ProjectEvaluatorsToolbar({
 }) {
   return (
     <View
-      padding="size-200"
+      padding="size-100"
       borderBottomWidth="thin"
       borderBottomColor="default"
       flex="none"

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
@@ -37,7 +37,7 @@ export function ProjectEvaluatorsToolbar({
         />
         <Flex direction="row" alignItems="center" gap="size-100" flex="none">
           <AddProjectEvaluatorMenu
-            size="S"
+            size="M"
             onSelectCreationMode={onSelectCreationMode}
           />
         </Flex>

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
@@ -1,0 +1,47 @@
+import { DebouncedSearch, Flex, View } from "@phoenix/components";
+import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
+import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
+
+/**
+ * The evaluators tab's own header: search on the left, creation on the right.
+ * Both live in the tab's content rather than the project tab bar, so the tab
+ * bar stays pure navigation and this page owns its creation state.
+ */
+export function ProjectEvaluatorsToolbar({
+  filter,
+  onFilterChange,
+  onSelectCreationMode,
+}: {
+  filter: string;
+  onFilterChange: (filter: string) => void;
+  onSelectCreationMode: (mode: ProjectEvaluatorCreationMode) => void;
+}) {
+  return (
+    <View
+      padding="size-200"
+      borderBottomWidth="thin"
+      borderBottomColor="default"
+      flex="none"
+    >
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        gap="size-100"
+      >
+        <DebouncedSearch
+          aria-label="Search evaluators by name"
+          placeholder="Search evaluators by name"
+          defaultValue={filter}
+          onChange={onFilterChange}
+        />
+        <Flex direction="row" alignItems="center" gap="size-100" flex="none">
+          <AddProjectEvaluatorMenu
+            size="S"
+            onSelectCreationMode={onSelectCreationMode}
+          />
+        </Flex>
+      </Flex>
+    </View>
+  );
+}

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<190822e07fb07cb9d72e9addc1894231>>
+ * @generated SignedSource<<73baeaaeec65037620cdccb76819f671>>
  * @lightSyntaxTransform
  */
 
@@ -236,7 +236,9 @@ return {
               {
                 "alias": null,
                 "args": (v4/*:: as any*/),
-                "filters": null,
+                "filters": [
+                  "filter"
+                ],
                 "handle": "connection",
                 "key": "ProjectEvaluatorsTable_evaluators",
                 "kind": "LinkedHandle",

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8c886ff43e7b1e0fa4aeacd1d05e4e84>>
+ * @generated SignedSource<<4fb7526f611a86bf3404cb887e325e60>>
  * @lightSyntaxTransform
  */
 
@@ -9,8 +9,14 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type ProjectEvaluatorFilterColumn = "name";
+export type ProjectEvaluatorFilter = {
+  col: ProjectEvaluatorFilterColumn;
+  value: string;
+};
 export type ProjectEvaluatorsTablePaginationQuery$variables = {
   after?: string | null;
+  filter?: ProjectEvaluatorFilter | null;
   first?: number | null;
   id: string;
 };
@@ -30,6 +36,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "after"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "filter"
   },
   {
     "defaultValue": 30,
@@ -54,6 +65,11 @@ v2 = [
     "kind": "Variable",
     "name": "after",
     "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
   },
   {
     "kind": "Variable",
@@ -246,7 +262,9 @@ return {
               {
                 "alias": null,
                 "args": (v2/*:: as any*/),
-                "filters": null,
+                "filters": [
+                  "filter"
+                ],
                 "handle": "connection",
                 "key": "ProjectEvaluatorsTable_evaluators",
                 "kind": "LinkedHandle",
@@ -262,16 +280,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f9012014df16916951937bc118ef17e1",
+    "cacheID": "54db04379164fa924f78bc296643425d",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsTablePaginationQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $first: Int = 30\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_2HEEH6\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_2HEEH6 on Project {\n  evaluators(first: $first, after: $after) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  evaluator {\n    __typename\n    kind\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_G9cLv\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_G9cLv on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  evaluator {\n    __typename\n    kind\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1955deb1a62439f39c55f2ce985be809";
+(node as any).hash = "e32f1d4594df375d4292c05d795eecba";
 
 export default node;

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0fddde0a7ec83a998fa7eafecf3d70fa>>
+ * @generated SignedSource<<41257a23e83fe69735107a60219f9167>>
  * @lightSyntaxTransform
  */
 
@@ -46,6 +46,11 @@ return {
       "name": "after"
     },
     {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "filter"
+    },
+    {
       "defaultValue": 30,
       "kind": "LocalArgument",
       "name": "first"
@@ -84,7 +89,13 @@ return {
   "selections": [
     {
       "alias": "evaluators",
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "filter",
+          "variableName": "filter"
+        }
+      ],
       "concreteType": "ProjectEvaluatorConnection",
       "kind": "LinkedField",
       "name": "__ProjectEvaluatorsTable_evaluators_connection",
@@ -223,6 +234,6 @@ return {
 };
 })();
 
-(node as any).hash = "1955deb1a62439f39c55f2ce985be809";
+(node as any).hash = "e32f1d4594df375d4292c05d795eecba";
 
 export default node;

--- a/src/phoenix/server/api/input_types/ProjectEvaluatorFilter.py
+++ b/src/phoenix/server/api/input_types/ProjectEvaluatorFilter.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class ProjectEvaluatorFilterColumn(Enum):
+    name = "name"
+
+
+@strawberry.input(description="The filter key and value for project evaluator connections")
+class ProjectEvaluatorFilter:
+    col: ProjectEvaluatorFilterColumn
+    value: str

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -12,10 +12,12 @@ from aioitertools.itertools import groupby, islice
 from openinference.semconv.trace import SpanAttributes
 from pandas import DataFrame
 from sqlalchemy import Select, and_, case, desc, distinct, exists, func, or_, select
+from sqlalchemy import cast as sqlalchemy_cast
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.expression import tuple_
 from sqlalchemy.sql.functions import percentile_cont
+from sqlalchemy.sql.sqltypes import String
 from strawberry import ID, UNSET, lazy
 from strawberry.relay import Connection, Edge, GlobalID, Node, NodeID, PageInfo
 from strawberry.types import Info
@@ -29,6 +31,7 @@ from phoenix.server.api.annotation_metrics import build_entity_weighted_annotati
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest
 from phoenix.server.api.extensions import RequireForwardPaginationExtension
+from phoenix.server.api.input_types.ProjectEvaluatorFilter import ProjectEvaluatorFilter
 from phoenix.server.api.input_types.ProjectSessionSort import (
     ProjectSessionSort,
     ProjectSessionSortConfig,
@@ -336,6 +339,7 @@ class Project(Node):
         last: Optional[int] = None,
         after: Optional[str] = None,
         before: Optional[str] = None,
+        filter: Optional[ProjectEvaluatorFilter] = UNSET,
     ) -> Connection[ProjectEvaluator]:
         args = ConnectionArgs(
             first=first,
@@ -343,17 +347,20 @@ class Project(Node):
             last=last,
             before=before if isinstance(before, CursorString) else None,
         )
-        async with info.context.db.read() as session:
-            records = list(
-                await session.scalars(
-                    select(models.ProjectEvaluatorCriteria)
-                    .where(models.ProjectEvaluatorCriteria.project_id == self.id)
-                    .order_by(
-                        models.ProjectEvaluatorCriteria.name,
-                        models.ProjectEvaluatorCriteria.id,
-                    )
-                )
+        stmt = (
+            select(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.project_id == self.id)
+            .order_by(
+                models.ProjectEvaluatorCriteria.name,
+                models.ProjectEvaluatorCriteria.id,
             )
+        )
+        if filter and (value := filter.value.strip()):
+            column = getattr(models.ProjectEvaluatorCriteria, filter.col.value)
+            # `name` is an Identifier-typed column; compare it as text so LIKE applies.
+            stmt = stmt.where(sqlalchemy_cast(column, String).ilike(f"%{value}%"))
+        async with info.context.db.read() as session:
+            records = list(await session.scalars(stmt))
         return connection_from_list(
             data=[ProjectEvaluator(id=record.id, db_record=record) for record in records],
             args=args,

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -1,5 +1,5 @@
 from secrets import token_hex
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from sqlalchemy import func, select
@@ -88,6 +88,16 @@ query($id: ID!) {{
     ... on Project {{
       name
       evaluators {{ edges {{ node {{ {_PROJECT_EVALUATOR_FIELDS} }} }} }}
+    }}
+  }}
+}}
+"""
+
+_FILTERED_PROJECT_EVALUATORS = f"""
+query($id: ID!, $filter: ProjectEvaluatorFilter) {{
+  node(id: $id) {{
+    ... on Project {{
+      evaluators(filter: $filter) {{ edges {{ node {{ {_PROJECT_EVALUATOR_FIELDS} }} }} }}
     }}
   }}
 }}
@@ -526,6 +536,40 @@ async def test_project_llm_evaluator_create_update_delete(
         {"input": {"projectEvaluatorIds": [created["id"]]}},
     )
     assert delete_result.data and not delete_result.errors
+
+
+async def test_project_evaluators_filters_by_name(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    project = await _add_project(db)
+    project_gid = str(GlobalID("Project", str(project.id)))
+    for name in ("hallucination-judge", "toxicity-judge", "relevance"):
+        result = await gql_client.execute(
+            _CREATE_LLM,
+            {"input": _llm_input(project, name=name, text="Evaluate {{input}}")},
+        )
+        assert result.data and not result.errors
+
+    async def _names(filter_value: Optional[str]) -> list[str]:
+        result = await gql_client.execute(
+            _FILTERED_PROJECT_EVALUATORS,
+            {
+                "id": project_gid,
+                "filter": None if filter_value is None else {"col": "name", "value": filter_value},
+            },
+        )
+        assert result.data and not result.errors
+        return [edge["node"]["name"] for edge in result.data["node"]["evaluators"]["edges"]]
+
+    all_names = ["hallucination-judge", "relevance", "toxicity-judge"]
+    assert await _names(None) == all_names
+    # Substring match spanning more than one evaluator, and case insensitive.
+    assert await _names("judge") == ["hallucination-judge", "toxicity-judge"]
+    assert await _names("HALLUC") == ["hallucination-judge"]
+    assert await _names("nothing-matches-this") == []
+    # A blank search is not a filter -- it must not exclude everything.
+    assert await _names("   ") == all_names
 
 
 async def test_update_project_llm_evaluator_preserves_description_and_owner_on_no_op_save(

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -94,11 +94,7 @@ def _patch_playground_client(monkeypatch: pytest.MonkeyPatch, client: _StubLLMCl
 
 class _StubSandboxBackend:
     secret_values: tuple[str, ...] = ()
-    # Duck-typed rather than a SandboxBackend subclass, since the stubbed session
-    # manager never invokes the backend's abstract methods. That means the real
-    # class's attribute defaults are not inherited and have to be mirrored here:
-    # CodeEvaluatorRunner reads `provider` to pick the Python harness, and empty
-    # is SandboxBackend's own default for a non-Monty backend.
+    # Duck-typed, so SandboxBackend's defaults must be mirrored.
     provider: str = ""
 
 

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -94,6 +94,12 @@ def _patch_playground_client(monkeypatch: pytest.MonkeyPatch, client: _StubLLMCl
 
 class _StubSandboxBackend:
     secret_values: tuple[str, ...] = ()
+    # Duck-typed rather than a SandboxBackend subclass, since the stubbed session
+    # manager never invokes the backend's abstract methods. That means the real
+    # class's attribute defaults are not inherited and have to be mirrored here:
+    # CodeEvaluatorRunner reads `provider` to pick the Python harness, and empty
+    # is SandboxBackend's own default for a non-Monty backend.
+    provider: str = ""
 
 
 class _StubSandboxSession:


### PR DESCRIPTION
Closes #15292.

The **Add evaluator** menu lived in the project tab bar. That forced `ProjectPage` to own evaluator creation state, and put the action far from the table it acts on. This moves it into the evaluators tab content, next to a name search.

## Changes

**Frontend**

- New `ProjectEvaluatorsToolbar`: debounced name search on the left, `AddProjectEvaluatorMenu` on the right. Rendered by `ProjectEvaluatorsPage`, above the Suspense boundary so it does not flash on load.
- Creation state moves from `ProjectPage` to `ProjectEvaluatorsPage` — the `createLlmEvaluator` / `createCodeEvaluator` search params, the `creationMode` state, and the create slideover. `ProjectPage` still clears those params on tab change so a slideover does not reopen when you return to the tab.
- The `.project-tab-bar__actions` slot and its row wrapper are gone; `TabList` renders its own bottom border again, as it does elsewhere.
- A search matching nothing now shows a filtered-empty state instead of the creation gallery.

**Backend**

- `Project.evaluators` takes a `filter: ProjectEvaluatorFilter` argument (`col: name`), mirroring `Dataset.datasetEvaluators`. Filtering server-side keeps search consistent with pagination — a client-side filter would only ever see the loaded page. `name` is an `Identifier`-typed column, so it is cast to text before `ILIKE`. A blank/whitespace value is treated as no filter.

## Verification

- `make typecheck-frontend`, `make typecheck-python`, `make lint-frontend`, `make lint-python` — clean, no new warnings.
- `tests/unit/server/api/mutations/test_project_evaluator_mutations.py` — 19 passed on **both** SQLite and Postgres, including a new `test_project_evaluators_filters_by_name` covering substring match, case insensitivity, no-match, and the blank-search case.
- Full frontend unit suite: 201 files, 2222 passed.
- Existing Playwright specs locate the button by accessible name (`getByRole("button", { name: "Add evaluator" })`), so they are unaffected by the move.

**Not verified in a browser** — I did not spin up the app to look at the toolbar rendering. Worth a visual check before merge.

## Notes

- `ProjectEvaluatorsEmptyGallery` still renders its own second `CreateProjectEvaluatorSlideover` instance. That duplication is real but belongs to #15297 (route-driven slideovers), so it is untouched here.
- Only two of the four creation modes remain URL-addressable; also #15297.

## Unrelated fix carried here to get CI green

`tests/unit/server/online_eval/test_consumer.py::test_code_criteria_input_mapping_override_is_used_during_execution` fails on Postgres with `AttributeError: '_StubSandboxBackend' object has no attribute 'provider'`.

**This is broken on `version-online-evals` itself, not caused by this PR** — I verified `src/phoenix/server/api/evaluators.py` and `tests/unit/server/online_eval/test_consumer.py` are byte-identical between this branch and the base (66855be25), and reproduced the failure at that commit. Every PR targeting this branch is currently red for the same reason.

`CodeEvaluatorRunner` reads `sandbox_backend.provider` to choose between the Monty and Python harnesses. Every other backend stub in the suite subclasses `SandboxBackend` and inherits its `provider: ClassVar[str] = ""` default; this one is duck-typed and was missed in the sandbox API rename that 66855be25 was cleaning up. Added the mirrored default with a comment explaining why it has to be restated.

Happy to split this into its own PR against `version-online-evals` if you'd rather keep this one single-purpose.
