### PR TITLE
docs: add v20.0.0 entry to MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 # Migrations
 
+## v19.x to v20.0.0
+
+No action is required to upgrade from v19.x to v20.0.0. The new agent session persistence feature adds database tables
+via a schema migration that is applied automatically on startup.
+
 ## v18.x to v19.0.0
 
 ### Built-in OAuth2 authorization server

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,8 +2,18 @@
 
 ## v19.x to v20.0.0
 
-No action is required to upgrade from v19.x to v20.0.0. The new agent session persistence feature adds database tables
-via a schema migration that is applied automatically on startup.
+No action is required to upgrade from v19.x to v20.0.0.
+
+### Agent session persistence
+
+Conversations with the Phoenix agent are now persisted server-side. Sessions survive page reloads and can be browsed,
+restored, and continued later — from the browser or from the `pxi` terminal client, interchangeably. The terminal
+client gains session management commands (`/new`, `/temporary`, `/sessions`, `/model`, and `/compact` for summarizing
+older context into a checkpoint on long-running sessions).
+
+To support this, the release adds two database tables (`agent_sessions` and `agent_session_messages`) via a schema
+migration that is applied automatically on startup, and the agent now speaks the `/agent_sessions` endpoints in place
+of the previous `/agents/server` endpoint. No configuration changes are needed.
 
 ## v18.x to v19.0.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,10 +11,6 @@ restored, and continued later — from the browser or from the `pxi` terminal cl
 client gains session management commands (`/new`, `/temporary`, `/sessions`, `/model`, and `/compact` for summarizing
 older context into a checkpoint on long-running sessions).
 
-To support this, the release adds two database tables (`agent_sessions` and `agent_session_messages`) via a schema
-migration that is applied automatically on startup, and the agent now speaks the `/agent_sessions` endpoints in place
-of the previous `/agents/server` endpoint. No configuration changes are needed.
-
 ## v18.x to v19.0.0
 
 ### Built-in OAuth2 authorization server


### PR DESCRIPTION
## Summary

Adds a MIGRATION.md entry for v20.0.0. There are no breaking changes requiring user action; the major version bump accompanies the agent session persistence feature (#14143), whose database schema migration is applied automatically on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)