### PR TITLE
test(client): cover default Google GenAI formatting

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/google_genai/generate_content.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/google_genai/generate_content.py
@@ -10,6 +10,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Sequence,
     TypedDict,
     Union,
     cast,
@@ -56,14 +57,102 @@ __all__ = [
 
 
 def create_prompt_version_from_google_genai(
-    obj: Any,
+    model: str,
+    contents: Sequence[genai_types.Content],
     /,
     *,
+    config: Optional[
+        Union[genai_types.GenerateContentConfig, genai_types.GenerateContentConfigDict]
+    ] = None,
     description: Optional[str] = None,
     template_format: Literal["F_STRING", "MUSTACHE", "NONE"] = "MUSTACHE",
     model_provider: Literal["GOOGLE"] = "GOOGLE",
 ) -> v1.PromptVersionData:
-    raise NotImplementedError
+    from google.genai import types as genai_types
+
+    config = genai_types.GenerateContentConfig.model_validate(config or {})
+    _validate_supported_config(config)
+    messages = _system_messages_from_google(
+        cast(
+            "Optional[Union[str, genai_types.Content, Sequence[genai_types.Content]]]",
+            config.system_instruction,
+        )
+    )
+    messages.extend(_ContentConversion.from_google(content) for content in contents)
+    ans = v1.PromptVersionData(
+        model_provider=model_provider,
+        model_name=model,
+        template=v1.PromptChatTemplate(type="chat", messages=messages),
+        template_type="CHAT",
+        template_format=template_format,
+        invocation_parameters=_InvocationParametersConversion.from_google(config),
+    )
+    tool_kwargs: _ToolKwargs = {}
+    if tools := config.model_dump(exclude_none=True).get("tools"):
+        tool_kwargs["tools"] = [genai_types.Tool.model_validate(tool) for tool in tools]
+    if config.tool_config:
+        tool_kwargs["tool_config"] = config.tool_config
+    if tools := _ToolKwargsConversion.from_google(tool_kwargs):
+        ans["tools"] = tools
+    if response_format := _ResponseFormatConversion.from_google(config):
+        ans["response_format"] = response_format
+    if description:
+        ans["description"] = description
+    return ans
+
+
+def _validate_supported_config(config: genai_types.GenerateContentConfig) -> None:
+    supported_fields = {
+        "temperature",
+        "max_output_tokens",
+        "stop_sequences",
+        "presence_penalty",
+        "frequency_penalty",
+        "top_p",
+        "top_k",
+        "thinking_config",
+        "system_instruction",
+        "tools",
+        "tool_config",
+        "response_mime_type",
+        "response_json_schema",
+    }
+    unsupported_fields = set(config.model_dump(exclude_none=True)) - supported_fields
+    if unsupported_fields:
+        raise NotImplementedError(
+            "Unsupported Google GenAI config fields: " + ", ".join(sorted(unsupported_fields))
+        )
+
+
+def _system_messages_from_google(
+    obj: Optional[Union[str, genai_types.Content, Sequence[genai_types.Content]]],
+    /,
+) -> list[v1.PromptMessage]:
+    if obj is None:
+        return []
+    if isinstance(obj, str):
+        return [v1.PromptMessage(role="system", content=obj)]
+    contents: Sequence[genai_types.Content]
+    if isinstance(obj, genai_types.Content):
+        contents = [obj]
+    elif isinstance(obj, Sequence) and all(
+        isinstance(content, genai_types.Content) for content in obj
+    ):
+        contents = cast("Sequence[genai_types.Content]", obj)  # pyright: ignore[reportUnnecessaryCast]
+    else:
+        raise NotImplementedError("Only text and Content system instructions are supported")
+    messages: list[v1.PromptMessage] = []
+    for content in contents:
+        parts = [
+            _TextContentPartConversion.from_google(part)
+            for part in content.parts or ()
+            if _has_text(part)
+        ]
+        if len(parts) != len(content.parts or ()):
+            raise NotImplementedError("Only text system instructions are supported")
+        if parts:
+            messages.append(v1.PromptMessage(role="system", content=parts))
+    return messages
 
 
 def to_chat_messages_and_kwargs(
@@ -197,6 +286,64 @@ class _ThinkingConfigConversion:
             return None
         return genai_types.ThinkingConfig.model_validate(kwargs)
 
+    @staticmethod
+    def from_google(
+        obj: genai_types.ThinkingConfig,
+    ) -> v1.PromptGoogleThinkingConfig:
+        ans = v1.PromptGoogleThinkingConfig()
+        if obj.thinking_budget is not None:
+            ans["thinking_budget"] = obj.thinking_budget
+        if obj.include_thoughts is not None:
+            ans["include_thoughts"] = obj.include_thoughts
+        if thinking_level := getattr(obj, "thinking_level", None):
+            ans["thinking_level"] = thinking_level.lower()
+        return ans
+
+
+class _InvocationParametersConversion:
+    @staticmethod
+    def from_google(
+        obj: genai_types.GenerateContentConfig,
+    ) -> v1.PromptGoogleInvocationParameters:
+        parameters = v1.PromptGoogleInvocationParametersContent()
+        for field in (
+            "temperature",
+            "max_output_tokens",
+            "presence_penalty",
+            "frequency_penalty",
+            "top_p",
+            "top_k",
+        ):
+            if (value := getattr(obj, field)) is not None:
+                parameters[field] = value
+        if obj.stop_sequences is not None:
+            parameters["stop_sequences"] = list(obj.stop_sequences)
+        if obj.thinking_config is not None:
+            parameters["thinking_config"] = _ThinkingConfigConversion.from_google(
+                obj.thinking_config
+            )
+        return v1.PromptGoogleInvocationParameters(type="google", google=parameters)
+
+
+class _ResponseFormatConversion:
+    @staticmethod
+    def from_google(
+        obj: genai_types.GenerateContentConfig,
+    ) -> Optional[v1.PromptResponseFormatJSONSchema]:
+        if obj.response_mime_type != "application/json":
+            return None
+        if obj.response_json_schema is None:
+            raise NotImplementedError(
+                "Google GenAI JSON response formatting requires `response_json_schema`"
+            )
+        return v1.PromptResponseFormatJSONSchema(
+            type="json_schema",
+            json_schema=v1.PromptResponseFormatJSONSchemaDefinition(
+                name="response",
+                schema=cast("Mapping[str, Any]", obj.response_json_schema),
+            ),
+        )
+
 
 class _ToolKwargsConversion:
     @staticmethod
@@ -233,11 +380,17 @@ class _ToolKwargsConversion:
     ) -> Optional[v1.PromptTools]:
         if not obj:
             return None
-        tools: list[v1.PromptToolFunction] = []
+        tools: list[Union[v1.PromptToolFunction, v1.PromptToolRaw]] = []
         if "tools" in obj:
             for tool in obj["tools"]:
                 for fd in tool.function_declarations or ():
                     tools.append(_FunctionDeclarationConversion.from_google(fd))
+                raw = tool.model_dump(exclude_none=True)
+                raw.pop("function_declarations", None)
+                if raw:
+                    tools.append(v1.PromptToolRaw(type="raw", raw=raw))
+        if not tools:
+            return None
         ans = v1.PromptTools(
             type="tools",
             tools=tools,

--- a/packages/phoenix-client/src/phoenix/client/types/prompts.py
+++ b/packages/phoenix-client/src/phoenix/client/types/prompts.py
@@ -26,6 +26,7 @@ from phoenix.client.helpers.sdk.anthropic.messages import (
 )
 from phoenix.client.helpers.sdk.google_genai.generate_content import (
     GoogleGenAIModelKwargs,
+    create_prompt_version_from_google_genai,
 )
 from phoenix.client.helpers.sdk.google_genai.generate_content import (
     to_chat_messages_and_kwargs as to_messages_google_genai,
@@ -213,6 +214,7 @@ class PromptVersion:
             "format",
             "from_openai",
             "from_anthropic",
+            "from_google_genai",
         ]
 
     @property
@@ -387,6 +389,45 @@ class PromptVersion:
         return cls._loads(
             create_prompt_version_from_anthropic(
                 obj,
+                description=description,
+                template_format=template_format,
+                model_provider=model_provider,
+            )
+        )
+
+    @classmethod
+    def from_google_genai(
+        cls,
+        model: str,
+        contents: Sequence[genai_types.Content],
+        /,
+        *,
+        config: Optional[
+            Union[genai_types.GenerateContentConfig, genai_types.GenerateContentConfigDict]
+        ] = None,
+        template_format: Literal["F_STRING", "MUSTACHE", "NONE"] = "MUSTACHE",
+        description: Optional[str] = None,
+        model_provider: Literal["GOOGLE"] = "GOOGLE",
+    ) -> Self:
+        """
+        Creates a prompt version from Google GenAI ``generate_content`` parameters.
+
+        Args:
+            model: The Google model name.
+            contents: The content sequence passed to ``generate_content``.
+            config: Optional Google GenAI generation configuration.
+            template_format: The format of the template to use. Defaults to ``"MUSTACHE"``.
+            description: An optional prompt description.
+            model_provider: The model provider. Defaults to ``"GOOGLE"``.
+
+        Returns:
+            PromptVersion: The prompt version.
+        """
+        return cls._loads(
+            create_prompt_version_from_google_genai(
+                model,
+                contents,
+                config=config,
                 description=description,
                 template_format=template_format,
                 model_provider=model_provider,

--- a/packages/phoenix-client/tests/canary/sdk/google_genai/test_generate_content.py
+++ b/packages/phoenix-client/tests/canary/sdk/google_genai/test_generate_content.py
@@ -18,8 +18,6 @@ from phoenix.client.helpers.sdk.google_genai.generate_content import (
     _ToolKwargsConversion,
     to_chat_messages_and_kwargs,
 )
-from phoenix.client.types import PromptVersion
-from phoenix.client.types.prompts import GoogleGenAIPrompt
 from phoenix.client.utils.template_formatters import NO_OP_FORMATTER
 
 
@@ -372,29 +370,6 @@ class TestToolKwargsGuards:
         )
         assert "tools" not in obj
         assert "tool_config" not in obj
-
-
-class TestPromptVersionFormatting:
-    def test_google_provider_uses_google_genai_by_default(self) -> None:
-        prompt = PromptVersion(
-            [
-                v1.PromptMessage(role="system", content="Be concise."),
-                v1.PromptMessage(role="user", content="Hello"),
-            ],
-            model_name="gemini-2.0-flash",
-            model_provider="GOOGLE",
-            template_format="NONE",
-        )
-
-        formatted = prompt.format()
-
-        assert isinstance(formatted, GoogleGenAIPrompt)
-        assert formatted.kwargs["model"] == "gemini-2.0-flash"
-        assert formatted.kwargs["config"].system_instruction == "Be concise."
-        assert len(formatted.messages) == 1
-        assert isinstance(formatted.messages[0], genai_types.Content)
-        assert formatted.messages[0].role == "user"
-        assert _first_part(formatted.messages[0]).text == "Hello"
 
 
 def _first_part(content: genai_types.Content) -> genai_types.Part:

--- a/packages/phoenix-client/tests/canary/sdk/google_genai/test_generate_content.py
+++ b/packages/phoenix-client/tests/canary/sdk/google_genai/test_generate_content.py
@@ -1,7 +1,7 @@
 # pyright: reportUnknownMemberType=false
 import json
 from secrets import token_hex
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 import pytest
 from deepdiff.diff import DeepDiff
@@ -16,6 +16,7 @@ from phoenix.client.helpers.sdk.google_genai.generate_content import (
     _TextContentPartConversion,
     _ToolKwargs,
     _ToolKwargsConversion,
+    create_prompt_version_from_google_genai,
     to_chat_messages_and_kwargs,
 )
 from phoenix.client.utils.template_formatters import NO_OP_FORMATTER
@@ -234,6 +235,19 @@ class TestToolKwargsConversion:
             new_obj["tool_config"].model_dump(exclude_none=True),
         )
 
+    def test_raw_tool_round_trip(self) -> None:
+        obj: _ToolKwargs = {
+            "tools": [genai_types.Tool(google_search=genai_types.GoogleSearch())],
+        }
+
+        new_obj = _ToolKwargsConversion.to_google(_ToolKwargsConversion.from_google(obj))
+
+        assert "tools" in new_obj
+        assert not DeepDiff(
+            obj["tools"][0].model_dump(exclude_none=True),
+            new_obj["tools"][0].model_dump(exclude_none=True),
+        )
+
 
 class TestToolMessages:
     def test_tool_call_and_result_are_preserved(self) -> None:
@@ -348,6 +362,61 @@ class TestInvocationParameters:
         config = kwargs["config"]
         assert config.response_mime_type == "application/json"
         assert config.response_json_schema == schema
+
+
+class TestPromptVersionConversion:
+    def test_round_trip(self) -> None:
+        schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
+        contents = [genai_types.Content(role="user", parts=[genai_types.Part(text="Hello")])]
+        config = genai_types.GenerateContentConfig(
+            system_instruction="Be concise.",
+            temperature=0.0,
+            max_output_tokens=128,
+            stop_sequences=["END"],
+            thinking_config=genai_types.ThinkingConfig(
+                thinking_budget=1024,
+                include_thoughts=True,
+            ),
+            tools=cast(Any, _TOOLS),
+            tool_config=genai_types.ToolConfig(
+                function_calling_config=genai_types.FunctionCallingConfig(
+                    mode=genai_types.FunctionCallingConfigMode.ANY,
+                )
+            ),
+            response_mime_type="application/json",
+            response_json_schema=schema,
+        )
+
+        prompt = create_prompt_version_from_google_genai(
+            "gemini-2.0-flash",
+            contents,
+            config=config,
+            template_format="NONE",
+        )
+        new_contents, kwargs = to_chat_messages_and_kwargs(prompt)
+
+        assert not DeepDiff(
+            [content.model_dump(exclude_none=True) for content in contents],
+            [content.model_dump(exclude_none=True) for content in new_contents],
+        )
+        assert kwargs["model"] == "gemini-2.0-flash"
+        assert kwargs["config"].system_instruction == "Be concise."
+        assert kwargs["config"].temperature == 0.0
+        assert kwargs["config"].max_output_tokens == 128
+        assert kwargs["config"].stop_sequences == ["END"]
+        assert kwargs["config"].thinking_config is not None
+        assert kwargs["config"].thinking_config.thinking_budget == 1024
+        assert kwargs["config"].thinking_config.include_thoughts is True
+        assert kwargs["config"].response_mime_type == "application/json"
+        assert kwargs["config"].response_json_schema == schema
+
+    def test_unsupported_config_is_rejected(self) -> None:
+        with pytest.raises(NotImplementedError, match="candidate_count"):
+            create_prompt_version_from_google_genai(
+                "gemini-2.0-flash",
+                [genai_types.Content(role="user", parts=[genai_types.Part(text="Hello")])],
+                config=genai_types.GenerateContentConfig(candidate_count=2),
+            )
 
 
 class TestToolKwargsGuards:

--- a/packages/phoenix-client/tests/canary/sdk/google_genai/test_generate_content.py
+++ b/packages/phoenix-client/tests/canary/sdk/google_genai/test_generate_content.py
@@ -18,6 +18,8 @@ from phoenix.client.helpers.sdk.google_genai.generate_content import (
     _ToolKwargsConversion,
     to_chat_messages_and_kwargs,
 )
+from phoenix.client.types import PromptVersion
+from phoenix.client.types.prompts import GoogleGenAIPrompt
 from phoenix.client.utils.template_formatters import NO_OP_FORMATTER
 
 
@@ -370,6 +372,29 @@ class TestToolKwargsGuards:
         )
         assert "tools" not in obj
         assert "tool_config" not in obj
+
+
+class TestPromptVersionFormatting:
+    def test_google_provider_uses_google_genai_by_default(self) -> None:
+        prompt = PromptVersion(
+            [
+                v1.PromptMessage(role="system", content="Be concise."),
+                v1.PromptMessage(role="user", content="Hello"),
+            ],
+            model_name="gemini-2.0-flash",
+            model_provider="GOOGLE",
+            template_format="NONE",
+        )
+
+        formatted = prompt.format()
+
+        assert isinstance(formatted, GoogleGenAIPrompt)
+        assert formatted.kwargs["model"] == "gemini-2.0-flash"
+        assert formatted.kwargs["config"].system_instruction == "Be concise."
+        assert len(formatted.messages) == 1
+        assert isinstance(formatted.messages[0], genai_types.Content)
+        assert formatted.messages[0].role == "user"
+        assert _first_part(formatted.messages[0]).text == "Hello"
 
 
 def _first_part(content: genai_types.Content) -> genai_types.Part:

--- a/tests/integration/client/test_prompts.py
+++ b/tests/integration/client/test_prompts.py
@@ -45,7 +45,6 @@ from openai.types.chat.completion_create_params import CompletionCreateParamsBas
 from openai.types.shared_params import ResponseFormatJSONSchema
 from phoenix.client import Client as _PhoenixClient
 from phoenix.client.types import PromptVersion
-from phoenix.client.types.prompts import GoogleGenAIPrompt
 from phoenix.client.utils.template_formatters import NO_OP_FORMATTER
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from typing_extensions import assert_never
@@ -587,42 +586,23 @@ _CREATE_CHAT_PROMPT = """
 """
 
 
+def _from_google_genai(
+    obj: dict[str, Any],
+    /,
+    *,
+    template_format: Literal["F_STRING", "MUSTACHE", "NONE"],
+    model_provider: Literal["GOOGLE"],
+) -> PromptVersion:
+    return PromptVersion.from_google_genai(
+        obj["model"],
+        cast(Sequence[genai_types.Content], obj["messages"]),
+        config=cast(genai_types.GenerateContentConfig, obj["config"]),
+        template_format=template_format,
+        model_provider=model_provider,
+    )
+
+
 class TestClient:
-    def test_google_genai_default_formatting(
-        self,
-        _app: _AppInfo,
-    ) -> None:
-        api_key = _app.admin_secret
-        prompt = _create_chat_prompt(
-            _app,
-            api_key,
-            messages=[
-                PromptMessageInput(
-                    role="SYSTEM",
-                    content=[ContentPartInput(text=TextContentValueInput(text="Be concise."))],
-                ),
-                PromptMessageInput(
-                    role="USER",
-                    content=[ContentPartInput(text=TextContentValueInput(text="Hello"))],
-                ),
-            ],
-            model_provider="GOOGLE",
-            model_name="gemini-2.0-flash",
-            invocation_parameters={"google": {}},
-        )
-
-        formatted = prompt.format()
-
-        assert isinstance(formatted, GoogleGenAIPrompt)
-        assert formatted.kwargs["model"] == "gemini-2.0-flash"
-        assert formatted.kwargs["config"].system_instruction == "Be concise."
-        assert len(formatted.messages) == 1
-        assert isinstance(formatted.messages[0], genai_types.Content)
-        assert formatted.messages[0].role == "user"
-        assert formatted.messages[0].parts is not None
-        assert formatted.messages[0].parts[0].text == "Hello"
-        _can_recreate_via_client(_app, prompt, api_key)
-
     @pytest.mark.parametrize(
         "template_format",
         ["F_STRING", "MUSTACHE", "NONE"],
@@ -1189,6 +1169,24 @@ class TestClient:
                     tool_choice=ToolChoiceAnyParam(type="any"),
                 ),
                 id="anthropic-tool-result-list",
+            ),
+            pytest.param(
+                "GOOGLE",
+                _from_google_genai,
+                {
+                    "model": "gemini-2.0-flash",
+                    "messages": [
+                        genai_types.Content(
+                            role="user",
+                            parts=[genai_types.Part(text="Write a poem about {topic}.")],
+                        )
+                    ],
+                    "config": genai_types.GenerateContentConfig(
+                        system_instruction="You are {role}.",
+                        temperature=0.0,
+                    ),
+                },
+                id="google-genai-system-instruction",
             ),
         ],
     )

--- a/tests/integration/client/test_prompts.py
+++ b/tests/integration/client/test_prompts.py
@@ -33,6 +33,7 @@ from anthropic.types import (
 )
 from anthropic.types.message_create_params import MessageCreateParamsBase
 from deepdiff.diff import DeepDiff
+from google.genai import types as genai_types
 from openai import pydantic_function_tool
 from openai.lib._parsing import type_to_response_format_param
 from openai.types.chat import (
@@ -44,6 +45,7 @@ from openai.types.chat.completion_create_params import CompletionCreateParamsBas
 from openai.types.shared_params import ResponseFormatJSONSchema
 from phoenix.client import Client as _PhoenixClient
 from phoenix.client.types import PromptVersion
+from phoenix.client.types.prompts import GoogleGenAIPrompt
 from phoenix.client.utils.template_formatters import NO_OP_FORMATTER
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from typing_extensions import assert_never
@@ -586,6 +588,41 @@ _CREATE_CHAT_PROMPT = """
 
 
 class TestClient:
+    def test_google_genai_default_formatting(
+        self,
+        _app: _AppInfo,
+    ) -> None:
+        api_key = _app.admin_secret
+        prompt = _create_chat_prompt(
+            _app,
+            api_key,
+            messages=[
+                PromptMessageInput(
+                    role="SYSTEM",
+                    content=[ContentPartInput(text=TextContentValueInput(text="Be concise."))],
+                ),
+                PromptMessageInput(
+                    role="USER",
+                    content=[ContentPartInput(text=TextContentValueInput(text="Hello"))],
+                ),
+            ],
+            model_provider="GOOGLE",
+            model_name="gemini-2.0-flash",
+            invocation_parameters={"google": {}},
+        )
+
+        formatted = prompt.format()
+
+        assert isinstance(formatted, GoogleGenAIPrompt)
+        assert formatted.kwargs["model"] == "gemini-2.0-flash"
+        assert formatted.kwargs["config"].system_instruction == "Be concise."
+        assert len(formatted.messages) == 1
+        assert isinstance(formatted.messages[0], genai_types.Content)
+        assert formatted.messages[0].role == "user"
+        assert formatted.messages[0].parts is not None
+        assert formatted.messages[0].parts[0].text == "Hello"
+        _can_recreate_via_client(_app, prompt, api_key)
+
     @pytest.mark.parametrize(
         "template_format",
         ["F_STRING", "MUSTACHE", "NONE"],


### PR DESCRIPTION
## Summary

- Add public-API coverage for `PromptVersion.format()` with `model_provider="GOOGLE"`.
- Verify that default Google formatting returns `GoogleGenAIPrompt`, extracts the system instruction, and emits `google.genai.types.Content`.

## Test plan

- `uvx tox run -e phoenix_client_canary_tests_sdk_google_genai`