### PR TITLE
chore(ddl): regenerate schema assets

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -1158,12 +1158,11 @@ CREATE TABLE public.agent_sessions (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
     CONSTRAINT fk_agent_sessions_custom_provider_id_generative_model_c_af13
-        FOREIGN KEY
-        (custom_provider_id)
+        FOREIGN KEY (custom_provider_id)
         REFERENCES public.generative_model_custom_providers (id)
         ON DELETE SET NULL,
-    CONSTRAINT fk_agent_sessions_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_agent_sessions_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1191,10 +1190,9 @@ CREATE TABLE public.agent_session_messages (
     CONSTRAINT pk_agent_session_messages PRIMARY KEY (id),
     CONSTRAINT uq_agent_session_messages_message_id
         UNIQUE (message_id),
-    CHECK (((message_id)::text ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'::text)),
+    CONSTRAINT "ck_agent_session_messages_`valid_message_id`" CHECK (((message_id)::text ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'::text)),
     CONSTRAINT fk_agent_session_messages_agent_session_id_agent_sessions
-        FOREIGN KEY
-        (agent_session_id)
+        FOREIGN KEY (agent_session_id)
         REFERENCES public.agent_sessions (id)
         ON DELETE CASCADE
 );
@@ -1217,8 +1215,7 @@ CREATE TABLE public.agent_session_snapshots (
     CONSTRAINT uq_agent_session_snapshots_agent_session_id
         UNIQUE (agent_session_id),
     CONSTRAINT fk_agent_session_snapshots_agent_session_id_agent_sessions
-        FOREIGN KEY
-        (agent_session_id)
+        FOREIGN KEY (agent_session_id)
         REFERENCES public.agent_sessions (id)
         ON DELETE CASCADE
 );

--- a/scripts/ddl/sqlite_schema.sql
+++ b/scripts/ddl/sqlite_schema.sql
@@ -283,7 +283,6 @@ CREATE TABLE spans (
 
 CREATE INDEX ix_cumulative_llm_token_count_total ON spans
     ((cumulative_llm_token_count_prompt + cumulative_llm_token_count_completion));
-CREATE INDEX ix_latency ON spans ((end_time - start_time));
 CREATE INDEX ix_spans_parent_id ON spans (parent_id);
 CREATE INDEX ix_spans_session_id ON spans (JSON_EXTRACT(attributes, '$."session"."id"'))
     WHERE JSON_EXTRACT(attributes, '$."session"."id"') IS NOT NULL;
@@ -744,6 +743,7 @@ CREATE TABLE dataset_evaluators (
 
 CREATE INDEX ix_dataset_evaluators_evaluator_id ON dataset_evaluators (evaluator_id);
 CREATE INDEX ix_dataset_evaluators_project_id ON dataset_evaluators (project_id);
+CREATE INDEX ix_dataset_evaluators_user_id ON dataset_evaluators (user_id);
 
 
 -- Table: experiments
@@ -1067,6 +1067,84 @@ CREATE TABLE generative_model_custom_providers (
         ON DELETE SET NULL
 );
 
+CREATE INDEX ix_generative_model_custom_providers_user_id ON generative_model_custom_providers
+    (user_id);
+
+
+-- Table: agent_sessions
+-- ---------------------
+CREATE TABLE agent_sessions (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    project_name VARCHAR NOT NULL,
+    user_id INTEGER,
+    title VARCHAR NOT NULL,
+    model_provider VARCHAR NOT NULL,
+    model_name VARCHAR NOT NULL,
+    custom_provider_id INTEGER,
+    is_ephemeral BOOLEAN NOT NULL,
+    heartbeat_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT fk_agent_sessions_custom_provider_id_generative_model_custom_providers
+        FOREIGN KEY (custom_provider_id)
+        REFERENCES generative_model_custom_providers (id)
+        ON DELETE SET NULL,
+    CONSTRAINT fk_agent_sessions_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_sessions_custom_provider_id ON agent_sessions
+    (custom_provider_id);
+CREATE INDEX ix_agent_sessions_ephemeral_updated_at ON agent_sessions (updated_at)
+    WHERE is_ephemeral IS TRUE;
+CREATE INDEX ix_agent_sessions_updated_at_id ON agent_sessions (updated_at, id);
+CREATE INDEX ix_agent_sessions_user_id_updated_at ON agent_sessions
+    (user_id, updated_at DESC);
+
+
+-- Table: agent_session_messages
+-- -----------------------------
+CREATE TABLE agent_session_messages (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    agent_session_id INTEGER NOT NULL,
+    message JSONB NOT NULL,
+    message_id VARCHAR NOT NULL GENERATED ALWAYS AS (JSON_EXTRACT(message, '$."id"')) STORED,
+    is_compaction_message BOOLEAN NOT NULL GENERATED ALWAYS AS (coalesce(JSON_EXTRACT(message, '$."metadata"."phoenix"."isCompactionMessage"'), 0)) STORED,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT uq_agent_session_messages_message_id UNIQUE (message_id),
+    CONSTRAINT "ck_agent_session_messages_`valid_message_id`"
+        CHECK (message_id GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'),
+    CONSTRAINT fk_agent_session_messages_agent_session_id_agent_sessions
+        FOREIGN KEY (agent_session_id)
+        REFERENCES agent_sessions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_session_messages_agent_session_id_id ON agent_session_messages
+    (agent_session_id, id);
+CREATE INDEX ix_agent_session_messages_compaction ON agent_session_messages
+    (agent_session_id, id DESC)
+    WHERE is_compaction_message;
+
+
+-- Table: agent_session_snapshots
+-- ------------------------------
+CREATE TABLE agent_session_snapshots (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    agent_session_id INTEGER NOT NULL,
+    bashkit_snapshot BLOB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT uq_agent_session_snapshots_agent_session_id UNIQUE (agent_session_id),
+    CONSTRAINT fk_agent_session_snapshots_agent_session_id_agent_sessions
+        FOREIGN KEY (agent_session_id)
+        REFERENCES agent_sessions (id)
+        ON DELETE CASCADE
+);
+
 
 -- Table: oauth2_authorization_codes
 -- ---------------------------------
@@ -1259,6 +1337,11 @@ CREATE TABLE experiment_prompt_tasks (
         REFERENCES experiment_jobs (type, id)
         ON DELETE CASCADE
 );
+
+CREATE INDEX ix_experiment_prompt_tasks_custom_provider_id ON experiment_prompt_tasks
+    (custom_provider_id);
+CREATE INDEX ix_experiment_prompt_tasks_prompt_version_id ON experiment_prompt_tasks
+    (prompt_version_id);
 
 
 -- Table: prompt_version_tags
@@ -1498,6 +1581,8 @@ CREATE TABLE secrets (
         REFERENCES users (id)
         ON DELETE SET NULL
 );
+
+CREATE INDEX ix_secrets_user_id ON secrets (user_id);
 
 
 -- Table: span_annotations


### PR DESCRIPTION
## Summary
- regenerate checked-in PostgreSQL and SQLite DDL from current migrations
- synchronize SQLite agent-session tables, indexes, and constraints

## Test plan
- [x] `make schema-ddl`