### PR TITLE
fix: bake client tool timing metadata into the local transcript on resolution

### DIFF
--- a/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
+++ b/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
@@ -2,7 +2,9 @@ import { isToolUIPart } from "ai";
 import { Environment, Network, RecordSource, Store } from "relay-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { createClientToolTimingRecorder } from "@phoenix/agent/chat/clientToolTimings";
 import {
+  applyClientToolTimingMetadata,
   createAgentSessionChat,
   getTurnClientState,
 } from "@phoenix/agent/chat/createAgentSessionChat";
@@ -33,6 +35,99 @@ async function flushMicrotasks() {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe("applyClientToolTimingMetadata", () => {
+  it("bakes recorded timings into the resolved part so a resend survives the recorder clearing", () => {
+    let now = new Date("2026-08-11T16:08:57.143Z");
+    const toolTimings = createClientToolTimingRecorder({
+      getCurrentTime: () => now,
+    });
+    toolTimings.recordStart("tool-call-1");
+    now = new Date("2026-08-11T16:08:57.150Z");
+    toolTimings.recordEnd("tool-call-1");
+    const messages: AgentUIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: `tool-${EDIT_PROMPT_TOOL_NAME}`,
+            toolCallId: "tool-call-1",
+            state: "output-available",
+            input: { edits: [] },
+            output: "done",
+            callProviderMetadata: CLIENT_EXECUTION_METADATA,
+          } as AgentUIMessagePart,
+        ],
+      },
+    ];
+
+    const updated = applyClientToolTimingMetadata({
+      messages,
+      toolCallId: "tool-call-1",
+      toolTimings,
+    });
+
+    // The transcript copy now matches the enriched wire payload, so building
+    // a resend after toolTimings.clear() reproduces the persisted part.
+    toolTimings.clear();
+    const part = updated[0]?.parts.find((candidate) =>
+      isToolUIPart(candidate)
+    );
+    expect(part).toMatchObject({
+      callProviderMetadata: {
+        phoenix: {
+          toolExecutionEnvironment: "client",
+          clientStartedAt: "2026-08-11T16:08:57.143Z",
+          clientEndedAt: "2026-08-11T16:08:57.150Z",
+        },
+      },
+    });
+    // The original messages are not mutated.
+    expect(messages[0]?.parts[0]).toMatchObject({
+      callProviderMetadata: CLIENT_EXECUTION_METADATA,
+    });
+    expect(
+      (messages[0]?.parts[0] as { callProviderMetadata: object })
+        .callProviderMetadata
+    ).toEqual(CLIENT_EXECUTION_METADATA);
+  });
+
+  it("returns the same array when the call has no recorded timings", () => {
+    const toolTimings = createClientToolTimingRecorder();
+    const messages: AgentUIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: `tool-${EDIT_PROMPT_TOOL_NAME}`,
+            toolCallId: "tool-call-1",
+            state: "output-available",
+            input: { edits: [] },
+            output: "done",
+            callProviderMetadata: CLIENT_EXECUTION_METADATA,
+          } as AgentUIMessagePart,
+        ],
+      },
+    ];
+
+    expect(
+      applyClientToolTimingMetadata({
+        messages,
+        toolCallId: "tool-call-1",
+        toolTimings,
+      })
+    ).toBe(messages);
+    expect(
+      applyClientToolTimingMetadata({
+        messages,
+        toolCallId: "tool-call-unknown",
+        toolTimings,
+      })
+    ).toBe(messages);
+  });
 });
 
 describe("createAgentSessionChat rehydration", () => {

--- a/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
+++ b/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
@@ -72,9 +72,7 @@ describe("applyClientToolTimingMetadata", () => {
     // The transcript copy now matches the enriched wire payload, so building
     // a resend after toolTimings.clear() reproduces the persisted part.
     toolTimings.clear();
-    const part = updated[0]?.parts.find((candidate) =>
-      isToolUIPart(candidate)
-    );
+    const part = updated[0]?.parts.find((candidate) => isToolUIPart(candidate));
     expect(part).toMatchObject({
       callProviderMetadata: {
         phoenix: {

--- a/app/src/agent/chat/createAgentSessionChat.ts
+++ b/app/src/agent/chat/createAgentSessionChat.ts
@@ -4,9 +4,13 @@ import { commitLocalUpdate } from "react-relay";
 
 import {
   buildAgentChatRequestBody,
+  enrichMessageWithClientToolMetadata,
   type AgentModelSelection,
 } from "@phoenix/agent/chat/buildAgentChatRequestBody";
-import { createClientToolTimingRecorder } from "@phoenix/agent/chat/clientToolTimings";
+import {
+  createClientToolTimingRecorder,
+  type ClientToolTimingRecorder,
+} from "@phoenix/agent/chat/clientToolTimings";
 import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
 import {
   partitionPendingClientToolCalls,
@@ -163,6 +167,19 @@ export function createAgentSessionChat({
           store.getState().markToolCallInterrupted(toolCall.toolCallId);
         }
         await chat.addToolOutput(toolOutput);
+        // Bake the browser-recorded timings into the transcript copy of the
+        // resolved part. Request-time enrichment stamps them onto the wire
+        // payload only, and the recorder clears when the turn completes, so
+        // without this a resend of the output after turn completion (e.g. a
+        // new user message re-carrying the preceding assistant message's
+        // resolved outputs before the poll syncs the persisted transcript)
+        // could not reproduce the persisted part and would be rejected as a
+        // divergent result.
+        chat.messages = applyClientToolTimingMetadata({
+          messages: chat.messages,
+          toolCallId: toolCall.toolCallId,
+          toolTimings,
+        });
       },
       appendMessagePart: (part) => {
         chat.messages = appendPartToToolMessage({
@@ -348,6 +365,40 @@ export function createAgentSessionChat({
   recoverPendingToolCalls();
   turnClientStateByChat.set(chat, { toolTimings, recoverPendingToolCalls });
   return chat;
+}
+
+/**
+ * Write the recorder's timing metadata for a resolved tool call back into the
+ * message that owns it, using the same enrichment the request payload gets so
+ * the local part stays byte-identical to what the server persists.
+ */
+export function applyClientToolTimingMetadata({
+  messages,
+  toolCallId,
+  toolTimings,
+}: {
+  messages: AgentUIMessage[];
+  toolCallId: string;
+  toolTimings: ClientToolTimingRecorder;
+}): AgentUIMessage[] {
+  const messageIndex = messages.findIndex((message) =>
+    message.parts.some(
+      (part) => isToolUIPart(part) && part.toolCallId === toolCallId
+    )
+  );
+  if (messageIndex === -1) {
+    return messages;
+  }
+  const enrichedMessage = enrichMessageWithClientToolMetadata({
+    message: messages[messageIndex],
+    toolTimings,
+  });
+  if (enrichedMessage === messages[messageIndex]) {
+    return messages;
+  }
+  return messages.map((message, index) =>
+    index === messageIndex ? enrichedMessage : message
+  );
 }
 
 function appendPartToToolMessage({


### PR DESCRIPTION
## Problem

Same bug as #15325, alternative fix for comparison. Accepting an `edit_prompt` suggestion in PXI and immediately sending a message returns a 409:

```
agent_session_tool_outputs_conflict
Tool output 'call_…' differs from the persisted result for its already-resolved call; reload the conversation
```

## Root cause

The server requires a resend of an already-resolved tool output to be byte-identical to the persisted part, but the client can't reproduce those bytes:

- `enrichMessageWithClientToolMetadata` stamps `phoenix.clientStartedAt` / `clientEndedAt` onto the **request payload only** — never onto the local `chat.messages` part.
- `toolTimings.clear()` runs at turn end, so the recorder can't re-derive them.

A new user message re-carries the preceding assistant message's resolved outputs; in the window between turn completion and the next poll sync those outputs lack the timing fields and read as divergent.

## Fix (client-side)

Write the recorder's timings back into the resolved part right after `chat.addToolOutput`, via a new `applyClientToolTimingMetadata` helper that reuses the same enrichment the wire payload gets — so the local transcript stays byte-identical to what the server persists, and resends survive the recorder clearing. This also removes the local/persisted transcript divergence itself, rather than making the server tolerant of it.

**CLI:** no counterpart needed — the CLI executes no client tools and never submits `toolOutputs` (documented in `js/packages/phoenix-cli/src/pxi/client.ts` and `types.ts`).

## Comparison with #15325

- This PR eliminates the divergence at the source (local transcript fidelity), but byte-equality across client/server round-trips stays load-bearing — any future server-side normalization of persisted parts would reintroduce the conflict.
- #15325 makes the server comparison timing-insensitive, protecting the whole class regardless of client behavior.
- The two are complementary; either alone fixes the reported repro.

## Testing

- New unit tests for `applyClientToolTimingMetadata` (timings baked immutably; no-op without recorded timings)
- `createAgentSessionChat`, `buildAgentChatRequestBody`, and `toolOutputFlush` suites pass (24 tests); `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)