### PR TITLE
fix(ci): regenerate UI message stream fixtures for ai@7.0.58

### DIFF
--- a/tests/unit/server/agents/fixtures/ui_message_stream/fixtures.json
+++ b/tests/unit/server/agents/fixtures/ui_message_stream/fixtures.json
@@ -1,6 +1,6 @@
 [
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > text",
     "input": {
@@ -105,7 +105,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > errors",
     "input": {
@@ -121,7 +121,7 @@
     "writes": []
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when text-delta is received without text-start",
     "input": {
@@ -156,7 +156,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when reasoning-delta is received without reasoning-start",
     "input": {
@@ -191,7 +191,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when tool-input-delta is received without tool-input-start",
     "input": {
@@ -226,7 +226,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should not read Object.prototype for missing text part ids",
     "input": {
@@ -261,7 +261,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should not read Object.prototype for missing reasoning part ids",
     "input": {
@@ -296,7 +296,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should not read Object.prototype for missing partial tool call ids",
     "input": {
@@ -331,7 +331,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when text-end is received without text-start",
     "input": {
@@ -365,7 +365,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when reasoning-end is received without reasoning-start",
     "input": {
@@ -399,7 +399,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw UIMessageStreamError with correct properties for text-delta without text-start",
     "input": {
@@ -434,7 +434,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw UIMessageStreamError with correct properties for tool-input-delta without tool-input-start",
     "input": {
@@ -469,7 +469,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip",
     "input": {
@@ -655,7 +655,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with existing assistant message",
     "input": {
@@ -910,7 +910,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with multiple assistant texts",
     "input": {
@@ -1233,7 +1233,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with multiple assistant reasoning",
     "input": {
@@ -1735,7 +1735,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with output-error",
     "input": {
@@ -1911,7 +1911,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > message metadata",
     "input": {
@@ -2119,7 +2119,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > message metadata delayed after finish",
     "input": {
@@ -2228,7 +2228,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > message metadata with existing assistant lastMessage",
     "input": {
@@ -2346,7 +2346,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool call streaming",
     "input": {
@@ -2488,7 +2488,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > start with message id",
     "input": {
@@ -2593,7 +2593,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > reasoning",
     "input": {
@@ -3127,7 +3127,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > onToolCall is executed",
     "input": {
@@ -3183,7 +3183,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > sources",
     "input": {
@@ -3295,7 +3295,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > file parts",
     "input": {
@@ -3524,7 +3524,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > file parts with providerMetadata",
     "input": {
@@ -3613,7 +3613,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (single part)",
     "input": {
@@ -3661,7 +3661,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (transient part)",
     "input": {
@@ -3697,7 +3697,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (single part with id and replacement update)",
     "input": {
@@ -3766,7 +3766,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (single part with id and merge update)",
     "input": {
@@ -3847,7 +3847,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed static tools",
     "input": {
@@ -4054,7 +4054,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed static tools > should preserve separate call and result provider metadata for static tools",
     "input": {
@@ -4166,7 +4166,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed dynamic tools",
     "input": {
@@ -4386,7 +4386,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed dynamic tools > should preserve separate call and result provider metadata for dynamic tools",
     "input": {
@@ -4498,7 +4498,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed dynamic tools > should preserve tool metadata on dynamic tool parts",
     "input": {
@@ -4594,7 +4594,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > should call onToolCall for client-executed tools",
     "input": {
@@ -4650,7 +4650,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > dynamic tools",
     "input": {
@@ -4863,7 +4863,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider metadata",
     "input": {
@@ -5062,7 +5062,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > provider metadata during input-streaming",
     "input": {
@@ -5204,7 +5204,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool input error",
     "input": {
@@ -5314,7 +5314,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool input error with dynamic flag mismatch",
     "input": {
@@ -5425,7 +5425,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > preliminary tool results",
     "input": {
@@ -5570,7 +5570,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool title support > static tool with title",
     "input": {
@@ -5696,7 +5696,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool title support > dynamic tool with title",
     "input": {
@@ -5837,7 +5837,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool title support > tool with title in error state",
     "input": {
@@ -5940,7 +5940,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval requests (static tool)",
     "input": {
@@ -6015,7 +6015,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval requests (dynamic tool)",
     "input": {
@@ -6093,7 +6093,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval request with signature",
     "input": {
@@ -6170,7 +6170,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval response with signature",
     "input": {
@@ -6274,7 +6274,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval request without signature",
     "input": {
@@ -6349,7 +6349,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > automatic tool approval denial (static tool)",
     "input": {
@@ -6482,7 +6482,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > automatic tool approval with execution (dynamic tool)",
     "input": {
@@ -6622,7 +6622,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > initial tool execution after approval (static tool)",
     "input": {
@@ -6797,7 +6797,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > initial tool execution after approval (dynamic tool)",
     "input": {
@@ -6978,7 +6978,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > initial tool execution with preliminary results after approval (static tool)",
     "input": {
@@ -7211,7 +7211,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool execution denial (static tool)",
     "input": {
@@ -7381,7 +7381,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > tool execution denial (dynamic tool)",
     "input": {
@@ -7556,7 +7556,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "upstream",
     "name": "processUIMessageStream > custom",
     "input": {
@@ -7605,7 +7605,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix custom chunks > durable error part and standard error",
     "input": {
@@ -7649,7 +7649,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix custom chunks > transient session and persistence events",
     "input": {
@@ -7683,7 +7683,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix protocol passthrough > abort and done do not change the message",
     "input": {
@@ -7712,7 +7712,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix protocol coverage > source document",
     "input": {
@@ -7745,7 +7745,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix stream > interleaved preliminary subagent output",
     "input": {
@@ -7974,7 +7974,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix stream > forced skill step before model output",
     "input": {
@@ -8147,7 +8147,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix stream > typed assistant metadata",
     "input": {
@@ -8195,7 +8195,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.48",
+    "upstreamTag": "ai@7.0.58",
     "source": "phoenix",
     "name": "Phoenix stream > client tool continuation",
     "input": {


### PR DESCRIPTION
## Summary

Fixes the Typescript CI failure on `version-agent-session-persistence` (#14143).

The **UI Message Stream Fixture Codegen** job failed because the committed `tests/unit/server/agents/fixtures/ui_message_stream/fixtures.json` was generated against `ai@7.0.48`, while the lockfile now resolves `ai@7.0.58`. Re-running `make ui-message-stream-fixtures` changes only the 67 `upstreamTag` provenance fields — no fixture content changes. Nothing asserts on `upstreamTag`, and the full `app` test suite passes locally after the regen.

## CI failures intentionally left alone

- **OpenAPI Schema Backward Compatibility** — fails because the branch deletes the legacy `/agents/{agent_id}/sessions/{session_id}/chat` and `.../summary` endpoints. This check is not required and red is the established outcome for intentional `feat!:` endpoint removals: #13140 and #12538 both merged with it failing.
- **PXI Evals** — pre-existing failures on this branch (failing on every run since Aug 4), out of scope per discussion.

Python CI, Playwright, and all other checks pass on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)