### PR TITLE
ci: report publications from PyPI, publish root after siblings

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       phoenix_path: ${{ steps.paths.outputs.phoenix_path }}
       package_paths: ${{ steps.paths.outputs.package_paths }}
+      expected: ${{ steps.paths.outputs.expected }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -54,13 +55,16 @@ jobs:
         run: |
           NEED_PHOENIX=''
           NEED_PACKAGES='[]'
+          EXPECTED='[]'
           for path in $(jq -r 'keys[]' .release-please-manifest.json); do
             [ -z "$path" ] && continue
             NAME=$(jq -r --arg p "$path" '.packages[$p]["package-name"] // empty' release-please-config.json)
             VERSION=$(jq -r --arg p "$path" '.[$p]' .release-please-manifest.json)
             if [ -z "$NAME" ] || [ "$VERSION" = "null" ] || [ -z "$VERSION" ]; then
               echo "Including $path (name or version missing)"
+              [ "$VERSION" = "null" ] && VERSION=''
               if [ "$path" = "." ]; then NEED_PHOENIX='.'; else NEED_PACKAGES=$(jq -c --arg p "$path" '. + [$p]' <<< "$NEED_PACKAGES"); fi
+              EXPECTED=$(jq -c --arg p "$path" --arg n "$NAME" --arg v "$VERSION" '. + [{path: $p, name: $n, version: $v}]' <<< "$EXPECTED")
               continue
             fi
             HTTP=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${NAME}/${VERSION}/json")
@@ -71,14 +75,19 @@ jobs:
               else
                 NEED_PACKAGES=$(jq -c --arg p "$path" '. + [$p]' <<< "$NEED_PACKAGES")
               fi
+              EXPECTED=$(jq -c --arg p "$path" --arg n "$NAME" --arg v "$VERSION" '. + [{path: $p, name: $n, version: $v}]' <<< "$EXPECTED")
             else
               echo "${NAME}==${VERSION} already on PyPI, skipping"
             fi
           done
-          echo "phoenix_path=$NEED_PHOENIX" >> $GITHUB_OUTPUT
-          echo "package_paths=$NEED_PACKAGES" >> $GITHUB_OUTPUT
+          {
+            echo "phoenix_path=$NEED_PHOENIX"
+            echo "package_paths=$NEED_PACKAGES"
+            echo "expected=$EXPECTED"
+          } >> "$GITHUB_OUTPUT"
           echo "Phoenix path: $NEED_PHOENIX"
           echo "Package paths: $NEED_PACKAGES"
+          echo "Expected: $EXPECTED"
 
   build-phoenix:
     name: Build Phoenix (main package)
@@ -150,7 +159,12 @@ jobs:
   publish-phoenix:
     name: Publish Phoenix (main package)
     runs-on: ubuntu-latest
-    needs: build-phoenix
+    needs: [build-phoenix, publish-packages]
+    # `!cancelled()` suppresses the success() that GitHub otherwise prepends to a
+    # job `if:`, so the build gate has to be spelled out. `!= 'failure'` rather
+    # than `== 'success'` because publish-packages is skipped on a release that
+    # ships only the root package, and succeeds when every matrix leg skips.
+    if: ${{ !cancelled() && needs.build-phoenix.result == 'success' && needs.publish-packages.result != 'failure' }}
     environment:
       name: pypi
       url: https://pypi.org/p/arize-phoenix
@@ -394,23 +408,29 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Trigger dependency update workflow
         if: steps.check.outputs.needed == 'true'
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_PATH: ${{ matrix.path }}
+          PACKAGE_NAME: ${{ matrix.package_name }}
         run: |
-          VERSION=$(jq -r --arg p "${{ matrix.path }}" '.[$p] // empty' .release-please-manifest.json)
+          VERSION=$(jq -r --arg p "$MATRIX_PATH" '.[$p] // empty' .release-please-manifest.json)
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version for $MATRIX_PATH in .release-please-manifest.json"
+            exit 1
+          fi
           gh workflow run update-phoenix-package-versions.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --field package="${{ matrix.package_name }}" \
+            --field package="$PACKAGE_NAME" \
             --field version="$VERSION"
 
   slack:
-    name: Slack notification
-    # Depends on the build jobs too, not just the publish ones: a publish job
-    # is gated on its build succeeding, so a failed build leaves it *skipped*
-    # rather than failed. Watching only publish results therefore reports
-    # success for a package that never shipped, as long as some other package
-    # published in the same run.
+    name: Publication report
+    # A publish job concluding `success` never means its packages shipped: every
+    # leg of the matrix can skip via `needed=false` and still aggregate to
+    # success, and a publish job gated on its build is left *skipped* rather
+    # than failed when that build breaks. The report therefore asks PyPI which
+    # exact versions are actually there, and uses job conclusions only to say
+    # where an unpublished package got stuck.
     needs:
       - list-python-packages
       - build-phoenix
@@ -421,38 +441,118 @@ jobs:
       - build-sqlean
       - publish-sqlean
       - trigger-version-updates
-    if: >-
-      always() && inputs.feature_branch == '' &&
-      (contains(needs.*.result, 'failure')
-      || needs.publish-phoenix.result != 'skipped'
-      || needs.publish-packages.result != 'skipped'
-      || needs.publish-sqlean.result != 'skipped')
+    if: ${{ always() && inputs.feature_branch == '' }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Set notification content
+      - name: Confirm expected versions on PyPI
         id: notify
         env:
+          EXPECTED: ${{ needs.list-python-packages.outputs.expected }}
+          LIST_RESULT: ${{ needs.list-python-packages.result }}
+          SQLEAN_SOURCES_RESULT: ${{ needs.sqlean-sources.result }}
+          SQLEAN_NEEDED: ${{ needs.sqlean-sources.outputs.needed }}
           PHOENIX_RESULT: ${{ needs.publish-phoenix.result }}
           PACKAGES_RESULT: ${{ needs.publish-packages.result }}
           SQLEAN_RESULT: ${{ needs.publish-sqlean.result }}
           ANY_FAILURE: ${{ contains(needs.*.result, 'failure') }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$ANY_FAILURE" = "true" ]; then
+          STATE=indeterminate
+          DETAIL=''
+          CONFIRMED=''
+          UNCONFIRMED=''
+          if [ "$LIST_RESULT" != "success" ]; then
+            DETAIL="list-python-packages did not complete (result: ${LIST_RESULT})"
+          elif ! jq -e 'type == "array"' > /dev/null 2>&1 <<< "$EXPECTED"; then
+            DETAIL="the expected-package list is missing or unparseable"
+          else
+            # arize-phoenix-sqlean has no release tag until release-please cuts its
+            # first release, and skipping it then is not a partial train. Keep it
+            # expected when the job that answers that question did not succeed.
+            EXPECTED=$(jq -c --arg needed "$SQLEAN_NEEDED" --arg sources "$SQLEAN_SOURCES_RESULT" \
+              '[.[] | select(.path != "packages/phoenix-sqlean" or $needed == "true" or $sources != "success")]' <<< "$EXPECTED")
+            if [ "$(jq -r 'length' <<< "$EXPECTED")" -eq 0 ]; then
+              STATE=nothing-expected
+            else
+              for i in $(jq -r 'to_entries[].key' <<< "$EXPECTED"); do
+                PKG_PATH=$(jq -r --argjson i "$i" '.[$i].path' <<< "$EXPECTED")
+                NAME=$(jq -r --argjson i "$i" '.[$i].name' <<< "$EXPECTED")
+                VERSION=$(jq -r --argjson i "$i" '.[$i].version' <<< "$EXPECTED")
+                case "$PKG_PATH" in
+                  .) WHERE="publish-phoenix: ${PHOENIX_RESULT}" ;;
+                  packages/phoenix-sqlean) WHERE="publish-sqlean: ${SQLEAN_RESULT}" ;;
+                  *) WHERE="publish-packages: ${PACKAGES_RESULT}" ;;
+                esac
+                if [ -z "$NAME" ] || [ -z "$VERSION" ]; then
+                  UNCONFIRMED="${UNCONFIRMED}- ${PKG_PATH}: no package name or version in the release manifest (${WHERE})"$'\n'
+                  continue
+                fi
+                HTTP=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${NAME}/${VERSION}/json")
+                if [ "$HTTP" = "200" ]; then
+                  CONFIRMED="${CONFIRMED}- ${NAME}==${VERSION}"$'\n'
+                else
+                  UNCONFIRMED="${UNCONFIRMED}- ${NAME}==${VERSION}: not on PyPI (HTTP ${HTTP}) (${WHERE})"$'\n'
+                fi
+              done
+              if [ -z "$UNCONFIRMED" ]; then STATE=success; else STATE=partial; fi
+            fi
+          fi
+
+          case "$STATE" in
+            success) HEADLINE="PYPI Publication Succeeded" ;;
+            partial)
+              if [ "$ANY_FAILURE" = "true" ]; then
+                HEADLINE="🚨🚨🚨 PYPI Publication Failed 🚨🚨🚨"
+              else
+                HEADLINE="🚨🚨🚨 PYPI Publication Incomplete 🚨🚨🚨"
+              fi
+              ;;
+            indeterminate) HEADLINE="🚨🚨🚨 PYPI Publication Report Unavailable 🚨🚨🚨" ;;
+            nothing-expected) HEADLINE="No packages were expected to publish" ;;
+          esac
+
+          NOTE=''
+          if [ "$STATE" = "success" ] && [ "$ANY_FAILURE" = "true" ]; then
+            NOTE="Every expected version published, but a job in this run failed."
+          fi
+          if [ "$STATE" = "indeterminate" ]; then
+            NOTE="${DETAIL}. Job conclusions — publish-phoenix: ${PHOENIX_RESULT}, publish-packages: ${PACKAGES_RESULT}, publish-sqlean: ${SQLEAN_RESULT}."
+          fi
+
+          {
+            echo "## ${HEADLINE}"
+            echo ""
+            if [ -n "$NOTE" ]; then
+              echo "$NOTE"
+              echo ""
+            fi
+            if [ -n "$CONFIRMED" ]; then
+              echo "Confirmed on PyPI:"
+              echo ""
+              printf '%s\n' "$CONFIRMED"
+            fi
+            if [ -n "$UNCONFIRMED" ]; then
+              echo "Not confirmed on PyPI:"
+              echo ""
+              printf '%s\n' "$UNCONFIRMED"
+            fi
+            echo "$RUN_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$STATE" != "nothing-expected" ]; then
             {
               echo "text<<EOF"
-              echo "🚨🚨🚨 PYPI Publication Failed 🚨🚨🚨"
+              echo "$HEADLINE"
+              if [ -n "$NOTE" ]; then
+                echo "$NOTE"
+              fi
+              if [ -n "$UNCONFIRMED" ]; then
+                printf 'Not confirmed on PyPI:\n%s' "$UNCONFIRMED"
+              fi
               echo "$RUN_URL"
               echo "EOF"
-            } >> $GITHUB_OUTPUT
-          elif [ "$PHOENIX_RESULT" = "success" ] || [ "$PACKAGES_RESULT" = "success" ] || [ "$SQLEAN_RESULT" = "success" ]; then
-            {
-              echo "text<<EOF"
-              echo "PYPI Publication Succeeded"
-              echo "$RUN_URL"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           fi
       - name: Send message to Slack
         if: steps.notify.outputs.text != ''
@@ -506,6 +606,7 @@ jobs:
               - 'src/phoenix/**'
               - 'app/src/**'
               - 'pyproject.toml'
+              - 'packages/**'
             phoenix-client:
               - 'packages/phoenix-client/**'
             phoenix-evals:
@@ -549,11 +650,28 @@ jobs:
       - name: Stamp dev version
         env:
           HEAD_SHA: ${{ needs.preview-changes.outputs.sha }}
+          PYPROJECT_PATH: pyproject.toml
+          SELF_NAME: arize-phoenix
+          CLIENT_CHANGED: ${{ needs.preview-changes.outputs['phoenix-client'] }}
+          EVALS_CHANGED: ${{ needs.preview-changes.outputs['phoenix-evals'] }}
+          OTEL_CHANGED: ${{ needs.preview-changes.outputs['phoenix-otel'] }}
         run: |
           python - <<'PY'
-          import re, os
-          path = "src/phoenix/version.py"
+          import os, re, sys
+
+          SIBLINGS = {
+              "arize-phoenix-client": ("packages/phoenix-client/pyproject.toml", "CLIENT_CHANGED"),
+              "arize-phoenix-evals": ("packages/phoenix-evals/pyproject.toml", "EVALS_CHANGED"),
+              "arize-phoenix-otel": ("packages/phoenix-otel/pyproject.toml", "OTEL_CHANGED"),
+          }
+
+          def canon(name):
+              return re.sub(r"[-_.]+", "-", name).lower()
+
           suffix = int(os.environ["HEAD_SHA"][:7], 16)
+          me = canon(os.environ["SELF_NAME"])
+
+          path = "src/phoenix/version.py"
           content = open(path).read()
           new = re.sub(
               r'(__version__ = ")([^"]+)(")',
@@ -561,6 +679,80 @@ jobs:
               content,
           )
           open(path, "w").write(new)
+
+          # Every preview job stamps from the same head SHA, so each one can derive
+          # its siblings' dev versions itself. Pinning them is what makes the wheel
+          # installable as a set: [tool.uv.sources] workspace linkage is uv-local
+          # and never reaches wheel metadata, so an unpinned floor is satisfied by
+          # the stable release and the dev sibling is simply never selected.
+          version_re = re.compile(r'(?m)^version = "([^"]+)"')
+          dev = {}
+          for name, (manifest, changed) in SIBLINGS.items():
+              if os.environ.get(changed) != "true" or canon(name) == me:
+                  continue
+              found = version_re.search(open(manifest).read())
+              if not found:
+                  sys.exit(f"::error::No version key in {manifest}")
+              dev[canon(name)] = f"{found.group(1)}.dev{suffix}"
+
+          path = os.environ["PYPROJECT_PATH"]
+          lines = open(path).read().split("\n")
+          string_re = re.compile(r"\"[^\"]*\"|'[^']*'")
+          req_re = re.compile(
+              r"\"([A-Za-z0-9][A-Za-z0-9._-]*)(\[[^\]\"]*\])?([^\"]*)\""
+              r"|'([A-Za-z0-9][A-Za-z0-9._-]*)(\[[^\]']*\])?([^']*)'"
+          )
+          rewrites = {c: 0 for c in dev}
+
+          def pin(match):
+              double = match.group(1) is not None
+              quote = '"' if double else "'"
+              name = match.group(1) if double else match.group(4)
+              extras = (match.group(2) if double else match.group(5)) or ""
+              rest = (match.group(3) if double else match.group(6)) or ""
+              target = dev.get(canon(name))
+              if target is None:
+                  return match.group(0)
+              rewrites[canon(name)] += 1
+              marker = ";" + rest.split(";", 1)[1] if ";" in rest else ""
+              return f"{quote}{name}{extras}=={target}{marker}{quote}"
+
+          # Only PEP 621 requirement lists are rewritten; [tool.uv] names these
+          # packages too and its entries are not dependency specifiers.
+          table, key, depth, scanned = "", None, 0, []
+          for i, line in enumerate(lines):
+              header = re.match(r"\s*\[([^\]]+)\]\s*$", line)
+              if header:
+                  table, key, depth = header.group(1), None, 0
+                  continue
+              bare = string_re.sub("", line)
+              if depth == 0:
+                  assign = re.match(r"\s*([A-Za-z0-9_.\"'-]+)\s*=", line)
+                  key = assign.group(1) if assign else key
+              if table.startswith("project"):
+                  scanned.append(line)
+                  requirements = table == "project.optional-dependencies" or (
+                      table == "project" and key == "dependencies"
+                  )
+                  if requirements and (depth > 0 or "[" in bare):
+                      lines[i] = req_re.sub(pin, line)
+              depth = max(0, depth + bare.count("[") - bare.count("]"))
+
+          quoted = string_re.findall("\n".join(scanned))
+          for name in SIBLINGS:
+              if canon(name) not in dev:
+                  continue
+              boundary = rf"(?<![A-Za-z0-9._-]){re.escape(name)}(?![A-Za-z0-9._-])"
+              declared = sum(1 for q in quoted if re.search(boundary, q))
+              if declared != rewrites[canon(name)]:
+                  sys.exit(
+                      f"::error::{path} declares {name} in a form this step cannot "
+                      f"rewrite ({declared} declared, {rewrites[canon(name)]} rewritten)"
+                  )
+              if rewrites[canon(name)]:
+                  print(f"Pinned {name} to {dev[canon(name)]} in {path}")
+
+          open(path, "w").write("\n".join(lines))
           PY
       - name: Build distribution
         run: rm -rf dist && uv build
@@ -623,11 +815,39 @@ jobs:
         env:
           PYPROJECT_PATH: ${{ matrix.path }}/pyproject.toml
           HEAD_SHA: ${{ needs.preview-changes.outputs.sha }}
+          SELF_NAME: ${{ matrix.package_name }}
+          CLIENT_CHANGED: ${{ needs.preview-changes.outputs['phoenix-client'] }}
+          EVALS_CHANGED: ${{ needs.preview-changes.outputs['phoenix-evals'] }}
+          OTEL_CHANGED: ${{ needs.preview-changes.outputs['phoenix-otel'] }}
         run: |
           python - <<'PY'
-          import re, os
-          path = os.environ["PYPROJECT_PATH"]
+          import os, re, sys
+
+          SIBLINGS = {
+              "arize-phoenix-client": ("packages/phoenix-client/pyproject.toml", "CLIENT_CHANGED"),
+              "arize-phoenix-evals": ("packages/phoenix-evals/pyproject.toml", "EVALS_CHANGED"),
+              "arize-phoenix-otel": ("packages/phoenix-otel/pyproject.toml", "OTEL_CHANGED"),
+          }
+
+          def canon(name):
+              return re.sub(r"[-_.]+", "-", name).lower()
+
           suffix = int(os.environ["HEAD_SHA"][:7], 16)
+          me = canon(os.environ["SELF_NAME"])
+
+          # Sibling base versions are read before this package's own manifest is
+          # stamped, and never include this package, so no version is suffixed twice.
+          version_re = re.compile(r'(?m)^version = "([^"]+)"')
+          dev = {}
+          for name, (manifest, changed) in SIBLINGS.items():
+              if os.environ.get(changed) != "true" or canon(name) == me:
+                  continue
+              found = version_re.search(open(manifest).read())
+              if not found:
+                  sys.exit(f"::error::No version key in {manifest}")
+              dev[canon(name)] = f"{found.group(1)}.dev{suffix}"
+
+          path = os.environ["PYPROJECT_PATH"]
           content = open(path).read()
           new = re.sub(
               r'(?m)^(version = ")([^"]+)(")',
@@ -635,6 +855,69 @@ jobs:
               content,
           )
           open(path, "w").write(new)
+
+          # Every preview job stamps from the same head SHA, so each one can derive
+          # its siblings' dev versions itself. Pinning them is what makes the wheel
+          # installable as a set: [tool.uv.sources] workspace linkage is uv-local
+          # and never reaches wheel metadata, so an unpinned floor is satisfied by
+          # the stable release and the dev sibling is simply never selected.
+          lines = open(path).read().split("\n")
+          string_re = re.compile(r"\"[^\"]*\"|'[^']*'")
+          req_re = re.compile(
+              r"\"([A-Za-z0-9][A-Za-z0-9._-]*)(\[[^\]\"]*\])?([^\"]*)\""
+              r"|'([A-Za-z0-9][A-Za-z0-9._-]*)(\[[^\]']*\])?([^']*)'"
+          )
+          rewrites = {c: 0 for c in dev}
+
+          def pin(match):
+              double = match.group(1) is not None
+              quote = '"' if double else "'"
+              name = match.group(1) if double else match.group(4)
+              extras = (match.group(2) if double else match.group(5)) or ""
+              rest = (match.group(3) if double else match.group(6)) or ""
+              target = dev.get(canon(name))
+              if target is None:
+                  return match.group(0)
+              rewrites[canon(name)] += 1
+              marker = ";" + rest.split(";", 1)[1] if ";" in rest else ""
+              return f"{quote}{name}{extras}=={target}{marker}{quote}"
+
+          # Only PEP 621 requirement lists are rewritten; [tool.uv] names these
+          # packages too and its entries are not dependency specifiers.
+          table, key, depth, scanned = "", None, 0, []
+          for i, line in enumerate(lines):
+              header = re.match(r"\s*\[([^\]]+)\]\s*$", line)
+              if header:
+                  table, key, depth = header.group(1), None, 0
+                  continue
+              bare = string_re.sub("", line)
+              if depth == 0:
+                  assign = re.match(r"\s*([A-Za-z0-9_.\"'-]+)\s*=", line)
+                  key = assign.group(1) if assign else key
+              if table.startswith("project"):
+                  scanned.append(line)
+                  requirements = table == "project.optional-dependencies" or (
+                      table == "project" and key == "dependencies"
+                  )
+                  if requirements and (depth > 0 or "[" in bare):
+                      lines[i] = req_re.sub(pin, line)
+              depth = max(0, depth + bare.count("[") - bare.count("]"))
+
+          quoted = string_re.findall("\n".join(scanned))
+          for name in SIBLINGS:
+              if canon(name) not in dev:
+                  continue
+              boundary = rf"(?<![A-Za-z0-9._-]){re.escape(name)}(?![A-Za-z0-9._-])"
+              declared = sum(1 for q in quoted if re.search(boundary, q))
+              if declared != rewrites[canon(name)]:
+                  sys.exit(
+                      f"::error::{path} declares {name} in a form this step cannot "
+                      f"rewrite ({declared} declared, {rewrites[canon(name)]} rewritten)"
+                  )
+              if rewrites[canon(name)]:
+                  print(f"Pinned {name} to {dev[canon(name)]} in {path}")
+
+          open(path, "w").write("\n".join(lines))
           PY
       - name: Build distribution
         if: steps.check.outputs.needed == 'true'

--- a/.github/workflows/update-phoenix-package-versions.yml
+++ b/.github/workflows/update-phoenix-package-versions.yml
@@ -33,13 +33,23 @@ jobs:
           ref: main
           persist-credentials: false
 
-      - name: Validate version input
+      - name: Validate inputs
         run: |
           echo "Dispatch trigger: $PACKAGE_NAME $PACKAGE_VERSION"
-          
+
+          # The `choice` input constrains the dispatch UI but not the API, which
+          # accepts any string.
+          case "$PACKAGE_NAME" in
+            arize-phoenix-client|arize-phoenix-evals|arize-phoenix-otel) ;;
+            *)
+              echo "::error::Unsupported package: '$PACKAGE_NAME'"
+              exit 1
+              ;;
+          esac
+
           # Validate version format (basic semver check)
           if ! echo "$PACKAGE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
-            echo "❌ Error: Invalid version format: $PACKAGE_VERSION"
+            echo "::error::Invalid version format: '$PACKAGE_VERSION'"
             echo "Expected semantic version (e.g., 1.2.3, 1.2.3-alpha.1, 1.2.3+build.1)"
             exit 1
           fi
@@ -49,13 +59,12 @@ jobs:
         run: |
           # Extract current version from pyproject.toml
           CURRENT_VERSION=$(grep -E "^\s*\"$PACKAGE_NAME>=" pyproject.toml | head -n 1 | sed -n "s/.*$PACKAGE_NAME>=\([0-9.]*\).*/\1/p")
-          
+
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-            echo "❌ Error: Could not find $PACKAGE_NAME dependency in pyproject.toml"
-            exit 0
+            echo "::error::Could not find $PACKAGE_NAME dependency in pyproject.toml"
+            exit 1
           fi
-          
+
           if [ "$CURRENT_VERSION" != "$PACKAGE_VERSION" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
             echo "📦 Update needed for $PACKAGE_NAME: $CURRENT_VERSION → $PACKAGE_VERSION"
@@ -84,17 +93,32 @@ jobs:
         id: verify-changed-files
         if: steps.check-update.outputs.needs_update == 'true'
         run: |
-          # Safety check: verify that sed actually modified the file
           if git diff --exit-code pyproject.toml; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "⚠️  Warning: No changes detected - sed may have failed silently"
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "✓ Changes verified:"
-            git diff pyproject.toml
+            echo "::error::No changes detected — sed failed silently"
+            exit 1
           fi
 
+          # The bump must land on the single floor line and nowhere else, so that
+          # any upper bound and the inline rationale comment on that line survive.
+          NUMSTAT=$(git diff --numstat -- pyproject.toml)
+          if [ "$NUMSTAT" != "$(printf '1\t1\tpyproject.toml')" ]; then
+            echo "::error::Expected exactly one changed line in pyproject.toml, got: $NUMSTAT"
+            git diff pyproject.toml
+            exit 1
+          fi
+
+          CHANGED_LINE=$(git diff -U0 -- pyproject.toml | grep -E '^\+[^+]' | sed 's/^+//')
+          {
+            echo "changed=true"
+            echo "changed_line<<EOF"
+            echo "$CHANGED_LINE"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "✓ Changes verified:"
+          git diff pyproject.toml
+
       - name: Create Pull Request
+        id: create-pr
         if: steps.check-update.outputs.needs_update == 'true' && steps.verify-changed-files.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
@@ -112,3 +136,19 @@ jobs:
           branch: update-phoenix-${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}
           base: main
           delete-branch: true
+
+      - name: Record result in job summary
+        if: steps.check-update.outputs.needs_update == 'true' && steps.verify-changed-files.outputs.changed == 'true'
+        env:
+          CHANGED_LINE: ${{ steps.verify-changed-files.outputs.changed_line }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          PR_OPERATION: ${{ steps.create-pr.outputs.pull-request-operation }}
+        run: |
+          {
+            echo "## Dependency floor bump"
+            echo ""
+            echo "- Package: \`$PACKAGE_NAME\`"
+            echo "- Version: \`$PACKAGE_VERSION\`"
+            echo "- Changed line: \`$CHANGED_LINE\`"
+            echo "- Pull request: ${PR_URL:-none} (${PR_OPERATION:-no operation})"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The publish workflow currently reports success when any one package ships, and publishes the root package concurrently with its siblings. A publish job concluding `success` never meant its packages actually shipped — every leg of the matrix can skip via `needed=false` and still aggregate to success, and a publish job gated on its build is left *skipped* rather than failed when that build breaks. The Slack step ORs the three publish results, so a package that never published is invisible.

This makes the workflow report what PyPI actually has, then orders the root publish after the sibling matrix. It also makes preview dev wheels reference each other, and makes the dependency floor bump fail when it fails.

## What ships

**Publication report.** `list-python-packages` now emits the expected package names and exact versions alongside the paths it already computes. The final aggregation job confirms each expected `name==version` against PyPI with the same exact-version probe, and reports one of four distinguishable states: every expected version confirmed; a partial train naming each unconfirmed package alongside the job conclusion that explains where it got stuck; nothing expected; or expectation data unavailable. Job conclusions are diagnostic context and never proof of publication. The full report goes to the job summary on every release-mode run; Slack is suppressed only when nothing was expected.

`arize-phoenix-sqlean` has no release tag until release-please cuts its first release, and skipping it then is legitimate rather than a partial train. The report drops it from the expected set only when the job that answers that question succeeded and reported the tag absent — a failed or skipped `sqlean-sources` keeps it expected.

**Root publishes after its siblings.** `publish-phoenix` gains one `needs:` edge on `publish-packages`, guarded as:

```yaml
if: ${{ !cancelled() && needs.build-phoenix.result == 'success' && needs.publish-packages.result != 'failure' }}
```

A job `if:` containing no status-check function is implicitly ANDed with `success()` over all of `needs:`, so a bare `needs.publish-packages.result == 'success'` edge would stop publishing the root package on every release that ships no sibling — the common case. `!cancelled()` evaluates true on a skipped upstream and suppresses that implicit prepend, which is also why the build gate has to be spelled out again: `!cancelled()` deletes it too.

**Preview dev wheels reference their sibling dev wheels.** Stamping previously rewrote only the version key, so a preview root wheel shipped `arize-phoenix-client>=2.13.0` — satisfied by the stable 2.13.0, so pip had no reason to select the dev sibling and the combination the branch changed went untested. `[tool.uv.sources]` workspace linkage is uv-local and never reaches wheel metadata, so it cannot bridge that gap.

Every preview job stamps from the same head SHA, so each derives its siblings' dev versions itself and pins existing requirements on them to `==<that run's dev version>`. Requirements declared inside extras are covered — `packages/phoenix-client` declares `arize-phoenix-evals` in its `evals` extra, so a `[project] dependencies`-only rewrite would miss it. Requirements on packages the run does not stamp are left alone, no dependency is ever introduced, and a declared sibling appearing in a form the step cannot rewrite fails the build rather than publishing incoherent metadata. The preview paths filter now watches `packages/**`, so a sibling-only branch produces a root preview at all.

**The floor bump fails when it fails.** Four points that previously went green on failure now terminate non-zero: a failed `gh workflow run` dispatch (the step no longer carries `continue-on-error`), an empty manifest version, an absent dependency line, and a rewrite that changes nothing. A `git diff --numstat` assertion requires exactly one changed line, so a line-blind `sed` that strays past the intended floor line fails rather than silently reformatting something else — which is also what keeps any upper bound and same-line rationale comment on that pin intact. A successful bump records the package, version, the changed line, and the resulting pull request URL in the job summary.

## What this PR does not change

- **The sqlean job triad.** `sqlean-sources`, `build-sqlean`, and `publish-sqlean` are byte-identical to `main`, including the tag-resolution contract that skips when the release tag does not exist yet. The report *reads* `sqlean-sources.outputs.needed`; it changes nothing in those jobs.
- **Matrix leg ordering.** Exactly one ordering edge ships — root after the sibling matrix. The legs are not ordered against each other, because the package graph has no inter-package edges to order.
- **Publishing topology.** Each PyPI project's Trusted Publisher is bound to a distinct GitHub environment and `environment` is a job-level key, so one job-or-matrix-leg per project is structural. No `environment:` block changed and publishing was not collapsed into a sequential job.
- **Run status.** The report does not fail its own job on a partial or indeterminate train — it reports. `pypi-smoke-test.yml` gates on `conclusion == 'success'`, so making the report authoritative over run status is a change with a blast radius beyond this one, and is left alone deliberately.
- **Preview publishing targets.** Previews still go through the production Trusted Publishers; no `repository-url` was added anywhere.
- **release-please ownership.** `release-please-config.json`, `.release-please-manifest.json`, and every package `version` field are untouched.
- **Stale bump PRs.** Merging, supersession, and stale-PR monitoring are out of scope; this only makes a bump that fails say so.

## Design notes

The reporting rewrite comes before the ordering edge on purpose. The notification is the only instrument that reveals whether the ordering is correct, and the pre-existing OR-of-results step would have announced a skip-induced non-publish as "PYPI Publication Succeeded" — so an ordering edge landing first would have shipped partial release trains that reported success, with the smoke test's `workflow_run` gate unable to catch it either.

The guards on the existing jobs at `publish-packages`, `publish-sqlean`, and `trigger-version-updates` read as though the graph is explicitly failure-tolerant, but they contain no status-check function and are therefore redundant with the implicit `success()` — they are no-ops. They are left as-is: rewriting them to `!cancelled() && … != 'failure'` would change which jobs run on a skipped upstream, which is a behavioural change beyond ordering and reporting.

The sibling-pinning step is duplicated across the two preview jobs rather than factored into a shared script, matching how dev-version stamping is already duplicated there.

## Test plan

Workflow changes cannot be exercised end-to-end from a branch, so the step scripts were extracted and run directly, and the rest was argued against the diff.

Executed locally:

- **Publication report**, driven through six states with the PyPI probe stubbed: all-confirmed → "Succeeded"; a package absent from PyPI while `publish-packages: success` → "Incomplete", naming the package with that conclusion (the exact case the old step called success); valid empty expected set → "No packages were expected to publish" with Slack suppressed; expectation data unavailable via a failed list job, and malformed data on a *successful* list job → "Report Unavailable" in both, distinct from nothing-expected; sqlean tag-absent → correctly not reported; sqlean tag-present and unpublished → reported with its conclusion.
- **Preview sibling pinning**, against copies of the real manifests: root preview with client+evals stamped pins both and leaves `arize-phoenix-otel>=0.17.0` and both `[tool.uv]` blocks untouched; root preview with nothing stamped leaves `pyproject.toml` byte-identical; the client leg rewrites the extras-declared `arize-phoenix-evals` (which carries no version specifier) and stamps its own version exactly once; the otel leg with siblings it does not declare exits clean and introduces nothing; a declaration the step cannot rewrite exits non-zero with an error before any upload.
- **Floor bump**, against a copy of the real root `pyproject.toml` with the evals pin given an upper bound and a same-line rationale comment: `>=3.4.0,<4  # …` became `>=3.9.1,<4  # …` with both preserved, `--numstat` returned exactly one changed line, and the changed line was captured for the summary.
- `actionlint` on both files introduces no new findings — 15 informational `SC2086` plus one `SC2129` against 22 and one on `main`, i.e. seven fewer, since the changed steps quote `"$GITHUB_OUTPUT"` and pass matrix values through `env:`.
- `zizmor` reports no findings on both files.

Argued against the diff, not executed: the four ordering paths (success, sibling failure, cancellation, all-skipped matrix, plus the phoenix-only release where `publish-packages` resolves `skipped`); the floor bump's non-zero exits; and that the rewritten manifest reaches wheel metadata (hatchling emits `[project].dependencies` verbatim, but no wheel was built here).

Worth exercising before relying on it: a preview dispatch on a branch touching both `src/phoenix/` and `packages/phoenix-client/`, and one full release run.
