### PR TITLE
feat(online-evals): LLM project evaluator details page

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -20,6 +20,9 @@ import {
 } from "@phoenix/pages/dataset/evaluators/EvaluatorTracePage";
 import { EvaluatorsPage } from "@phoenix/pages/evaluators/EvaluatorsPage";
 import { evaluatorsPageLoader } from "@phoenix/pages/evaluators/evaluatorsPageLoader";
+import type { ProjectEvaluatorDetailsLoaderData } from "@phoenix/pages/project/evaluators/projectEvaluatorDetailsLoader";
+import { projectEvaluatorDetailsLoader } from "@phoenix/pages/project/evaluators/projectEvaluatorDetailsLoader";
+import { ProjectEvaluatorDetailsPage } from "@phoenix/pages/project/evaluators/ProjectEvaluatorDetailsPage";
 import { RootLayout } from "@phoenix/pages/RootLayout";
 import { settingsPromptsPageLoader } from "@phoenix/pages/settings/prompts/settingsPromptsPageLoader";
 import { RetentionPolicyDetailsDrawer } from "@phoenix/pages/settings/RetentionPolicyDetailsDrawer";
@@ -149,6 +152,19 @@ const revalidateOnPathChange: ShouldRevalidateFunction = ({
   defaultShouldRevalidate,
 }) => {
   if (currentUrl.pathname === nextUrl.pathname) return false;
+  return defaultShouldRevalidate;
+};
+
+// Re-run the loader when a navigation comes back up from a nested child route
+// — above all closing an edit slideover, which must show fresh data on the
+// page beneath it — while leaving descents into the child to the default
+// (which skips them, since the params don't change).
+const revalidateOnReturnFromChildRoute: ShouldRevalidateFunction = ({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}) => {
+  if (currentUrl.pathname.startsWith(`${nextUrl.pathname}/`)) return true;
   return defaultShouldRevalidate;
 };
 
@@ -510,8 +526,39 @@ export const appRouteObjects = createRoutesFromElements(
                     },
                   }}
                 />
+              </Route>
+            </Route>
+            {/* The evaluator details page is a full page rather than a tab,
+                mirroring the dataset evaluator details route. The edit
+                slideover nests beneath it so it opens over the details view. */}
+            <Route
+              path="evaluators"
+              handle={{
+                crumb: () => "evaluators",
+                agentRoute: {
+                  label: "Project Evaluators",
+                  description:
+                    "Create and manage project evaluators — online evals that automatically run against live spans.",
+                },
+              }}
+            >
+              <Route
+                path=":projectEvaluatorId"
+                element={<ProjectEvaluatorDetailsPage />}
+                loader={projectEvaluatorDetailsLoader}
+                shouldRevalidate={revalidateOnReturnFromChildRoute}
+                handle={{
+                  crumb: (data: ProjectEvaluatorDetailsLoaderData) =>
+                    data?.evaluatorDisplayName || "evaluator",
+                  agentRoute: {
+                    label: "Project Evaluator Details",
+                    description:
+                      "Inspect a project evaluator's configuration and scope policy — model, prompt template, output configs, input mapping, evaluation target, filter condition, sampling rate, and enabled state. The projectEvaluatorId route param uses the GraphQL ProjectEvaluator.id Relay node ID, not the underlying Evaluator.id.",
+                  },
+                }}
+              >
                 <Route
-                  path=":projectEvaluatorId/edit"
+                  path="edit"
                   element={<EditProjectEvaluatorPage />}
                   handle={{
                     agentRoute: {

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -155,19 +155,6 @@ const revalidateOnPathChange: ShouldRevalidateFunction = ({
   return defaultShouldRevalidate;
 };
 
-// Re-run the loader when a navigation comes back up from a nested child route
-// — above all closing an edit slideover, which must show fresh data on the
-// page beneath it — while leaving descents into the child to the default
-// (which skips them, since the params don't change).
-const revalidateOnReturnFromChildRoute: ShouldRevalidateFunction = ({
-  currentUrl,
-  nextUrl,
-  defaultShouldRevalidate,
-}) => {
-  if (currentUrl.pathname.startsWith(`${nextUrl.pathname}/`)) return true;
-  return defaultShouldRevalidate;
-};
-
 // :projectId's loader depends only on its own param. Same-URL requests
 // (useRevalidator) defer to the router's default so manual revalidation works.
 export const revalidateOnProjectChange: ShouldRevalidateFunction = ({
@@ -546,7 +533,6 @@ export const appRouteObjects = createRoutesFromElements(
                 path=":projectEvaluatorId"
                 element={<ProjectEvaluatorDetailsPage />}
                 loader={projectEvaluatorDetailsLoader}
-                shouldRevalidate={revalidateOnReturnFromChildRoute}
                 handle={{
                   crumb: (data: ProjectEvaluatorDetailsLoaderData) =>
                     data?.evaluatorDisplayName || "evaluator",

--- a/app/src/components/evaluators/EvaluatorDetailsSection.tsx
+++ b/app/src/components/evaluators/EvaluatorDetailsSection.tsx
@@ -1,0 +1,67 @@
+import { css } from "@emotion/react";
+
+import { Flex, Heading, Text } from "@phoenix/components";
+
+/**
+ * The bordered card wrapping each section of a read-only evaluator details
+ * view, shared by the dataset and project evaluator details pages.
+ */
+export const evaluatorDetailsCardCSS = css`
+  border-radius: var(--global-rounding-medium);
+  padding: var(--global-dimension-size-200);
+  margin-top: var(--global-dimension-size-50);
+  border: 1px solid var(--global-border-color-default);
+  overflow: hidden;
+`;
+
+/**
+ * Read-only list of an evaluator's input mapping: which evaluator inputs map
+ * to which paths on the evaluated payload, plus any fixed literal values.
+ * Renders nothing when both mappings are empty.
+ */
+export function EvaluatorInputMappingDetails({
+  inputMapping,
+}: {
+  inputMapping: {
+    literalMapping?: Record<string, boolean | string | number> | null;
+    pathMapping?: Record<string, string> | null;
+  } | null;
+}) {
+  const literalMapping = inputMapping?.literalMapping;
+  const pathMapping = inputMapping?.pathMapping;
+
+  const hasLiteralMapping =
+    literalMapping && Object.keys(literalMapping).length > 0;
+  const hasPathMapping = pathMapping && Object.keys(pathMapping).length > 0;
+
+  if (!hasLiteralMapping && !hasPathMapping) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column" gap="size-100">
+      <Heading level={2}>Input Mapping</Heading>
+      <div css={evaluatorDetailsCardCSS}>
+        <Flex direction="column" gap="size-100">
+          {pathMapping &&
+            Object.entries(pathMapping).map(([key, value]) => (
+              <Text key={key} size="S">
+                <Text weight="heavy">{key}:</Text> {value || "Not mapped"}
+              </Text>
+            ))}
+          {literalMapping &&
+            Object.entries(literalMapping).map(([key, value]) => (
+              <Text key={key} size="S">
+                <Text weight="heavy">{key}:</Text>{" "}
+                {typeof value === "boolean"
+                  ? value
+                    ? "Yes"
+                    : "No"
+                  : String(value)}
+              </Text>
+            ))}
+        </Flex>
+      </div>
+    </Flex>
+  );
+}

--- a/app/src/pages/dataset/evaluators/LLMDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/LLMDatasetEvaluatorDetails.tsx
@@ -1,9 +1,12 @@
-import { css } from "@emotion/react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
 import { Flex, Heading, Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import {
+  evaluatorDetailsCardCSS,
+  EvaluatorInputMappingDetails,
+} from "@phoenix/components/evaluators/EvaluatorDetailsSection";
 import { inferIncludeExplanationFromPrompt } from "@phoenix/components/evaluators/utils";
 import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { PromptChatMessages } from "@phoenix/components/prompt/PromptChatMessagesCard";
@@ -95,15 +98,7 @@ export function LLMDatasetEvaluatorDetails({
           return (
             <Flex direction="column" gap="size-100">
               <Heading level={2}>Evaluator Annotation</Heading>
-              <div
-                css={css`
-                  border-radius: var(--global-rounding-medium);
-                  padding: var(--global-dimension-size-200);
-                  margin-top: var(--global-dimension-size-50);
-                  border: 1px solid var(--global-border-color-default);
-                  overflow: hidden;
-                `}
-              >
+              <div css={evaluatorDetailsCardCSS}>
                 <Flex direction="column" gap="size-100">
                   <Truncate title={outputConfig.name}>
                     <Text size="S">
@@ -167,61 +162,7 @@ export function LLMDatasetEvaluatorDetails({
           <PromptChatMessages promptVersion={evaluator.promptVersion} />
         )}
       </Flex>
-      <LLMEvaluatorInputMapping inputMapping={inputMapping} />
-    </Flex>
-  );
-}
-
-function LLMEvaluatorInputMapping({
-  inputMapping,
-}: {
-  inputMapping: {
-    literalMapping?: Record<string, boolean | string | number> | null;
-    pathMapping?: Record<string, string> | null;
-  } | null;
-}) {
-  const literalMapping = inputMapping?.literalMapping;
-  const pathMapping = inputMapping?.pathMapping;
-
-  const hasLiteralMapping =
-    literalMapping && Object.keys(literalMapping).length > 0;
-  const hasPathMapping = pathMapping && Object.keys(pathMapping).length > 0;
-
-  if (!hasLiteralMapping && !hasPathMapping) {
-    return null;
-  }
-
-  return (
-    <Flex direction="column" gap="size-100">
-      <Heading level={2}>Input Mapping</Heading>
-      <div
-        css={css`
-          border-radius: var(--global-rounding-medium);
-          padding: var(--global-dimension-size-200);
-          margin-top: var(--global-dimension-size-50);
-          border: 1px solid var(--global-border-color-default);
-        `}
-      >
-        <Flex direction="column" gap="size-100">
-          {pathMapping &&
-            Object.entries(pathMapping).map(([key, value]) => (
-              <Text key={key} size="S">
-                <Text weight="heavy">{key}:</Text> {value || "Not mapped"}
-              </Text>
-            ))}
-          {literalMapping &&
-            Object.entries(literalMapping).map(([key, value]) => (
-              <Text key={key} size="S">
-                <Text weight="heavy">{key}:</Text>{" "}
-                {typeof value === "boolean"
-                  ? value
-                    ? "Yes"
-                    : "No"
-                  : String(value)}
-              </Text>
-            ))}
-        </Flex>
-      </div>
+      <EvaluatorInputMappingDetails inputMapping={inputMapping} />
     </Flex>
   );
 }

--- a/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { ModalOverlayProps } from "react-aria-components";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
+import { useRevalidator } from "react-router";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
@@ -311,6 +312,10 @@ function EditLlmProjectEvaluatorContent({
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
 }) {
   const notifySuccess = useNotifySuccess();
+  // The mutation payload carries only the scope scalars; the details page
+  // beneath this slideover also renders the prompt and output configs, so
+  // re-run its loader once the save lands.
+  const { revalidate } = useRevalidator();
   const playgroundStore = usePlaygroundStore();
   const instanceId = usePlaygroundContext((state) => state.instances[0].id);
   invariant(instanceId != null, "instanceId is required");
@@ -406,6 +411,7 @@ function EditLlmProjectEvaluatorContent({
         },
         onCompleted: () => {
           notifySuccess({ title: "Evaluator updated" });
+          void revalidate();
           onClose();
           resolve({
             ok: true,
@@ -484,6 +490,8 @@ function EditCodeProjectEvaluator({
   const initialInputMappingJson = JSON.stringify(evaluator.inputMapping);
   const [scope, setScope] = useState(() => getScope(evaluator));
   const [error, setError] = useState<string>();
+  // See the LLM edit path: the details page loader must re-run after a save.
+  const { revalidate } = useRevalidator();
   const trackStoreForDirtyCheck = useEvaluatorFormDirtyCheck({
     registerDirtyCheck,
     scope,
@@ -635,6 +643,7 @@ function EditCodeProjectEvaluator({
                 },
                 onCompleted: () => {
                   notifySuccess({ title: "Evaluator updated" });
+                  void revalidate();
                   onClose();
                 },
                 onError: (mutationError) =>

--- a/app/src/pages/project/evaluators/LLMProjectEvaluatorDetails.tsx
+++ b/app/src/pages/project/evaluators/LLMProjectEvaluatorDetails.tsx
@@ -1,0 +1,283 @@
+import { css } from "@emotion/react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import { Flex, Heading, Text } from "@phoenix/components";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { inferIncludeExplanationFromPrompt } from "@phoenix/components/evaluators/utils";
+import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
+import { PromptChatMessages } from "@phoenix/components/prompt/PromptChatMessagesCard";
+import { PromptLink } from "@phoenix/pages/evaluators/PromptCell";
+import { readPromptInvocationParameters } from "@phoenix/pages/playground/PromptInvocationParametersReadableFragment";
+import type {
+  LLMProjectEvaluatorDetails_projectEvaluator$data,
+  LLMProjectEvaluatorDetails_projectEvaluator$key,
+} from "@phoenix/pages/project/evaluators/__generated__/LLMProjectEvaluatorDetails_projectEvaluator.graphql";
+
+const sectionCardCSS = css`
+  border-radius: var(--global-rounding-medium);
+  padding: var(--global-dimension-size-200);
+  margin-top: var(--global-dimension-size-50);
+  border: 1px solid var(--global-border-color-default);
+  overflow: hidden;
+`;
+
+/**
+ * Read-only view of an LLM project evaluator's configuration: the annotation
+ * it produces, the prompt and model it runs, and the span-to-prompt input
+ * mapping. Mirrors LLMDatasetEvaluatorDetails, but a project evaluator keeps
+ * its input mapping on the ProjectEvaluator rather than the evaluator itself.
+ */
+export function LLMProjectEvaluatorDetails({
+  projectEvaluatorRef,
+}: {
+  projectEvaluatorRef: LLMProjectEvaluatorDetails_projectEvaluator$key;
+}) {
+  const projectEvaluator = useFragment(
+    graphql`
+      fragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {
+        id
+        inputMapping {
+          literalMapping
+          pathMapping
+        }
+        evaluator {
+          kind
+          ... on LLMEvaluator {
+            prompt {
+              id
+              name
+            }
+            promptVersion {
+              modelName
+              modelProvider
+              invocationParameters {
+                ...PromptInvocationParametersReadableFragment
+              }
+              tools {
+                tools {
+                  __typename
+                  ... on PromptToolFunction {
+                    function {
+                      parameters
+                    }
+                  }
+                  ... on PromptToolRaw {
+                    raw
+                  }
+                }
+              }
+              ...PromptChatMessagesCard__main
+            }
+            promptVersionTag {
+              name
+            }
+            outputConfigs {
+              __typename
+              ... on CategoricalAnnotationConfig {
+                name
+                optimizationDirection
+                values {
+                  label
+                  score
+                }
+              }
+              ... on ContinuousAnnotationConfig {
+                name
+                optimizationDirection
+                lowerBound
+                upperBound
+              }
+              ... on FreeformAnnotationConfig {
+                name
+                optimizationDirection
+              }
+            }
+          }
+        }
+      }
+    `,
+    projectEvaluatorRef
+  );
+
+  const evaluator = projectEvaluator.evaluator;
+  const inputMapping = projectEvaluator.inputMapping;
+
+  if (evaluator.kind !== "LLM") {
+    throw new Error("LLMProjectEvaluatorDetails called for non-LLM evaluator");
+  }
+
+  const includeExplanation = inferIncludeExplanationFromPrompt(
+    evaluator.promptVersion?.tools
+  );
+  const outputConfig = evaluator.outputConfigs?.[0];
+  const invocationParameters = readPromptInvocationParameters(
+    evaluator.promptVersion?.invocationParameters
+  )?.parameters;
+  const invocationParameterEntries = Object.entries(
+    invocationParameters ?? {}
+  ).filter(([, value]) => value != null);
+
+  return (
+    <Flex direction="column" gap="size-300">
+      {outputConfig && (
+        <EvaluatorAnnotationSection
+          outputConfig={outputConfig}
+          includeExplanation={includeExplanation}
+        />
+      )}
+      <Flex direction="column" gap="size-100">
+        <Heading level={2}>Prompt</Heading>
+        <Flex justifyContent="space-between" alignItems="center">
+          {evaluator.prompt?.id && evaluator.prompt.name ? (
+            <PromptLink
+              promptId={evaluator.prompt.id}
+              promptName={evaluator.prompt.name}
+              promptVersionTag={evaluator.promptVersionTag?.name}
+            />
+          ) : (
+            <div />
+          )}
+          {evaluator.promptVersion?.modelName && (
+            <Flex alignItems="center" gap="size-50">
+              <GenerativeProviderIcon
+                provider={evaluator.promptVersion.modelProvider}
+                height={14}
+              />
+              <Text size="S" color="text-700">
+                {evaluator.promptVersion.modelName}
+              </Text>
+            </Flex>
+          )}
+        </Flex>
+        {invocationParameterEntries.length > 0 && (
+          <Flex justifyContent="end" gap="size-100" wrap>
+            {invocationParameterEntries.map(([name, value]) => (
+              <Text key={name} size="XS" color="text-700" fontFamily="mono">
+                {name}:{" "}
+                {typeof value === "object"
+                  ? JSON.stringify(value)
+                  : String(value)}
+              </Text>
+            ))}
+          </Flex>
+        )}
+        {evaluator.promptVersion && (
+          <PromptChatMessages promptVersion={evaluator.promptVersion} />
+        )}
+      </Flex>
+      <ProjectEvaluatorInputMapping inputMapping={inputMapping} />
+    </Flex>
+  );
+}
+
+type OutputConfig = NonNullable<
+  LLMProjectEvaluatorDetails_projectEvaluator$data["evaluator"]["outputConfigs"]
+>[number];
+
+function EvaluatorAnnotationSection({
+  outputConfig,
+  includeExplanation,
+}: {
+  outputConfig: OutputConfig;
+  includeExplanation: boolean;
+}) {
+  if (outputConfig.__typename === "%other") {
+    return null;
+  }
+  return (
+    <Flex direction="column" gap="size-100">
+      <Heading level={2}>Evaluator Annotation</Heading>
+      <div css={sectionCardCSS}>
+        <Flex direction="column" gap="size-100">
+          <Truncate title={outputConfig.name}>
+            <Text size="S">
+              <Text weight="heavy">Name:</Text> {outputConfig.name}
+            </Text>
+          </Truncate>
+          {outputConfig.optimizationDirection && (
+            <Text size="S">
+              <Text weight="heavy">Optimization Direction:</Text>{" "}
+              {outputConfig.optimizationDirection}
+            </Text>
+          )}
+          {outputConfig.__typename === "CategoricalAnnotationConfig" &&
+            outputConfig.values.length > 0 && (
+              <Text>
+                <Text size="S" weight="heavy">
+                  Values:{" "}
+                </Text>
+                {outputConfig.values.map((v, valIdx, arr) => (
+                  <Text key={valIdx} size="S">
+                    {v.label}
+                    {v.score != null ? ` (${v.score})` : ""}
+                    {valIdx < arr.length - 1 ? ", " : ""}
+                  </Text>
+                ))}
+              </Text>
+            )}
+          {outputConfig.__typename === "ContinuousAnnotationConfig" &&
+            (outputConfig.lowerBound != null ||
+              outputConfig.upperBound != null) && (
+              <Text size="S">
+                <Text weight="heavy">Range:</Text>{" "}
+                {outputConfig.lowerBound ?? "-∞"} to{" "}
+                {outputConfig.upperBound ?? "∞"}
+              </Text>
+            )}
+          <Text size="S">
+            <Text weight="heavy">Explanations:</Text>{" "}
+            {includeExplanation ? "Enabled" : "Disabled"}
+          </Text>
+        </Flex>
+      </div>
+    </Flex>
+  );
+}
+
+function ProjectEvaluatorInputMapping({
+  inputMapping,
+}: {
+  inputMapping: {
+    literalMapping?: Record<string, boolean | string | number> | null;
+    pathMapping?: Record<string, string> | null;
+  } | null;
+}) {
+  const literalMapping = inputMapping?.literalMapping;
+  const pathMapping = inputMapping?.pathMapping;
+
+  const hasLiteralMapping =
+    literalMapping && Object.keys(literalMapping).length > 0;
+  const hasPathMapping = pathMapping && Object.keys(pathMapping).length > 0;
+
+  if (!hasLiteralMapping && !hasPathMapping) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column" gap="size-100">
+      <Heading level={2}>Input Mapping</Heading>
+      <div css={sectionCardCSS}>
+        <Flex direction="column" gap="size-100">
+          {pathMapping &&
+            Object.entries(pathMapping).map(([key, value]) => (
+              <Text key={key} size="S">
+                <Text weight="heavy">{key}:</Text> {value || "Not mapped"}
+              </Text>
+            ))}
+          {literalMapping &&
+            Object.entries(literalMapping).map(([key, value]) => (
+              <Text key={key} size="S">
+                <Text weight="heavy">{key}:</Text>{" "}
+                {typeof value === "boolean"
+                  ? value
+                    ? "Yes"
+                    : "No"
+                  : String(value)}
+              </Text>
+            ))}
+        </Flex>
+      </div>
+    </Flex>
+  );
+}

--- a/app/src/pages/project/evaluators/LLMProjectEvaluatorDetails.tsx
+++ b/app/src/pages/project/evaluators/LLMProjectEvaluatorDetails.tsx
@@ -1,9 +1,12 @@
-import { css } from "@emotion/react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
 import { Flex, Heading, Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import {
+  evaluatorDetailsCardCSS,
+  EvaluatorInputMappingDetails,
+} from "@phoenix/components/evaluators/EvaluatorDetailsSection";
 import { inferIncludeExplanationFromPrompt } from "@phoenix/components/evaluators/utils";
 import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { PromptChatMessages } from "@phoenix/components/prompt/PromptChatMessagesCard";
@@ -13,14 +16,7 @@ import type {
   LLMProjectEvaluatorDetails_projectEvaluator$data,
   LLMProjectEvaluatorDetails_projectEvaluator$key,
 } from "@phoenix/pages/project/evaluators/__generated__/LLMProjectEvaluatorDetails_projectEvaluator.graphql";
-
-const sectionCardCSS = css`
-  border-radius: var(--global-rounding-medium);
-  padding: var(--global-dimension-size-200);
-  margin-top: var(--global-dimension-size-50);
-  border: 1px solid var(--global-border-color-default);
-  overflow: hidden;
-`;
+import { safelyStringifyJSON } from "@phoenix/utils/jsonUtils";
 
 /**
  * Read-only view of an LLM project evaluator's configuration: the annotation
@@ -36,7 +32,6 @@ export function LLMProjectEvaluatorDetails({
   const projectEvaluator = useFragment(
     graphql`
       fragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {
-        id
         inputMapping {
           literalMapping
           pathMapping
@@ -61,9 +56,6 @@ export function LLMProjectEvaluatorDetails({
                     function {
                       parameters
                     }
-                  }
-                  ... on PromptToolRaw {
-                    raw
                   }
                 }
               }
@@ -155,9 +147,9 @@ export function LLMProjectEvaluatorDetails({
             {invocationParameterEntries.map(([name, value]) => (
               <Text key={name} size="XS" color="text-700" fontFamily="mono">
                 {name}:{" "}
-                {typeof value === "object"
-                  ? JSON.stringify(value)
-                  : String(value)}
+                {typeof value === "string"
+                  ? value
+                  : (safelyStringifyJSON(value).json ?? "")}
               </Text>
             ))}
           </Flex>
@@ -166,7 +158,7 @@ export function LLMProjectEvaluatorDetails({
           <PromptChatMessages promptVersion={evaluator.promptVersion} />
         )}
       </Flex>
-      <ProjectEvaluatorInputMapping inputMapping={inputMapping} />
+      <EvaluatorInputMappingDetails inputMapping={inputMapping} />
     </Flex>
   );
 }
@@ -188,7 +180,7 @@ function EvaluatorAnnotationSection({
   return (
     <Flex direction="column" gap="size-100">
       <Heading level={2}>Evaluator Annotation</Heading>
-      <div css={sectionCardCSS}>
+      <div css={evaluatorDetailsCardCSS}>
         <Flex direction="column" gap="size-100">
           <Truncate title={outputConfig.name}>
             <Text size="S">
@@ -229,53 +221,6 @@ function EvaluatorAnnotationSection({
             <Text weight="heavy">Explanations:</Text>{" "}
             {includeExplanation ? "Enabled" : "Disabled"}
           </Text>
-        </Flex>
-      </div>
-    </Flex>
-  );
-}
-
-function ProjectEvaluatorInputMapping({
-  inputMapping,
-}: {
-  inputMapping: {
-    literalMapping?: Record<string, boolean | string | number> | null;
-    pathMapping?: Record<string, string> | null;
-  } | null;
-}) {
-  const literalMapping = inputMapping?.literalMapping;
-  const pathMapping = inputMapping?.pathMapping;
-
-  const hasLiteralMapping =
-    literalMapping && Object.keys(literalMapping).length > 0;
-  const hasPathMapping = pathMapping && Object.keys(pathMapping).length > 0;
-
-  if (!hasLiteralMapping && !hasPathMapping) {
-    return null;
-  }
-
-  return (
-    <Flex direction="column" gap="size-100">
-      <Heading level={2}>Input Mapping</Heading>
-      <div css={sectionCardCSS}>
-        <Flex direction="column" gap="size-100">
-          {pathMapping &&
-            Object.entries(pathMapping).map(([key, value]) => (
-              <Text key={key} size="S">
-                <Text weight="heavy">{key}:</Text> {value || "Not mapped"}
-              </Text>
-            ))}
-          {literalMapping &&
-            Object.entries(literalMapping).map(([key, value]) => (
-              <Text key={key} size="S">
-                <Text weight="heavy">{key}:</Text>{" "}
-                {typeof value === "boolean"
-                  ? value
-                    ? "Yes"
-                    : "No"
-                  : String(value)}
-              </Text>
-            ))}
         </Flex>
       </div>
     </Flex>

--- a/app/src/pages/project/evaluators/ProjectEvaluatorDetailsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorDetailsPage.tsx
@@ -1,0 +1,180 @@
+import { css } from "@emotion/react";
+import { Suspense } from "react";
+import { Outlet, useLoaderData, useNavigate } from "react-router";
+import invariant from "tiny-invariant";
+
+import {
+  Button,
+  Flex,
+  Heading,
+  Icon,
+  Icons,
+  LazyTabPanel,
+  PageHeader,
+  Tab,
+  TabList,
+  Tabs,
+  Text,
+  View,
+} from "@phoenix/components";
+import { Empty } from "@phoenix/components/core/empty";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { useOwnedPreloadedQuery } from "@phoenix/hooks";
+import type { projectEvaluatorDetailsLoaderQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql";
+import { LLMProjectEvaluatorDetails } from "@phoenix/pages/project/evaluators/LLMProjectEvaluatorDetails";
+import type { projectEvaluatorDetailsLoader } from "@phoenix/pages/project/evaluators/projectEvaluatorDetailsLoader";
+import { projectEvaluatorDetailsLoaderGQL } from "@phoenix/pages/project/evaluators/projectEvaluatorDetailsLoader";
+import { ProjectEvaluatorEnabledSwitch } from "@phoenix/pages/project/evaluators/ProjectEvaluatorEnabledSwitch";
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
+import { ProjectEvaluatorScopeDetails } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeDetails";
+
+type ProjectEvaluatorNode = Extract<
+  NonNullable<
+    projectEvaluatorDetailsLoaderQuery["response"]["projectEvaluator"]
+  >,
+  { readonly __typename: "ProjectEvaluator" }
+>;
+
+const mainCSS = css`
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+  height: 100%;
+  .tabs {
+    flex: 1 1 auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    div[role="tablist"] {
+      flex: none;
+    }
+  }
+`;
+
+export function ProjectEvaluatorDetailsPage() {
+  const loaderData = useLoaderData<typeof projectEvaluatorDetailsLoader>();
+  invariant(loaderData, "loaderData is required");
+  if (loaderData.queryRef == null) {
+    return <ProjectEvaluatorNotFound />;
+  }
+  return <ProjectEvaluatorDetailsPageLoaded queryRef={loaderData.queryRef} />;
+}
+
+function ProjectEvaluatorDetailsPageLoaded({
+  queryRef,
+}: {
+  queryRef: NonNullable<
+    Awaited<ReturnType<typeof projectEvaluatorDetailsLoader>>["queryRef"]
+  >;
+}) {
+  const data = useOwnedPreloadedQuery<projectEvaluatorDetailsLoaderQuery>({
+    query: projectEvaluatorDetailsLoaderGQL,
+    queryRef,
+  });
+  const projectEvaluator = data.projectEvaluator;
+  if (projectEvaluator?.__typename !== "ProjectEvaluator") {
+    return <ProjectEvaluatorNotFound />;
+  }
+  return (
+    <ProjectEvaluatorDetailsPageContent projectEvaluator={projectEvaluator} />
+  );
+}
+
+function ProjectEvaluatorDetailsPageContent({
+  projectEvaluator,
+}: {
+  projectEvaluator: ProjectEvaluatorNode;
+}) {
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
+  const evaluator = projectEvaluator.evaluator;
+  const isLLMEvaluator = evaluator.kind === "LLM";
+  const canEdit = evaluator.kind === "LLM" || evaluator.kind === "CODE";
+
+  return (
+    <main css={mainCSS}>
+      <PageHeader
+        title={
+          <Heading level={1}>
+            <Truncate
+              maxWidth="100%"
+              title={`Evaluator: ${projectEvaluator.name}`}
+            >{`Evaluator: ${projectEvaluator.name}`}</Truncate>
+          </Heading>
+        }
+        subTitle={evaluator.description}
+        extra={
+          <Flex direction="row" alignItems="center" gap="size-200">
+            <Flex direction="row" alignItems="center" gap="size-100">
+              <Text size="S" color="text-700">
+                Enabled
+              </Text>
+              <ProjectEvaluatorEnabledSwitch
+                projectEvaluatorId={projectEvaluator.id}
+                name={projectEvaluator.name}
+                enabled={projectEvaluator.enabled}
+              />
+            </Flex>
+            {canEdit && (
+              <Button
+                variant="primary"
+                onPress={() => navigate(paths.edit(projectEvaluator.id))}
+                leadingVisual={<Icon svg={<Icons.Edit />} />}
+              >
+                Edit
+              </Button>
+            )}
+          </Flex>
+        }
+      />
+      <Tabs defaultSelectedKey="configuration">
+        <TabList>
+          <Tab id="configuration">Configuration</Tab>
+        </TabList>
+        <LazyTabPanel id="configuration">
+          <View width="100%" overflow="auto" height="100%">
+            <View padding="size-200">
+              <Flex
+                direction="column"
+                gap="size-300"
+                maxWidth={1600}
+                marginStart="auto"
+                marginEnd="auto"
+              >
+                <ProjectEvaluatorScopeDetails
+                  projectEvaluatorRef={projectEvaluator}
+                />
+                {isLLMEvaluator && (
+                  <LLMProjectEvaluatorDetails
+                    projectEvaluatorRef={projectEvaluator}
+                  />
+                )}
+              </Flex>
+            </View>
+          </View>
+        </LazyTabPanel>
+      </Tabs>
+      {/* The edit slideover route renders over the page. */}
+      <Suspense>
+        <Outlet />
+      </Suspense>
+    </main>
+  );
+}
+
+function ProjectEvaluatorNotFound() {
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
+  return (
+    <main>
+      <View paddingTop="size-1000">
+        <Flex direction="column" alignItems="center" gap="size-200">
+          <Empty message="This evaluator does not exist or has been deleted." />
+          <Button onPress={() => navigate(paths.list)}>
+            Back to evaluators
+          </Button>
+        </Flex>
+      </View>
+    </main>
+  );
+}

--- a/app/src/pages/project/evaluators/ProjectEvaluatorDetailsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorDetailsPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "@phoenix/components";
 import { Empty } from "@phoenix/components/core/empty";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import type { OwnedPreloadedQueryRef } from "@phoenix/hooks";
 import { useOwnedPreloadedQuery } from "@phoenix/hooks";
 import type { projectEvaluatorDetailsLoaderQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql";
 import { LLMProjectEvaluatorDetails } from "@phoenix/pages/project/evaluators/LLMProjectEvaluatorDetails";
@@ -27,13 +28,6 @@ import { projectEvaluatorDetailsLoaderGQL } from "@phoenix/pages/project/evaluat
 import { ProjectEvaluatorEnabledSwitch } from "@phoenix/pages/project/evaluators/ProjectEvaluatorEnabledSwitch";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import { ProjectEvaluatorScopeDetails } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeDetails";
-
-type ProjectEvaluatorNode = Extract<
-  NonNullable<
-    projectEvaluatorDetailsLoaderQuery["response"]["projectEvaluator"]
-  >,
-  { readonly __typename: "ProjectEvaluator" }
->;
 
 const mainCSS = css`
   display: flex;
@@ -63,10 +57,10 @@ export function ProjectEvaluatorDetailsPage() {
 function ProjectEvaluatorDetailsPageLoaded({
   queryRef,
 }: {
-  queryRef: NonNullable<
-    Awaited<ReturnType<typeof projectEvaluatorDetailsLoader>>["queryRef"]
-  >;
+  queryRef: OwnedPreloadedQueryRef<projectEvaluatorDetailsLoaderQuery>;
 }) {
+  const navigate = useNavigate();
+  const paths = useProjectEvaluatorPaths();
   const data = useOwnedPreloadedQuery<projectEvaluatorDetailsLoaderQuery>({
     query: projectEvaluatorDetailsLoaderGQL,
     queryRef,
@@ -75,18 +69,6 @@ function ProjectEvaluatorDetailsPageLoaded({
   if (projectEvaluator?.__typename !== "ProjectEvaluator") {
     return <ProjectEvaluatorNotFound />;
   }
-  return (
-    <ProjectEvaluatorDetailsPageContent projectEvaluator={projectEvaluator} />
-  );
-}
-
-function ProjectEvaluatorDetailsPageContent({
-  projectEvaluator,
-}: {
-  projectEvaluator: ProjectEvaluatorNode;
-}) {
-  const navigate = useNavigate();
-  const paths = useProjectEvaluatorPaths();
   const evaluator = projectEvaluator.evaluator;
   const isLLMEvaluator = evaluator.kind === "LLM";
   const canEdit = evaluator.kind === "LLM" || evaluator.kind === "CODE";

--- a/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
@@ -1,26 +1,18 @@
-import { css } from "@emotion/react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
 import { Flex, Heading, Text } from "@phoenix/components";
+import { evaluatorDetailsCardCSS } from "@phoenix/components/evaluators/EvaluatorDetailsSection";
 import type { ProjectEvaluatorScopeDetails_projectEvaluator$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql";
 import {
   formatEvaluationTarget,
   formatSamplingRate,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
-const sectionCardCSS = css`
-  border-radius: var(--global-rounding-medium);
-  padding: var(--global-dimension-size-200);
-  margin-top: var(--global-dimension-size-50);
-  border: 1px solid var(--global-border-color-default);
-  overflow: hidden;
-`;
-
 /**
  * Read-only view of the policy a project evaluator runs under: what it
- * targets, which spans it matches, how many of them it samples, and whether
- * it is currently running at all.
+ * targets, which spans it matches, and how many of them it samples. Whether
+ * the evaluator runs at all is the page header's enabled switch.
  */
 export function ProjectEvaluatorScopeDetails({
   projectEvaluatorRef,
@@ -33,7 +25,6 @@ export function ProjectEvaluatorScopeDetails({
         evaluationTarget
         filterCondition
         samplingRate
-        enabled
       }
     `,
     projectEvaluatorRef
@@ -42,7 +33,7 @@ export function ProjectEvaluatorScopeDetails({
   return (
     <Flex direction="column" gap="size-100">
       <Heading level={2}>Scope</Heading>
-      <div css={sectionCardCSS}>
+      <div css={evaluatorDetailsCardCSS}>
         <Flex direction="column" gap="size-100">
           <Text size="S">
             <Text weight="heavy">Target:</Text>{" "}
@@ -61,10 +52,6 @@ export function ProjectEvaluatorScopeDetails({
           <Text size="S">
             <Text weight="heavy">Sampling Rate:</Text>{" "}
             {formatSamplingRate(projectEvaluator.samplingRate)}
-          </Text>
-          <Text size="S">
-            <Text weight="heavy">Enabled:</Text>{" "}
-            {projectEvaluator.enabled ? "Yes" : "No"}
           </Text>
         </Flex>
       </div>

--- a/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
@@ -1,0 +1,73 @@
+import { css } from "@emotion/react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import { Flex, Heading, Text } from "@phoenix/components";
+import type { ProjectEvaluatorScopeDetails_projectEvaluator$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql";
+import {
+  formatEvaluationTarget,
+  formatSamplingRate,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+
+const sectionCardCSS = css`
+  border-radius: var(--global-rounding-medium);
+  padding: var(--global-dimension-size-200);
+  margin-top: var(--global-dimension-size-50);
+  border: 1px solid var(--global-border-color-default);
+  overflow: hidden;
+`;
+
+/**
+ * Read-only view of the policy a project evaluator runs under: what it
+ * targets, which spans it matches, how many of them it samples, and whether
+ * it is currently running at all.
+ */
+export function ProjectEvaluatorScopeDetails({
+  projectEvaluatorRef,
+}: {
+  projectEvaluatorRef: ProjectEvaluatorScopeDetails_projectEvaluator$key;
+}) {
+  const projectEvaluator = useFragment(
+    graphql`
+      fragment ProjectEvaluatorScopeDetails_projectEvaluator on ProjectEvaluator {
+        evaluationTarget
+        filterCondition
+        samplingRate
+        enabled
+      }
+    `,
+    projectEvaluatorRef
+  );
+
+  return (
+    <Flex direction="column" gap="size-100">
+      <Heading level={2}>Scope</Heading>
+      <div css={sectionCardCSS}>
+        <Flex direction="column" gap="size-100">
+          <Text size="S">
+            <Text weight="heavy">Target:</Text>{" "}
+            {formatEvaluationTarget(projectEvaluator.evaluationTarget)}
+          </Text>
+          <Text size="S">
+            <Text weight="heavy">Filter:</Text>{" "}
+            {projectEvaluator.filterCondition ? (
+              <Text size="S" fontFamily="mono">
+                {projectEvaluator.filterCondition}
+              </Text>
+            ) : (
+              "All spans"
+            )}
+          </Text>
+          <Text size="S">
+            <Text weight="heavy">Sampling Rate:</Text>{" "}
+            {formatSamplingRate(projectEvaluator.samplingRate)}
+          </Text>
+          <Text size="S">
+            <Text weight="heavy">Enabled:</Text>{" "}
+            {projectEvaluator.enabled ? "Yes" : "No"}
+          </Text>
+        </Flex>
+      </div>
+    </Flex>
+  );
+}

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -158,10 +158,24 @@ export function AttachCodeProjectEvaluatorPage() {
   );
 }
 
+/**
+ * The edit route is nested under the evaluator's details page, so closing the
+ * slideover lands on the details view it was opened over rather than the list.
+ */
+function useCloseEditSlideover(projectEvaluatorId: string) {
+  const navigate = useNavigate();
+  const { details } = useProjectEvaluatorPaths();
+  return (isOpen: boolean) => {
+    if (!isOpen) {
+      navigate(details(projectEvaluatorId), { replace: true });
+    }
+  };
+}
+
 export function EditProjectEvaluatorPage() {
   const { projectEvaluatorId } = useParams();
   invariant(projectEvaluatorId, "projectEvaluatorId is required");
-  const onOpenChange = useCloseSlideover();
+  const onOpenChange = useCloseEditSlideover(projectEvaluatorId);
   const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
   if (
     evaluator.evaluator.kind !== "LLM" &&

--- a/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -21,16 +21,18 @@ import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/proj
 import { ProjectEvaluatorSlideoverError } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideoverError";
 
 /**
- * Closes the slideover by returning to the evaluators list. Replaces rather
- * than pushes, so a slideover the user has dismissed does not sit one step back
- * in history waiting to be reopened.
+ * Closes the slideover by leaving its route — to the evaluators list unless
+ * the caller names another destination. Replaces rather than pushes, so a
+ * slideover the user has dismissed does not sit one step back in history
+ * waiting to be reopened.
  */
-function useCloseSlideover() {
+function useCloseSlideover(to?: string) {
   const navigate = useNavigate();
   const { list } = useProjectEvaluatorPaths();
+  const destination = to ?? list;
   return (isOpen: boolean) => {
     if (!isOpen) {
-      navigate(list, { replace: true });
+      navigate(destination, { replace: true });
     }
   };
 }
@@ -158,24 +160,13 @@ export function AttachCodeProjectEvaluatorPage() {
   );
 }
 
-/**
- * The edit route is nested under the evaluator's details page, so closing the
- * slideover lands on the details view it was opened over rather than the list.
- */
-function useCloseEditSlideover(projectEvaluatorId: string) {
-  const navigate = useNavigate();
-  const { details } = useProjectEvaluatorPaths();
-  return (isOpen: boolean) => {
-    if (!isOpen) {
-      navigate(details(projectEvaluatorId), { replace: true });
-    }
-  };
-}
-
 export function EditProjectEvaluatorPage() {
   const { projectEvaluatorId } = useParams();
   invariant(projectEvaluatorId, "projectEvaluatorId is required");
-  const onOpenChange = useCloseEditSlideover(projectEvaluatorId);
+  // The edit route nests under the evaluator's details page, so closing lands
+  // on the details view it was opened over rather than the list.
+  const { details } = useProjectEvaluatorPaths();
+  const onOpenChange = useCloseSlideover(details(projectEvaluatorId));
   const { evaluator, sandboxConfigs } = useProjectEvaluator(projectEvaluatorId);
   if (
     evaluator.evaluator.kind !== "LLM" &&

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -13,12 +13,15 @@ import {
   Flex,
   Icon,
   Icons,
+  Link,
   LoadMoreButton,
   Text,
   View,
 } from "@phoenix/components";
 import { CompactEmptyState } from "@phoenix/components/core/empty";
-import { tableCSS } from "@phoenix/components/table/styles";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import type { ProjectEvaluatorsTable_project$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql";
 import type { ProjectEvaluatorsTable_row$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql";
@@ -26,6 +29,10 @@ import { ProjectEvaluatorActionMenu } from "@phoenix/pages/project/evaluators/Pr
 import { ProjectEvaluatorEnabledSwitch } from "@phoenix/pages/project/evaluators/ProjectEvaluatorEnabledSwitch";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import { ProjectEvaluatorsEmptyState } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsEmptyState";
+import {
+  formatEvaluationTarget,
+  formatSamplingRate,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 const PAGE_SIZE = 30;
 
@@ -128,6 +135,11 @@ export function ProjectEvaluatorsTable({
       {
         header: "Name",
         accessorKey: "name",
+        cell: ({ getValue, row }) => (
+          <Link to={paths.details(row.original.id)}>
+            <Truncate maxWidth="100%">{getValue() as string}</Truncate>
+          </Link>
+        ),
       },
       {
         id: "target",
@@ -153,11 +165,13 @@ export function ProjectEvaluatorsTable({
         id: "enabled",
         header: "Enabled",
         cell: ({ row }) => (
-          <ProjectEvaluatorEnabledSwitch
-            projectEvaluatorId={row.original.id}
-            name={row.original.name}
-            enabled={row.original.enabled}
-          />
+          <StopPropagation>
+            <ProjectEvaluatorEnabledSwitch
+              projectEvaluatorId={row.original.id}
+              name={row.original.name}
+              enabled={row.original.enabled}
+            />
+          </StopPropagation>
         ),
       },
       {
@@ -174,7 +188,7 @@ export function ProjectEvaluatorsTable({
         ),
       },
     ],
-    [projectId, openEditSlideover]
+    [projectId, openEditSlideover, paths]
   );
   // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({
@@ -195,7 +209,7 @@ export function ProjectEvaluatorsTable({
   }
   return (
     <div css={scrollableAreaCSS}>
-      <table css={tableCSS} aria-label="Project evaluators">
+      <table css={selectableTableCSS} aria-label="Project evaluators">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
@@ -223,7 +237,10 @@ export function ProjectEvaluatorsTable({
         ) : (
           <tbody>
             {rows.map((row) => (
-              <tr key={row.id}>
+              <tr
+                key={row.id}
+                onClick={() => navigate(paths.details(row.original.id))}
+              >
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -246,15 +263,4 @@ export function ProjectEvaluatorsTable({
       ) : null}
     </div>
   );
-}
-
-function formatEvaluationTarget(target: "SPAN" | "TRACE" | "SESSION") {
-  return `${target.charAt(0)}${target.slice(1).toLowerCase()}`;
-}
-
-function formatSamplingRate(samplingRate: number) {
-  return new Intl.NumberFormat(undefined, {
-    style: "percent",
-    maximumFractionDigits: 2,
-  }).format(samplingRate);
 }

--- a/app/src/pages/project/evaluators/__generated__/LLMProjectEvaluatorDetails_projectEvaluator.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/LLMProjectEvaluatorDetails_projectEvaluator.graphql.ts
@@ -1,0 +1,654 @@
+/**
+ * @generated SignedSource<<5fd8189e9f474b912538e4a7843686f0>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type LLMProjectEvaluatorDetails_projectEvaluator$data = {
+  readonly evaluator: {
+    readonly kind: EvaluatorKind;
+    readonly outputConfigs?: ReadonlyArray<{
+      readonly __typename: "CategoricalAnnotationConfig";
+      readonly name: string;
+      readonly optimizationDirection: OptimizationDirection;
+      readonly values: ReadonlyArray<{
+        readonly label: string;
+        readonly score: number | null;
+      }>;
+    } | {
+      readonly __typename: "ContinuousAnnotationConfig";
+      readonly lowerBound: number | null;
+      readonly name: string;
+      readonly optimizationDirection: OptimizationDirection;
+      readonly upperBound: number | null;
+    } | {
+      readonly __typename: "FreeformAnnotationConfig";
+      readonly name: string;
+      readonly optimizationDirection: OptimizationDirection;
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    }>;
+    readonly prompt?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly promptVersion?: {
+      readonly invocationParameters: {
+        readonly " $fragmentSpreads": FragmentRefs<"PromptInvocationParametersReadableFragment">;
+      };
+      readonly modelName: string;
+      readonly modelProvider: ModelProvider;
+      readonly tools: {
+        readonly tools: ReadonlyArray<{
+          readonly __typename: "PromptToolFunction";
+          readonly function: {
+            readonly parameters: any;
+          };
+        } | {
+          readonly __typename: "PromptToolRaw";
+          readonly raw: any;
+        } | {
+          // This will never be '%other', but we need some
+          // value in case none of the concrete values match.
+          readonly __typename: "%other";
+        }>;
+      } | null;
+      readonly " $fragmentSpreads": FragmentRefs<"PromptChatMessagesCard__main">;
+    };
+    readonly promptVersionTag?: {
+      readonly name: string;
+    } | null;
+  };
+  readonly id: string;
+  readonly inputMapping: {
+    readonly literalMapping: any;
+    readonly pathMapping: any;
+  };
+  readonly " $fragmentType": "LLMProjectEvaluatorDetails_projectEvaluator";
+};
+export type LLMProjectEvaluatorDetails_projectEvaluator$key = {
+  readonly " $data"?: LLMProjectEvaluatorDetails_projectEvaluator$data;
+  readonly " $fragmentSpreads": FragmentRefs<"LLMProjectEvaluatorDetails_projectEvaluator">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "temperature",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "frequencyPenalty",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "presencePenalty",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "topP",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "extraBody",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "stopSequences",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "LLMProjectEvaluatorDetails_projectEvaluator",
+  "selections": [
+    (v0/*:: as any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "EvaluatorInputMapping",
+      "kind": "LinkedField",
+      "name": "inputMapping",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "literalMapping",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "pathMapping",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "evaluator",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "kind",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Prompt",
+              "kind": "LinkedField",
+              "name": "prompt",
+              "plural": false,
+              "selections": [
+                (v0/*:: as any*/),
+                (v1/*:: as any*/)
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "PromptVersion",
+              "kind": "LinkedField",
+              "name": "promptVersion",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "modelName",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "modelProvider",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": null,
+                  "kind": "LinkedField",
+                  "name": "invocationParameters",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "InlineDataFragmentSpread",
+                      "name": "PromptInvocationParametersReadableFragment",
+                      "selections": [
+                        (v2/*:: as any*/),
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            (v3/*:: as any*/),
+                            {
+                              "alias": "openaiMaxTokens",
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "maxTokens",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "maxCompletionTokens",
+                              "storageKey": null
+                            },
+                            (v4/*:: as any*/),
+                            (v5/*:: as any*/),
+                            (v6/*:: as any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "seed",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "stop",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "reasoningEffort",
+                              "storageKey": null
+                            },
+                            (v7/*:: as any*/)
+                          ],
+                          "type": "PromptOpenAIInvocationParameters",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": "anthropicMaxTokens",
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "maxTokens",
+                              "storageKey": null
+                            },
+                            (v3/*:: as any*/),
+                            (v6/*:: as any*/),
+                            (v8/*:: as any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "PromptAnthropicOutputConfig",
+                              "kind": "LinkedField",
+                              "name": "outputConfig",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "effort",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": null,
+                              "kind": "LinkedField",
+                              "name": "thinking",
+                              "plural": false,
+                              "selections": [
+                                (v2/*:: as any*/),
+                                {
+                                  "kind": "InlineFragment",
+                                  "selections": [
+                                    {
+                                      "alias": null,
+                                      "args": null,
+                                      "kind": "ScalarField",
+                                      "name": "disabled",
+                                      "storageKey": null
+                                    }
+                                  ],
+                                  "type": "PromptAnthropicThinkingDisabled",
+                                  "abstractKey": null
+                                },
+                                {
+                                  "kind": "InlineFragment",
+                                  "selections": [
+                                    {
+                                      "alias": null,
+                                      "args": null,
+                                      "kind": "ScalarField",
+                                      "name": "budgetTokens",
+                                      "storageKey": null
+                                    },
+                                    {
+                                      "alias": "enabledDisplay",
+                                      "args": null,
+                                      "kind": "ScalarField",
+                                      "name": "display",
+                                      "storageKey": null
+                                    }
+                                  ],
+                                  "type": "PromptAnthropicThinkingEnabled",
+                                  "abstractKey": null
+                                },
+                                {
+                                  "kind": "InlineFragment",
+                                  "selections": [
+                                    {
+                                      "alias": "adaptiveDisplay",
+                                      "args": null,
+                                      "kind": "ScalarField",
+                                      "name": "display",
+                                      "storageKey": null
+                                    }
+                                  ],
+                                  "type": "PromptAnthropicThinkingAdaptive",
+                                  "abstractKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            },
+                            (v7/*:: as any*/)
+                          ],
+                          "type": "PromptAnthropicInvocationParameters",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            (v3/*:: as any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "maxOutputTokens",
+                              "storageKey": null
+                            },
+                            (v8/*:: as any*/),
+                            (v5/*:: as any*/),
+                            (v4/*:: as any*/),
+                            (v6/*:: as any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "topK",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "PromptGoogleThinkingConfig",
+                              "kind": "LinkedField",
+                              "name": "thinkingConfig",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "thinkingBudget",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "thinkingLevel",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "includeThoughts",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "type": "PromptGoogleInvocationParameters",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": "awsMaxTokens",
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "maxTokens",
+                              "storageKey": null
+                            },
+                            (v3/*:: as any*/),
+                            (v6/*:: as any*/),
+                            (v8/*:: as any*/)
+                          ],
+                          "type": "PromptAwsInvocationParameters",
+                          "abstractKey": null
+                        }
+                      ],
+                      "args": null,
+                      "argumentDefinitions": []
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "PromptTools",
+                  "kind": "LinkedField",
+                  "name": "tools",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": null,
+                      "kind": "LinkedField",
+                      "name": "tools",
+                      "plural": true,
+                      "selections": [
+                        (v2/*:: as any*/),
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "PromptToolFunctionDefinition",
+                              "kind": "LinkedField",
+                              "name": "function",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "parameters",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "type": "PromptToolFunction",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "raw",
+                              "storageKey": null
+                            }
+                          ],
+                          "type": "PromptToolRaw",
+                          "abstractKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "PromptChatMessagesCard__main"
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "PromptVersionTag",
+              "kind": "LinkedField",
+              "name": "promptVersionTag",
+              "plural": false,
+              "selections": [
+                (v1/*:: as any*/)
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "outputConfigs",
+              "plural": true,
+              "selections": [
+                (v2/*:: as any*/),
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*:: as any*/),
+                    (v9/*:: as any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CategoricalAnnotationValue",
+                      "kind": "LinkedField",
+                      "name": "values",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "label",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "score",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "CategoricalAnnotationConfig",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*:: as any*/),
+                    (v9/*:: as any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "lowerBound",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "upperBound",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "ContinuousAnnotationConfig",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*:: as any*/),
+                    (v9/*:: as any*/)
+                  ],
+                  "type": "FreeformAnnotationConfig",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "LLMEvaluator",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ProjectEvaluator",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "53848aac7911c1aab099aedd39065036";
+
+export default node;

--- a/app/src/pages/project/evaluators/__generated__/LLMProjectEvaluatorDetails_projectEvaluator.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/LLMProjectEvaluatorDetails_projectEvaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5fd8189e9f474b912538e4a7843686f0>>
+ * @generated SignedSource<<bf86473a5f192e9a8aaff703bd0c421f>>
  * @lightSyntaxTransform
  */
 
@@ -55,9 +55,6 @@ export type LLMProjectEvaluatorDetails_projectEvaluator$data = {
             readonly parameters: any;
           };
         } | {
-          readonly __typename: "PromptToolRaw";
-          readonly raw: any;
-        } | {
           // This will never be '%other', but we need some
           // value in case none of the concrete values match.
           readonly __typename: "%other";
@@ -69,7 +66,6 @@ export type LLMProjectEvaluatorDetails_projectEvaluator$data = {
       readonly name: string;
     } | null;
   };
-  readonly id: string;
   readonly inputMapping: {
     readonly literalMapping: any;
     readonly pathMapping: any;
@@ -86,66 +82,59 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "name",
   "storageKey": null
 },
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "__typename",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "temperature",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "temperature",
+  "name": "frequencyPenalty",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "frequencyPenalty",
+  "name": "presencePenalty",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "presencePenalty",
+  "name": "topP",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "topP",
+  "name": "extraBody",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "extraBody",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "stopSequences",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -158,7 +147,6 @@ return {
   "metadata": null,
   "name": "LLMProjectEvaluatorDetails_projectEvaluator",
   "selections": [
-    (v0/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -210,8 +198,14 @@ return {
               "name": "prompt",
               "plural": false,
               "selections": [
-                (v0/*:: as any*/),
-                (v1/*:: as any*/)
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                (v0/*:: as any*/)
               ],
               "storageKey": null
             },
@@ -249,11 +243,11 @@ return {
                       "kind": "InlineDataFragmentSpread",
                       "name": "PromptInvocationParametersReadableFragment",
                       "selections": [
-                        (v2/*:: as any*/),
+                        (v1/*:: as any*/),
                         {
                           "kind": "InlineFragment",
                           "selections": [
-                            (v3/*:: as any*/),
+                            (v2/*:: as any*/),
                             {
                               "alias": "openaiMaxTokens",
                               "args": null,
@@ -268,9 +262,9 @@ return {
                               "name": "maxCompletionTokens",
                               "storageKey": null
                             },
+                            (v3/*:: as any*/),
                             (v4/*:: as any*/),
                             (v5/*:: as any*/),
-                            (v6/*:: as any*/),
                             {
                               "alias": null,
                               "args": null,
@@ -292,7 +286,7 @@ return {
                               "name": "reasoningEffort",
                               "storageKey": null
                             },
-                            (v7/*:: as any*/)
+                            (v6/*:: as any*/)
                           ],
                           "type": "PromptOpenAIInvocationParameters",
                           "abstractKey": null
@@ -307,9 +301,9 @@ return {
                               "name": "maxTokens",
                               "storageKey": null
                             },
-                            (v3/*:: as any*/),
-                            (v6/*:: as any*/),
-                            (v8/*:: as any*/),
+                            (v2/*:: as any*/),
+                            (v5/*:: as any*/),
+                            (v7/*:: as any*/),
                             {
                               "alias": null,
                               "args": null,
@@ -336,7 +330,7 @@ return {
                               "name": "thinking",
                               "plural": false,
                               "selections": [
-                                (v2/*:: as any*/),
+                                (v1/*:: as any*/),
                                 {
                                   "kind": "InlineFragment",
                                   "selections": [
@@ -389,7 +383,7 @@ return {
                               ],
                               "storageKey": null
                             },
-                            (v7/*:: as any*/)
+                            (v6/*:: as any*/)
                           ],
                           "type": "PromptAnthropicInvocationParameters",
                           "abstractKey": null
@@ -397,7 +391,7 @@ return {
                         {
                           "kind": "InlineFragment",
                           "selections": [
-                            (v3/*:: as any*/),
+                            (v2/*:: as any*/),
                             {
                               "alias": null,
                               "args": null,
@@ -405,10 +399,10 @@ return {
                               "name": "maxOutputTokens",
                               "storageKey": null
                             },
-                            (v8/*:: as any*/),
-                            (v5/*:: as any*/),
+                            (v7/*:: as any*/),
                             (v4/*:: as any*/),
-                            (v6/*:: as any*/),
+                            (v3/*:: as any*/),
+                            (v5/*:: as any*/),
                             {
                               "alias": null,
                               "args": null,
@@ -462,9 +456,9 @@ return {
                               "name": "maxTokens",
                               "storageKey": null
                             },
-                            (v3/*:: as any*/),
-                            (v6/*:: as any*/),
-                            (v8/*:: as any*/)
+                            (v2/*:: as any*/),
+                            (v5/*:: as any*/),
+                            (v7/*:: as any*/)
                           ],
                           "type": "PromptAwsInvocationParameters",
                           "abstractKey": null
@@ -492,7 +486,7 @@ return {
                       "name": "tools",
                       "plural": true,
                       "selections": [
-                        (v2/*:: as any*/),
+                        (v1/*:: as any*/),
                         {
                           "kind": "InlineFragment",
                           "selections": [
@@ -517,20 +511,6 @@ return {
                           ],
                           "type": "PromptToolFunction",
                           "abstractKey": null
-                        },
-                        {
-                          "kind": "InlineFragment",
-                          "selections": [
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "raw",
-                              "storageKey": null
-                            }
-                          ],
-                          "type": "PromptToolRaw",
-                          "abstractKey": null
                         }
                       ],
                       "storageKey": null
@@ -554,7 +534,7 @@ return {
               "name": "promptVersionTag",
               "plural": false,
               "selections": [
-                (v1/*:: as any*/)
+                (v0/*:: as any*/)
               ],
               "storageKey": null
             },
@@ -566,12 +546,12 @@ return {
               "name": "outputConfigs",
               "plural": true,
               "selections": [
-                (v2/*:: as any*/),
+                (v1/*:: as any*/),
                 {
                   "kind": "InlineFragment",
                   "selections": [
-                    (v1/*:: as any*/),
-                    (v9/*:: as any*/),
+                    (v0/*:: as any*/),
+                    (v8/*:: as any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -604,8 +584,8 @@ return {
                 {
                   "kind": "InlineFragment",
                   "selections": [
-                    (v1/*:: as any*/),
-                    (v9/*:: as any*/),
+                    (v0/*:: as any*/),
+                    (v8/*:: as any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -627,8 +607,8 @@ return {
                 {
                   "kind": "InlineFragment",
                   "selections": [
-                    (v1/*:: as any*/),
-                    (v9/*:: as any*/)
+                    (v0/*:: as any*/),
+                    (v8/*:: as any*/)
                   ],
                   "type": "FreeformAnnotationConfig",
                   "abstractKey": null
@@ -649,6 +629,6 @@ return {
 };
 })();
 
-(node as any).hash = "53848aac7911c1aab099aedd39065036";
+(node as any).hash = "6fdf5926d2b416baccc4a12f21117549";
 
 export default node;

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0594ef95c2efca8045f03aa1bc894c54>>
+ * @generated SignedSource<<263d3240e8057ed789c4eb1d86d7cfd9>>
  * @lightSyntaxTransform
  */
 
@@ -11,7 +11,6 @@ import { ReaderFragment } from 'relay-runtime';
 export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
 import { FragmentRefs } from "relay-runtime";
 export type ProjectEvaluatorScopeDetails_projectEvaluator$data = {
-  readonly enabled: boolean;
   readonly evaluationTarget: EvaluationTarget;
   readonly filterCondition: string;
   readonly samplingRate: number;
@@ -48,19 +47,12 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "samplingRate",
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "enabled",
-      "storageKey": null
     }
   ],
   "type": "ProjectEvaluator",
   "abstractKey": null
 };
 
-(node as any).hash = "83eb231c25da9938f9c3b1406257e559";
+(node as any).hash = "206d2fc44e707d0e5030e443056ed522";
 
 export default node;

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
@@ -1,0 +1,66 @@
+/**
+ * @generated SignedSource<<0594ef95c2efca8045f03aa1bc894c54>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
+import { FragmentRefs } from "relay-runtime";
+export type ProjectEvaluatorScopeDetails_projectEvaluator$data = {
+  readonly enabled: boolean;
+  readonly evaluationTarget: EvaluationTarget;
+  readonly filterCondition: string;
+  readonly samplingRate: number;
+  readonly " $fragmentType": "ProjectEvaluatorScopeDetails_projectEvaluator";
+};
+export type ProjectEvaluatorScopeDetails_projectEvaluator$key = {
+  readonly " $data"?: ProjectEvaluatorScopeDetails_projectEvaluator$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProjectEvaluatorScopeDetails_projectEvaluator">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ProjectEvaluatorScopeDetails_projectEvaluator",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "evaluationTarget",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "filterCondition",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "samplingRate",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "enabled",
+      "storageKey": null
+    }
+  ],
+  "type": "ProjectEvaluator",
+  "abstractKey": null
+};
+
+(node as any).hash = "83eb231c25da9938f9c3b1406257e559";
+
+export default node;

--- a/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<77ed31cd36c2c6d21e24d1428295118a>>
+ * @generated SignedSource<<d8be6762e6535732a53ffabc13e1517d>>
  * @lightSyntaxTransform
  */
 
@@ -18,17 +18,11 @@ export type projectEvaluatorDetailsLoaderQuery$data = {
     readonly __typename: "ProjectEvaluator";
     readonly enabled: boolean;
     readonly evaluator: {
-      readonly __typename: string;
       readonly description: string | null;
-      readonly id: string;
       readonly kind: EvaluatorKind;
-      readonly name: string;
     };
     readonly id: string;
     readonly name: string;
-    readonly project: {
-      readonly id: string;
-    };
     readonly " $fragmentSpreads": FragmentRefs<"LLMProjectEvaluatorDetails_projectEvaluator" | "ProjectEvaluatorScopeDetails_projectEvaluator">;
   } | {
     // This will never be '%other', but we need some
@@ -84,83 +78,70 @@ v5 = {
   "name": "enabled",
   "storageKey": null
 },
-v6 = [
-  (v3/*:: as any*/)
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Project",
-  "kind": "LinkedField",
-  "name": "project",
-  "plural": false,
-  "selections": (v6/*:: as any*/),
-  "storageKey": null
-},
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "kind",
   "storageKey": null
 },
-v9 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v10 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "temperature",
   "storageKey": null
 },
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "frequencyPenalty",
   "storageKey": null
 },
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "presencePenalty",
   "storageKey": null
 },
-v13 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "topP",
   "storageKey": null
 },
-v14 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extraBody",
   "storageKey": null
 },
-v15 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "stopSequences",
   "storageKey": null
 },
-v16 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "toolCallId",
   "storageKey": null
 },
-v17 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -189,7 +170,6 @@ return {
               (v3/*:: as any*/),
               (v4/*:: as any*/),
               (v5/*:: as any*/),
-              (v7/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -198,11 +178,8 @@ return {
                 "name": "evaluator",
                 "plural": false,
                 "selections": [
-                  (v2/*:: as any*/),
-                  (v3/*:: as any*/),
-                  (v8/*:: as any*/),
-                  (v4/*:: as any*/),
-                  (v9/*:: as any*/)
+                  (v6/*:: as any*/),
+                  (v7/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -248,7 +225,6 @@ return {
             "selections": [
               (v4/*:: as any*/),
               (v5/*:: as any*/),
-              (v7/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -258,10 +234,9 @@ return {
                 "plural": false,
                 "selections": [
                   (v2/*:: as any*/),
+                  (v6/*:: as any*/),
+                  (v7/*:: as any*/),
                   (v3/*:: as any*/),
-                  (v8/*:: as any*/),
-                  (v4/*:: as any*/),
-                  (v9/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
@@ -316,7 +291,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v10/*:: as any*/),
+                                  (v8/*:: as any*/),
                                   {
                                     "alias": "openaiMaxTokens",
                                     "args": null,
@@ -331,9 +306,9 @@ return {
                                     "name": "maxCompletionTokens",
                                     "storageKey": null
                                   },
+                                  (v9/*:: as any*/),
+                                  (v10/*:: as any*/),
                                   (v11/*:: as any*/),
-                                  (v12/*:: as any*/),
-                                  (v13/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -355,7 +330,7 @@ return {
                                     "name": "reasoningEffort",
                                     "storageKey": null
                                   },
-                                  (v14/*:: as any*/)
+                                  (v12/*:: as any*/)
                                 ],
                                 "type": "PromptOpenAIInvocationParameters",
                                 "abstractKey": null
@@ -370,9 +345,9 @@ return {
                                     "name": "maxTokens",
                                     "storageKey": null
                                   },
-                                  (v10/*:: as any*/),
+                                  (v8/*:: as any*/),
+                                  (v11/*:: as any*/),
                                   (v13/*:: as any*/),
-                                  (v15/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -452,7 +427,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v14/*:: as any*/)
+                                  (v12/*:: as any*/)
                                 ],
                                 "type": "PromptAnthropicInvocationParameters",
                                 "abstractKey": null
@@ -460,7 +435,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v10/*:: as any*/),
+                                  (v8/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -468,10 +443,10 @@ return {
                                     "name": "maxOutputTokens",
                                     "storageKey": null
                                   },
-                                  (v15/*:: as any*/),
-                                  (v12/*:: as any*/),
-                                  (v11/*:: as any*/),
                                   (v13/*:: as any*/),
+                                  (v10/*:: as any*/),
+                                  (v9/*:: as any*/),
+                                  (v11/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -525,9 +500,9 @@ return {
                                     "name": "maxTokens",
                                     "storageKey": null
                                   },
-                                  (v10/*:: as any*/),
-                                  (v13/*:: as any*/),
-                                  (v15/*:: as any*/)
+                                  (v8/*:: as any*/),
+                                  (v11/*:: as any*/),
+                                  (v13/*:: as any*/)
                                 ],
                                 "type": "PromptAwsInvocationParameters",
                                 "abstractKey": null
@@ -575,20 +550,6 @@ return {
                                       }
                                     ],
                                     "type": "PromptToolFunction",
-                                    "abstractKey": null
-                                  },
-                                  {
-                                    "kind": "InlineFragment",
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "raw",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "type": "PromptToolRaw",
                                     "abstractKey": null
                                   }
                                 ],
@@ -676,7 +637,7 @@ return {
                                                 "name": "toolCall",
                                                 "plural": false,
                                                 "selections": [
-                                                  (v16/*:: as any*/),
+                                                  (v14/*:: as any*/),
                                                   {
                                                     "alias": null,
                                                     "args": null,
@@ -714,7 +675,7 @@ return {
                                                 "name": "toolResult",
                                                 "plural": false,
                                                 "selections": [
-                                                  (v16/*:: as any*/),
+                                                  (v14/*:: as any*/),
                                                   {
                                                     "alias": null,
                                                     "args": null,
@@ -800,7 +761,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v4/*:: as any*/),
-                              (v17/*:: as any*/),
+                              (v15/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -834,7 +795,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v4/*:: as any*/),
-                              (v17/*:: as any*/),
+                              (v15/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -857,14 +818,16 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v4/*:: as any*/),
-                              (v17/*:: as any*/)
+                              (v15/*:: as any*/)
                             ],
                             "type": "FreeformAnnotationConfig",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v6/*:: as any*/),
+                            "selections": [
+                              (v3/*:: as any*/)
+                            ],
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -934,16 +897,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4c8871078b64a39cfb0db4b8fafc2a24",
+    "cacheID": "f18f52daf4c636d1195c47b43012f779",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorDetailsLoaderQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorDetailsLoaderQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      enabled\n      project {\n        id\n      }\n      evaluator {\n        __typename\n        id\n        kind\n        name\n        description\n      }\n      ...ProjectEvaluatorScopeDetails_projectEvaluator\n      ...LLMProjectEvaluatorDetails_projectEvaluator\n    }\n    id\n  }\n}\n\nfragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        invocationParameters {\n          __typename\n          ...PromptInvocationParametersReadableFragment\n        }\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorScopeDetails_projectEvaluator on ProjectEvaluator {\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n"
+    "text": "query projectEvaluatorDetailsLoaderQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      enabled\n      evaluator {\n        __typename\n        kind\n        description\n        id\n      }\n      ...ProjectEvaluatorScopeDetails_projectEvaluator\n      ...LLMProjectEvaluatorDetails_projectEvaluator\n    }\n    id\n  }\n}\n\nfragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        invocationParameters {\n          __typename\n          ...PromptInvocationParametersReadableFragment\n        }\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n          }\n        }\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorScopeDetails_projectEvaluator on ProjectEvaluator {\n  evaluationTarget\n  filterCondition\n  samplingRate\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "324f9bae15f3e5102936daf712f10c8f";
+(node as any).hash = "19cd32d57eee75b584335b893573a8e4";
 
 export default node;

--- a/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,0 +1,949 @@
+/**
+ * @generated SignedSource<<77ed31cd36c2c6d21e24d1428295118a>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type projectEvaluatorDetailsLoaderQuery$variables = {
+  projectEvaluatorId: string;
+};
+export type projectEvaluatorDetailsLoaderQuery$data = {
+  readonly projectEvaluator: {
+    readonly __typename: "ProjectEvaluator";
+    readonly enabled: boolean;
+    readonly evaluator: {
+      readonly __typename: string;
+      readonly description: string | null;
+      readonly id: string;
+      readonly kind: EvaluatorKind;
+      readonly name: string;
+    };
+    readonly id: string;
+    readonly name: string;
+    readonly project: {
+      readonly id: string;
+    };
+    readonly " $fragmentSpreads": FragmentRefs<"LLMProjectEvaluatorDetails_projectEvaluator" | "ProjectEvaluatorScopeDetails_projectEvaluator">;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type projectEvaluatorDetailsLoaderQuery = {
+  response: projectEvaluatorDetailsLoaderQuery$data;
+  variables: projectEvaluatorDetailsLoaderQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectEvaluatorId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectEvaluatorId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v6 = [
+  (v3/*:: as any*/)
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Project",
+  "kind": "LinkedField",
+  "name": "project",
+  "plural": false,
+  "selections": (v6/*:: as any*/),
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "kind",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "temperature",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "frequencyPenalty",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "presencePenalty",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "topP",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "extraBody",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "stopSequences",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "toolCallId",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "projectEvaluatorDetailsLoaderQuery",
+    "selections": [
+      {
+        "alias": "projectEvaluator",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*:: as any*/),
+              (v4/*:: as any*/),
+              (v5/*:: as any*/),
+              (v7/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "evaluator",
+                "plural": false,
+                "selections": [
+                  (v2/*:: as any*/),
+                  (v3/*:: as any*/),
+                  (v8/*:: as any*/),
+                  (v4/*:: as any*/),
+                  (v9/*:: as any*/)
+                ],
+                "storageKey": null
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectEvaluatorScopeDetails_projectEvaluator"
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "LLMProjectEvaluatorDetails_projectEvaluator"
+              }
+            ],
+            "type": "ProjectEvaluator",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "projectEvaluatorDetailsLoaderQuery",
+    "selections": [
+      {
+        "alias": "projectEvaluator",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v4/*:: as any*/),
+              (v5/*:: as any*/),
+              (v7/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "evaluator",
+                "plural": false,
+                "selections": [
+                  (v2/*:: as any*/),
+                  (v3/*:: as any*/),
+                  (v8/*:: as any*/),
+                  (v4/*:: as any*/),
+                  (v9/*:: as any*/),
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Prompt",
+                        "kind": "LinkedField",
+                        "name": "prompt",
+                        "plural": false,
+                        "selections": [
+                          (v3/*:: as any*/),
+                          (v4/*:: as any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PromptVersion",
+                        "kind": "LinkedField",
+                        "name": "promptVersion",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "modelName",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "modelProvider",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "invocationParameters",
+                            "plural": false,
+                            "selections": [
+                              (v2/*:: as any*/),
+                              {
+                                "kind": "TypeDiscriminator",
+                                "abstractKey": "__isPromptInvocationParameters"
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v10/*:: as any*/),
+                                  {
+                                    "alias": "openaiMaxTokens",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxTokens",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxCompletionTokens",
+                                    "storageKey": null
+                                  },
+                                  (v11/*:: as any*/),
+                                  (v12/*:: as any*/),
+                                  (v13/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "seed",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "stop",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "reasoningEffort",
+                                    "storageKey": null
+                                  },
+                                  (v14/*:: as any*/)
+                                ],
+                                "type": "PromptOpenAIInvocationParameters",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": "anthropicMaxTokens",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxTokens",
+                                    "storageKey": null
+                                  },
+                                  (v10/*:: as any*/),
+                                  (v13/*:: as any*/),
+                                  (v15/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptAnthropicOutputConfig",
+                                    "kind": "LinkedField",
+                                    "name": "outputConfig",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "effort",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": null,
+                                    "kind": "LinkedField",
+                                    "name": "thinking",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*:: as any*/),
+                                      {
+                                        "kind": "InlineFragment",
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "disabled",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "type": "PromptAnthropicThinkingDisabled",
+                                        "abstractKey": null
+                                      },
+                                      {
+                                        "kind": "InlineFragment",
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "budgetTokens",
+                                            "storageKey": null
+                                          },
+                                          {
+                                            "alias": "enabledDisplay",
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "display",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "type": "PromptAnthropicThinkingEnabled",
+                                        "abstractKey": null
+                                      },
+                                      {
+                                        "kind": "InlineFragment",
+                                        "selections": [
+                                          {
+                                            "alias": "adaptiveDisplay",
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "display",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "type": "PromptAnthropicThinkingAdaptive",
+                                        "abstractKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v14/*:: as any*/)
+                                ],
+                                "type": "PromptAnthropicInvocationParameters",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v10/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxOutputTokens",
+                                    "storageKey": null
+                                  },
+                                  (v15/*:: as any*/),
+                                  (v12/*:: as any*/),
+                                  (v11/*:: as any*/),
+                                  (v13/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "topK",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptGoogleThinkingConfig",
+                                    "kind": "LinkedField",
+                                    "name": "thinkingConfig",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "thinkingBudget",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "thinkingLevel",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "includeThoughts",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "PromptGoogleInvocationParameters",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": "awsMaxTokens",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxTokens",
+                                    "storageKey": null
+                                  },
+                                  (v10/*:: as any*/),
+                                  (v13/*:: as any*/),
+                                  (v15/*:: as any*/)
+                                ],
+                                "type": "PromptAwsInvocationParameters",
+                                "abstractKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PromptTools",
+                            "kind": "LinkedField",
+                            "name": "tools",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": null,
+                                "kind": "LinkedField",
+                                "name": "tools",
+                                "plural": true,
+                                "selections": [
+                                  (v2/*:: as any*/),
+                                  {
+                                    "kind": "InlineFragment",
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "PromptToolFunctionDefinition",
+                                        "kind": "LinkedField",
+                                        "name": "function",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "parameters",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "type": "PromptToolFunction",
+                                    "abstractKey": null
+                                  },
+                                  {
+                                    "kind": "InlineFragment",
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "raw",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "type": "PromptToolRaw",
+                                    "abstractKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "provider",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "modelProvider",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "template",
+                            "plural": false,
+                            "selections": [
+                              (v2/*:: as any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptMessage",
+                                    "kind": "LinkedField",
+                                    "name": "messages",
+                                    "plural": true,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "role",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": null,
+                                        "kind": "LinkedField",
+                                        "name": "content",
+                                        "plural": true,
+                                        "selections": [
+                                          (v2/*:: as any*/),
+                                          {
+                                            "kind": "InlineFragment",
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "concreteType": "TextContentValue",
+                                                "kind": "LinkedField",
+                                                "name": "text",
+                                                "plural": false,
+                                                "selections": [
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "text",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "type": "TextContentPart",
+                                            "abstractKey": null
+                                          },
+                                          {
+                                            "kind": "InlineFragment",
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "concreteType": "ToolCallContentValue",
+                                                "kind": "LinkedField",
+                                                "name": "toolCall",
+                                                "plural": false,
+                                                "selections": [
+                                                  (v16/*:: as any*/),
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "concreteType": "ToolCallFunction",
+                                                    "kind": "LinkedField",
+                                                    "name": "toolCall",
+                                                    "plural": false,
+                                                    "selections": [
+                                                      {
+                                                        "alias": null,
+                                                        "args": null,
+                                                        "kind": "ScalarField",
+                                                        "name": "arguments",
+                                                        "storageKey": null
+                                                      },
+                                                      (v4/*:: as any*/)
+                                                    ],
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "type": "ToolCallContentPart",
+                                            "abstractKey": null
+                                          },
+                                          {
+                                            "kind": "InlineFragment",
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "concreteType": "ToolResultContentValue",
+                                                "kind": "LinkedField",
+                                                "name": "toolResult",
+                                                "plural": false,
+                                                "selections": [
+                                                  (v16/*:: as any*/),
+                                                  {
+                                                    "alias": null,
+                                                    "args": null,
+                                                    "kind": "ScalarField",
+                                                    "name": "result",
+                                                    "storageKey": null
+                                                  }
+                                                ],
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "type": "ToolResultContentPart",
+                                            "abstractKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "PromptChatTemplate",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "template",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "PromptStringTemplate",
+                                "abstractKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "templateType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "templateFormat",
+                            "storageKey": null
+                          },
+                          (v3/*:: as any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PromptVersionTag",
+                        "kind": "LinkedField",
+                        "name": "promptVersionTag",
+                        "plural": false,
+                        "selections": [
+                          (v4/*:: as any*/),
+                          (v3/*:: as any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "outputConfigs",
+                        "plural": true,
+                        "selections": [
+                          (v2/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v4/*:: as any*/),
+                              (v17/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "label",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v4/*:: as any*/),
+                              (v17/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lowerBound",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "upperBound",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v4/*:: as any*/),
+                              (v17/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v6/*:: as any*/),
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "LLMEvaluator",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "evaluationTarget",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "filterCondition",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "samplingRate",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EvaluatorInputMapping",
+                "kind": "LinkedField",
+                "name": "inputMapping",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "literalMapping",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "pathMapping",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "ProjectEvaluator",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4c8871078b64a39cfb0db4b8fafc2a24",
+    "id": null,
+    "metadata": {},
+    "name": "projectEvaluatorDetailsLoaderQuery",
+    "operationKind": "query",
+    "text": "query projectEvaluatorDetailsLoaderQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      enabled\n      project {\n        id\n      }\n      evaluator {\n        __typename\n        id\n        kind\n        name\n        description\n      }\n      ...ProjectEvaluatorScopeDetails_projectEvaluator\n      ...LLMProjectEvaluatorDetails_projectEvaluator\n    }\n    id\n  }\n}\n\nfragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {\n  id\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        invocationParameters {\n          __typename\n          ...PromptInvocationParametersReadableFragment\n        }\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorScopeDetails_projectEvaluator on ProjectEvaluator {\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "324f9bae15f3e5102936daf712f10c8f";
+
+export default node;

--- a/app/src/pages/project/evaluators/projectEvaluatorDetailsLoader.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorDetailsLoader.ts
@@ -14,14 +14,8 @@ export const projectEvaluatorDetailsLoaderGQL = graphql`
         id
         name
         enabled
-        project {
-          id
-        }
         evaluator {
-          __typename
-          id
           kind
-          name
           description
         }
         ...ProjectEvaluatorScopeDetails_projectEvaluator
@@ -53,32 +47,31 @@ export async function projectEvaluatorDetailsLoader(
   const { projectEvaluatorId } = args.params;
   invariant(projectEvaluatorId, "projectEvaluatorId is required");
 
-  let evaluatorDisplayName: string | null = null;
-  let found = false;
+  let data: projectEvaluatorDetailsLoaderQuery["response"] | undefined;
   try {
-    const data = await fetchQuery<projectEvaluatorDetailsLoaderQuery>(
+    data = await fetchQuery<projectEvaluatorDetailsLoaderQuery>(
       RelayEnvironment,
       projectEvaluatorDetailsLoaderGQL,
       { projectEvaluatorId }
     ).toPromise();
-    if (data?.projectEvaluator?.__typename === "ProjectEvaluator") {
-      found = true;
-      evaluatorDisplayName = data.projectEvaluator.name;
-    }
   } catch {
-    // A malformed or stale id falls through to the not-found state.
+    // The server rejects ids that don't name a live evaluator, so a malformed
+    // or stale id surfaces here; fall through to the not-found state rather
+    // than the route error boundary.
   }
 
-  const queryRef = found
-    ? loadQuery<projectEvaluatorDetailsLoaderQuery>(
-        RelayEnvironment,
-        projectEvaluatorDetailsLoaderGQL,
-        { projectEvaluatorId }
-      )
-    : null;
+  const node = data?.projectEvaluator;
+  const projectEvaluator =
+    node?.__typename === "ProjectEvaluator" ? node : null;
 
   return {
-    queryRef,
-    evaluatorDisplayName,
+    queryRef: projectEvaluator
+      ? loadQuery<projectEvaluatorDetailsLoaderQuery>(
+          RelayEnvironment,
+          projectEvaluatorDetailsLoaderGQL,
+          { projectEvaluatorId }
+        )
+      : null,
+    evaluatorDisplayName: projectEvaluator?.name ?? null,
   };
 }

--- a/app/src/pages/project/evaluators/projectEvaluatorDetailsLoader.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorDetailsLoader.ts
@@ -1,0 +1,84 @@
+import { fetchQuery, graphql, loadQuery } from "react-relay";
+import type { LoaderFunctionArgs } from "react-router";
+import invariant from "tiny-invariant";
+
+import RelayEnvironment from "@phoenix/RelayEnvironment";
+
+import type { projectEvaluatorDetailsLoaderQuery } from "./__generated__/projectEvaluatorDetailsLoaderQuery.graphql";
+
+export const projectEvaluatorDetailsLoaderGQL = graphql`
+  query projectEvaluatorDetailsLoaderQuery($projectEvaluatorId: ID!) {
+    projectEvaluator: node(id: $projectEvaluatorId) {
+      __typename
+      ... on ProjectEvaluator {
+        id
+        name
+        enabled
+        project {
+          id
+        }
+        evaluator {
+          __typename
+          id
+          kind
+          name
+          description
+        }
+        ...ProjectEvaluatorScopeDetails_projectEvaluator
+        ...LLMProjectEvaluatorDetails_projectEvaluator
+      }
+    }
+  }
+`;
+
+export type ProjectEvaluatorDetailsLoaderData = Awaited<
+  ReturnType<typeof projectEvaluatorDetailsLoader>
+>;
+
+/**
+ * Loads the data required for the project evaluator details page.
+ *
+ * The id in the URL may name a deleted evaluator or nothing at all, so a
+ * failed or empty lookup resolves to a null query ref — the page renders a
+ * not-found state — rather than rejecting into the route error boundary.
+ */
+export async function projectEvaluatorDetailsLoader(
+  args: LoaderFunctionArgs
+): Promise<{
+  queryRef: ReturnType<
+    typeof loadQuery<projectEvaluatorDetailsLoaderQuery>
+  > | null;
+  evaluatorDisplayName: string | null;
+}> {
+  const { projectEvaluatorId } = args.params;
+  invariant(projectEvaluatorId, "projectEvaluatorId is required");
+
+  let evaluatorDisplayName: string | null = null;
+  let found = false;
+  try {
+    const data = await fetchQuery<projectEvaluatorDetailsLoaderQuery>(
+      RelayEnvironment,
+      projectEvaluatorDetailsLoaderGQL,
+      { projectEvaluatorId }
+    ).toPromise();
+    if (data?.projectEvaluator?.__typename === "ProjectEvaluator") {
+      found = true;
+      evaluatorDisplayName = data.projectEvaluator.name;
+    }
+  } catch {
+    // A malformed or stale id falls through to the not-found state.
+  }
+
+  const queryRef = found
+    ? loadQuery<projectEvaluatorDetailsLoaderQuery>(
+        RelayEnvironment,
+        projectEvaluatorDetailsLoaderGQL,
+        { projectEvaluatorId }
+      )
+    : null;
+
+  return {
+    queryRef,
+    evaluatorDisplayName,
+  };
+}

--- a/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -47,6 +47,8 @@ export function useProjectEvaluatorPaths() {
         withCurrentSearch(
           `${list}/new/attach/${encodeURIComponent(evaluatorId)}`
         ),
+      details: (projectEvaluatorId: string) =>
+        withCurrentSearch(`${list}/${encodeURIComponent(projectEvaluatorId)}`),
       edit: (projectEvaluatorId: string) =>
         withCurrentSearch(
           `${list}/${encodeURIComponent(projectEvaluatorId)}/edit`

--- a/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -75,12 +75,16 @@ export function formatEvaluationTarget(
   return `${target.charAt(0)}${target.slice(1).toLowerCase()}`;
 }
 
+// Hoisted: Intl.NumberFormat construction does locale resolution, and the
+// evaluators table calls this per row per render.
+const samplingRateFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
+
 /** Formats a sampling fraction (0-1) as a percentage for display. */
 export function formatSamplingRate(samplingRate: number): string {
-  return new Intl.NumberFormat(undefined, {
-    style: "percent",
-    maximumFractionDigits: 2,
-  }).format(samplingRate);
+  return samplingRateFormatter.format(samplingRate);
 }
 
 export type ProjectEvaluatorMappingDiagnostic = {

--- a/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -68,6 +68,21 @@ export function toProjectEvaluatorSamplingFraction(percent: number): number {
   return Math.min(100, Math.max(0, percent)) / 100;
 }
 
+/** "SPAN" -> "Span", for display in the evaluators table and details page. */
+export function formatEvaluationTarget(
+  target: ProjectEvaluatorGraphQLTarget
+): string {
+  return `${target.charAt(0)}${target.slice(1).toLowerCase()}`;
+}
+
+/** Formats a sampling fraction (0-1) as a percentage for display. */
+export function formatSamplingRate(samplingRate: number): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "percent",
+    maximumFractionDigits: 2,
+  }).format(samplingRate);
+}
+
 export type ProjectEvaluatorMappingDiagnostic = {
   variable: string;
   path: string;

--- a/app/tests/projects.spec.ts
+++ b/app/tests/projects.spec.ts
@@ -23,6 +23,7 @@ async function createProject(
 const EVALUATORS_URL = /\/projects\/[^/]+\/evaluators(\?|$)/;
 const NEW_LLM_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/new\/llm(\?|$)/;
 const EDIT_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/[^/]+\/edit(\?|$)/;
+const EVALUATOR_DETAILS_URL = /\/projects\/[^/]+\/evaluators\/[^/]+(\?|$)/;
 
 async function clickSortableHeaderAndExpect(
   header: Locator,
@@ -261,6 +262,19 @@ test.describe.serial("Projects", () => {
       evaluatorRow.getByRole("cell", { name: "100%" })
     ).toBeVisible();
 
+    // The evaluator's name links to its read-only details page.
+    await evaluatorRow
+      .getByRole("link", { name: evaluatorName, exact: true })
+      .click();
+    await expect(page).toHaveURL(EVALUATOR_DETAILS_URL);
+    await expect(
+      page.getByRole("heading", { name: `Evaluator: ${evaluatorName}` })
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Scope" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Prompt" })).toBeVisible();
+    await page.goBack();
+    await expect(page).toHaveURL(EVALUATORS_URL);
+
     await evaluatorRow
       .getByRole("button", { name: "Evaluator actions" })
       .click();
@@ -274,6 +288,16 @@ test.describe.serial("Projects", () => {
     await editDialog.getByRole("button", { name: "Update" }).click();
     await expect(editDialog).not.toBeVisible();
 
+    // The edit slideover is nested under the details page, so saving lands on
+    // the details view showing the fresh name.
+    await expect(page).toHaveURL(EVALUATOR_DETAILS_URL);
+    await expect(
+      page.getByRole("heading", { name: `Evaluator: ${updatedEvaluatorName}` })
+    ).toBeVisible();
+
+    // Deletion lives on the list's row action menu, not the details page.
+    await page.goBack();
+    await expect(page).toHaveURL(EVALUATORS_URL);
     const updatedRow = table
       .getByRole("row")
       .filter({ hasText: updatedEvaluatorName });


### PR DESCRIPTION
Part of #11650. Closes #15307.

A project evaluator could only be inspected by opening the edit form. This adds a read-only details page at `/projects/:projectId/evaluators/:projectEvaluatorId`, mirroring the dataset evaluator details page's shape (`PageHeader` + `Tabs`), and lands the shell the code-evaluator details and traces tabs will build on.

<img width="2526" height="1250" alt="Screenshot 2026-08-11 at 10 44 39 AM" src="https://github.com/user-attachments/assets/aa08bba3-2e48-45cd-8d31-661c80e1ed07" />
