### PR TITLE
feat(online-evals): show projects in the evaluators table used-in column

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -458,6 +458,7 @@ type BuiltInEvaluator implements Evaluator & Node {
   updatedAt: DateTime!
   isBuiltin: Boolean!
   datasets(first: Int = 50, after: String): DatasetConnection!
+  projects(first: Int = 50, after: String): ProjectConnection!
   datasetEvaluators: [DatasetEvaluator!]!
   inputSchema: JSON
   user: User
@@ -608,6 +609,7 @@ type CodeEvaluator implements Evaluator & Node {
   updatedAt: DateTime!
   isBuiltin: Boolean!
   datasets(first: Int = 50, after: String): DatasetConnection!
+  projects(first: Int = 50, after: String): ProjectConnection!
   datasetEvaluators: [DatasetEvaluator!]!
   sandboxConfig: SandboxConfig
   inputMapping: EvaluatorInputMapping!
@@ -1685,6 +1687,7 @@ interface Evaluator implements Node {
   updatedAt: DateTime!
   isBuiltin: Boolean!
   datasets(first: Int = 50, after: String): DatasetConnection!
+  projects(first: Int = 50, after: String): ProjectConnection!
   datasetEvaluators: [DatasetEvaluator!]!
 }
 
@@ -2447,6 +2450,7 @@ type LLMEvaluator implements Evaluator & Node {
   updatedAt: DateTime!
   isBuiltin: Boolean!
   datasets(first: Int = 50, after: String): DatasetConnection!
+  projects(first: Int = 50, after: String): ProjectConnection!
   datasetEvaluators: [DatasetEvaluator!]!
   outputConfigs: [BuiltInEvaluatorOutputConfig!]!
   prompt: Prompt!

--- a/app/src/components/project/ProjectToken.tsx
+++ b/app/src/components/project/ProjectToken.tsx
@@ -13,6 +13,11 @@ export interface ProjectTokenProps extends Pick<
   name: string;
   gradientStartColor: string;
   gradientEndColor: string;
+  /**
+   * Destination to navigate to when the token is pressed.
+   * Defaults to the project's configuration page.
+   */
+  to?: string;
 }
 
 /**
@@ -30,6 +35,7 @@ export function ProjectToken({
   maxWidth,
   onRemove,
   isDisabled,
+  to,
 }: ProjectTokenProps) {
   const navigate = useNavigate();
   return (
@@ -45,7 +51,7 @@ export function ProjectToken({
         />
       }
       title={name}
-      onPress={() => navigate(`/projects/${projectId}/config`)}
+      onPress={() => navigate(to ?? `/projects/${projectId}/config`)}
       onRemove={onRemove}
       isDisabled={isDisabled}
     >

--- a/app/src/components/project/ProjectToken.tsx
+++ b/app/src/components/project/ProjectToken.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from "react-router";
-
 import type { TokenProps } from "@phoenix/components";
 import { Token } from "@phoenix/components";
 
@@ -7,37 +5,31 @@ import { GradientCircle } from "./GradientCircle";
 
 export interface ProjectTokenProps extends Pick<
   TokenProps,
-  "size" | "maxWidth" | "onRemove" | "isDisabled"
+  "size" | "maxWidth" | "onPress" | "onRemove" | "isDisabled"
 > {
-  projectId: string;
   name: string;
   gradientStartColor: string;
   gradientEndColor: string;
-  /**
-   * Destination to navigate to when the token is pressed.
-   * Defaults to the project's configuration page.
-   */
-  to?: string;
 }
 
 /**
  * A token representing a project, with the project's color gradient as a
- * leading visual so projects can be identified at a glance. Pressing the
- * token navigates to the project's configuration page. When `onRemove` is
- * provided, a remove button is displayed on the token.
+ * leading visual so projects can be identified at a glance. Purely
+ * presentational: to navigate on click, compose it inside a react-router
+ * `Link`, or pass `onPress` when the token also has an `onRemove` button
+ * (a button cannot nest inside an anchor). When `onRemove` is provided, a
+ * remove button is displayed on the token.
  */
 export function ProjectToken({
-  projectId,
   name,
   gradientStartColor,
   gradientEndColor,
   size = "M",
   maxWidth,
+  onPress,
   onRemove,
   isDisabled,
-  to,
 }: ProjectTokenProps) {
-  const navigate = useNavigate();
   return (
     <Token
       size={size}
@@ -51,7 +43,7 @@ export function ProjectToken({
         />
       }
       title={name}
-      onPress={() => navigate(to ?? `/projects/${projectId}/config`)}
+      onPress={onPress}
       onRemove={onRemove}
       isDisabled={isDisabled}
     >

--- a/app/src/pages/evaluators/EvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/EvaluatorsTable.tsx
@@ -28,6 +28,7 @@ import { Flex, Icon, Icons, Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { EvaluatorKindToken } from "@phoenix/components/evaluators/EvaluatorKindToken";
 import { GenerativeProviderIcon } from "@phoenix/components/generative";
+import { ProjectToken } from "@phoenix/components/project";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableExpandButton } from "@phoenix/components/table/TableExpandButton";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
@@ -91,6 +92,16 @@ const readRow = (row: EvaluatorsTable_row$key) => {
             node {
               id
               name
+            }
+          }
+        }
+        projects(first: 10) {
+          edges {
+            node {
+              id
+              name
+              gradientStartColor
+              gradientEndColor
             }
           }
         }
@@ -187,6 +198,23 @@ const filterRows = (
     return [{ ...parent, children: matchingChildren }];
   });
 };
+
+const UsedInLink = ({
+  to,
+  icon,
+  name,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  name: string;
+}) => (
+  <Link to={to}>
+    <Flex direction="row" gap="size-50" alignItems="center">
+      <Icon svg={icon} />
+      <Truncate maxWidth="10rem">{name}</Truncate>
+    </Flex>
+  </Link>
+);
 
 type EvaluatorsTableProps = {
   /**
@@ -375,23 +403,40 @@ export const EvaluatorsTable = ({
         cell: ({ row }) => {
           if (row.original.rowType === "evaluator") {
             const datasets = row.original.data.datasets?.edges ?? [];
-            if (datasets.length === 0) {
+            const projects = row.original.data.projects?.edges ?? [];
+            if (datasets.length === 0 && projects.length === 0) {
               return "--";
             }
             return (
               <Flex direction="row" gap="size-100" wrap="wrap">
                 {datasets.map(({ node }) => (
-                  <Link key={node.id} to={`/datasets/${node.id}`}>
-                    {node.name}
-                  </Link>
+                  <UsedInLink
+                    key={node.id}
+                    to={`/datasets/${node.id}`}
+                    icon={<Icons.Database />}
+                    name={node.name}
+                  />
+                ))}
+                {projects.map(({ node }) => (
+                  <ProjectToken
+                    key={node.id}
+                    projectId={node.id}
+                    name={node.name}
+                    gradientStartColor={node.gradientStartColor}
+                    gradientEndColor={node.gradientEndColor}
+                    to={`/projects/${node.id}/evaluators`}
+                    maxWidth="10rem"
+                  />
                 ))}
               </Flex>
             );
           }
           return (
-            <Link to={`/datasets/${row.original.data.dataset.id}`}>
-              {row.original.data.dataset.name}
-            </Link>
+            <UsedInLink
+              to={`/datasets/${row.original.data.dataset.id}`}
+              icon={<Icons.Database />}
+              name={row.original.data.dataset.name}
+            />
           );
         },
       },

--- a/app/src/pages/evaluators/EvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/EvaluatorsTable.tsx
@@ -418,15 +418,18 @@ export const EvaluatorsTable = ({
                   />
                 ))}
                 {projects.map(({ node }) => (
-                  <ProjectToken
+                  <Link
                     key={node.id}
-                    projectId={node.id}
-                    name={node.name}
-                    gradientStartColor={node.gradientStartColor}
-                    gradientEndColor={node.gradientEndColor}
                     to={`/projects/${node.id}/evaluators`}
-                    maxWidth="10rem"
-                  />
+                    style={{ textDecoration: "none" }}
+                  >
+                    <ProjectToken
+                      name={node.name}
+                      gradientStartColor={node.gradientStartColor}
+                      gradientEndColor={node.gradientEndColor}
+                      maxWidth="10rem"
+                    />
+                  </Link>
                 ))}
               </Flex>
             );

--- a/app/src/pages/evaluators/__generated__/EvaluatorsTable_row.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/EvaluatorsTable_row.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<029f9fd4481a1a17472d1fd2b2478d50>>
+ * @generated SignedSource<<cc33de91ea6b11cfd7fc33812f9beae1>>
  * @lightSyntaxTransform
  */
 
@@ -39,6 +39,16 @@ export type EvaluatorsTable_row$data = {
   readonly id: string;
   readonly kind: EvaluatorKind;
   readonly name: string;
+  readonly projects: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly gradientEndColor: string;
+        readonly gradientStartColor: string;
+        readonly id: string;
+        readonly name: string;
+      };
+    }>;
+  };
   readonly prompt?: {
     readonly id: string;
     readonly name: string;
@@ -67,6 +77,6 @@ const node: ReaderInlineDataFragment = {
   "name": "EvaluatorsTable_row"
 };
 
-(node as any).hash = "d6cb203c1f400edc5472e768c8255fdd";
+(node as any).hash = "77f21a94045da35ebe17a8fcbceb3cfd";
 
 export default node;

--- a/app/src/pages/evaluators/__generated__/GlobalEvaluatorsTableEvaluatorsQuery.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/GlobalEvaluatorsTableEvaluatorsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ab28cf6158717bcf5f87488551163026>>
+ * @generated SignedSource<<21ade129a4b544132197f94f13ce651d>>
  * @lightSyntaxTransform
  */
 
@@ -108,10 +108,17 @@ v5 = {
   "storageKey": null
 },
 v6 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v7 = [
   (v2/*:: as any*/),
   (v3/*:: as any*/)
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "User",
@@ -214,13 +221,7 @@ return {
                   (v5/*:: as any*/),
                   {
                     "alias": null,
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "first",
-                        "value": 10
-                      }
-                    ],
+                    "args": (v6/*:: as any*/),
                     "concreteType": "DatasetConnection",
                     "kind": "LinkedField",
                     "name": "datasets",
@@ -241,7 +242,7 @@ return {
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
-                            "selections": (v6/*:: as any*/),
+                            "selections": (v7/*:: as any*/),
                             "storageKey": null
                           }
                         ],
@@ -249,6 +250,55 @@ return {
                       }
                     ],
                     "storageKey": "datasets(first:10)"
+                  },
+                  {
+                    "alias": null,
+                    "args": (v6/*:: as any*/),
+                    "concreteType": "ProjectConnection",
+                    "kind": "LinkedField",
+                    "name": "projects",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ProjectEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Project",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v2/*:: as any*/),
+                              (v3/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "gradientStartColor",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "gradientEndColor",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "projects(first:10)"
                   },
                   {
                     "alias": null,
@@ -269,10 +319,10 @@ return {
                         "kind": "LinkedField",
                         "name": "dataset",
                         "plural": false,
-                        "selections": (v6/*:: as any*/),
+                        "selections": (v7/*:: as any*/),
                         "storageKey": null
                       },
-                      (v7/*:: as any*/)
+                      (v8/*:: as any*/)
                     ],
                     "storageKey": null
                   },
@@ -286,7 +336,7 @@ return {
                         "kind": "LinkedField",
                         "name": "prompt",
                         "plural": false,
-                        "selections": (v6/*:: as any*/),
+                        "selections": (v7/*:: as any*/),
                         "storageKey": null
                       },
                       {
@@ -328,7 +378,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v7/*:: as any*/)
+                      (v8/*:: as any*/)
                     ],
                     "type": "LLMEvaluator",
                     "abstractKey": null
@@ -336,7 +386,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v7/*:: as any*/)
+                      (v8/*:: as any*/)
                     ],
                     "type": "CodeEvaluator",
                     "abstractKey": null
@@ -409,12 +459,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "806b6b553af840b55a5ee39077eea562",
+    "cacheID": "4ce9661bcdb676a3e61710b3add96ed2",
     "id": null,
     "metadata": {},
     "name": "GlobalEvaluatorsTableEvaluatorsQuery",
     "operationKind": "query",
-    "text": "query GlobalEvaluatorsTableEvaluatorsQuery(\n  $after: String = null\n  $filter: EvaluatorFilter = null\n  $first: Int = 100\n  $sort: EvaluatorSort = null\n) {\n  ...GlobalEvaluatorsTable_evaluators_3JsJJ3\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  datasets(first: 10) {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n  datasetEvaluators {\n    id\n    name\n    description\n    updatedAt\n    dataset {\n      id\n      name\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersionTag {\n      name\n      id\n    }\n    promptVersion {\n      modelName\n      modelProvider\n      id\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on CodeEvaluator {\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n}\n\nfragment GlobalEvaluatorsTable_evaluators_3JsJJ3 on Query {\n  evaluators(first: $first, after: $after, sort: $sort, filter: $filter) {\n    edges {\n      node {\n        __typename\n        ...EvaluatorsTable_row\n        id\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query GlobalEvaluatorsTableEvaluatorsQuery(\n  $after: String = null\n  $filter: EvaluatorFilter = null\n  $first: Int = 100\n  $sort: EvaluatorSort = null\n) {\n  ...GlobalEvaluatorsTable_evaluators_3JsJJ3\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  datasets(first: 10) {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n  projects(first: 10) {\n    edges {\n      node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n      }\n    }\n  }\n  datasetEvaluators {\n    id\n    name\n    description\n    updatedAt\n    dataset {\n      id\n      name\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersionTag {\n      name\n      id\n    }\n    promptVersion {\n      modelName\n      modelProvider\n      id\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on CodeEvaluator {\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n}\n\nfragment GlobalEvaluatorsTable_evaluators_3JsJJ3 on Query {\n  evaluators(first: $first, after: $after, sort: $sort, filter: $filter) {\n    edges {\n      node {\n        __typename\n        ...EvaluatorsTable_row\n        id\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/evaluators/__generated__/GlobalEvaluatorsTable_evaluators.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/GlobalEvaluatorsTable_evaluators.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<11171255bd06a75d7a3d7d44e8bea9b9>>
+ * @generated SignedSource<<c8228c691f37b54aa9ac22b7d60dd1ce>>
  * @lightSyntaxTransform
  */
 
@@ -60,10 +60,17 @@ v4 = {
   "storageKey": null
 },
 v5 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v6 = [
   (v1/*:: as any*/),
   (v2/*:: as any*/)
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "User",
@@ -195,13 +202,7 @@ return {
                     (v4/*:: as any*/),
                     {
                       "alias": null,
-                      "args": [
-                        {
-                          "kind": "Literal",
-                          "name": "first",
-                          "value": 10
-                        }
-                      ],
+                      "args": (v5/*:: as any*/),
                       "concreteType": "DatasetConnection",
                       "kind": "LinkedField",
                       "name": "datasets",
@@ -222,7 +223,7 @@ return {
                               "kind": "LinkedField",
                               "name": "node",
                               "plural": false,
-                              "selections": (v5/*:: as any*/),
+                              "selections": (v6/*:: as any*/),
                               "storageKey": null
                             }
                           ],
@@ -230,6 +231,55 @@ return {
                         }
                       ],
                       "storageKey": "datasets(first:10)"
+                    },
+                    {
+                      "alias": null,
+                      "args": (v5/*:: as any*/),
+                      "concreteType": "ProjectConnection",
+                      "kind": "LinkedField",
+                      "name": "projects",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "ProjectEdge",
+                          "kind": "LinkedField",
+                          "name": "edges",
+                          "plural": true,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Project",
+                              "kind": "LinkedField",
+                              "name": "node",
+                              "plural": false,
+                              "selections": [
+                                (v1/*:: as any*/),
+                                (v2/*:: as any*/),
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "gradientStartColor",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "gradientEndColor",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": "projects(first:10)"
                     },
                     {
                       "alias": null,
@@ -250,10 +300,10 @@ return {
                           "kind": "LinkedField",
                           "name": "dataset",
                           "plural": false,
-                          "selections": (v5/*:: as any*/),
+                          "selections": (v6/*:: as any*/),
                           "storageKey": null
                         },
-                        (v6/*:: as any*/)
+                        (v7/*:: as any*/)
                       ],
                       "storageKey": null
                     },
@@ -267,7 +317,7 @@ return {
                           "kind": "LinkedField",
                           "name": "prompt",
                           "plural": false,
-                          "selections": (v5/*:: as any*/),
+                          "selections": (v6/*:: as any*/),
                           "storageKey": null
                         },
                         {
@@ -307,7 +357,7 @@ return {
                           ],
                           "storageKey": null
                         },
-                        (v6/*:: as any*/)
+                        (v7/*:: as any*/)
                       ],
                       "type": "LLMEvaluator",
                       "abstractKey": null
@@ -315,7 +365,7 @@ return {
                     {
                       "kind": "InlineFragment",
                       "selections": [
-                        (v6/*:: as any*/)
+                        (v7/*:: as any*/)
                       ],
                       "type": "CodeEvaluator",
                       "abstractKey": null

--- a/app/src/pages/evaluators/__generated__/evaluatorsPageLoaderQuery.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/evaluatorsPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<59bd0a7f2213d14bff4d241537756e07>>
+ * @generated SignedSource<<5516fbc9a363408d6cbae0465cee53ce>>
  * @lightSyntaxTransform
  */
 
@@ -55,10 +55,17 @@ v4 = {
   "storageKey": null
 },
 v5 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v6 = [
   (v1/*:: as any*/),
   (v2/*:: as any*/)
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "User",
@@ -161,13 +168,7 @@ return {
                   (v4/*:: as any*/),
                   {
                     "alias": null,
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "first",
-                        "value": 10
-                      }
-                    ],
+                    "args": (v5/*:: as any*/),
                     "concreteType": "DatasetConnection",
                     "kind": "LinkedField",
                     "name": "datasets",
@@ -188,7 +189,7 @@ return {
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
-                            "selections": (v5/*:: as any*/),
+                            "selections": (v6/*:: as any*/),
                             "storageKey": null
                           }
                         ],
@@ -196,6 +197,55 @@ return {
                       }
                     ],
                     "storageKey": "datasets(first:10)"
+                  },
+                  {
+                    "alias": null,
+                    "args": (v5/*:: as any*/),
+                    "concreteType": "ProjectConnection",
+                    "kind": "LinkedField",
+                    "name": "projects",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ProjectEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Project",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v1/*:: as any*/),
+                              (v2/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "gradientStartColor",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "gradientEndColor",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "projects(first:10)"
                   },
                   {
                     "alias": null,
@@ -216,10 +266,10 @@ return {
                         "kind": "LinkedField",
                         "name": "dataset",
                         "plural": false,
-                        "selections": (v5/*:: as any*/),
+                        "selections": (v6/*:: as any*/),
                         "storageKey": null
                       },
-                      (v6/*:: as any*/)
+                      (v7/*:: as any*/)
                     ],
                     "storageKey": null
                   },
@@ -233,7 +283,7 @@ return {
                         "kind": "LinkedField",
                         "name": "prompt",
                         "plural": false,
-                        "selections": (v5/*:: as any*/),
+                        "selections": (v6/*:: as any*/),
                         "storageKey": null
                       },
                       {
@@ -275,7 +325,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v6/*:: as any*/)
+                      (v7/*:: as any*/)
                     ],
                     "type": "LLMEvaluator",
                     "abstractKey": null
@@ -283,7 +333,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v6/*:: as any*/)
+                      (v7/*:: as any*/)
                     ],
                     "type": "CodeEvaluator",
                     "abstractKey": null
@@ -356,12 +406,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f7ca6037bc581f46e9eff3f8926d813b",
+    "cacheID": "5e960186398429af14b96bc79af97e5b",
     "id": null,
     "metadata": {},
     "name": "evaluatorsPageLoaderQuery",
     "operationKind": "query",
-    "text": "query evaluatorsPageLoaderQuery {\n  ...GlobalEvaluatorsTable_evaluators\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  datasets(first: 10) {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n  datasetEvaluators {\n    id\n    name\n    description\n    updatedAt\n    dataset {\n      id\n      name\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersionTag {\n      name\n      id\n    }\n    promptVersion {\n      modelName\n      modelProvider\n      id\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on CodeEvaluator {\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n}\n\nfragment GlobalEvaluatorsTable_evaluators on Query {\n  evaluators(first: 100) {\n    edges {\n      node {\n        __typename\n        ...EvaluatorsTable_row\n        id\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query evaluatorsPageLoaderQuery {\n  ...GlobalEvaluatorsTable_evaluators\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  datasets(first: 10) {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n  projects(first: 10) {\n    edges {\n      node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n      }\n    }\n  }\n  datasetEvaluators {\n    id\n    name\n    description\n    updatedAt\n    dataset {\n      id\n      name\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersionTag {\n      name\n      id\n    }\n    promptVersion {\n      modelName\n      modelProvider\n      id\n    }\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  ... on CodeEvaluator {\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n}\n\nfragment GlobalEvaluatorsTable_evaluators on Query {\n  evaluators(first: 100) {\n    edges {\n      node {\n        __typename\n        ...EvaluatorsTable_row\n        id\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/RetentionPoliciesTable.tsx
+++ b/app/src/pages/settings/RetentionPoliciesTable.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { graphql, readInlineData, usePaginationFragment } from "react-relay";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 
 import { Flex, Text } from "@phoenix/components";
 import { ProjectToken } from "@phoenix/components/project";
@@ -150,12 +150,16 @@ export const RetentionPoliciesTable = ({
             <Flex direction="row" gap="size-50" wrap alignItems="center">
               {visibleProjects.map((project) => (
                 <StopPropagation key={project.id}>
-                  <ProjectToken
-                    projectId={project.id}
-                    name={project.name}
-                    gradientStartColor={project.gradientStartColor}
-                    gradientEndColor={project.gradientEndColor}
-                  />
+                  <Link
+                    to={`/projects/${project.id}/config`}
+                    style={{ textDecoration: "none" }}
+                  >
+                    <ProjectToken
+                      name={project.name}
+                      gradientStartColor={project.gradientStartColor}
+                      gradientEndColor={project.gradientEndColor}
+                    />
+                  </Link>
                 </StopPropagation>
               ))}
               {hiddenProjectsCount > 0 && (

--- a/app/src/pages/settings/RetentionPolicyProjects.tsx
+++ b/app/src/pages/settings/RetentionPolicyProjects.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import { Suspense, useRef, useState } from "react";
 import { graphql, useMutation } from "react-relay";
+import { useNavigate } from "react-router";
 
 import {
   Button,
@@ -68,6 +69,7 @@ export function RetentionPolicyProjects({
 }) {
   const [filterText, setFilterText] = useState("");
   const { contains } = useFilter({ sensitivity: "base" });
+  const navigate = useNavigate();
   const notifyError = useNotifyError();
   const [patchPolicy] = useMutation<RetentionPolicyProjectsPatchMutation>(
     graphql`
@@ -164,12 +166,12 @@ export function RetentionPolicyProjects({
             {visibleProjects.map((project) => (
               <li key={project.id}>
                 <ProjectToken
-                  projectId={project.id}
                   name={project.name}
                   gradientStartColor={project.gradientStartColor}
                   gradientEndColor={project.gradientEndColor}
                   size="L"
                   maxWidth="100%"
+                  onPress={() => navigate(`/projects/${project.id}/config`)}
                   onRemove={
                     canManage
                       ? () => patchProjects("remove", project.id)

--- a/app/stories/ProjectToken.stories.tsx
+++ b/app/stories/ProjectToken.stories.tsx
@@ -17,7 +17,6 @@ const meta: Meta<typeof ProjectToken> = {
     layout: "centered",
   },
   args: {
-    projectId: "UHJvamVjdDox",
     name: "playground",
     ...GRADIENTS[0],
   },

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -66,6 +66,7 @@ from .project_by_name import ProjectByNameDataLoader
 from .project_evaluator_criteria_by_id import ProjectEvaluatorCriteriaByIdDataLoader
 from .project_has_traces import ProjectHasTracesDataLoader
 from .project_ids_by_trace_retention_policy_id import ProjectIdsByTraceRetentionPolicyIdDataLoader
+from .projects_by_evaluator import ProjectsByEvaluatorDataLoader
 from .prompt_label_usage_counts import PromptLabelUsageCountsDataLoader
 from .prompt_labels_by_prompt import PromptLabelsByPromptDataLoader
 from .prompt_version_counts import PromptVersionCountDataLoader
@@ -222,6 +223,7 @@ class DataLoaders:
     project_fields: TableFieldsDataLoader
     project_evaluator_criteria_by_id: ProjectEvaluatorCriteriaByIdDataLoader
     project_trace_retention_policy_fields: TableFieldsDataLoader
+    projects_by_evaluator: ProjectsByEvaluatorDataLoader
     projects_by_trace_retention_policy_id: ProjectIdsByTraceRetentionPolicyIdDataLoader
     prompt_fields: TableFieldsDataLoader
     prompt_label_fields: TableFieldsDataLoader
@@ -396,6 +398,7 @@ def build_data_loaders(
         num_spans_per_trace=NumSpansPerTraceDataLoader(db),
         project_fields=TableFieldsDataLoader(db, models.Project),
         project_evaluator_criteria_by_id=ProjectEvaluatorCriteriaByIdDataLoader(db),
+        projects_by_evaluator=ProjectsByEvaluatorDataLoader(db),
         projects_by_trace_retention_policy_id=ProjectIdsByTraceRetentionPolicyIdDataLoader(db),
         prompt_fields=TableFieldsDataLoader(db, models.Prompt),
         prompt_label_fields=TableFieldsDataLoader(db, models.PromptLabel),

--- a/src/phoenix/server/api/dataloaders/projects_by_evaluator.py
+++ b/src/phoenix/server/api/dataloaders/projects_by_evaluator.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+EvaluatorID: TypeAlias = int
+Key: TypeAlias = EvaluatorID
+Result: TypeAlias = list[models.Project]
+
+
+class ProjectsByEvaluatorDataLoader(DataLoader[Key, Result]):
+    """Batches requests for projects associated with evaluators."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        projects_by_evaluator: dict[Key, list[models.Project]] = defaultdict(list)
+
+        async with self._db.read() as session:
+            stmt = (
+                select(models.ProjectEvaluatorCriteria.evaluator_id, models.Project)
+                .join(
+                    models.Project,
+                    models.ProjectEvaluatorCriteria.project_id == models.Project.id,
+                )
+                .where(models.ProjectEvaluatorCriteria.evaluator_id.in_(keys))
+                .distinct()
+                .order_by(models.Project.name.asc())
+            )
+            for row in await session.execute(stmt):
+                evaluator_id, project = row
+                projects_by_evaluator[evaluator_id].append(project)
+
+        return [projects_by_evaluator.get(key, []) for key in keys]

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -122,6 +122,21 @@ class Evaluator(Node):
         return connection_from_list([Dataset(id=d.id, db_record=d) for d in dataset_records], args)
 
     @strawberry.field
+    async def projects(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        after: Optional[CursorString] = UNSET,
+    ) -> Connection[Annotated["Project", strawberry.lazy(".Project")]]:
+        args = ConnectionArgs(first=first, after=after if isinstance(after, CursorString) else None)
+        project_records = await info.context.data_loaders.projects_by_evaluator.load(self.id)
+        from .Project import Project
+
+        return connection_from_list(
+            [Project(id=project.id, db_record=project) for project in project_records], args
+        )
+
+    @strawberry.field
     async def dataset_evaluators(
         self,
         info: Info[Context, None],

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -107,6 +107,31 @@ class TestEvaluatorFields:
             session.add_all([de_1, de_2])
             await session.flush()
 
+            # Project evaluator associations for the untagged evaluator
+            project_a = models.Project(name=f"project-a-{token_hex(4)}")
+            project_b = models.Project(name=f"project-b-{token_hex(4)}")
+            session.add_all([project_a, project_b])
+            await session.flush()
+
+            criteria_1 = models.ProjectEvaluatorCriteria(
+                project_id=project_a.id,
+                evaluator_id=untagged.id,
+                name=Identifier("criteria_one"),
+                filter_condition="",
+                sampling_rate=1.0,
+                evaluation_target="SPAN",
+            )
+            criteria_2 = models.ProjectEvaluatorCriteria(
+                project_id=project_b.id,
+                evaluator_id=untagged.id,
+                name=Identifier("criteria_two"),
+                filter_condition="",
+                sampling_rate=1.0,
+                evaluation_target="SPAN",
+            )
+            session.add_all([criteria_1, criteria_2])
+            await session.flush()
+
         ids = {
             "prompt": prompt.id,
             "v1": v1.id,
@@ -116,6 +141,8 @@ class TestEvaluatorFields:
             "tagged": tagged.id,
             "de_1": de_1.id,
             "de_2": de_2.id,
+            "project_a": project_a.id,
+            "project_b": project_b.id,
         }
         yield ids
 
@@ -201,6 +228,48 @@ class TestEvaluatorFields:
         )
         assert not resp.errors and resp.data
         assert resp.data["node"]["datasetEvaluators"] == []
+
+    async def test_projects_field(
+        self, _test_data: dict[str, Any], gql_client: AsyncGraphQLClient
+    ) -> None:
+        """Test Evaluator.projects returns projects associated via project evaluator criteria."""
+        # Untagged evaluator is attached to two projects as a project evaluator
+        resp = await gql_client.execute(
+            """query ($id: ID!) {
+                node(id: $id) {
+                    ... on Evaluator {
+                        projects(first: 10) {
+                            edges { node { id name } }
+                        }
+                    }
+                }
+            }""",
+            variables={"id": str(GlobalID(LLMEvaluator.__name__, str(_test_data["untagged"])))},
+        )
+        assert not resp.errors and resp.data
+        projects = [edge["node"] for edge in resp.data["node"]["projects"]["edges"]]
+        returned_ids = [project["id"] for project in projects]
+        # Sorted by project name ascending: project-a before project-b
+        assert returned_ids == [
+            str(GlobalID("Project", str(_test_data["project_a"]))),
+            str(GlobalID("Project", str(_test_data["project_b"]))),
+        ]
+
+        # Tagged evaluator is not attached to any project
+        resp = await gql_client.execute(
+            """query ($id: ID!) {
+                node(id: $id) {
+                    ... on Evaluator {
+                        projects(first: 10) {
+                            edges { node { id } }
+                        }
+                    }
+                }
+            }""",
+            variables={"id": str(GlobalID(LLMEvaluator.__name__, str(_test_data["tagged"])))},
+        )
+        assert not resp.errors and resp.data
+        assert resp.data["node"]["projects"]["edges"] == []
 
 
 class TestDatasetEvaluatorDescriptionFallback:


### PR DESCRIPTION
Closes #15327. Part of #11650.

The global evaluators table's "used in" column only reflected dataset usage — an evaluator attached to a project as a project evaluator showed `--`, with no way to tell from the list that it was in use.

## Back end

- New `ProjectsByEvaluatorDataLoader` batches project lookups through the `project_evaluator_criteria` association (distinct, sorted by project name), mirroring the existing `datasets_by_evaluator` loader.
- The `Evaluator` GraphQL interface gains a `projects` connection, inherited by `LLMEvaluator`, `CodeEvaluator`, and `BuiltInEvaluator`. Schema regenerated.

## Front end

- The "used in" column renders both usage types: datasets as icon links (as before, now with a database icon), and projects as `ProjectToken` pills (gradient circle + name, same look as the retention policy config views), each linking to the project's evaluators tab.
- `ProjectToken` is now purely presentational — it no longer owns navigation. Call sites compose it with a react-router `Link` (evaluators table, retention policies table) or pass `onPress` when the token also has a remove button and can't nest inside an anchor (retention policy detail view). Existing destinations are unchanged.
- `--` now only renders when an evaluator is used by neither datasets nor projects.

## Testing

- New `test_projects_field` covers an evaluator attached to two projects (asserts name-sorted order) and an evaluator attached to none; full `test_Evaluator.py` suite passes.
- `ruff`, `mypy`, `tsc --noEmit`, `oxlint`, `oxfmt` clean.