### PR TITLE
fix(server): classify Google errors and correct release version

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2699,25 +2699,17 @@ class GoogleStreamingClient(PlaygroundStreamingClient["GoogleAsyncClient"]):
 
     @override
     def is_rate_limit_error(self, e: Exception) -> bool:
-        # The Interactions API raises RateLimitError for HTTP 429 responses.
-        from google.genai._interactions._exceptions import RateLimitError
+        from google.genai.errors import APIError
 
-        return isinstance(e, RateLimitError)
+        return isinstance(e, APIError) and e.code == 429
 
     @override
     def is_transient_error(self, e: Exception) -> bool:
-        from google.genai._interactions._exceptions import (
-            APIConnectionError,
-            APITimeoutError,
-            InternalServerError,
-        )
+        from google.genai.errors import APIError
 
-        if isinstance(e, (APIConnectionError, APITimeoutError, InternalServerError)):
-            return True
-        status_code = getattr(e, "status_code", None)
-        if status_code and 500 <= status_code < 600:
-            return True
-        return False
+        if isinstance(e, APIError):
+            return 500 <= e.code < 600
+        return super().is_transient_error(e)
 
     @override
     def get_rate_limit_key(self) -> Hashable:

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2699,7 +2699,7 @@ class GoogleStreamingClient(PlaygroundStreamingClient["GoogleAsyncClient"]):
 
     @override
     def is_rate_limit_error(self, e: Exception) -> bool:
-        # Google GenAI uses Stainless SDK with RateLimitError (429)
+        # The Interactions API raises RateLimitError for HTTP 429 responses.
         from google.genai._interactions._exceptions import RateLimitError
 
         return isinstance(e, RateLimitError)

--- a/src/phoenix/version.py
+++ b/src/phoenix/version.py
@@ -1,2 +1,1 @@
-# Managed by Release Please.
 __version__ = "19.21.0"

--- a/src/phoenix/version.py
+++ b/src/phoenix/version.py
@@ -1,1 +1,2 @@
+# Managed by Release Please.
 __version__ = "19.21.0"

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -41,6 +41,7 @@ from phoenix.server.api.helpers.playground_clients import (
     AzureOpenAIReasoningNonStreamingClient,
     AzureOpenAIResponsesAPIStreamingClient,
     AzureOpenAIStreamingClient,
+    GoogleStreamingClient,
     OpenAIBaseStreamingClient,
     OpenAIReasoningNonStreamingClient,
     OpenAIResponsesAPIStreamingClient,
@@ -56,6 +57,25 @@ from phoenix.server.api.types.ChatCompletionSubscriptionPayload import TextChunk
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 from phoenix.server.types import DbSessionFactory
 from tests.unit.vcr import CustomVCR
+
+
+class TestGoogleStreamingClient:
+    @pytest.fixture
+    def client(self) -> GoogleStreamingClient:
+        return object.__new__(GoogleStreamingClient)
+
+    def test_rate_limit_error(self, client: GoogleStreamingClient) -> None:
+        from google.genai.errors import ClientError
+
+        assert client.is_rate_limit_error(ClientError(429, {}))
+        assert not client.is_rate_limit_error(ClientError(400, {}))
+
+    def test_transient_error(self, client: GoogleStreamingClient) -> None:
+        from google.genai.errors import ClientError, ServerError
+
+        assert client.is_transient_error(ServerError(500, {}))
+        assert not client.is_transient_error(ClientError(400, {}))
+        assert client.is_transient_error(TimeoutError())
 
 
 class TestOpenAIBaseStreamingClient:


### PR DESCRIPTION
## Summary
- classify Google generate-content errors through the public `google.genai.errors` API
- preserve timeout and connection retry handling through the shared fallback
- force the next `arize-phoenix` release to 19.22.0 while keeping the Google formatter breaking change scoped to `arize-phoenix-client` 3.0.0

## Test plan
- [x] `uv run pytest tests/unit/server/api/helpers/test_playground_clients.py -k TestGoogleStreamingClient -q`
- [x] `uv run ruff check src/phoenix/server/api/helpers/playground_clients.py tests/unit/server/api/helpers/test_playground_clients.py`
- [ ] Confirm Release Please updates root release PR #15288 to 19.22.0
- [ ] Confirm client release PR #14304 remains 3.0.0

Release-As: 19.22.0