### PR TITLE
ci: report dependency-floor resolution and run the client without evals

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -138,6 +138,28 @@ jobs:
           version: "0.11.31"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
+  phoenix-client-no-evals:
+    name: Phoenix Client without Evals
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.phoenix_client == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            requirements/
+            scripts/
+            packages/phoenix-client/
+            packages/phoenix-executors/
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.31"
+      - run: uvx tox run -e phoenix_client_no_evals -- -ra -x
+
   phoenix-evals:
     name: Phoenix Evals
     runs-on: ubuntu-latest
@@ -462,6 +484,61 @@ jobs:
       - name: Check lockfile is up to date
         run: uv lock --check
 
+  floor-resolution:
+    name: Resolve dependency floors
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.uv_lock == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+      - name: Set up `uv`
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.11.31"
+      - name: Resolve dependencies at their declared floors
+        # `uv pip compile --no-sources` is what reaches PyPI for the Phoenix packages. The
+        # project-level `uv lock` never does: workspace membership supplies the only candidate for
+        # a member under every flag combination, so a lock-based form of this check would report
+        # success without resolving a published version at all.
+        run: |
+          echo attempted > "${RUNNER_TEMP}/attempted"
+          resolver_exit=0
+          uv pip compile pyproject.toml \
+            --no-sources --resolution lowest-direct \
+            --output-file "${RUNNER_TEMP}/floors.txt" > "${RUNNER_TEMP}/resolver.log" 2>&1 || resolver_exit=$?
+          unpinned=$(grep -c 'is unpinned' "${RUNNER_TEMP}/resolver.log" || true)
+          cat "${RUNNER_TEMP}/resolver.log"
+          {
+            echo "### Floor resolution"
+            echo
+            echo "| Measure | Value |"
+            echo "| --- | --- |"
+            echo "| Resolver exit code | \`${resolver_exit}\` |"
+            echo "| Direct dependencies with no lower bound | ${unpinned} |"
+            echo
+            echo "A non-zero exit means the lowest versions this project declares do not install"
+            echo "together. The unpinned count is the distance to fixing that: each one lets the"
+            echo "resolver reach an arbitrarily old release."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "resolver exit code: ${resolver_exit}"
+          echo "unpinned direct dependencies: ${unpinned}"
+      - name: Confirm the resolution ran
+        if: always()
+        # Without this, a resolution step that never executed is indistinguishable from one that
+        # found nothing to report, and the green check reads as coverage either way.
+        run: |
+          test -f "${RUNNER_TEMP}/attempted" || {
+            echo "No resolution was attempted on a run that changed dependency metadata." >&2
+            exit 1
+          }
+
   format-and-lint:
     name: Format and Lint
     runs-on: ${{ matrix.os }}
@@ -758,6 +835,7 @@ jobs:
       - format-and-lint
       - changes
       - phoenix-client
+      - phoenix-client-no-evals
       - phoenix-evals
       - phoenix-executors
       - phoenix-executors-compat

--- a/packages/phoenix-client/tests/client/utils/test_executors.py
+++ b/packages/phoenix-client/tests/client/utils/test_executors.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.util
 import os
 import platform
 import queue
@@ -9,15 +10,20 @@ import textwrap
 import threading
 import time
 from typing import Any, Iterator, Sequence, Union, overload
+from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
 import nest_asyncio  # type: ignore[import-untyped]
 import pytest
+from phoenix.executors import exceptions as shared_exceptions
 from phoenix.executors import executors as shared_executors
 
+from phoenix.client import exceptions as client_exceptions
+from phoenix.client.exceptions import SpanCreationError
 from phoenix.client.utils import executors
 from phoenix.client.utils.executors import (
     AsyncExecutor,
+    ConcurrencyController,
     ExecutionStatus,
     SyncExecutor,
     get_executor_on_sync_context,
@@ -652,6 +658,10 @@ def test_re_exports_are_the_shared_objects_not_copies() -> None:
         assert getattr(executors, name) is getattr(shared_executors, name)
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("phoenix.evals") is None,
+    reason="there is no import order to exercise when arize-phoenix-evals is not installed",
+)
 @pytest.mark.parametrize(
     "first_import",
     ["phoenix.client.utils.executors", "phoenix.evals"],
@@ -681,3 +691,24 @@ def test_legacy_class_lookup_survives_either_import_order(first_import: str) -> 
     )
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
+
+
+def test_exceptions_re_export_the_shared_base() -> None:
+    # The executors sort failures by exception class identity. This package declares its own
+    # subclasses of the base below, so a locally-redeclared base would drop every one of them out
+    # of the tier it selects without changing a single call site.
+    assert client_exceptions.PhoenixException is shared_exceptions.PhoenixException
+    assert "PhoenixException" in client_exceptions.__all__
+
+
+async def test_this_package_s_domain_error_fails_fast() -> None:
+    async def always_raises(payload: Any) -> Any:
+        raise SpanCreationError("spans rejected")
+
+    executor = AsyncExecutor(always_raises, concurrency=1, max_retries=2, exit_on_error=False)
+    with mock.patch.object(ConcurrencyController, "record_error") as record_error:
+        _, details = await executor.execute([0])
+
+    assert len(details[0].exceptions) == 1, "a domain error is not worth retrying"
+    assert details[0].status is ExecutionStatus.FAILED
+    assert record_error.call_count == 0, "and it says nothing about the provider's rate limits"

--- a/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
@@ -6,15 +6,20 @@ import signal
 import sys
 import threading
 import time
+from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
 import nest_asyncio
 import pytest
+from phoenix.executors import exceptions as shared_exceptions
 from phoenix.executors import executors as shared_executors
 
+from phoenix.evals import exceptions as evals_exceptions
 from phoenix.evals import executors
+from phoenix.evals.exceptions import PhoenixTemplateMappingError
 from phoenix.evals.executors import (
     AsyncExecutor,
+    ConcurrencyController,
     ExecutionStatus,
     SyncExecutor,
     get_executor_on_sync_context,
@@ -774,3 +779,24 @@ def test_re_exports_are_the_shared_objects_not_copies():
     # separately-defined class here would break classification across package boundaries.
     for name in FROZEN_EXECUTOR_NAMES:
         assert getattr(executors, name) is getattr(shared_executors, name)
+
+
+def test_exceptions_re_export_the_shared_base():
+    # The executors sort failures by exception class identity. This package declares its own
+    # subclasses of the base below, so a locally-redeclared base would drop every one of them out
+    # of the tier it selects without changing a single call site.
+    assert evals_exceptions.PhoenixException is shared_exceptions.PhoenixException
+    assert "PhoenixException" in evals_exceptions.__all__
+
+
+async def test_this_package_s_domain_error_fails_fast():
+    async def always_raises(payload):
+        raise PhoenixTemplateMappingError("no mapping for the template")
+
+    executor = AsyncExecutor(always_raises, concurrency=1, max_retries=2, exit_on_error=False)
+    with mock.patch.object(ConcurrencyController, "record_error") as record_error:
+        _, details = await executor.execute([0])
+
+    assert len(details[0].exceptions) == 1, "a domain error is not worth retrying"
+    assert details[0].status is ExecutionStatus.FAILED
+    assert record_error.call_count == 0, "and it says nothing about the provider's rate limits"

--- a/requirements/packages/phoenix-client-no-evals.txt
+++ b/requirements/packages/phoenix-client-no-evals.txt
@@ -1,0 +1,7 @@
+-r ../ci.txt
+pandas<3
+pandas-stubs<3
+google-generativeai>=0.8.4
+openai>=1.62.0
+anthropic>=0.49.0
+nest-asyncio

--- a/requirements/packages/phoenix-client.txt
+++ b/requirements/packages/phoenix-client.txt
@@ -1,8 +1,2 @@
--r ../ci.txt
+-r phoenix-client-no-evals.txt
 arize-phoenix-evals
-pandas<3
-pandas-stubs<3
-google-generativeai>=0.8.4
-openai>=1.62.0
-anthropic>=0.49.0
-nest-asyncio

--- a/scripts/assert_package_absent.py
+++ b/scripts/assert_package_absent.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Fail if a distribution is installed in the current environment.
+
+An environment that exists to prove something still works *without* a package proves nothing once
+that package creeps back into its resolved set — every test passes, and the green result reads as
+coverage for a configuration that was never built.
+"""
+
+import sys
+from importlib.metadata import PackageNotFoundError, version
+
+
+def main(names: list[str]) -> int:
+    installed = []
+    for name in names:
+        try:
+            installed.append(f"{name}=={version(name)}")
+        except PackageNotFoundError:
+            continue
+    if installed:
+        print(f"expected to be absent but installed: {', '.join(installed)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"usage: {sys.argv[0]} <distribution-name> [...]", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(main(sys.argv[1:]))

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,18 @@ commands =
   {envbindir}/mypy --strict .
   {envbindir}/pytest {posargs} tests/client
 
+[testenv:phoenix_client_no_evals]
+description = Run tests for the arize-phoenix-client package without arize-phoenix-evals installed
+changedir = packages/phoenix-client/
+commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/packages/phoenix-client-no-evals.txt
+  uv pip install --strict --reinstall-package arize-phoenix-executors {toxinidir}/packages/phoenix-executors
+  uv pip install --strict --reinstall-package arize-phoenix-client .
+commands =
+  uv pip list -v
+  python {toxinidir}/scripts/assert_package_absent.py arize-phoenix-evals
+  {envbindir}/pytest {posargs} tests/client
+
 [testenv:phoenix_client_canary_tests_sdk_openai]
 description = Run phoenix-client canary tests for third-party SDK: anthropic
 changedir = packages/phoenix-client/


### PR DESCRIPTION

## Summary

Our declared dependency floors are largely untested claims. Nothing in CI ever resolves the project
against the *lowest* versions its own metadata permits, so a floor can be wrong — too low to install,
or missing entirely — and stay wrong indefinitely. This adds a job that measures that, plus an
environment that checks the client still works without its optional evals dependency.

The floor job reports; it does not gate. It cannot gate yet, and the numbers it publishes say why.

## What ships

**A dependency-floor resolution report** (`floor-resolution` in `python-CI.yml`), attached to the same
path filter as the lockfile check, since that filter is the only one matching `**/pyproject.toml`. It
runs `uv pip compile --no-sources --resolution lowest-direct` against the root manifest and publishes
two numbers to the run summary on every eligible run, including a failing one:

| Measure | Current value |
| --- | --- |
| Resolver exit code | `1` |
| Direct dependencies with no lower bound | `28` |

The exit code is 1 because the lowest `scikit-learn` we permit is a 2011 release whose build cannot
find numpy. The 28 is the distance to fixing that — each unbounded dependency is one the resolver may
take arbitrarily far back. Neither number blocks a merge today; the job is deliberately absent from
the required-checks list. When the root resolution exits zero, promoting it is a one-line change.

A second step fails if no resolution was attempted. A job that quietly did nothing and a job that
found nothing to report are otherwise indistinguishable in the checks list, and the green mark reads
as coverage either way.

**An evals-absent client environment** (`phoenix_client_no_evals`), running the client suite with
`arize-phoenix-evals` not installed. `arize-phoenix-evals` is an optional extra, so the base client is
expected to work without it, but nothing verified that. The environment asserts the package really is
absent from the resolved set before running anything — an environment that silently regained the
package would pass every test and prove nothing.

It found something on its first run: a test drives a subprocess importing `phoenix.evals`
unconditionally, so it failed under an evals-absent install. Its precondition is now declared.

**Exception-base coverage at both package surfaces.** The client and evals executors are re-exports of
one shared implementation, and both packages declare their own subclasses of the shared
`PhoenixException`. The executors pick a failure tier by exception class identity, so a locally
redeclared base would drop every one of those subclasses out of the fail-fast tier without changing a
single call site. `executors` and `rate_limiters` already had identity pins at both surfaces;
`exceptions` did not.

## What this PR does not change

- **No floors are added or altered.** The 28 unbounded root dependencies stay unbounded. Bounding them
  is a much larger change with its own risk profile and review surface, and it is what the reported
  number exists to size.
- **No `[tool.uv.sources]` or `[tool.uv.workspace]` changes.** The floor job works around workspace
  linkage rather than modifying it.
- **`tox -e phoenix_client` and `tox -e phoenix_evals` behave identically.** `phoenix-client.txt` is
  split so the evals-absent environment can reuse it, but the two files resolve to the set the single
  file resolved to before.
- **The floor job does not gate merges.** It is not in the required-checks list.

## Design notes

**Why `uv pip compile` and not `uv lock`.** The obvious form of this check — `uv lock --resolution
lowest-direct` — cannot work here and would pass forever without testing anything. For a workspace
member, membership itself supplies the only resolution candidate; neither `--no-sources` nor
`--no-sources-package` redirects to the registry, they only restore the constraint check. So a floor
*below* the local version becomes unsatisfiable rather than fetched. The `uv pip` interface does fall
back to the registry, and is already the idiom used elsewhere in `tox.ini`.

**Why the output file is a real path.** `uv pip compile` writes its output atomically through a temp
file created beside the destination, so `--output-file /dev/null` makes a fully successful resolution
exit 2 trying to write into `/dev/`. That would have made "exits zero" unreachable and misreported
every clean resolution as a failure.

**Why the report is staged rather than a gate.** A floor gate that silently passes on exactly the pull
requests it was written for is worse than no gate, because it reads as coverage. Reporting a number
that is currently bad is honest about the state and gives a metric to close.

## Test plan

- `tox -e phoenix_client` — 635 passed. Unchanged from base, including pyright and `mypy --strict`.
- `tox -e phoenix_client_no_evals` — 633 passed, 2 skipped. `arize-phoenix-evals` confirmed absent
  from the resolved set; the absence assertion was checked in both directions.
- `tox -e phoenix_evals` — 685 passed.
- `tox -e phoenix_executors_mixed_version` — 3 passed, unaffected.
- Floor job step script executed verbatim against the root manifest (exit 1, 28 unpinned) and against
  `packages/phoenix-otel/pyproject.toml`, which resolves cleanly (exit 0, 4 unpinned) — confirming the
  report is correct on both the failing and the succeeding path, and that the step itself exits 0
  either way.
- `actionlint` on `python-CI.yml`: same six pre-existing findings as base, none in the added jobs.
- `make format-python && make lint-python && git diff --exit-code`: clean.
- Both commits verified green in isolation.

