### PR TITLE
ci: consolidate release into one CI-gated workflow

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -2,9 +2,15 @@ name: Publish Docker images
 permissions:
   contents: read
 on:
-  push:
-    tags:
-      - "arize-phoenix-v*"
+  # Called by release.yml as the gated Docker step of a release. `version` is
+  # the released arize-phoenix version (from the release-please manifest). No
+  # tag-push trigger: images ship only after release.yml's CI gate passes,
+  # never straight off a tag on an un-verified build.
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 jobs:
   push_to_registry:
@@ -27,13 +33,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Extract version from tag
+      - name: Resolve version
         id: extract_version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/arize-phoenix-v}" >> $GITHUB_ENV
-          echo "VERSION=${GITHUB_REF#refs/tags/arize-phoenix-v}" >> $GITHUB_OUTPUT
-          echo "MAJOR_VERSION=$(echo ${GITHUB_REF#refs/tags/arize-phoenix-v} | cut -d. -f1)" >> $GITHUB_ENV
-          echo "MINOR_VERSION=$(echo ${GITHUB_REF#refs/tags/arize-phoenix-v} | cut -d. -f2)" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "MAJOR_VERSION=$(echo "$VERSION" | cut -d. -f1)" >> $GITHUB_ENV
+          echo "MINOR_VERSION=$(echo "$VERSION" | cut -d. -f2)" >> $GITHUB_ENV
 
       - name: Set BASE_IMAGE environment variable
         id: set-base-image

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -11,6 +11,15 @@ on:
       version:
         required: true
         type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_PASSWORD:
+        required: true
+      MY_RELEASE_PLEASE_TOKEN:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: false
 
 jobs:
   push_to_registry:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,6 +16,9 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
 
 name: Publish Python packages
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,10 +8,18 @@ on:
         required: false
         type: string
         default: ""
+  # Called by release.yml as the gated Python-publish step of a release. No
+  # feature_branch is passed, so it defaults to "" and runs the release flow.
+  workflow_call:
+    inputs:
+      feature_branch:
+        required: false
+        type: string
+        default: ""
 
 name: Publish Python packages
 
-# This workflow has two modes, both dispatched manually:
+# This workflow has two modes:
 #   - Release (feature_branch empty): the production flow — build from
 #     release-please tags and publish final versions to PyPI.
 #   - Preview (feature_branch set): publish PEP 440 development (dev) pre-releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,8 @@ jobs:
       id-token: write
       actions: write
     uses: ./.github/workflows/publish.yaml
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   publish-docker:
     name: Publish Docker images
@@ -135,4 +136,8 @@ jobs:
     uses: ./.github/workflows/docker-build-release.yml
     with:
       version: ${{ needs.release-please.outputs.phoenix_version }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      MY_RELEASE_PLEASE_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,134 @@ on:
 
 name: release
 
+# One release workflow, driven by release-please.
+#
+# A release starts when the release-please PR is merged to main. That merge is
+# this run's github.sha — the exact commit CI runs on. Before anything ships we
+# wait for that commit's required CI checks to conclude green (await-ci):
+# "release at will, only if CI passes". Publishing then runs as gated jobs in
+# this single workflow — Python packages via publish.yaml and Docker images via
+# docker-build-release.yml — instead of being fired blindly with
+# `gh workflow run` or off a tag push.
+#
+# Left on their own tracks (not consolidated here): npm packages
+# (typescript-packages-publish.yml, changesets) and the Helm chart
+# (helm-release.yaml, which runs off the version-bump PR that Docker opens).
+
+permissions: {}
+
 jobs:
-  release:
+  release-please:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
       pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
+      phoenix_version: ${{ steps.version.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
         id: release
-      - name: Trigger publish
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.release.outputs.releases_created == 'true'
-        run: gh workflow run publish.yaml --repo ${{ github.repository }}
+        with:
+          persist-credentials: false
+          sparse-checkout: .release-please-manifest.json
+          sparse-checkout-cone-mode: false
+      - name: Read arize-phoenix version from manifest
+        id: version
+        if: steps.release.outputs.releases_created == 'true'
+        run: |
+          v=$(jq -r '.["."] // empty' .release-please-manifest.json)
+          if [ -z "$v" ]; then echo "::error::No version for root (.) in manifest"; exit 1; fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+  # Gate: block all publishing until the release commit's required CI checks are
+  # green. Those checks run on this same push, so they may not exist yet when we
+  # start — poll until each required workflow has a completed run for github.sha,
+  # fail fast if any concludes non-success, and time out rather than hang.
+  await-ci:
+    name: Wait for CI to pass
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for required checks on the release commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          required=("Python CI" "Typescript CI" "Typescript Packages CI" "Playwright Tests")
+          timeout=$(( 60 * 60 ))   # 60 minutes
+          interval=30
+          waited=0
+          while :; do
+            runs=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=100")
+            pending=()
+            for wf in "${required[@]}"; do
+              read -r status conclusion < <(
+                echo "$runs" | jq -r --arg n "$wf" '
+                  [.workflow_runs[] | select(.name == $n)]
+                  | sort_by(.run_started_at) | last
+                  | "\(.status // "missing") \(.conclusion // "none")"'
+              )
+              case "$status" in
+                completed)
+                  if [ "$conclusion" != "success" ]; then
+                    echo "::error::$wf concluded '$conclusion' on $SHA — aborting release"
+                    exit 1
+                  fi
+                  echo "PASS  $wf"
+                  ;;
+                *)
+                  echo "wait  $wf ($status)"
+                  pending+=("$wf")
+                  ;;
+              esac
+            done
+            if [ "${#pending[@]}" -eq 0 ]; then
+              echo "All required checks passed."
+              break
+            fi
+            if [ "$waited" -ge "$timeout" ]; then
+              echo "::error::Timed out after ${timeout}s waiting for: ${pending[*]}"
+              exit 1
+            fi
+            sleep "$interval"
+            waited=$(( waited + interval ))
+          done
+
+  publish-python:
+    name: Publish Python packages
+    needs: [release-please, await-ci]
+    if: needs.release-please.outputs.releases_created == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      actions: write
+    uses: ./.github/workflows/publish.yaml
+    secrets: inherit
+
+  publish-docker:
+    name: Publish Docker images
+    needs: [release-please, await-ci]
+    # Only when the root arize-phoenix package itself was released — a
+    # sibling-only release (e.g. arize-phoenix-evals) ships no new image.
+    if: >-
+      needs.release-please.outputs.releases_created == 'true' &&
+      contains(fromJSON(needs.release-please.outputs.paths_released), '.')
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      version: ${{ needs.release-please.outputs.phoenix_version }}
+    secrets: inherit


### PR DESCRIPTION
Closes #15273.

Consolidates the release into a single, CI-gated `release.yml` so that a
release ships **at will, only if CI passes**, instead of firing publishes
blindly across several disconnected runs.

## The human flow is unchanged
You still merge PRs to `main`, `release-please` still keeps a release PR open,
and **merging that release PR is still the "release now" action.** The only
difference: the release now *waits for CI to be green* on that commit before
anything publishes, and it all happens in one run you can watch top to bottom.

## What the release run now does
```
release-please  -> creates the GitHub release + tags, reads the arize-phoenix version
      |
await-ci        -> polls the release commit's (github.sha) CI runs; proceeds only
      |            when Python CI, Typescript CI, Typescript Packages CI, and
      |            Playwright Tests all conclude success (fails fast otherwise)
      +-- publish-python  (PyPI, via publish.yaml called in-run)
      +-- publish-docker  (Docker, via docker-build-release.yml called in-run)
```

## Changes
- **`release.yml`** — rewritten as the orchestrator: `release-please` -> `await-ci`
  gate -> gated publish jobs. Replaces the fire-and-forget `gh workflow run publish.yaml`.
- **`publish.yaml`** — gains a `workflow_call` trigger (keeps `workflow_dispatch`
  for manual/preview runs).
- **`docker-build-release.yml`** — gains `workflow_call`, takes `version` as an
  input instead of parsing the tag ref, and **drops its `arize-phoenix-v*`
  tag-push trigger** so images can only ship through a gated release. (Verified
  no other workflow consumes that tag.)

## Scope / caveats
- **npm and Helm are intentionally left on their own tracks.** npm
  (`typescript-packages-publish.yml`, changesets) still publishes on every push
  to main **without a CI gate** — so the "CI passes" guarantee currently covers
  PyPI + Docker, not npm. Unifying npm is a follow-up.
- **Timeout / recovery:** the gate waits up to 60 min (CI maxes ~12 min today, so
  ~5x headroom). If CI fails or the gate times out, `release-please` has already
  created the release + tags but **nothing publishes** — recover with
  **"Re-run failed jobs"** once CI is green. Note Docker no longer has a manual
  `workflow_dispatch` fallback (publish.yaml still does).
- **First release is the live test** — workflow changes can't be dry-run. The
  gate matches CI runs by workflow `name:` (`Python CI`, `Typescript CI`,
  `Typescript Packages CI`, `Playwright Tests`); those names are the contract.

