### PR TITLE
fix(agents): prevent exported session ID collisions

### DIFF
--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from hashlib import sha256
 from typing import NamedTuple, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,9 +21,16 @@ TURN_LOCK_STALENESS = timedelta(seconds=60)
 """How long after its last heartbeat a turn lock is considered abandoned."""
 
 
-def get_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
+def get_otel_session_id(
+    *,
+    project_name: str,
+    agent_session_rowid: int,
+    agent_session_created_at: datetime,
+) -> str:
+    """Return a stable OTel session ID unique across Phoenix database instances."""
     agent_session_gid = GlobalID(type_name="AgentSession", node_id=str(agent_session_rowid))
-    return f"{project_name}:{agent_session_gid}"
+    created_at_fingerprint = sha256(agent_session_created_at.isoformat().encode()).hexdigest()[:16]
+    return f"{project_name}:{agent_session_gid}:{created_at_fingerprint}"
 
 
 def is_turn_active(heartbeat_at: Optional[datetime], *, now: datetime) -> bool:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -2802,6 +2802,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 otel_session_id = get_otel_session_id(
                     project_name=project_name,
                     agent_session_rowid=agent_session_rowid,
+                    agent_session_created_at=agent_session.created_at,
                 )
         except AgentError as exc:
             raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -954,6 +954,7 @@ async def test_chat_turn_persists_session_transcript(
         persisted_session_id = get_otel_session_id(
             project_name=agent_session.project_name,
             agent_session_rowid=agent_session.id,
+            agent_session_created_at=agent_session.created_at,
         )
         # No bash command this turn, so no shell-state snapshot row.
         assert await session.scalar(select(models.AgentSessionSnapshot)) is None
@@ -3756,6 +3757,7 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
                 == get_otel_session_id(
                     project_name=agent_session.project_name,
                     agent_session_rowid=agent_session.id,
+                    agent_session_created_at=agent_session.created_at,
                 )
             )
         )

--- a/tests/unit/server/api/helpers/test_agent_sessions.py
+++ b/tests/unit/server/api/helpers/test_agent_sessions.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from strawberry.relay import GlobalID
 
@@ -10,11 +12,29 @@ from phoenix.server.agents.model_selection import (
 )
 from phoenix.server.api.helpers.agent_sessions import (
     get_agent_session_model,
+    get_otel_session_id,
     resolve_model_routing,
     set_session_model,
 )
 from phoenix.server.encryption import EncryptionService
 from phoenix.server.types import DbSessionFactory
+
+
+def test_get_otel_session_id_fingerprints_session_creation_time() -> None:
+    created_at = datetime(2026, 8, 11, 19, 45, 0, 123456, tzinfo=timezone.utc)
+
+    session_id = get_otel_session_id(
+        project_name="pxi_dev",
+        agent_session_rowid=1,
+        agent_session_created_at=created_at,
+    )
+
+    assert session_id == f"pxi_dev:{GlobalID('AgentSession', '1')}:69163ce23e52267d"
+    assert session_id != get_otel_session_id(
+        project_name="pxi_dev",
+        agent_session_rowid=1,
+        agent_session_created_at=created_at + timedelta(microseconds=1),
+    )
 
 
 async def _add_custom_provider(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -521,16 +521,18 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
             row.message_id for row in source_messages
         )
         # The branch gets its own OTel session identity (derived from its own
-        # row id) and uses the currently configured trace project.
+        # row id and creation time) and uses the currently configured trace project.
         source_session, branch_session = sorted(
             agent_sessions, key=lambda agent_session: agent_session.id
         )
         assert get_otel_session_id(
             project_name=branch_session.project_name,
             agent_session_rowid=branch_session.id,
+            agent_session_created_at=branch_session.created_at,
         ) != get_otel_session_id(
             project_name=source_session.project_name,
             agent_session_rowid=source_session.id,
+            agent_session_created_at=source_session.created_at,
         )
         assert branch_session.project_name == configured_project_name
         assert branch_session.project_name != source_session.project_name


### PR DESCRIPTION
## Summary

- append a 16-character SHA-256 fingerprint of `agent_session.created_at` to PXI OTel session IDs
- keep the existing project name and AgentSession GlobalID components for readability
- update trace ingestion and tests to use the collision-resistant identifier

## Why

Agent session row IDs are auto-incrementing and only unique within a Phoenix database. Exporting local PXI traces into Phoenix Cloud could therefore merge them into an unrelated remote session when both instances used the same project name and row ID. Including the session creation timestamp fingerprint distinguishes sessions created in separate Phoenix instances without significantly increasing identifier length.

## Testing

- `make format-python`
- `make lint-python`
- focused unit tests: 9 passed, 8 skipped
- targeted mypy check: no issues

Full `make test-python` was blocked by stale local virtualenv/tox entrypoints referencing a different checkout; the focused tests were rerun through the current checkout's Python environment.