### PR TITLE
feat(online-evals): route-driven project evaluator slideovers with real titles

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -51,8 +51,10 @@ import type {
   SpanPlaygroundPageLoaderData,
 } from "./pages";
 import {
+  AttachCodeProjectEvaluatorPage,
   AuthenticatedRoot,
   authenticatedRootLoader,
+  CopyLlmProjectEvaluatorPage,
   dashboardsLoader,
   DashboardsEmptyPage,
   DashboardsRoot,
@@ -62,6 +64,7 @@ import {
   DatasetsPage,
   datasetVersionsLoader,
   DatasetVersionsPage,
+  EditProjectEvaluatorPage,
   ErrorElement,
   ExamplePage,
   examplesLoader,
@@ -73,6 +76,8 @@ import {
   homeLoader,
   LoggedOutPage,
   LoginPage,
+  NewCodeProjectEvaluatorPage,
+  NewLlmProjectEvaluatorPage,
   OAuth2ConsentPage,
   PlaygroundPage,
   playgroundPageLoader,
@@ -83,6 +88,7 @@ import {
   ProfilePage,
   ProfilePreferencesPage,
   ProjectEvaluatorsPage,
+  projectEvaluatorsLoader,
   ProjectIndexPage,
   projectLoader,
   ProjectMetricsPage,
@@ -451,6 +457,7 @@ export const appRouteObjects = createRoutesFromElements(
               <Route
                 path="evaluators"
                 element={<ProjectEvaluatorsPage />}
+                loader={projectEvaluatorsLoader}
                 handle={{
                   agentRoute: {
                     label: "Project Evaluators",
@@ -458,7 +465,63 @@ export const appRouteObjects = createRoutesFromElements(
                       "Create and manage project evaluators — online evals that automatically run against live spans.",
                   },
                 }}
-              />
+              >
+                <Route
+                  path="new/llm"
+                  element={<NewLlmProjectEvaluatorPage />}
+                  handle={{
+                    agentRoute: {
+                      label: "New Project LLM Evaluator",
+                      description:
+                        "Author a new LLM-as-a-judge evaluator for a project from scratch.",
+                    },
+                  }}
+                />
+                <Route
+                  path="new/code"
+                  element={<NewCodeProjectEvaluatorPage />}
+                  handle={{
+                    agentRoute: {
+                      label: "New Project Code Evaluator",
+                      description:
+                        "Author a new Python or TypeScript code evaluator for a project from scratch.",
+                    },
+                  }}
+                />
+                <Route
+                  path="new/copy/:evaluatorId"
+                  element={<CopyLlmProjectEvaluatorPage />}
+                  handle={{
+                    agentRoute: {
+                      label: "Copy LLM Evaluator Into Project",
+                      description:
+                        "Create a project evaluator seeded from an existing LLM evaluator. The evaluatorId route param uses the GraphQL Evaluator.id Relay node ID of the evaluator being copied.",
+                    },
+                  }}
+                />
+                <Route
+                  path="new/attach/:evaluatorId"
+                  element={<AttachCodeProjectEvaluatorPage />}
+                  handle={{
+                    agentRoute: {
+                      label: "Attach Code Evaluator To Project",
+                      description:
+                        "Attach an existing code evaluator to a project. The evaluatorId route param uses the GraphQL Evaluator.id Relay node ID of the evaluator being attached.",
+                    },
+                  }}
+                />
+                <Route
+                  path=":projectEvaluatorId/edit"
+                  element={<EditProjectEvaluatorPage />}
+                  handle={{
+                    agentRoute: {
+                      label: "Edit Project Evaluator",
+                      description:
+                        "Edit a project evaluator's definition and scope. The projectEvaluatorId route param uses the GraphQL ProjectEvaluator.id Relay node ID, not the underlying Evaluator.id.",
+                    },
+                  }}
+                />
+              </Route>
             </Route>
           </Route>
         </Route>

--- a/app/src/components/core/dialog/Dialog.tsx
+++ b/app/src/components/core/dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { HTMLAttributes, Ref } from "react";
-import { createContext, useContext, useId } from "react";
+import { useContext } from "react";
 import {
   Dialog as AriaDialog,
   type DialogProps as AriaDialogProps,
@@ -22,40 +22,21 @@ const dialogCSS = css`
   overscroll-behavior: none !important;
 `;
 
-/**
- * The id the dialog points `aria-labelledby` at, which {@link DialogTitle}
- * puts on its heading.
- *
- * react-aria wires that link itself from the title slot, but resolves it in a
- * layout effect that runs once: a title rendered behind a `Suspense` boundary
- * has not mounted by then, so the dialog is left unlabelled for good. Owning
- * the id keeps a dialog's accessible name equal to its visible title no matter
- * when the title arrives.
- */
-const DialogTitleIdContext = createContext<string | null>(null);
-
 export function Dialog({
   ref,
   children,
   ...props
 }: DialogProps & { ref?: Ref<HTMLDialogElement> }) {
-  const titleId = useId();
-  // A dialog named some other way keeps that name; the title is then just a
-  // heading.
-  const isNamedByTitle = !props["aria-label"] && !props["aria-labelledby"];
   return (
-    <DialogTitleIdContext.Provider value={isNamedByTitle ? titleId : null}>
-      <AriaDialog
-        data-testid="dialog"
-        aria-labelledby={isNamedByTitle ? titleId : undefined}
-        {...props}
-        css={dialogCSS}
-        className={classNames(props.className, "react-aria-Dialog")}
-        ref={ref}
-      >
-        {children}
-      </AriaDialog>
-    </DialogTitleIdContext.Provider>
+    <AriaDialog
+      data-testid="dialog"
+      {...props}
+      css={dialogCSS}
+      className={classNames(props.className, "react-aria-Dialog")}
+      ref={ref}
+    >
+      {children}
+    </AriaDialog>
   );
 }
 
@@ -107,26 +88,13 @@ export const DialogHeader = ({ children, ...props }: DialogHeaderProps) => {
 
 export type DialogTitleProps = HeadingProps;
 
-// Titles that name a record can be arbitrarily long; keep one to a single line
-// so it cannot crowd out the actions beside it in the header.
-const dialogTitleCSS = css`
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
 export const DialogTitle = ({ children, ...props }: DialogTitleProps) => {
-  const titleId = useContext(DialogTitleIdContext);
   return (
     <Heading
       level={2}
       data-testid="dialog-title"
-      css={dialogTitleCSS}
+      slot="title"
       {...props}
-      // After the spread: the dialog points `aria-labelledby` here, so this id
-      // is the link and not a default a caller may override.
-      id={titleId ?? props.id}
       className={classNames(props.className, "dialog__title")}
     >
       {children}

--- a/app/src/components/core/dialog/Dialog.tsx
+++ b/app/src/components/core/dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { HTMLAttributes, Ref } from "react";
-import { useContext } from "react";
+import { createContext, useContext, useId } from "react";
 import {
   Dialog as AriaDialog,
   type DialogProps as AriaDialogProps,
@@ -22,21 +22,40 @@ const dialogCSS = css`
   overscroll-behavior: none !important;
 `;
 
+/**
+ * The id the dialog points `aria-labelledby` at, which {@link DialogTitle}
+ * puts on its heading.
+ *
+ * react-aria wires that link itself from the title slot, but resolves it in a
+ * layout effect that runs once: a title rendered behind a `Suspense` boundary
+ * has not mounted by then, so the dialog is left unlabelled for good. Owning
+ * the id keeps a dialog's accessible name equal to its visible title no matter
+ * when the title arrives.
+ */
+const DialogTitleIdContext = createContext<string | null>(null);
+
 export function Dialog({
   ref,
   children,
   ...props
 }: DialogProps & { ref?: Ref<HTMLDialogElement> }) {
+  const titleId = useId();
+  // A dialog named some other way keeps that name; the title is then just a
+  // heading.
+  const isNamedByTitle = !props["aria-label"] && !props["aria-labelledby"];
   return (
-    <AriaDialog
-      data-testid="dialog"
-      {...props}
-      css={dialogCSS}
-      className={classNames(props.className, "react-aria-Dialog")}
-      ref={ref}
-    >
-      {children}
-    </AriaDialog>
+    <DialogTitleIdContext.Provider value={isNamedByTitle ? titleId : null}>
+      <AriaDialog
+        data-testid="dialog"
+        aria-labelledby={isNamedByTitle ? titleId : undefined}
+        {...props}
+        css={dialogCSS}
+        className={classNames(props.className, "react-aria-Dialog")}
+        ref={ref}
+      >
+        {children}
+      </AriaDialog>
+    </DialogTitleIdContext.Provider>
   );
 }
 
@@ -88,13 +107,26 @@ export const DialogHeader = ({ children, ...props }: DialogHeaderProps) => {
 
 export type DialogTitleProps = HeadingProps;
 
+// Titles that name a record can be arbitrarily long; keep one to a single line
+// so it cannot crowd out the actions beside it in the header.
+const dialogTitleCSS = css`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 export const DialogTitle = ({ children, ...props }: DialogTitleProps) => {
+  const titleId = useContext(DialogTitleIdContext);
   return (
     <Heading
       level={2}
       data-testid="dialog-title"
-      slot="title"
+      css={dialogTitleCSS}
       {...props}
+      // After the spread: the dialog points `aria-labelledby` here, so this id
+      // is the link and not a default a caller may override.
+      id={titleId ?? props.id}
       className={classNames(props.className, "dialog__title")}
     >
       {children}

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -25,17 +25,10 @@ import {
   useTimeRange,
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
-import {
-  CREATE_CODE_EVALUATOR_PARAM,
-  CREATE_LLM_EVALUATOR_PARAM,
-  SPAN_FILTER_CONDITION_PARAM,
-} from "@phoenix/constants/searchParams";
+import { SPAN_FILTER_CONDITION_PARAM } from "@phoenix/constants/searchParams";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
-import {
-  clearSelectionScopedParams,
-  withSearchParams,
-} from "@phoenix/utils/urlUtils";
+import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 
 import type { ProjectPageQueriesProjectConfigQuery as ProjectPageProjectConfigQueryType } from "./__generated__/ProjectPageQueriesProjectConfigQuery.graphql";
 import type { ProjectPageQueriesSessionsQuery as ProjectPageSessionsQueryType } from "./__generated__/ProjectPageQueriesSessionsQuery.graphql";
@@ -377,14 +370,7 @@ function ProjectPageContentBody({
   const onTabChange = useCallback(
     (index: number) => {
       startTransition(() => {
-        // The evaluators tab owns these; drop them so it does not reopen.
-        const search = withSearchParams(
-          clearSelectionScopedParams(location.search),
-          (params) => {
-            params.delete(CREATE_LLM_EVALUATOR_PARAM);
-            params.delete(CREATE_CODE_EVALUATOR_PARAM);
-          }
-        );
+        const search = clearSelectionScopedParams(location.search);
         const tab = TAB_PATH_BY_INDEX[index] ?? "spans";
         navigate({
           pathname: `${rootPath}/${tab}`,

--- a/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
+++ b/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
@@ -1,12 +1,12 @@
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import type {
   MenuTriggerProps,
   SubmenuTriggerProps,
 } from "react-aria-components";
 import { MenuSection, SubmenuTrigger } from "react-aria-components";
-import { useLazyLoadQuery, useRelayEnvironment } from "react-relay";
+import { useLazyLoadQuery } from "react-relay";
+import { useNavigate } from "react-router";
 
-import { Alert } from "@phoenix/components/core/alert";
 import type { ButtonProps } from "@phoenix/components/core/button";
 import { Button } from "@phoenix/components/core/button";
 import { Text } from "@phoenix/components/core/content";
@@ -22,67 +22,38 @@ import {
 } from "@phoenix/components/core/menu";
 import { View } from "@phoenix/components/core/view";
 import type { projectEvaluatorOptionsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptionsQuery.graphql";
-import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
-import {
-  buildAttachCodeCreationMode,
-  buildCopyLlmCreationMode,
-  fetchProjectEvaluatorDetails,
-  isCodeProjectEvaluatorDetails,
-  isLlmProjectEvaluatorDetails,
-  projectEvaluatorOptionsQuery as projectEvaluatorOptionsQueryNode,
-  UNSUPPORTED_PROMPT_TEMPLATE_ERROR,
-} from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+import { projectEvaluatorOptionsQuery as projectEvaluatorOptionsQueryNode } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 
 export const AddProjectEvaluatorMenu = ({
   size,
-  onSelectCreationMode,
   ...props
 }: {
   size: ButtonProps["size"];
-  onSelectCreationMode: (mode: ProjectEvaluatorCreationMode) => void;
 } & Omit<MenuTriggerProps, "children">) => {
-  const [selectionError, setSelectionError] = useState<string | null>(null);
   return (
-    <>
-      <MenuTrigger {...props}>
-        <Button
-          variant="primary"
-          size={size}
-          leadingVisual={<Icon svg={<Icons.Plus />} />}
-        >
-          Add evaluator
-        </Button>
-        {/* Keep the query inside the popover so the evaluator list is fetched
-            only when the menu opens. */}
-        <MenuContainer minHeight="auto">
-          <Suspense fallback={<Loading />}>
-            <AddProjectEvaluatorMenuItems
-              onSelectCreationMode={(mode) => {
-                setSelectionError(null);
-                onSelectCreationMode(mode);
-              }}
-              onSelectionError={setSelectionError}
-            />
-          </Suspense>
-        </MenuContainer>
-      </MenuTrigger>
-      {selectionError ? (
-        <View paddingTop="size-100">
-          <Alert variant="danger">{selectionError}</Alert>
-        </View>
-      ) : null}
-    </>
+    <MenuTrigger {...props}>
+      <Button
+        variant="primary"
+        size={size}
+        leadingVisual={<Icon svg={<Icons.Plus />} />}
+      >
+        Add evaluator
+      </Button>
+      {/* Keep the query inside the popover so the evaluator list is fetched
+          only when the menu opens. */}
+      <MenuContainer minHeight="auto">
+        <Suspense fallback={<Loading />}>
+          <AddProjectEvaluatorMenuItems />
+        </Suspense>
+      </MenuContainer>
+    </MenuTrigger>
   );
 };
 
-function AddProjectEvaluatorMenuItems({
-  onSelectCreationMode,
-  onSelectionError,
-}: {
-  onSelectCreationMode: (mode: ProjectEvaluatorCreationMode) => void;
-  onSelectionError: (error: string | null) => void;
-}) {
-  const environment = useRelayEnvironment();
+function AddProjectEvaluatorMenuItems() {
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
   const data = useLazyLoadQuery<projectEvaluatorOptionsQuery>(
     projectEvaluatorOptionsQueryNode,
     {},
@@ -102,9 +73,9 @@ function AddProjectEvaluatorMenuItems({
         aria-label="Add evaluator"
         onAction={(action) => {
           if (action === "createEvaluator") {
-            onSelectCreationMode({ kind: "scratch" });
+            navigate(paths.newLlm);
           } else if (action === "createCodeEvaluator") {
-            onSelectCreationMode({ kind: "newCode" });
+            navigate(paths.newCode);
           }
         }}
       >
@@ -120,28 +91,7 @@ function AddProjectEvaluatorMenuItems({
             label="Copy existing LLM evaluator"
             icon={<Icons.LLMOutput />}
             evaluators={llmEvaluators}
-            onAction={async (evaluatorId) => {
-              onSelectionError(null);
-              try {
-                const evaluator = await fetchProjectEvaluatorDetails({
-                  environment,
-                  evaluatorId,
-                });
-                if (!isLlmProjectEvaluatorDetails(evaluator)) {
-                  throw new Error("Expected an LLM evaluator");
-                }
-                const result = buildCopyLlmCreationMode(evaluator);
-                if (!result.ok) {
-                  onSelectionError(UNSUPPORTED_PROMPT_TEMPLATE_ERROR);
-                  return;
-                }
-                onSelectCreationMode(result.mode);
-              } catch {
-                onSelectionError(
-                  "Unable to load evaluator details. Try again."
-                );
-              }
-            }}
+            onAction={(evaluatorId) => navigate(paths.copyLlm(evaluatorId))}
           />
         </MenuSection>
         <MenuSection>
@@ -156,23 +106,7 @@ function AddProjectEvaluatorMenuItems({
             label="Attach existing code evaluator"
             icon={<Icons.Code />}
             evaluators={codeEvaluators}
-            onAction={async (evaluatorId) => {
-              onSelectionError(null);
-              try {
-                const evaluator = await fetchProjectEvaluatorDetails({
-                  environment,
-                  evaluatorId,
-                });
-                if (!isCodeProjectEvaluatorDetails(evaluator)) {
-                  throw new Error("Expected a code evaluator");
-                }
-                onSelectCreationMode(buildAttachCodeCreationMode(evaluator));
-              } catch {
-                onSelectionError(
-                  "Unable to load evaluator details. Try again."
-                );
-              }
-            }}
+            onAction={(evaluatorId) => navigate(paths.attachCode(evaluatorId))}
           />
         </MenuSection>
       </Menu>
@@ -200,7 +134,7 @@ function EvaluatorSubmenu({
     name: string;
     description: string | null;
   }>;
-  onAction: (id: string) => void | Promise<void>;
+  onAction: (id: string) => void;
 } & Omit<SubmenuTriggerProps, "children">) {
   const hasEvaluators = evaluators.length > 0;
   return (

--- a/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -42,11 +42,13 @@ import { refetchProjectEvaluators } from "@phoenix/pages/project/evaluators/refe
 import type { CodeEvaluatorLanguage } from "@phoenix/types";
 
 export const CreateProjectCodeEvaluatorDialogContent = ({
+  title,
   projectId,
   scope,
   onScopeChange,
   onSuccess,
 }: {
+  title: string;
   projectId: string;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
@@ -213,7 +215,7 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
 
   return (
     <EvaluatorFormDialogContent
-      title="Create project evaluator"
+      title={title}
       submitLabel="Create"
       onSubmit={onSubmit}
       isSubmitting={isCreating}

--- a/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -1,12 +1,9 @@
-import { Suspense, useRef, useState } from "react";
+import { useState } from "react";
 import type { ModalOverlayProps } from "react-aria-components";
 import { graphql, useMutation, useRelayEnvironment } from "react-relay";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import { Dialog } from "@phoenix/components/core/dialog";
-import { Loading } from "@phoenix/components/core/loading";
-import { Modal, ModalOverlay } from "@phoenix/components/core/overlay/Modal";
 import { createDefaultFreeformOutputConfig } from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
 import { EditLLMEvaluatorDialogContent } from "@phoenix/components/evaluators/EditLLMEvaluatorDialogContent";
 import { getSpanEvaluatorDefaultMessages } from "@phoenix/components/evaluators/EvaluatorChatTemplate/utils";
@@ -28,13 +25,10 @@ import {
 import type { CreateProjectEvaluatorSlideoverAddCodeMutation } from "@phoenix/pages/project/evaluators/__generated__/CreateProjectEvaluatorSlideoverAddCodeMutation.graphql";
 import { CreateProjectCodeEvaluatorDialogContent } from "@phoenix/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent";
 import { createProjectLlmEvaluator } from "@phoenix/pages/project/evaluators/createProjectLlmEvaluator";
-import {
-  DiscardEvaluatorChangesDialog,
-  isModalUnderlay,
-} from "@phoenix/pages/project/evaluators/DiscardEvaluatorChangesDialog";
 import { ProjectCodeEvaluatorDialogContent } from "@phoenix/pages/project/evaluators/ProjectCodeEvaluatorDialogContent";
 import { ProjectEvaluatorFormSections } from "@phoenix/pages/project/evaluators/ProjectEvaluatorFormSections";
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
+import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideover";
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
 import {
   toProjectEvaluatorGraphQLTarget,
@@ -99,57 +93,21 @@ export const CreateProjectEvaluatorSlideover = ({
 }: {
   projectId: string;
   creationMode: ProjectEvaluatorCreationMode;
-} & ModalOverlayProps) => {
-  const dirtyCheckRef = useRef<EvaluatorFormDirtyCheck>(() => false);
-  const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
-  // Known here, above the dialog, so it can both name the dialog and be the
-  // heading the dialog's body renders.
-  const title = getProjectEvaluatorCreationTitle(creationMode);
-  return (
-    <>
-      <ModalOverlay
-        {...props}
-        isDismissable
-        shouldCloseOnInteractOutside={(element) => {
-          if (!isModalUnderlay(element)) {
-            return false;
-          }
-          if (dirtyCheckRef.current()) {
-            setIsDiscardConfirmOpen(true);
-            return false;
-          }
-          return true;
-        }}
-      >
-        <Modal variant="slideover" size="fullscreen">
-          <Dialog aria-label={title}>
-            {({ close }) => (
-              <Suspense fallback={<Loading />}>
-                <CreateProjectEvaluatorDialogForMode
-                  onClose={close}
-                  projectId={projectId}
-                  creationMode={creationMode}
-                  title={title}
-                  registerDirtyCheck={(check) => {
-                    dirtyCheckRef.current = check;
-                  }}
-                />
-              </Suspense>
-            )}
-          </Dialog>
-        </Modal>
-      </ModalOverlay>
-      <DiscardEvaluatorChangesDialog
-        isOpen={isDiscardConfirmOpen}
-        onKeepEditing={() => setIsDiscardConfirmOpen(false)}
-        onDiscard={() => {
-          setIsDiscardConfirmOpen(false);
-          props.onOpenChange?.(false);
-        }}
+} & Omit<ModalOverlayProps, "children">) => (
+  <ProjectEvaluatorSlideover
+    {...props}
+    title={getProjectEvaluatorCreationTitle(creationMode)}
+  >
+    {(close, registerDirtyCheck) => (
+      <CreateProjectEvaluatorDialogForMode
+        onClose={close}
+        projectId={projectId}
+        creationMode={creationMode}
+        registerDirtyCheck={registerDirtyCheck}
       />
-    </>
-  );
-};
+    )}
+  </ProjectEvaluatorSlideover>
+);
 
 function CreateProjectEvaluatorDialogForMode(
   props: Parameters<typeof CreateProjectEvaluatorDialog>[0]
@@ -180,13 +138,11 @@ const CreateProjectEvaluatorDialog = ({
   onClose,
   projectId,
   creationMode,
-  title,
   registerDirtyCheck,
 }: {
   onClose: () => void;
   projectId: string;
   creationMode: ProjectEvaluatorCreationMode;
-  title: string;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) => {
   const notifySuccess = useNotifySuccess();
@@ -266,6 +222,10 @@ const CreateProjectEvaluatorDialog = ({
     onClose();
     notifySuccess({ title: "Evaluator created" });
   };
+
+  // The same pure derivation the slideover used to name the dialog, so the
+  // heading below and the accessible name are always the same string.
+  const title = getProjectEvaluatorCreationTitle(creationMode);
 
   return (
     <EvaluatorStoreProvider initialState={initialState}>

--- a/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -76,12 +76,8 @@ export type ProjectEvaluatorCreationMode =
       requiredVariables: string[];
     };
 
-/**
- * The slideover heading, which names both the flow and the kind of evaluator
- * being created. The `Dialog` takes its accessible name from this heading, so
- * the two can never drift apart.
- */
-export function getProjectEvaluatorCreationTitle(
+/** The slideover heading: the flow, and the kind of evaluator it creates. */
+function getProjectEvaluatorCreationTitle(
   creationMode: ProjectEvaluatorCreationMode
 ): string {
   if (creationMode.kind === "scratch") {
@@ -106,6 +102,9 @@ export const CreateProjectEvaluatorSlideover = ({
 } & ModalOverlayProps) => {
   const dirtyCheckRef = useRef<EvaluatorFormDirtyCheck>(() => false);
   const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
+  // Known here, above the dialog, so it can both name the dialog and be the
+  // heading the dialog's body renders.
+  const title = getProjectEvaluatorCreationTitle(creationMode);
   return (
     <>
       <ModalOverlay
@@ -123,15 +122,14 @@ export const CreateProjectEvaluatorSlideover = ({
         }}
       >
         <Modal variant="slideover" size="fullscreen">
-          {/* No `aria-label`: the dialog is named by its title heading, so the
-              accessible name always matches the visible one. */}
-          <Dialog>
+          <Dialog aria-label={title}>
             {({ close }) => (
               <Suspense fallback={<Loading />}>
                 <CreateProjectEvaluatorDialogForMode
                   onClose={close}
                   projectId={projectId}
                   creationMode={creationMode}
+                  title={title}
                   registerDirtyCheck={(check) => {
                     dirtyCheckRef.current = check;
                   }}
@@ -182,11 +180,13 @@ const CreateProjectEvaluatorDialog = ({
   onClose,
   projectId,
   creationMode,
+  title,
   registerDirtyCheck,
 }: {
   onClose: () => void;
   projectId: string;
   creationMode: ProjectEvaluatorCreationMode;
+  title: string;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) => {
   const notifySuccess = useNotifySuccess();
@@ -266,8 +266,6 @@ const CreateProjectEvaluatorDialog = ({
     onClose();
     notifySuccess({ title: "Evaluator created" });
   };
-
-  const title = getProjectEvaluatorCreationTitle(creationMode);
 
   return (
     <EvaluatorStoreProvider initialState={initialState}>

--- a/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -76,6 +76,26 @@ export type ProjectEvaluatorCreationMode =
       requiredVariables: string[];
     };
 
+/**
+ * The slideover heading, which names both the flow and the kind of evaluator
+ * being created. The `Dialog` takes its accessible name from this heading, so
+ * the two can never drift apart.
+ */
+export function getProjectEvaluatorCreationTitle(
+  creationMode: ProjectEvaluatorCreationMode
+): string {
+  if (creationMode.kind === "scratch") {
+    return "Create new LLM evaluator";
+  }
+  if (creationMode.kind === "newCode") {
+    return "Create new code evaluator";
+  }
+  if (creationMode.kind === "copy") {
+    return `Copy LLM evaluator “${creationMode.initialState.name}”`;
+  }
+  return `Attach code evaluator “${creationMode.name}”`;
+}
+
 export const CreateProjectEvaluatorSlideover = ({
   projectId,
   creationMode,
@@ -103,7 +123,9 @@ export const CreateProjectEvaluatorSlideover = ({
         }}
       >
         <Modal variant="slideover" size="fullscreen">
-          <Dialog aria-label="Create project evaluator">
+          {/* No `aria-label`: the dialog is named by its title heading, so the
+              accessible name always matches the visible one. */}
+          <Dialog>
             {({ close }) => (
               <Suspense fallback={<Loading />}>
                 <CreateProjectEvaluatorDialogForMode
@@ -245,10 +267,13 @@ const CreateProjectEvaluatorDialog = ({
     notifySuccess({ title: "Evaluator created" });
   };
 
+  const title = getProjectEvaluatorCreationTitle(creationMode);
+
   return (
     <EvaluatorStoreProvider initialState={initialState}>
       {creationMode.kind === "newCode" ? (
         <CreateNewCodeProjectEvaluatorDialog
+          title={title}
           projectId={projectId}
           scope={scope}
           onScopeChange={setScope}
@@ -257,6 +282,7 @@ const CreateProjectEvaluatorDialog = ({
         />
       ) : creationMode.kind === "code" ? (
         <AttachCodeProjectEvaluatorDialog
+          title={title}
           projectId={projectId}
           creationMode={creationMode}
           scope={scope}
@@ -266,6 +292,7 @@ const CreateProjectEvaluatorDialog = ({
         />
       ) : (
         <CreateLlmProjectEvaluatorDialog
+          title={title}
           projectId={projectId}
           scope={scope}
           onScopeChange={setScope}
@@ -279,12 +306,14 @@ const CreateProjectEvaluatorDialog = ({
 };
 
 function CreateNewCodeProjectEvaluatorDialog({
+  title,
   projectId,
   scope,
   onScopeChange,
   onSuccess,
   registerDirtyCheck,
 }: {
+  title: string;
   projectId: string;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
@@ -300,6 +329,7 @@ function CreateNewCodeProjectEvaluatorDialog({
   trackStoreForDirtyCheck(store);
   return (
     <CreateProjectCodeEvaluatorDialogContent
+      title={title}
       projectId={projectId}
       scope={scope}
       onScopeChange={onScopeChange}
@@ -309,6 +339,7 @@ function CreateNewCodeProjectEvaluatorDialog({
 }
 
 function AttachCodeProjectEvaluatorDialog({
+  title,
   projectId,
   creationMode,
   scope,
@@ -316,6 +347,7 @@ function AttachCodeProjectEvaluatorDialog({
   onSuccess,
   registerDirtyCheck,
 }: {
+  title: string;
   projectId: string;
   creationMode: Extract<ProjectEvaluatorCreationMode, { kind: "code" }>;
   scope: ProjectEvaluatorScope;
@@ -353,6 +385,7 @@ function AttachCodeProjectEvaluatorDialog({
     `);
   return (
     <ProjectCodeEvaluatorDialogContent
+      title={title}
       projectId={projectId}
       evaluatorId={creationMode.evaluatorId}
       evaluatorName={creationMode.name}
@@ -402,6 +435,7 @@ function AttachCodeProjectEvaluatorDialog({
 }
 
 function CreateLlmProjectEvaluatorDialog({
+  title,
   projectId,
   scope,
   onScopeChange,
@@ -409,6 +443,7 @@ function CreateLlmProjectEvaluatorDialog({
   onSuccess,
   registerDirtyCheck,
 }: {
+  title: string;
   projectId: string;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
@@ -484,6 +519,7 @@ function CreateLlmProjectEvaluatorDialog({
 
   return (
     <ScratchLlmDialogContent
+      title={title}
       projectId={projectId}
       scope={scope}
       onScopeChange={onScopeChange}
@@ -498,6 +534,7 @@ function CreateLlmProjectEvaluatorDialog({
 }
 
 const ScratchLlmDialogContent = ({
+  title,
   projectId,
   scope,
   onScopeChange,
@@ -508,6 +545,7 @@ const ScratchLlmDialogContent = ({
   isSubmitting,
   error,
 }: {
+  title: string;
   projectId: string;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
@@ -521,7 +559,7 @@ const ScratchLlmDialogContent = ({
   const submitHint = useProjectEvaluatorSubmitHint({ isFilterValid });
   return (
     <EditLLMEvaluatorDialogContent
-      title="Create project evaluator"
+      title={title}
       onClose={onClose}
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}

--- a/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -1,10 +1,10 @@
-import { Suspense, useRef, useState } from "react";
+import { useState } from "react";
 import type { ModalOverlayProps } from "react-aria-components";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import { Dialog, Loading, Modal, ModalOverlay } from "@phoenix/components";
+import type { SandboxConfigOption } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import {
   extractCodeEvaluatorVariables,
@@ -28,14 +28,11 @@ import type { EditProjectEvaluatorSlideoverQuery } from "@phoenix/pages/project/
 import type { EditProjectEvaluatorSlideoverUpdateCodeMutation } from "@phoenix/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateCodeMutation.graphql";
 import type { EditProjectEvaluatorSlideoverUpdateLlmMutation } from "@phoenix/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateLlmMutation.graphql";
 import { CodeAuthoringFields } from "@phoenix/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent";
-import {
-  DiscardEvaluatorChangesDialog,
-  isModalUnderlay,
-} from "@phoenix/pages/project/evaluators/DiscardEvaluatorChangesDialog";
 import { ProjectCodeEvaluatorDialogContent } from "@phoenix/pages/project/evaluators/ProjectCodeEvaluatorDialogContent";
 import { ProjectEvaluatorFormSections } from "@phoenix/pages/project/evaluators/ProjectEvaluatorFormSections";
 import { convertProjectEvaluatorOutputConfigs } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
+import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideover";
 import {
   fromProjectEvaluatorGraphQLTarget,
   toProjectEvaluatorGraphQLTarget,
@@ -79,70 +76,32 @@ export function EditProjectEvaluatorSlideover({
   ...props
 }: {
   evaluator: ProjectEvaluatorNode;
-  sandboxConfigs: ProjectEvaluatorSandboxConfigs;
-} & ModalOverlayProps) {
-  const dirtyCheckRef = useRef<EvaluatorFormDirtyCheck>(() => false);
-  const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
-  const registerDirtyCheck = (check: EvaluatorFormDirtyCheck) => {
-    dirtyCheckRef.current = check;
-  };
-  const title = getEditProjectEvaluatorTitle(evaluator);
+  sandboxConfigs: SandboxConfigOption[];
+} & Omit<ModalOverlayProps, "children">) {
   return (
-    <>
-      <ModalOverlay
-        {...props}
-        isDismissable
-        shouldCloseOnInteractOutside={(element) => {
-          if (!isModalUnderlay(element)) {
-            return false;
-          }
-          if (dirtyCheckRef.current()) {
-            setIsDiscardConfirmOpen(true);
-            return false;
-          }
-          return true;
-        }}
-      >
-        <Modal variant="slideover" size="fullscreen">
-          <Dialog aria-label={title}>
-            {({ close }) => (
-              <Suspense fallback={<Loading />}>
-                {evaluator.evaluator.kind === "LLM" ? (
-                  <EditLlmProjectEvaluator
-                    evaluator={evaluator}
-                    title={title}
-                    onClose={close}
-                    registerDirtyCheck={registerDirtyCheck}
-                  />
-                ) : (
-                  <EditCodeProjectEvaluator
-                    evaluator={evaluator}
-                    sandboxConfigs={sandboxConfigs}
-                    title={title}
-                    onClose={close}
-                    registerDirtyCheck={registerDirtyCheck}
-                  />
-                )}
-              </Suspense>
-            )}
-          </Dialog>
-        </Modal>
-      </ModalOverlay>
-      <DiscardEvaluatorChangesDialog
-        isOpen={isDiscardConfirmOpen}
-        onKeepEditing={() => setIsDiscardConfirmOpen(false)}
-        onDiscard={() => {
-          setIsDiscardConfirmOpen(false);
-          props.onOpenChange?.(false);
-        }}
-      />
-    </>
+    <ProjectEvaluatorSlideover
+      {...props}
+      title={getEditProjectEvaluatorTitle(evaluator)}
+    >
+      {(close, registerDirtyCheck) =>
+        evaluator.evaluator.kind === "LLM" ? (
+          <EditLlmProjectEvaluator
+            evaluator={evaluator}
+            onClose={close}
+            registerDirtyCheck={registerDirtyCheck}
+          />
+        ) : (
+          <EditCodeProjectEvaluator
+            evaluator={evaluator}
+            sandboxConfigs={sandboxConfigs}
+            onClose={close}
+            registerDirtyCheck={registerDirtyCheck}
+          />
+        )
+      }
+    </ProjectEvaluatorSlideover>
   );
 }
-
-type ProjectEvaluatorSandboxConfigs = ReturnType<
-  typeof useProjectEvaluator
->["sandboxConfigs"];
 
 /** Loaded by the edit route, above the slideover. */
 export function useProjectEvaluator(projectEvaluatorId: string) {
@@ -318,12 +277,10 @@ function getScope(evaluator: ProjectEvaluatorNode): ProjectEvaluatorScope {
 
 function EditLlmProjectEvaluator({
   evaluator,
-  title,
   onClose,
   registerDirtyCheck,
 }: {
   evaluator: ProjectEvaluatorNode;
-  title: string;
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
@@ -336,7 +293,6 @@ function EditLlmProjectEvaluator({
       templateFormat={evaluator.evaluator.promptVersion?.templateFormat}
     >
       <EditLlmProjectEvaluatorContent
-        title={title}
         evaluator={evaluator}
         onClose={onClose}
         registerDirtyCheck={registerDirtyCheck}
@@ -347,12 +303,10 @@ function EditLlmProjectEvaluator({
 
 function EditLlmProjectEvaluatorContent({
   evaluator,
-  title,
   onClose,
   registerDirtyCheck,
 }: {
   evaluator: ProjectEvaluatorNode;
-  title: string;
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
@@ -475,7 +429,7 @@ function EditLlmProjectEvaluatorContent({
         trackStoreForDirtyCheck(store);
         return (
           <EditLLMEvaluatorDialogContent
-            title={title}
+            title={getEditProjectEvaluatorTitle(evaluator)}
             onClose={onClose}
             onSubmit={() => submit(store)}
             isSubmitting={isUpdating}
@@ -505,13 +459,11 @@ function EditLlmProjectEvaluatorContent({
 function EditCodeProjectEvaluator({
   evaluator,
   sandboxConfigs,
-  title,
   onClose,
   registerDirtyCheck,
 }: {
   evaluator: ProjectEvaluatorNode;
-  sandboxConfigs: ProjectEvaluatorSandboxConfigs;
-  title: string;
+  sandboxConfigs: SandboxConfigOption[];
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
@@ -589,7 +541,7 @@ function EditCodeProjectEvaluator({
         return (
           <ProjectCodeEvaluatorDialogContent
             mode="update"
-            title={title}
+            title={getEditProjectEvaluatorTitle(evaluator)}
             projectId={evaluator.project.id}
             evaluatorId={evaluator.evaluator.id}
             evaluatorName={evaluator.name}

--- a/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -4,21 +4,7 @@ import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import {
-  Alert,
-  Dialog,
-  Loading,
-  Modal,
-  ModalOverlay,
-  View,
-} from "@phoenix/components";
-import {
-  DialogCloseButton,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTitleExtra,
-} from "@phoenix/components/core/dialog";
+import { Dialog, Loading, Modal, ModalOverlay } from "@phoenix/components";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import {
   extractCodeEvaluatorVariables,
@@ -77,27 +63,30 @@ type ProjectEvaluatorNode = Extract<
   { readonly __typename: "ProjectEvaluator" }
 >;
 
-/**
- * The slideover heading, which names both the flow and the evaluator being
- * edited. The `Dialog` takes its accessible name from this heading, so the two
- * can never drift apart.
- */
-function getEditTitle(evaluator: ProjectEvaluatorNode): string {
-  const kindLabel = evaluator.evaluator.kind === "LLM" ? "LLM" : "code";
-  return `Edit ${kindLabel} evaluator “${evaluator.name}”`;
+/** The slideover heading: the flow, and the evaluator it edits. */
+function getEditProjectEvaluatorTitle(evaluator: ProjectEvaluatorNode): string {
+  const kind = evaluator.evaluator.kind === "LLM" ? "LLM" : "code";
+  return `Edit ${kind} evaluator “${evaluator.name}”`;
 }
 
+/**
+ * Takes the evaluator already loaded by the route rather than loading it here,
+ * so the title is known before the dialog mounts and can name it.
+ */
 export function EditProjectEvaluatorSlideover({
-  projectEvaluatorId,
+  evaluator,
+  sandboxConfigs,
   ...props
 }: {
-  projectEvaluatorId: string;
+  evaluator: ProjectEvaluatorNode;
+  sandboxConfigs: ProjectEvaluatorSandboxConfigs;
 } & ModalOverlayProps) {
   const dirtyCheckRef = useRef<EvaluatorFormDirtyCheck>(() => false);
   const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
   const registerDirtyCheck = (check: EvaluatorFormDirtyCheck) => {
     dirtyCheckRef.current = check;
   };
+  const title = getEditProjectEvaluatorTitle(evaluator);
   return (
     <>
       <ModalOverlay
@@ -115,16 +104,25 @@ export function EditProjectEvaluatorSlideover({
         }}
       >
         <Modal variant="slideover" size="fullscreen">
-          {/* No `aria-label`: the dialog is named by its title heading, so the
-              accessible name always matches the visible one. */}
-          <Dialog>
+          <Dialog aria-label={title}>
             {({ close }) => (
               <Suspense fallback={<Loading />}>
-                <EditProjectEvaluator
-                  projectEvaluatorId={projectEvaluatorId}
-                  onClose={close}
-                  registerDirtyCheck={registerDirtyCheck}
-                />
+                {evaluator.evaluator.kind === "LLM" ? (
+                  <EditLlmProjectEvaluator
+                    evaluator={evaluator}
+                    title={title}
+                    onClose={close}
+                    registerDirtyCheck={registerDirtyCheck}
+                  />
+                ) : (
+                  <EditCodeProjectEvaluator
+                    evaluator={evaluator}
+                    sandboxConfigs={sandboxConfigs}
+                    title={title}
+                    onClose={close}
+                    registerDirtyCheck={registerDirtyCheck}
+                  />
+                )}
               </Suspense>
             )}
           </Dialog>
@@ -142,7 +140,12 @@ export function EditProjectEvaluatorSlideover({
   );
 }
 
-function useProjectEvaluator(projectEvaluatorId: string) {
+type ProjectEvaluatorSandboxConfigs = ReturnType<
+  typeof useProjectEvaluator
+>["sandboxConfigs"];
+
+/** Loaded by the edit route, above the slideover. */
+export function useProjectEvaluator(projectEvaluatorId: string) {
   const data = useLazyLoadQuery<EditProjectEvaluatorSlideoverQuery>(
     graphql`
       query EditProjectEvaluatorSlideoverQuery($projectEvaluatorId: ID!) {
@@ -313,70 +316,17 @@ function getScope(evaluator: ProjectEvaluatorNode): ProjectEvaluatorScope {
   };
 }
 
-/**
- * Loads the evaluator once and picks the form from its own kind, so callers --
- * including a deep link that carries nothing but the id -- need not know
- * whether they are opening an LLM or a code evaluator.
- */
-function EditProjectEvaluator({
-  projectEvaluatorId,
-  onClose,
-  registerDirtyCheck,
-}: {
-  projectEvaluatorId: string;
-  onClose: () => void;
-  registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
-}) {
-  const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
-  if (evaluator.evaluator.kind === "LLM") {
-    return (
-      <EditLlmProjectEvaluator
-        evaluator={evaluator}
-        onClose={onClose}
-        registerDirtyCheck={registerDirtyCheck}
-      />
-    );
-  }
-  if (evaluator.evaluator.kind === "CODE") {
-    return (
-      <EditCodeProjectEvaluator
-        evaluator={evaluator}
-        sandboxConfigs={sandboxConfigs}
-        onClose={onClose}
-        registerDirtyCheck={registerDirtyCheck}
-      />
-    );
-  }
-  // Reachable only by a hand-written URL: the table offers Edit for authored
-  // evaluators alone.
-  return (
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>{`Cannot edit evaluator “${evaluator.name}”`}</DialogTitle>
-        <DialogTitleExtra>
-          <DialogCloseButton />
-        </DialogTitleExtra>
-      </DialogHeader>
-      <View padding="size-200">
-        <Alert variant="warning">
-          Built-in evaluators cannot be edited. Copy this evaluator to author
-          your own version of it.
-        </Alert>
-      </View>
-    </DialogContent>
-  );
-}
-
 function EditLlmProjectEvaluator({
   evaluator,
+  title,
   onClose,
   registerDirtyCheck,
 }: {
   evaluator: ProjectEvaluatorNode;
+  title: string;
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
-  invariant(evaluator.evaluator.kind === "LLM", "expected LLM evaluator");
   return (
     <EvaluatorPlaygroundProvider
       promptId={evaluator.evaluator.prompt?.id}
@@ -386,6 +336,7 @@ function EditLlmProjectEvaluator({
       templateFormat={evaluator.evaluator.promptVersion?.templateFormat}
     >
       <EditLlmProjectEvaluatorContent
+        title={title}
         evaluator={evaluator}
         onClose={onClose}
         registerDirtyCheck={registerDirtyCheck}
@@ -396,10 +347,12 @@ function EditLlmProjectEvaluator({
 
 function EditLlmProjectEvaluatorContent({
   evaluator,
+  title,
   onClose,
   registerDirtyCheck,
 }: {
   evaluator: ProjectEvaluatorNode;
+  title: string;
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
@@ -522,7 +475,7 @@ function EditLlmProjectEvaluatorContent({
         trackStoreForDirtyCheck(store);
         return (
           <EditLLMEvaluatorDialogContent
-            title={getEditTitle(evaluator)}
+            title={title}
             onClose={onClose}
             onSubmit={() => submit(store)}
             isSubmitting={isUpdating}
@@ -552,15 +505,16 @@ function EditLlmProjectEvaluatorContent({
 function EditCodeProjectEvaluator({
   evaluator,
   sandboxConfigs,
+  title,
   onClose,
   registerDirtyCheck,
 }: {
   evaluator: ProjectEvaluatorNode;
-  sandboxConfigs: ReturnType<typeof useProjectEvaluator>["sandboxConfigs"];
+  sandboxConfigs: ProjectEvaluatorSandboxConfigs;
+  title: string;
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
-  invariant(evaluator.evaluator.kind === "CODE", "expected code evaluator");
   const language = evaluator.evaluator.language as CodeEvaluatorLanguage;
   const initialSourceCode = evaluator.evaluator.sourceCode ?? "";
   const initialSandboxConfigId = evaluator.evaluator.sandboxConfig?.id ?? null;
@@ -635,7 +589,7 @@ function EditCodeProjectEvaluator({
         return (
           <ProjectCodeEvaluatorDialogContent
             mode="update"
-            title={getEditTitle(evaluator)}
+            title={title}
             projectId={evaluator.project.id}
             evaluatorId={evaluator.evaluator.id}
             evaluatorName={evaluator.name}

--- a/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -4,7 +4,21 @@ import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import { Dialog, Loading, Modal, ModalOverlay } from "@phoenix/components";
+import {
+  Alert,
+  Dialog,
+  Loading,
+  Modal,
+  ModalOverlay,
+  View,
+} from "@phoenix/components";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+} from "@phoenix/components/core/dialog";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import {
   extractCodeEvaluatorVariables,
@@ -63,13 +77,21 @@ type ProjectEvaluatorNode = Extract<
   { readonly __typename: "ProjectEvaluator" }
 >;
 
+/**
+ * The slideover heading, which names both the flow and the evaluator being
+ * edited. The `Dialog` takes its accessible name from this heading, so the two
+ * can never drift apart.
+ */
+function getEditTitle(evaluator: ProjectEvaluatorNode): string {
+  const kindLabel = evaluator.evaluator.kind === "LLM" ? "LLM" : "code";
+  return `Edit ${kindLabel} evaluator “${evaluator.name}”`;
+}
+
 export function EditProjectEvaluatorSlideover({
   projectEvaluatorId,
-  evaluatorKind,
   ...props
 }: {
   projectEvaluatorId: string;
-  evaluatorKind: "LLM" | "CODE";
 } & ModalOverlayProps) {
   const dirtyCheckRef = useRef<EvaluatorFormDirtyCheck>(() => false);
   const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
@@ -93,22 +115,16 @@ export function EditProjectEvaluatorSlideover({
         }}
       >
         <Modal variant="slideover" size="fullscreen">
-          <Dialog aria-label="Edit project evaluator">
+          {/* No `aria-label`: the dialog is named by its title heading, so the
+              accessible name always matches the visible one. */}
+          <Dialog>
             {({ close }) => (
               <Suspense fallback={<Loading />}>
-                {evaluatorKind === "LLM" ? (
-                  <EditLlmProjectEvaluator
-                    projectEvaluatorId={projectEvaluatorId}
-                    onClose={close}
-                    registerDirtyCheck={registerDirtyCheck}
-                  />
-                ) : evaluatorKind === "CODE" ? (
-                  <EditCodeProjectEvaluator
-                    projectEvaluatorId={projectEvaluatorId}
-                    onClose={close}
-                    registerDirtyCheck={registerDirtyCheck}
-                  />
-                ) : null}
+                <EditProjectEvaluator
+                  projectEvaluatorId={projectEvaluatorId}
+                  onClose={close}
+                  registerDirtyCheck={registerDirtyCheck}
+                />
               </Suspense>
             )}
           </Dialog>
@@ -297,7 +313,12 @@ function getScope(evaluator: ProjectEvaluatorNode): ProjectEvaluatorScope {
   };
 }
 
-function EditLlmProjectEvaluator({
+/**
+ * Loads the evaluator once and picks the form from its own kind, so callers --
+ * including a deep link that carries nothing but the id -- need not know
+ * whether they are opening an LLM or a code evaluator.
+ */
+function EditProjectEvaluator({
   projectEvaluatorId,
   onClose,
   registerDirtyCheck,
@@ -306,7 +327,55 @@ function EditLlmProjectEvaluator({
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
-  const { evaluator } = useProjectEvaluator(projectEvaluatorId);
+  const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
+  if (evaluator.evaluator.kind === "LLM") {
+    return (
+      <EditLlmProjectEvaluator
+        evaluator={evaluator}
+        onClose={onClose}
+        registerDirtyCheck={registerDirtyCheck}
+      />
+    );
+  }
+  if (evaluator.evaluator.kind === "CODE") {
+    return (
+      <EditCodeProjectEvaluator
+        evaluator={evaluator}
+        sandboxConfigs={sandboxConfigs}
+        onClose={onClose}
+        registerDirtyCheck={registerDirtyCheck}
+      />
+    );
+  }
+  // Reachable only by a hand-written URL: the table offers Edit for authored
+  // evaluators alone.
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{`Cannot edit evaluator “${evaluator.name}”`}</DialogTitle>
+        <DialogTitleExtra>
+          <DialogCloseButton />
+        </DialogTitleExtra>
+      </DialogHeader>
+      <View padding="size-200">
+        <Alert variant="warning">
+          Built-in evaluators cannot be edited. Copy this evaluator to author
+          your own version of it.
+        </Alert>
+      </View>
+    </DialogContent>
+  );
+}
+
+function EditLlmProjectEvaluator({
+  evaluator,
+  onClose,
+  registerDirtyCheck,
+}: {
+  evaluator: ProjectEvaluatorNode;
+  onClose: () => void;
+  registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
+}) {
   invariant(evaluator.evaluator.kind === "LLM", "expected LLM evaluator");
   return (
     <EvaluatorPlaygroundProvider
@@ -453,7 +522,7 @@ function EditLlmProjectEvaluatorContent({
         trackStoreForDirtyCheck(store);
         return (
           <EditLLMEvaluatorDialogContent
-            title="Edit project evaluator"
+            title={getEditTitle(evaluator)}
             onClose={onClose}
             onSubmit={() => submit(store)}
             isSubmitting={isUpdating}
@@ -481,15 +550,16 @@ function EditLlmProjectEvaluatorContent({
 }
 
 function EditCodeProjectEvaluator({
-  projectEvaluatorId,
+  evaluator,
+  sandboxConfigs,
   onClose,
   registerDirtyCheck,
 }: {
-  projectEvaluatorId: string;
+  evaluator: ProjectEvaluatorNode;
+  sandboxConfigs: ReturnType<typeof useProjectEvaluator>["sandboxConfigs"];
   onClose: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
-  const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
   invariant(evaluator.evaluator.kind === "CODE", "expected code evaluator");
   const language = evaluator.evaluator.language as CodeEvaluatorLanguage;
   const initialSourceCode = evaluator.evaluator.sourceCode ?? "";
@@ -565,6 +635,7 @@ function EditCodeProjectEvaluator({
         return (
           <ProjectCodeEvaluatorDialogContent
             mode="update"
+            title={getEditTitle(evaluator)}
             projectId={evaluator.project.id}
             evaluatorId={evaluator.evaluator.id}
             evaluatorName={evaluator.name}

--- a/app/src/pages/project/evaluators/ProjectCodeEvaluatorDialogContent.tsx
+++ b/app/src/pages/project/evaluators/ProjectCodeEvaluatorDialogContent.tsx
@@ -11,6 +11,7 @@ import {
 import type { ProjectEvaluatorScope } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 export const ProjectCodeEvaluatorDialogContent = ({
+  title,
   projectId,
   evaluatorId,
   evaluatorName,
@@ -25,6 +26,7 @@ export const ProjectCodeEvaluatorDialogContent = ({
   error,
   mode = "create",
 }: {
+  title: string;
   projectId: string;
   evaluatorId: string;
   evaluatorName: string;
@@ -44,11 +46,7 @@ export const ProjectCodeEvaluatorDialogContent = ({
   const [isFilterValid, setIsFilterValid] = useState(true);
   return (
     <EvaluatorFormDialogContent
-      title={
-        mode === "create"
-          ? "Create project evaluator"
-          : "Edit project evaluator"
-      }
+      title={title}
       submitLabel={mode === "create" ? "Attach evaluator" : "Save changes"}
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}

--- a/app/src/pages/project/evaluators/ProjectEvaluatorActionMenu.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorActionMenu.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router";
 
 import {
   Button,
@@ -13,7 +14,7 @@ import {
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { DeleteProjectEvaluatorDialog } from "@phoenix/pages/project/evaluators/DeleteProjectEvaluatorDialog";
-import { EditProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/EditProjectEvaluatorSlideover";
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 
 enum ProjectEvaluatorAction {
   EDIT = "edit",
@@ -31,7 +32,8 @@ export function ProjectEvaluatorActionMenu({
   evaluatorKind: "LLM" | "CODE" | "BUILTIN";
   evaluatorName: string;
 }) {
-  const [isEditOpen, setIsEditOpen] = useState(false);
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const canEdit = evaluatorKind === "LLM" || evaluatorKind === "CODE";
   return (
@@ -48,7 +50,7 @@ export function ProjectEvaluatorActionMenu({
             onAction={(action) => {
               switch (action) {
                 case ProjectEvaluatorAction.EDIT:
-                  setIsEditOpen(true);
+                  navigate(paths.edit(projectEvaluatorId));
                   break;
                 case ProjectEvaluatorAction.DELETE:
                   setIsDeleteOpen(true);
@@ -83,14 +85,6 @@ export function ProjectEvaluatorActionMenu({
           </Menu>
         </Popover>
       </MenuTrigger>
-      {canEdit ? (
-        <EditProjectEvaluatorSlideover
-          projectEvaluatorId={projectEvaluatorId}
-          evaluatorKind={evaluatorKind}
-          isOpen={isEditOpen}
-          onOpenChange={setIsEditOpen}
-        />
-      ) : null}
       <DeleteProjectEvaluatorDialog
         projectEvaluatorId={projectEvaluatorId}
         projectId={projectId}

--- a/app/src/pages/project/evaluators/ProjectEvaluatorActionMenu.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorActionMenu.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useNavigate } from "react-router";
 
 import {
   Button,
@@ -14,7 +13,6 @@ import {
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { DeleteProjectEvaluatorDialog } from "@phoenix/pages/project/evaluators/DeleteProjectEvaluatorDialog";
-import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 
 enum ProjectEvaluatorAction {
   EDIT = "edit",
@@ -26,14 +24,16 @@ export function ProjectEvaluatorActionMenu({
   projectId,
   evaluatorKind,
   evaluatorName,
+  onEdit,
 }: {
   projectEvaluatorId: string;
   projectId: string;
   evaluatorKind: "LLM" | "CODE" | "BUILTIN";
   evaluatorName: string;
+  /** Passed in by the table, so the edit path is derived once per render and
+   * not once per row. */
+  onEdit: (projectEvaluatorId: string) => void;
 }) {
-  const navigate = useNavigate();
-  const paths = useProjectEvaluatorPaths();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const canEdit = evaluatorKind === "LLM" || evaluatorKind === "CODE";
   return (
@@ -50,7 +50,7 @@ export function ProjectEvaluatorActionMenu({
             onAction={(action) => {
               switch (action) {
                 case ProjectEvaluatorAction.EDIT:
-                  navigate(paths.edit(projectEvaluatorId));
+                  onEdit(projectEvaluatorId);
                   break;
                 case ProjectEvaluatorAction.DELETE:
                   setIsDeleteOpen(true);

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideover.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { Suspense, useRef, useState } from "react";
+import type { ModalOverlayProps } from "react-aria-components";
+
+import { Dialog, Loading, Modal, ModalOverlay } from "@phoenix/components";
+import {
+  DiscardEvaluatorChangesDialog,
+  isModalUnderlay,
+} from "@phoenix/pages/project/evaluators/DiscardEvaluatorChangesDialog";
+import type { EvaluatorFormDirtyCheck } from "@phoenix/pages/project/evaluators/useEvaluatorFormDirtyCheck";
+
+/**
+ * The shell every project evaluator slideover renders into: the modal, the
+ * unsaved-changes guard, and the dialog itself.
+ *
+ * `title` is required and names the dialog, so a slideover cannot be built
+ * without an accessible name. Callers pass the same string to whatever renders
+ * the visible heading, which keeps the two equal by construction -- react-aria
+ * cannot derive the name from the heading here, because the heading is inside
+ * the `Suspense` boundary below and it stops looking before that resolves.
+ */
+export function ProjectEvaluatorSlideover({
+  title,
+  children,
+  ...props
+}: {
+  title: string;
+  /** Receives the dialog's own close, which the form calls when it is done. */
+  children: (
+    close: () => void,
+    registerDirtyCheck: RegisterDirtyCheck
+  ) => ReactNode;
+} & Omit<ModalOverlayProps, "children">) {
+  const dirtyCheckRef = useRef<EvaluatorFormDirtyCheck>(() => false);
+  const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
+  const registerDirtyCheck = (check: EvaluatorFormDirtyCheck) => {
+    dirtyCheckRef.current = check;
+  };
+  return (
+    <>
+      <ModalOverlay
+        {...props}
+        isDismissable
+        shouldCloseOnInteractOutside={(element) => {
+          if (!isModalUnderlay(element)) {
+            return false;
+          }
+          if (dirtyCheckRef.current()) {
+            setIsDiscardConfirmOpen(true);
+            return false;
+          }
+          return true;
+        }}
+      >
+        <Modal variant="slideover" size="fullscreen">
+          <Dialog aria-label={title}>
+            {({ close }) => (
+              <Suspense fallback={<Loading />}>
+                {children(close, registerDirtyCheck)}
+              </Suspense>
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+      <DiscardEvaluatorChangesDialog
+        isOpen={isDiscardConfirmOpen}
+        onKeepEditing={() => setIsDiscardConfirmOpen(false)}
+        onDiscard={() => {
+          setIsDiscardConfirmOpen(false);
+          props.onOpenChange?.(false);
+        }}
+      />
+    </>
+  );
+}
+
+export type RegisterDirtyCheck = (check: EvaluatorFormDirtyCheck) => void;

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverError.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverError.tsx
@@ -16,9 +16,10 @@ import {
 } from "@phoenix/components/core/dialog";
 
 /**
- * Why a slideover route cannot open what its URL names -- an evaluator of the
- * wrong kind, or one that no longer exists. Only a hand-written or stale link
- * reaches these, since the menus and the table link by kind.
+ * Why a slideover route cannot open the evaluator its URL names -- one of the
+ * wrong kind for the flow. Only a hand-written or stale link reaches this,
+ * since the menus and the table link by kind. An id that resolves to nothing
+ * throws out of the Relay query instead and is not handled here.
  */
 export function ProjectEvaluatorSlideoverError({
   title,

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverError.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverError.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  Dialog,
+  Modal,
+  ModalOverlay,
+  Text,
+  View,
+} from "@phoenix/components";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+} from "@phoenix/components/core/dialog";
+
+/**
+ * Why a slideover route cannot open what its URL names -- an evaluator of the
+ * wrong kind, or one that no longer exists. Only a hand-written or stale link
+ * reaches these, since the menus and the table link by kind.
+ */
+export function ProjectEvaluatorSlideoverError({
+  title,
+  message,
+  onOpenChange,
+}: {
+  title: string;
+  message: string;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  return (
+    <ModalOverlay isOpen isDismissable onOpenChange={onOpenChange}>
+      <Modal size="S">
+        <Dialog aria-label={title}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+              <DialogTitleExtra>
+                <DialogCloseButton />
+              </DialogTitleExtra>
+            </DialogHeader>
+            <View padding="size-200">
+              <Text>{message}</Text>
+            </View>
+            <DialogFooter>
+              <Button slot="close">Close</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { useNavigate, useParams } from "react-router";
 import invariant from "tiny-invariant";
@@ -19,16 +20,10 @@ import {
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import { ProjectEvaluatorSlideoverError } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideoverError";
 
-// Route elements for the project evaluator slideovers. Every creation flow and
-// the edit flow is its own route, so each is deep-linkable and the browser's
-// back button closes whichever one is open.
-
 /**
- * Returns the slideover's `onOpenChange`, which closes it by returning to the
- * evaluators list.
- *
- * Closing replaces rather than pushes, so a slideover the user has dismissed
- * does not sit one step back in history waiting to be reopened.
+ * Closes the slideover by returning to the evaluators list. Replaces rather
+ * than pushes, so a slideover the user has dismissed does not sit one step back
+ * in history waiting to be reopened.
  */
 function useCloseSlideover() {
   const navigate = useNavigate();
@@ -92,8 +87,18 @@ export function CopyLlmProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
   const onOpenChange = useCloseSlideover();
   const evaluator = useSourceEvaluator();
+  // Memoized: this walks every prompt message and mints fresh message ids, and
+  // the page re-renders under the open slideover (e.g. as the toolbar filter
+  // changes). A new object each time would rebuild the evaluator store too.
+  const built = useMemo(
+    () =>
+      evaluator && isLlmProjectEvaluatorDetails(evaluator)
+        ? buildCopyLlmCreationMode(evaluator)
+        : null,
+    [evaluator]
+  );
   const title = "Cannot copy evaluator";
-  if (!evaluator || !isLlmProjectEvaluatorDetails(evaluator)) {
+  if (!built) {
     return (
       <ProjectEvaluatorSlideoverError
         title={title}
@@ -102,7 +107,6 @@ export function CopyLlmProjectEvaluatorPage() {
       />
     );
   }
-  const built = buildCopyLlmCreationMode(evaluator);
   if (!built.ok) {
     return (
       <ProjectEvaluatorSlideoverError
@@ -126,7 +130,16 @@ export function AttachCodeProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
   const onOpenChange = useCloseSlideover();
   const evaluator = useSourceEvaluator();
-  if (!evaluator || !isCodeProjectEvaluatorDetails(evaluator)) {
+  // Memoized for the same reason as the copy route: it parses the evaluator's
+  // source twice to extract its variables.
+  const creationMode = useMemo(
+    () =>
+      evaluator && isCodeProjectEvaluatorDetails(evaluator)
+        ? buildAttachCodeCreationMode(evaluator)
+        : null,
+    [evaluator]
+  );
+  if (!creationMode) {
     return (
       <ProjectEvaluatorSlideoverError
         title="Cannot attach evaluator"
@@ -140,7 +153,7 @@ export function AttachCodeProjectEvaluatorPage() {
       isOpen
       onOpenChange={onOpenChange}
       projectId={projectId}
-      creationMode={buildAttachCodeCreationMode(evaluator)}
+      creationMode={creationMode}
     />
   );
 }
@@ -150,8 +163,6 @@ export function EditProjectEvaluatorPage() {
   invariant(projectEvaluatorId, "projectEvaluatorId is required");
   const onOpenChange = useCloseSlideover();
   const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
-  // Only a hand-written URL reaches this: the table offers Edit for authored
-  // evaluators alone.
   if (
     evaluator.evaluator.kind !== "LLM" &&
     evaluator.evaluator.kind !== "CODE"

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -1,0 +1,217 @@
+import { useMemo } from "react";
+import { useLazyLoadQuery } from "react-relay";
+import { useNavigate, useParams } from "react-router";
+import invariant from "tiny-invariant";
+
+import {
+  Button,
+  Dialog,
+  Modal,
+  ModalOverlay,
+  Text,
+  View,
+} from "@phoenix/components";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+} from "@phoenix/components/core/dialog";
+import type { projectEvaluatorDetailsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql";
+import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
+import { CreateProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
+import { EditProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/EditProjectEvaluatorSlideover";
+import {
+  buildAttachCodeCreationMode,
+  buildCopyLlmCreationMode,
+  isCodeProjectEvaluatorDetails,
+  isLlmProjectEvaluatorDetails,
+  projectEvaluatorDetailsQueryNode,
+  UNSUPPORTED_PROMPT_TEMPLATE_ERROR,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
+
+/**
+ * Route elements for the project evaluator slideovers. Every creation flow and
+ * the edit flow is its own route, so each is deep-linkable and the browser's
+ * back button closes whichever one is open.
+ */
+
+/**
+ * Returns the slideover's `onOpenChange`, which closes it by returning to the
+ * evaluators list.
+ *
+ * Closing replaces rather than pushes, so a slideover the user has dismissed
+ * does not sit one step back in history waiting to be reopened.
+ */
+function useCloseSlideover() {
+  const navigate = useNavigate();
+  const { list } = useProjectEvaluatorPaths();
+  return (isOpen: boolean) => {
+    if (!isOpen) {
+      navigate(list, { replace: true });
+    }
+  };
+}
+
+function useRouteProjectId() {
+  const { projectId } = useParams();
+  invariant(projectId, "projectId is required");
+  return projectId;
+}
+
+/**
+ * The evaluator a copy or attach route is seeded from. Suspends, so the
+ * slideover opens only once that evaluator has loaded.
+ */
+function useSourceEvaluator() {
+  const { evaluatorId } = useParams();
+  invariant(evaluatorId, "evaluatorId is required");
+  const data = useLazyLoadQuery<projectEvaluatorDetailsQuery>(
+    projectEvaluatorDetailsQueryNode,
+    { id: evaluatorId },
+    { fetchPolicy: "store-or-network" }
+  );
+  invariant(data.evaluator, "evaluator details could not be loaded");
+  return data.evaluator;
+}
+
+type CreationModeResult =
+  | { ok: true; mode: ProjectEvaluatorCreationMode }
+  | { ok: false; error: string };
+
+export function NewLlmProjectEvaluatorPage() {
+  const projectId = useRouteProjectId();
+  const onOpenChange = useCloseSlideover();
+  return (
+    <CreateProjectEvaluatorSlideover
+      isOpen
+      onOpenChange={onOpenChange}
+      projectId={projectId}
+      creationMode={{ kind: "scratch" }}
+    />
+  );
+}
+
+export function NewCodeProjectEvaluatorPage() {
+  const projectId = useRouteProjectId();
+  const onOpenChange = useCloseSlideover();
+  return (
+    <CreateProjectEvaluatorSlideover
+      isOpen
+      onOpenChange={onOpenChange}
+      projectId={projectId}
+      creationMode={{ kind: "newCode" }}
+    />
+  );
+}
+
+export function CopyLlmProjectEvaluatorPage() {
+  const projectId = useRouteProjectId();
+  const onOpenChange = useCloseSlideover();
+  const evaluator = useSourceEvaluator();
+  const result = useMemo<CreationModeResult>(() => {
+    if (!isLlmProjectEvaluatorDetails(evaluator)) {
+      return { ok: false, error: "This evaluator is not an LLM evaluator." };
+    }
+    const built = buildCopyLlmCreationMode(evaluator);
+    return built.ok
+      ? { ok: true, mode: built.mode }
+      : { ok: false, error: UNSUPPORTED_PROMPT_TEMPLATE_ERROR };
+  }, [evaluator]);
+  if (!result.ok) {
+    return (
+      <SlideoverErrorDialog
+        title="Cannot copy evaluator"
+        message={result.error}
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
+  return (
+    <CreateProjectEvaluatorSlideover
+      isOpen
+      onOpenChange={onOpenChange}
+      projectId={projectId}
+      creationMode={result.mode}
+    />
+  );
+}
+
+export function AttachCodeProjectEvaluatorPage() {
+  const projectId = useRouteProjectId();
+  const onOpenChange = useCloseSlideover();
+  const evaluator = useSourceEvaluator();
+  const creationMode = useMemo(
+    () =>
+      isCodeProjectEvaluatorDetails(evaluator)
+        ? buildAttachCodeCreationMode(evaluator)
+        : null,
+    [evaluator]
+  );
+  if (!creationMode) {
+    return (
+      <SlideoverErrorDialog
+        title="Cannot attach evaluator"
+        message="This evaluator is not a code evaluator."
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
+  return (
+    <CreateProjectEvaluatorSlideover
+      isOpen
+      onOpenChange={onOpenChange}
+      projectId={projectId}
+      creationMode={creationMode}
+    />
+  );
+}
+
+export function EditProjectEvaluatorPage() {
+  const { projectEvaluatorId } = useParams();
+  invariant(projectEvaluatorId, "projectEvaluatorId is required");
+  const onOpenChange = useCloseSlideover();
+  return (
+    <EditProjectEvaluatorSlideover
+      isOpen
+      onOpenChange={onOpenChange}
+      projectEvaluatorId={projectEvaluatorId}
+    />
+  );
+}
+
+function SlideoverErrorDialog({
+  title,
+  message,
+  onOpenChange,
+}: {
+  title: string;
+  message: string;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  return (
+    <ModalOverlay isOpen isDismissable onOpenChange={onOpenChange}>
+      <Modal size="S">
+        <Dialog>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+              <DialogTitleExtra>
+                <DialogCloseButton />
+              </DialogTitleExtra>
+            </DialogHeader>
+            <View padding="size-200">
+              <Text>{message}</Text>
+            </View>
+            <DialogFooter>
+              <Button slot="close">Close</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -1,28 +1,13 @@
-import { useMemo } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { useNavigate, useParams } from "react-router";
 import invariant from "tiny-invariant";
 
-import {
-  Button,
-  Dialog,
-  Modal,
-  ModalOverlay,
-  Text,
-  View,
-} from "@phoenix/components";
-import {
-  DialogCloseButton,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTitleExtra,
-} from "@phoenix/components/core/dialog";
 import type { projectEvaluatorDetailsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql";
-import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
 import { CreateProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
-import { EditProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/EditProjectEvaluatorSlideover";
+import {
+  EditProjectEvaluatorSlideover,
+  useProjectEvaluator,
+} from "@phoenix/pages/project/evaluators/EditProjectEvaluatorSlideover";
 import {
   buildAttachCodeCreationMode,
   buildCopyLlmCreationMode,
@@ -32,12 +17,11 @@ import {
   UNSUPPORTED_PROMPT_TEMPLATE_ERROR,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
+import { ProjectEvaluatorSlideoverError } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideoverError";
 
-/**
- * Route elements for the project evaluator slideovers. Every creation flow and
- * the edit flow is its own route, so each is deep-linkable and the browser's
- * back button closes whichever one is open.
- */
+// Route elements for the project evaluator slideovers. Every creation flow and
+// the edit flow is its own route, so each is deep-linkable and the browser's
+// back button closes whichever one is open.
 
 /**
  * Returns the slideover's `onOpenChange`, which closes it by returning to the
@@ -63,8 +47,9 @@ function useRouteProjectId() {
 }
 
 /**
- * The evaluator a copy or attach route is seeded from. Suspends, so the
- * slideover opens only once that evaluator has loaded.
+ * The evaluator a copy or attach route is seeded from, or null when the id in
+ * the URL names nothing. Suspends, so the slideover opens only once that
+ * evaluator has loaded.
  */
 function useSourceEvaluator() {
   const { evaluatorId } = useParams();
@@ -74,13 +59,8 @@ function useSourceEvaluator() {
     { id: evaluatorId },
     { fetchPolicy: "store-or-network" }
   );
-  invariant(data.evaluator, "evaluator details could not be loaded");
   return data.evaluator;
 }
-
-type CreationModeResult =
-  | { ok: true; mode: ProjectEvaluatorCreationMode }
-  | { ok: false; error: string };
 
 export function NewLlmProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
@@ -112,20 +92,22 @@ export function CopyLlmProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
   const onOpenChange = useCloseSlideover();
   const evaluator = useSourceEvaluator();
-  const result = useMemo<CreationModeResult>(() => {
-    if (!isLlmProjectEvaluatorDetails(evaluator)) {
-      return { ok: false, error: "This evaluator is not an LLM evaluator." };
-    }
-    const built = buildCopyLlmCreationMode(evaluator);
-    return built.ok
-      ? { ok: true, mode: built.mode }
-      : { ok: false, error: UNSUPPORTED_PROMPT_TEMPLATE_ERROR };
-  }, [evaluator]);
-  if (!result.ok) {
+  const title = "Cannot copy evaluator";
+  if (!evaluator || !isLlmProjectEvaluatorDetails(evaluator)) {
     return (
-      <SlideoverErrorDialog
-        title="Cannot copy evaluator"
-        message={result.error}
+      <ProjectEvaluatorSlideoverError
+        title={title}
+        message="This link does not name an LLM evaluator."
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
+  const built = buildCopyLlmCreationMode(evaluator);
+  if (!built.ok) {
+    return (
+      <ProjectEvaluatorSlideoverError
+        title={title}
+        message={UNSUPPORTED_PROMPT_TEMPLATE_ERROR}
         onOpenChange={onOpenChange}
       />
     );
@@ -135,7 +117,7 @@ export function CopyLlmProjectEvaluatorPage() {
       isOpen
       onOpenChange={onOpenChange}
       projectId={projectId}
-      creationMode={result.mode}
+      creationMode={built.mode}
     />
   );
 }
@@ -144,18 +126,11 @@ export function AttachCodeProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
   const onOpenChange = useCloseSlideover();
   const evaluator = useSourceEvaluator();
-  const creationMode = useMemo(
-    () =>
-      isCodeProjectEvaluatorDetails(evaluator)
-        ? buildAttachCodeCreationMode(evaluator)
-        : null,
-    [evaluator]
-  );
-  if (!creationMode) {
+  if (!evaluator || !isCodeProjectEvaluatorDetails(evaluator)) {
     return (
-      <SlideoverErrorDialog
+      <ProjectEvaluatorSlideoverError
         title="Cannot attach evaluator"
-        message="This evaluator is not a code evaluator."
+        message="This link does not name a code evaluator."
         onOpenChange={onOpenChange}
       />
     );
@@ -165,7 +140,7 @@ export function AttachCodeProjectEvaluatorPage() {
       isOpen
       onOpenChange={onOpenChange}
       projectId={projectId}
-      creationMode={creationMode}
+      creationMode={buildAttachCodeCreationMode(evaluator)}
     />
   );
 }
@@ -174,44 +149,27 @@ export function EditProjectEvaluatorPage() {
   const { projectEvaluatorId } = useParams();
   invariant(projectEvaluatorId, "projectEvaluatorId is required");
   const onOpenChange = useCloseSlideover();
+  const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
+  // Only a hand-written URL reaches this: the table offers Edit for authored
+  // evaluators alone.
+  if (
+    evaluator.evaluator.kind !== "LLM" &&
+    evaluator.evaluator.kind !== "CODE"
+  ) {
+    return (
+      <ProjectEvaluatorSlideoverError
+        title="Cannot edit evaluator"
+        message={`“${evaluator.name}” is a built-in evaluator, which cannot be edited. Copy it to author your own version.`}
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
   return (
     <EditProjectEvaluatorSlideover
       isOpen
       onOpenChange={onOpenChange}
-      projectEvaluatorId={projectEvaluatorId}
+      evaluator={evaluator}
+      sandboxConfigs={sandboxConfigs}
     />
-  );
-}
-
-function SlideoverErrorDialog({
-  title,
-  message,
-  onOpenChange,
-}: {
-  title: string;
-  message: string;
-  onOpenChange: (isOpen: boolean) => void;
-}) {
-  return (
-    <ModalOverlay isOpen isDismissable onOpenChange={onOpenChange}>
-      <Modal size="S">
-        <Dialog>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>{title}</DialogTitle>
-              <DialogTitleExtra>
-                <DialogCloseButton />
-              </DialogTitleExtra>
-            </DialogHeader>
-            <View padding="size-200">
-              <Text>{message}</Text>
-            </View>
-            <DialogFooter>
-              <Button slot="close">Close</Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
   );
 }

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyGallery.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyGallery.tsx
@@ -1,48 +1,32 @@
 import { css } from "@emotion/react";
-import { Suspense, useState } from "react";
-import { useLazyLoadQuery, useRelayEnvironment } from "react-relay";
+import { Suspense } from "react";
+import { useLazyLoadQuery } from "react-relay";
+import { useNavigate } from "react-router";
 
-import { Alert, Flex, Icon, Icons, Loading, Text } from "@phoenix/components";
+import { Flex, Icon, Icons, Loading, Text } from "@phoenix/components";
 import { LineClamp } from "@phoenix/components/core/utility/LineClamp";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import type { projectEvaluatorOptionsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptionsQuery.graphql";
-import {
-  CreateProjectEvaluatorSlideover,
-  type ProjectEvaluatorCreationMode,
-} from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
-import {
-  buildAttachCodeCreationMode,
-  buildCopyLlmCreationMode,
-  fetchProjectEvaluatorDetails,
-  isCodeProjectEvaluatorDetails,
-  isLlmProjectEvaluatorDetails,
-  projectEvaluatorOptionsQuery as projectEvaluatorOptionsQueryNode,
-  UNSUPPORTED_PROMPT_TEMPLATE_ERROR,
-} from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+import { projectEvaluatorOptionsQuery as projectEvaluatorOptionsQueryNode } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 
 // The Add evaluator menu is the overflow path for the full list.
 const MAX_COPY_CARDS = 4;
 const MAX_ATTACH_CARDS = 3;
 
-export function ProjectEvaluatorsEmptyGallery({
-  projectId,
-}: {
-  projectId: string;
-}) {
+export function ProjectEvaluatorsEmptyGallery() {
   return (
     <TableEmptyWrap>
       <Suspense fallback={<Loading />}>
-        <Gallery projectId={projectId} />
+        <Gallery />
       </Suspense>
     </TableEmptyWrap>
   );
 }
 
-function Gallery({ projectId }: { projectId: string }) {
-  const [creationMode, setCreationMode] =
-    useState<ProjectEvaluatorCreationMode | null>(null);
-  const [selectionError, setSelectionError] = useState<string | null>(null);
-  const environment = useRelayEnvironment();
+function Gallery() {
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
   const data = useLazyLoadQuery<projectEvaluatorOptionsQuery>(
     projectEvaluatorOptionsQueryNode,
     {},
@@ -68,13 +52,9 @@ function Gallery({ projectId }: { projectId: string }) {
       <Text size="S" fontStyle="italic" color="text-500">
         No evaluators are set up for this project
       </Text>
-      {selectionError ? <Alert variant="danger">{selectionError}</Alert> : null}
       <Flex direction="row" gap="size-125" width="100%">
         <div css={columnCSS}>
-          <button
-            css={cardCSS}
-            onClick={() => setCreationMode({ kind: "scratch" })}
-          >
+          <button css={cardCSS} onClick={() => navigate(paths.newLlm)}>
             <Flex direction="row" alignItems="center" gap="size-50">
               <Icon svg={<Icons.Plus />} />
               <Text size="S" weight="heavy">
@@ -91,28 +71,7 @@ function Gallery({ projectId }: { projectId: string }) {
             <button
               key={evaluator.id}
               css={cardCSS}
-              onClick={async () => {
-                setSelectionError(null);
-                try {
-                  const details = await fetchProjectEvaluatorDetails({
-                    environment,
-                    evaluatorId: evaluator.id,
-                  });
-                  if (!isLlmProjectEvaluatorDetails(details)) {
-                    throw new Error("Expected an LLM evaluator");
-                  }
-                  const result = buildCopyLlmCreationMode(details);
-                  if (!result.ok) {
-                    setSelectionError(UNSUPPORTED_PROMPT_TEMPLATE_ERROR);
-                    return;
-                  }
-                  setCreationMode(result.mode);
-                } catch {
-                  setSelectionError(
-                    "Unable to load evaluator details. Try again."
-                  );
-                }
-              }}
+              onClick={() => navigate(paths.copyLlm(evaluator.id))}
             >
               <Text size="S" weight="heavy">
                 Copy {evaluator.name}
@@ -126,10 +85,7 @@ function Gallery({ projectId }: { projectId: string }) {
           ))}
         </div>
         <div css={columnCSS}>
-          <button
-            css={cardCSS}
-            onClick={() => setCreationMode({ kind: "newCode" })}
-          >
+          <button css={cardCSS} onClick={() => navigate(paths.newCode)}>
             <Flex direction="row" alignItems="center" gap="size-50">
               <Icon svg={<Icons.Code />} />
               <Text size="S" weight="heavy">
@@ -146,23 +102,7 @@ function Gallery({ projectId }: { projectId: string }) {
             <button
               key={evaluator.id}
               css={cardCSS}
-              onClick={async () => {
-                setSelectionError(null);
-                try {
-                  const details = await fetchProjectEvaluatorDetails({
-                    environment,
-                    evaluatorId: evaluator.id,
-                  });
-                  if (!isCodeProjectEvaluatorDetails(details)) {
-                    throw new Error("Expected a code evaluator");
-                  }
-                  setCreationMode(buildAttachCodeCreationMode(details));
-                } catch {
-                  setSelectionError(
-                    "Unable to load evaluator details. Try again."
-                  );
-                }
-              }}
+              onClick={() => navigate(paths.attachCode(evaluator.id))}
             >
               <Text size="S" weight="heavy">
                 Attach {evaluator.name}
@@ -176,16 +116,6 @@ function Gallery({ projectId }: { projectId: string }) {
           ))}
         </div>
       </Flex>
-      {creationMode ? (
-        <CreateProjectEvaluatorSlideover
-          isOpen
-          onOpenChange={(isOpen) => {
-            if (!isOpen) setCreationMode(null);
-          }}
-          projectId={projectId}
-          creationMode={creationMode}
-        />
-      ) : null}
     </Flex>
   );
 }

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -1,17 +1,11 @@
 import { css } from "@emotion/react";
 import { Suspense, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import { useParams, useSearchParams } from "react-router";
+import { Outlet, useParams } from "react-router";
 import invariant from "tiny-invariant";
 
 import { Skeleton, View } from "@phoenix/components";
-import {
-  CREATE_CODE_EVALUATOR_PARAM,
-  CREATE_LLM_EVALUATOR_PARAM,
-} from "@phoenix/constants/searchParams";
 import type { ProjectEvaluatorsPageQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql";
-import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
-import { CreateProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
 import { ProjectEvaluatorsTable } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsTable";
 import { ProjectEvaluatorsToolbar } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsToolbar";
 
@@ -19,35 +13,6 @@ export function ProjectEvaluatorsPage() {
   const { projectId } = useParams();
   invariant(projectId, "projectId is required");
   const [filter, setFilter] = useState("");
-  const [searchParams, setSearchParams] = useSearchParams();
-  // Only two of the four creation modes are linkable today; see #15297.
-  const shouldOpenScratchFromUrl =
-    searchParams.get(CREATE_LLM_EVALUATOR_PARAM) === "true";
-  const shouldOpenNewCodeFromUrl =
-    searchParams.get(CREATE_CODE_EVALUATOR_PARAM) === "true";
-  const urlCreationMode: ProjectEvaluatorCreationMode | null =
-    shouldOpenScratchFromUrl
-      ? { kind: "scratch" }
-      : shouldOpenNewCodeFromUrl
-        ? { kind: "newCode" }
-        : null;
-  const [creationMode, setCreationMode] =
-    useState<ProjectEvaluatorCreationMode | null>(null);
-  const activeCreationMode = creationMode ?? urlCreationMode;
-  const clearCreationMode = () => {
-    setCreationMode(null);
-    if (shouldOpenScratchFromUrl || shouldOpenNewCodeFromUrl) {
-      setSearchParams(
-        (previousSearchParams) => {
-          const nextSearchParams = new URLSearchParams(previousSearchParams);
-          nextSearchParams.delete(CREATE_LLM_EVALUATOR_PARAM);
-          nextSearchParams.delete(CREATE_CODE_EVALUATOR_PARAM);
-          return nextSearchParams;
-        },
-        { replace: true }
-      );
-    }
-  };
   return (
     <main
       css={css`
@@ -57,24 +22,16 @@ export function ProjectEvaluatorsPage() {
         min-height: 0;
       `}
     >
-      <ProjectEvaluatorsToolbar
-        filter={filter}
-        onFilterChange={setFilter}
-        onSelectCreationMode={setCreationMode}
-      />
+      <ProjectEvaluatorsToolbar filter={filter} onFilterChange={setFilter} />
       <Suspense fallback={<ProjectEvaluatorsPageSkeleton />}>
         <ProjectEvaluatorsPageContent projectId={projectId} filter={filter} />
       </Suspense>
-      {activeCreationMode ? (
-        <CreateProjectEvaluatorSlideover
-          isOpen
-          onOpenChange={(isOpen) => {
-            if (!isOpen) clearCreationMode();
-          }}
-          projectId={projectId}
-          creationMode={activeCreationMode}
-        />
-      ) : null}
+      {/* The create and edit slideovers, each on its own nested route. The
+          copy and attach routes suspend while loading the evaluator they are
+          seeded from; the list stays interactive until the slideover opens. */}
+      <Suspense fallback={null}>
+        <Outlet />
+      </Suspense>
     </main>
   );
 }

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -205,7 +205,7 @@ export function ProjectEvaluatorsTable({
                 />
               </TableEmptyWrap>
             ) : (
-              <ProjectEvaluatorsEmptyGallery projectId={projectId} />
+              <ProjectEvaluatorsEmptyGallery />
             )
           ) : (
             <tbody>

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-table";
 import { startTransition, useCallback, useEffect, useMemo } from "react";
 import { graphql, readInlineData, usePaginationFragment } from "react-relay";
+import { useNavigate } from "react-router";
 
 import {
   Flex,
@@ -23,6 +24,7 @@ import type { ProjectEvaluatorsTable_project$key } from "@phoenix/pages/project/
 import type { ProjectEvaluatorsTable_row$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql";
 import { ProjectEvaluatorActionMenu } from "@phoenix/pages/project/evaluators/ProjectEvaluatorActionMenu";
 import { ProjectEvaluatorEnabledSwitch } from "@phoenix/pages/project/evaluators/ProjectEvaluatorEnabledSwitch";
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import { ProjectEvaluatorsEmptyGallery } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsEmptyGallery";
 
 const PAGE_SIZE = 30;
@@ -109,6 +111,12 @@ export function ProjectEvaluatorsTable({
     () => data.evaluators.edges.map(({ node }) => readRow(node)),
     [data.evaluators.edges]
   );
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
+  const openEditSlideover = useCallback(
+    (projectEvaluatorId: string) => navigate(paths.edit(projectEvaluatorId)),
+    [navigate, paths]
+  );
   const columns = useMemo<ColumnDef<TableRow>[]>(
     () => [
       {
@@ -155,11 +163,12 @@ export function ProjectEvaluatorsTable({
             projectId={projectId}
             evaluatorKind={row.original.evaluator.kind}
             evaluatorName={row.original.name}
+            onEdit={openEditSlideover}
           />
         ),
       },
     ],
-    [projectId]
+    [projectId, openEditSlideover]
   );
   // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsToolbar.tsx
@@ -1,20 +1,17 @@
 import { DebouncedSearch, Flex, View } from "@phoenix/components";
 import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
-import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
 
 /**
  * The evaluators tab's own header: search on the left, creation on the right.
  * Both live in the tab's content rather than the project tab bar, so the tab
- * bar stays pure navigation and this page owns its creation state.
+ * bar stays pure navigation.
  */
 export function ProjectEvaluatorsToolbar({
   filter,
   onFilterChange,
-  onSelectCreationMode,
 }: {
   filter: string;
   onFilterChange: (filter: string) => void;
-  onSelectCreationMode: (mode: ProjectEvaluatorCreationMode) => void;
 }) {
   return (
     <View
@@ -36,10 +33,7 @@ export function ProjectEvaluatorsToolbar({
           onChange={onFilterChange}
         />
         <Flex direction="row" alignItems="center" gap="size-100" flex="none">
-          <AddProjectEvaluatorMenu
-            size="M"
-            onSelectCreationMode={onSelectCreationMode}
-          />
+          <AddProjectEvaluatorMenu size="M" />
         </Flex>
       </Flex>
     </View>

--- a/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -131,7 +131,7 @@ export const projectEvaluatorDetailsQueryNode = graphql`
 export type ProjectEvaluatorOption =
   projectEvaluatorOptionsQuery$data["evaluators"]["edges"][number]["evaluator"];
 
-export type ProjectEvaluatorDetails = NonNullable<
+type ProjectEvaluatorDetails = NonNullable<
   projectEvaluatorDetailsQuery["response"]["evaluator"]
 >;
 type LlmProjectEvaluatorDetails = ProjectEvaluatorDetails & {

--- a/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -1,5 +1,4 @@
-import type { Environment } from "react-relay";
-import { fetchQuery, graphql } from "react-relay";
+import { graphql } from "react-relay";
 
 import {
   extractCodeEvaluatorVariables,
@@ -34,7 +33,7 @@ export const projectEvaluatorOptionsQuery = graphql`
   }
 `;
 
-const projectEvaluatorDetailsQueryNode = graphql`
+export const projectEvaluatorDetailsQueryNode = graphql`
   query projectEvaluatorDetailsQuery($id: ID!) {
     evaluator: node(id: $id) {
       __typename
@@ -174,24 +173,6 @@ export function isCodeProjectEvaluatorDetails(
     typeof evaluator.sourceCode === "string" &&
     Array.isArray(evaluator.outputConfigs)
   );
-}
-
-export async function fetchProjectEvaluatorDetails({
-  environment,
-  evaluatorId,
-}: {
-  environment: Environment;
-  evaluatorId: string;
-}): Promise<ProjectEvaluatorDetails> {
-  const data = await fetchQuery<projectEvaluatorDetailsQuery>(
-    environment,
-    projectEvaluatorDetailsQueryNode,
-    { id: evaluatorId }
-  ).toPromise();
-  if (!data?.evaluator) {
-    throw new Error("Evaluator details could not be loaded");
-  }
-  return data.evaluator;
 }
 
 export type BuildCopyLlmCreationModeResult =

--- a/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+
+import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
+
+/**
+ * Paths for the project evaluator slideovers.
+ *
+ * Every creation flow and the edit flow is a nested route under the evaluators
+ * tab rather than component state, so each one can be linked, restored on
+ * reload, and closed with the browser's back button.
+ *
+ * Evaluator ids are Relay global ids, which are base64 and may carry characters
+ * that are not path safe, so they are encoded into a single segment.
+ */
+
+export const projectEvaluatorsPath = (projectRootPath: string) =>
+  `${projectRootPath}/evaluators`;
+
+export const newLlmProjectEvaluatorPath = (projectRootPath: string) =>
+  `${projectEvaluatorsPath(projectRootPath)}/new/llm`;
+
+export const newCodeProjectEvaluatorPath = (projectRootPath: string) =>
+  `${projectEvaluatorsPath(projectRootPath)}/new/code`;
+
+export const copyLlmProjectEvaluatorPath = (
+  projectRootPath: string,
+  evaluatorId: string
+) =>
+  `${projectEvaluatorsPath(projectRootPath)}/new/copy/${encodeURIComponent(evaluatorId)}`;
+
+export const attachCodeProjectEvaluatorPath = (
+  projectRootPath: string,
+  evaluatorId: string
+) =>
+  `${projectEvaluatorsPath(projectRootPath)}/new/attach/${encodeURIComponent(evaluatorId)}`;
+
+export const editProjectEvaluatorPath = (
+  projectRootPath: string,
+  projectEvaluatorId: string
+) =>
+  `${projectEvaluatorsPath(projectRootPath)}/${encodeURIComponent(projectEvaluatorId)}/edit`;
+
+/**
+ * The evaluator slideover paths for the project currently in the URL.
+ */
+export function useProjectEvaluatorPaths() {
+  const { rootPath } = useProjectRootPath();
+  return useMemo(
+    () => ({
+      list: projectEvaluatorsPath(rootPath),
+      newLlm: newLlmProjectEvaluatorPath(rootPath),
+      newCode: newCodeProjectEvaluatorPath(rootPath),
+      copyLlm: (evaluatorId: string) =>
+        copyLlmProjectEvaluatorPath(rootPath, evaluatorId),
+      attachCode: (evaluatorId: string) =>
+        attachCodeProjectEvaluatorPath(rootPath, evaluatorId),
+      edit: (projectEvaluatorId: string) =>
+        editProjectEvaluatorPath(rootPath, projectEvaluatorId),
+    }),
+    [rootPath]
+  );
+}

--- a/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -2,61 +2,42 @@ import { useMemo } from "react";
 
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 
-/**
- * Paths for the project evaluator slideovers.
- *
- * Every creation flow and the edit flow is a nested route under the evaluators
- * tab rather than component state, so each one can be linked, restored on
- * reload, and closed with the browser's back button.
- *
- * Evaluator ids are Relay global ids, which are base64 and may carry characters
- * that are not path safe, so they are encoded into a single segment.
- */
-
-export const projectEvaluatorsPath = (projectRootPath: string) =>
+const projectEvaluatorsPath = (projectRootPath: string) =>
   `${projectRootPath}/evaluators`;
 
+/**
+ * Exported for the loader that forwards the legacy `?createLlmEvaluator` and
+ * `?createCodeEvaluator` links, which has a path rather than a project root.
+ */
 export const newLlmProjectEvaluatorPath = (projectRootPath: string) =>
   `${projectEvaluatorsPath(projectRootPath)}/new/llm`;
 
 export const newCodeProjectEvaluatorPath = (projectRootPath: string) =>
   `${projectEvaluatorsPath(projectRootPath)}/new/code`;
 
-export const copyLlmProjectEvaluatorPath = (
-  projectRootPath: string,
-  evaluatorId: string
-) =>
-  `${projectEvaluatorsPath(projectRootPath)}/new/copy/${encodeURIComponent(evaluatorId)}`;
-
-export const attachCodeProjectEvaluatorPath = (
-  projectRootPath: string,
-  evaluatorId: string
-) =>
-  `${projectEvaluatorsPath(projectRootPath)}/new/attach/${encodeURIComponent(evaluatorId)}`;
-
-export const editProjectEvaluatorPath = (
-  projectRootPath: string,
-  projectEvaluatorId: string
-) =>
-  `${projectEvaluatorsPath(projectRootPath)}/${encodeURIComponent(projectEvaluatorId)}/edit`;
-
 /**
  * The evaluator slideover paths for the project currently in the URL.
+ *
+ * Every creation flow and the edit flow is a nested route rather than component
+ * state, so each can be linked, restored on reload, and closed with the
+ * browser's back button. Evaluator ids are Relay global ids, which are base64
+ * and may carry characters that are not path safe, so they are encoded into a
+ * single segment.
  */
 export function useProjectEvaluatorPaths() {
   const { rootPath } = useProjectRootPath();
-  return useMemo(
-    () => ({
-      list: projectEvaluatorsPath(rootPath),
+  return useMemo(() => {
+    const list = projectEvaluatorsPath(rootPath);
+    return {
+      list,
       newLlm: newLlmProjectEvaluatorPath(rootPath),
       newCode: newCodeProjectEvaluatorPath(rootPath),
       copyLlm: (evaluatorId: string) =>
-        copyLlmProjectEvaluatorPath(rootPath, evaluatorId),
+        `${list}/new/copy/${encodeURIComponent(evaluatorId)}`,
       attachCode: (evaluatorId: string) =>
-        attachCodeProjectEvaluatorPath(rootPath, evaluatorId),
+        `${list}/new/attach/${encodeURIComponent(evaluatorId)}`,
       edit: (projectEvaluatorId: string) =>
-        editProjectEvaluatorPath(rootPath, projectEvaluatorId),
-    }),
-    [rootPath]
-  );
+        `${list}/${encodeURIComponent(projectEvaluatorId)}/edit`,
+    };
+  }, [rootPath]);
 }

--- a/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useLocation } from "react-router";
 
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 
@@ -26,18 +27,30 @@ export const newCodeProjectEvaluatorPath = (projectRootPath: string) =>
  */
 export function useProjectEvaluatorPaths() {
   const { rootPath } = useProjectRootPath();
+  // A slideover is a sub-view of the list, not a new destination, so opening
+  // and closing one carries the page's URL state -- above all a custom time
+  // range, which would otherwise be dropped on the way in and again on the way
+  // out.
+  const { search } = useLocation();
   return useMemo(() => {
     const list = projectEvaluatorsPath(rootPath);
+    const withCurrentSearch = (path: string) => `${path}${search}`;
     return {
-      list,
-      newLlm: newLlmProjectEvaluatorPath(rootPath),
-      newCode: newCodeProjectEvaluatorPath(rootPath),
+      list: withCurrentSearch(list),
+      newLlm: withCurrentSearch(newLlmProjectEvaluatorPath(rootPath)),
+      newCode: withCurrentSearch(newCodeProjectEvaluatorPath(rootPath)),
       copyLlm: (evaluatorId: string) =>
-        `${list}/new/copy/${encodeURIComponent(evaluatorId)}`,
+        withCurrentSearch(
+          `${list}/new/copy/${encodeURIComponent(evaluatorId)}`
+        ),
       attachCode: (evaluatorId: string) =>
-        `${list}/new/attach/${encodeURIComponent(evaluatorId)}`,
+        withCurrentSearch(
+          `${list}/new/attach/${encodeURIComponent(evaluatorId)}`
+        ),
       edit: (projectEvaluatorId: string) =>
-        `${list}/${encodeURIComponent(projectEvaluatorId)}/edit`,
+        withCurrentSearch(
+          `${list}/${encodeURIComponent(projectEvaluatorId)}/edit`
+        ),
     };
-  }, [rootPath]);
+  }, [rootPath, search]);
 }

--- a/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
@@ -1,0 +1,32 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect } from "react-router";
+
+import {
+  CREATE_CODE_EVALUATOR_PARAM,
+  CREATE_LLM_EVALUATOR_PARAM,
+} from "@phoenix/constants/searchParams";
+
+/**
+ * Forwards the retired `?createLlmEvaluator=true` / `?createCodeEvaluator=true`
+ * links to the creation routes that replaced them, so links minted before the
+ * slideovers became route-driven still open the right form.
+ */
+export function projectEvaluatorsLoader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  // A creation route is already matched; the params are only a list-page alias.
+  if (!/\/evaluators\/?$/.test(url.pathname)) {
+    return null;
+  }
+  const opensLlmForm =
+    url.searchParams.get(CREATE_LLM_EVALUATOR_PARAM) === "true";
+  const opensCodeForm =
+    url.searchParams.get(CREATE_CODE_EVALUATOR_PARAM) === "true";
+  if (!opensLlmForm && !opensCodeForm) {
+    return null;
+  }
+  url.searchParams.delete(CREATE_LLM_EVALUATOR_PARAM);
+  url.searchParams.delete(CREATE_CODE_EVALUATOR_PARAM);
+  const listPath = url.pathname.replace(/\/$/, "");
+  const creationPath = opensLlmForm ? "new/llm" : "new/code";
+  return redirect(`${listPath}/${creationPath}${url.search}`);
+}

--- a/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
@@ -1,20 +1,28 @@
 import type { LoaderFunctionArgs } from "react-router";
-import { redirect } from "react-router";
+import { replace } from "react-router";
 
 import {
   CREATE_CODE_EVALUATOR_PARAM,
   CREATE_LLM_EVALUATOR_PARAM,
 } from "@phoenix/constants/searchParams";
+import {
+  newCodeProjectEvaluatorPath,
+  newLlmProjectEvaluatorPath,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 /**
- * Forwards the retired `?createLlmEvaluator=true` / `?createCodeEvaluator=true`
- * links to the creation routes that replaced them, so links minted before the
- * slideovers became route-driven still open the right form.
+ * Forwards links that open a creation form with `?createLlmEvaluator=true` or
+ * `?createCodeEvaluator=true` to the routes that replaced them, so links minted
+ * before the slideovers became route-driven still open the right form. Both
+ * params remain the live mechanism on the dataset evaluators page.
  */
 export function projectEvaluatorsLoader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  // A creation route is already matched; the params are only a list-page alias.
-  if (!/\/evaluators\/?$/.test(url.pathname)) {
+  // This loader also runs for the nested creation routes, which have already
+  // matched; only the list path itself needs forwarding.
+  const projectRootPath = url.pathname.match(/^(.*)\/evaluators\/?$/)?.[1];
+  if (projectRootPath == null) {
     return null;
   }
   const opensLlmForm =
@@ -24,9 +32,14 @@ export function projectEvaluatorsLoader({ request }: LoaderFunctionArgs) {
   if (!opensLlmForm && !opensCodeForm) {
     return null;
   }
-  url.searchParams.delete(CREATE_LLM_EVALUATOR_PARAM);
-  url.searchParams.delete(CREATE_CODE_EVALUATOR_PARAM);
-  const listPath = url.pathname.replace(/\/$/, "");
-  const creationPath = opensLlmForm ? "new/llm" : "new/code";
-  return redirect(`${listPath}/${creationPath}${url.search}`);
+  const creationPath = opensLlmForm
+    ? newLlmProjectEvaluatorPath(projectRootPath)
+    : newCodeProjectEvaluatorPath(projectRootPath);
+  const search = withSearchParams(url.search, (params) => {
+    params.delete(CREATE_LLM_EVALUATOR_PARAM);
+    params.delete(CREATE_CODE_EVALUATOR_PARAM);
+  });
+  // `replace`, not `redirect`: a pushed entry would leave the legacy URL one
+  // step back, so the back button would land on it and be forwarded here again.
+  return replace(`${creationPath}${search}`);
 }

--- a/app/src/pages/project/index.tsx
+++ b/app/src/pages/project/index.tsx
@@ -5,4 +5,6 @@ export * from "./ProjectSpansPage";
 export * from "./ProjectTracesPage";
 export * from "./projectLoader";
 export * from "./evaluators/ProjectEvaluatorsPage";
+export * from "./evaluators/projectEvaluatorsLoader";
+export * from "./evaluators/ProjectEvaluatorSlideoverRoutes";
 export * from "./metrics/ProjectMetricsPage";

--- a/app/tests/projects.spec.ts
+++ b/app/tests/projects.spec.ts
@@ -18,6 +18,12 @@ async function createProject(
   await expect(page).toHaveURL(/\/projects\/.+/);
 }
 
+// The evaluator slideovers are routes, so the test asserts on them. Each ends
+// in `(\?|$)` because project pages always carry a time-range search param.
+const EVALUATORS_URL = /\/projects\/[^/]+\/evaluators(\?|$)/;
+const NEW_LLM_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/new\/llm(\?|$)/;
+const EDIT_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/[^/]+\/edit(\?|$)/;
+
 async function clickSortableHeaderAndExpect(
   header: Locator,
   direction: "ascending" | "descending"
@@ -201,7 +207,7 @@ test.describe.serial("Projects", () => {
     );
 
     await page.getByRole("tab", { name: "Evaluators" }).click();
-    await expect(page).toHaveURL(/\/projects\/.+\/evaluators/);
+    await expect(page).toHaveURL(EVALUATORS_URL);
     await page.getByRole("button", { name: "Add evaluator" }).click();
     await page
       .getByRole("menuitem", { name: "Create new LLM evaluator" })
@@ -209,10 +215,7 @@ test.describe.serial("Projects", () => {
 
     // The slideover is a route of its own, so it is linkable and closable with
     // the browser's back button.
-    // `(\?|$)` throughout: the project pages always carry a time-range param.
-    await expect(page).toHaveURL(
-      /\/projects\/[^/]+\/evaluators\/new\/llm(\?|$)/
-    );
+    await expect(page).toHaveURL(NEW_LLM_EVALUATOR_URL);
     const createDialog = page.getByRole("dialog", {
       name: "Create new LLM evaluator",
     });
@@ -222,7 +225,7 @@ test.describe.serial("Projects", () => {
     ).toBeVisible();
     await page.goBack();
     await expect(createDialog).not.toBeVisible();
-    await expect(page).toHaveURL(/\/projects\/[^/]+\/evaluators(\?|$)/);
+    await expect(page).toHaveURL(EVALUATORS_URL);
     await page.goForward();
     await expect(createDialog).toBeVisible();
     // The annotation output has a "Name" field too; the evaluator's own name is
@@ -251,9 +254,7 @@ test.describe.serial("Projects", () => {
       .getByRole("button", { name: "Evaluator actions" })
       .click();
     await page.getByRole("menuitem", { name: "Edit" }).click();
-    await expect(page).toHaveURL(
-      /\/projects\/[^/]+\/evaluators\/[^/]+\/edit(\?|$)/
-    );
+    await expect(page).toHaveURL(EDIT_EVALUATOR_URL);
     const editDialog = page.getByRole("dialog", {
       name: `Edit LLM evaluator “${evaluatorName}”`,
     });

--- a/app/tests/projects.spec.ts
+++ b/app/tests/projects.spec.ts
@@ -209,7 +209,10 @@ test.describe.serial("Projects", () => {
 
     // The slideover is a route of its own, so it is linkable and closable with
     // the browser's back button.
-    await expect(page).toHaveURL(/\/projects\/.+\/evaluators\/new\/llm$/);
+    // `(\?|$)` throughout: the project pages always carry a time-range param.
+    await expect(page).toHaveURL(
+      /\/projects\/[^/]+\/evaluators\/new\/llm(\?|$)/
+    );
     const createDialog = page.getByRole("dialog", {
       name: "Create new LLM evaluator",
     });
@@ -219,7 +222,7 @@ test.describe.serial("Projects", () => {
     ).toBeVisible();
     await page.goBack();
     await expect(createDialog).not.toBeVisible();
-    await expect(page).toHaveURL(/\/projects\/.+\/evaluators$/);
+    await expect(page).toHaveURL(/\/projects\/[^/]+\/evaluators(\?|$)/);
     await page.goForward();
     await expect(createDialog).toBeVisible();
     // The annotation output has a "Name" field too; the evaluator's own name is
@@ -248,7 +251,9 @@ test.describe.serial("Projects", () => {
       .getByRole("button", { name: "Evaluator actions" })
       .click();
     await page.getByRole("menuitem", { name: "Edit" }).click();
-    await expect(page).toHaveURL(/\/projects\/.+\/evaluators\/.+\/edit$/);
+    await expect(page).toHaveURL(
+      /\/projects\/[^/]+\/evaluators\/[^/]+\/edit(\?|$)/
+    );
     const editDialog = page.getByRole("dialog", {
       name: `Edit LLM evaluator “${evaluatorName}”`,
     });

--- a/app/tests/projects.spec.ts
+++ b/app/tests/projects.spec.ts
@@ -207,13 +207,21 @@ test.describe.serial("Projects", () => {
       .getByRole("menuitem", { name: "Create new LLM evaluator" })
       .click();
 
+    // The slideover is a route of its own, so it is linkable and closable with
+    // the browser's back button.
+    await expect(page).toHaveURL(/\/projects\/.+\/evaluators\/new\/llm$/);
     const createDialog = page.getByRole("dialog", {
-      name: "Create project evaluator",
+      name: "Create new LLM evaluator",
     });
     await expect(createDialog).toBeVisible();
     await expect(
       createDialog.getByRole("tab", { name: "Bindings" })
     ).toBeVisible();
+    await page.goBack();
+    await expect(createDialog).not.toBeVisible();
+    await expect(page).toHaveURL(/\/projects\/.+\/evaluators$/);
+    await page.goForward();
+    await expect(createDialog).toBeVisible();
     // The annotation output has a "Name" field too; the evaluator's own name is
     // the first one.
     await createDialog.getByLabel("Name").first().fill(evaluatorName);
@@ -240,8 +248,9 @@ test.describe.serial("Projects", () => {
       .getByRole("button", { name: "Evaluator actions" })
       .click();
     await page.getByRole("menuitem", { name: "Edit" }).click();
+    await expect(page).toHaveURL(/\/projects\/.+\/evaluators\/.+\/edit$/);
     const editDialog = page.getByRole("dialog", {
-      name: "Edit project evaluator",
+      name: `Edit LLM evaluator “${evaluatorName}”`,
     });
     await expect(editDialog).toBeVisible();
     await editDialog.getByLabel("Name").first().fill(updatedEvaluatorName);


### PR DESCRIPTION
Closes #15297 and #15296.

## Route-driven slideovers (#15297)

Every creation flow and the edit flow is now a nested route under the evaluators tab:

```
projects/:projectId/evaluators/new/llm
projects/:projectId/evaluators/new/code
projects/:projectId/evaluators/new/copy/:evaluatorId
projects/:projectId/evaluators/new/attach/:evaluatorId
projects/:projectId/evaluators/:projectEvaluatorId/edit
```

All five are deep-linkable, restore on reload, and close with the browser's back button.

- `ProjectEvaluatorSlideoverRoutes.tsx` holds the route elements; `projectEvaluatorPaths.ts` owns the paths.
- `ProjectEvaluatorsPage` holds no creation state and renders an `Outlet`. The toolbar menu, the empty gallery, and the row action menu all navigate, so the gallery's second `CreateProjectEvaluatorSlideover` instance is gone.
- **Each route preloads whatever its slideover needs.** Copy and attach load their source evaluator; edit loads the project evaluator. This replaces the menu awaiting `fetchProjectEvaluatorDetails` (deleted, along with the error handling duplicated across two components) and lets `EditProjectEvaluatorSlideover` take a loaded evaluator instead of an id, picking its form from `evaluator.kind`.
- `projectEvaluatorsLoader` forwards the retired `?createLlmEvaluator=true` / `?createCodeEvaluator=true` links. It uses `replace` rather than `redirect`, so the legacy URL does not sit one step back in history and bounce the back button forward again. Both constants stay — the dataset evaluators page still reads them.

## Titles (#15296)

Wording follows the Add-evaluator menu and the delete dialog:

| Flow | Title |
|---|---|
| LLM from scratch | `Create new LLM evaluator` |
| New code evaluator | `Create new code evaluator` |
| Copy an LLM evaluator | `Copy LLM evaluator “name”` |
| Attach a code evaluator | `Attach code evaluator “name”` |
| Edit | `Edit LLM evaluator “name”` / `Edit code evaluator “name”` |

Because the route preloads, the title is known above `<Dialog>` in every case. One string is computed there and used for both the `aria-label` and the visible heading, so they cannot drift. **No shared components are touched** — the diff is confined to `pages/project/evaluators`, the route table, and `ProjectPage`.

## Known issue this does not fix

react-aria links a dialog to its `slot="title"` heading in a layout effect that runs once, so a title rendered behind a `Suspense` boundary never gets linked and the dialog ends up with no accessible name. The project slideovers now sidestep it by naming the dialog explicitly, but the three dataset evaluator slideovers (`CreateLLMDatasetEvaluatorSlideover`, `CreateCodeDatasetEvaluatorSlideover`, `EditLLMDatasetEvaluatorSlideover`) have the same shape and are affected today. Fixing that properly means changing `Dialog`/`DialogTitle`, which is app-wide and belongs in its own PR against `main`.

## Verification

Driven against a local dev server: both create routes, deep-link reload, back closes / forward reopens, both legacy param redirects (including the back-button trap, now fixed), attach from the menu, edit with the correct name in both the heading and the accessible name, and the discard-changes guard still firing on backdrop click and closing via the route. Throwaway evaluators were created to exercise attach/edit and deleted afterwards.

`make lint-frontend`, `tsc --noEmit`, and `make test-frontend` (2222 passing) are clean. `projects.spec.ts` expectations are updated for the new titles, plus assertions for the URLs and back/forward — that spec has not been run locally.

Copy-an-LLM-evaluator is the one path not exercised live: it needs an existing LLM evaluator, which needs a configured model provider. It shares the route and title mechanism with attach, which was verified.