### PR TITLE
chore: release arize-phoenix-client 3.1.0

### DIFF
--- a/packages/phoenix-client/scripts/verify_atif_upload.py
+++ b/packages/phoenix-client/scripts/verify_atif_upload.py
@@ -4,7 +4,7 @@
 Usage:
     uv run python packages/phoenix-client/scripts/verify_atif_upload.py
 
-Requires Phoenix running at http://localhost:6006.
+Requires Phoenix running at http://localhost:6006 (override with PHOENIX_URL).
 Uploads multiple ATIF trajectories into projects so you can inspect
 the resulting traces in the Phoenix UI.
 """


### PR DESCRIPTION
## Summary

Forces release-please to propose **3.1.0** (instead of the 4.0.0 major bump currently on #15338) for the next `arize-phoenix-client` release, via a `Release-As` commit trailer.

Includes a small docstring cleanup in `scripts/verify_atif_upload.py` so the commit touches the package path (required for release-please to count it).

After this merges, release-please will refresh its release PR to propose 3.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Release-As: 3.1.0