### PR TITLE
fix(agents): emit full tool definitions on PXI LLM spans

### DIFF
--- a/js/app/src/pages/trace/span/LLMToolSchemasList.tsx
+++ b/js/app/src/pages/trace/span/LLMToolSchemasList.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { css } from "@emotion/react";
 
 import {
@@ -6,14 +7,17 @@ import {
   Counter,
   Flex,
   Text,
+  View,
 } from "@phoenix/components";
 import { SpanKindIcon } from "@phoenix/components/trace";
 
 import { defaultCardProps } from "./constants";
 import { MimeTypeCodeBlock } from "./MimeTypeCodeBlock";
+import { getToolSchemaDisplayParts } from "./utils";
 
 /**
- * A card displaying a single tool JSON schema available to the LLM.
+ * A card displaying a single tool available to the LLM — its name and
+ * description when the definition carries them, and its JSON schema.
  */
 function LLMToolSchema({
   toolSchema,
@@ -22,10 +26,14 @@ function LLMToolSchema({
   toolSchema: string;
   index: number;
 }) {
+  const { name, description } = useMemo(
+    () => getToolSchemaDisplayParts(toolSchema),
+    [toolSchema]
+  );
   const titleEl = (
     <Flex direction="row" gap="size-100" alignItems="center">
       <SpanKindIcon spanKind="tool" />
-      <Text weight="heavy">Tool</Text>
+      <Text weight="heavy">{name != null ? `Tool: ${name}` : "Tool"}</Text>
     </Flex>
   );
 
@@ -38,13 +46,30 @@ function LLMToolSchema({
       borderColor="yellow-300"
       extra={<CopyToClipboardButton text={toolSchema} />}
     >
+      {description != null ? (
+        <View
+          paddingStart="size-200"
+          paddingEnd="size-200"
+          paddingTop="size-100"
+          paddingBottom="size-100"
+          borderBottomColor="default"
+          borderBottomWidth="thin"
+        >
+          <Flex direction="column" alignItems="start" gap="size-50">
+            <Text color="text-700" fontStyle="italic">
+              Description
+            </Text>
+            <Text>{description}</Text>
+          </Flex>
+        </View>
+      ) : null}
       <MimeTypeCodeBlock value={toolSchema} mimeType={"json"} />
     </Card>
   );
 }
 
 /**
- * A list of the tool JSON schemas available to the LLM.
+ * A list of the tools available to the LLM.
  */
 export function LLMToolSchemasList({ toolSchemas }: { toolSchemas: string[] }) {
   return (

--- a/js/app/src/pages/trace/span/LLMToolSchemasList.tsx
+++ b/js/app/src/pages/trace/span/LLMToolSchemasList.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
 import { css } from "@emotion/react";
+import { useMemo } from "react";
 
 import {
   Card,

--- a/js/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/js/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import {
   getRerankerAttributes,
   getRetrieverAttributes,
   getToolAttributes,
+  getToolSchemaDisplayParts,
   groupDocumentEvaluationsByPosition,
   parseSpanAttributes,
 } from "../utils";
@@ -378,6 +379,85 @@ describe("getToolAttributes", () => {
       description: "Search the docs",
       parameters:
         '{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}',
+    });
+  });
+});
+
+describe("getToolSchemaDisplayParts", () => {
+  it("extracts name and description from a flat definition (pydantic-ai, Anthropic, Gemini, OpenAI Responses)", () => {
+    expect(
+      getToolSchemaDisplayParts(
+        JSON.stringify({
+          name: "get_weather",
+          description: "Look up the current weather for a city.",
+          parameters_json_schema: { type: "object" },
+        })
+      )
+    ).toEqual({
+      name: "get_weather",
+      description: "Look up the current weather for a city.",
+    });
+  });
+
+  it("extracts name and description from an OpenAI Chat Completions definition", () => {
+    expect(
+      getToolSchemaDisplayParts(
+        JSON.stringify({
+          type: "function",
+          function: {
+            name: "search",
+            description: "Searches the web",
+            parameters: { type: "object" },
+          },
+        })
+      )
+    ).toEqual({ name: "search", description: "Searches the web" });
+  });
+
+  it("extracts name and description from an AWS Bedrock toolSpec definition", () => {
+    expect(
+      getToolSchemaDisplayParts(
+        JSON.stringify({
+          toolSpec: {
+            name: "lookup",
+            description: "Looks things up",
+            inputSchema: { json: { type: "object" } },
+          },
+        })
+      )
+    ).toEqual({ name: "lookup", description: "Looks things up" });
+  });
+
+  it("falls back to the JSON-schema title and description of a bare parameters schema", () => {
+    expect(
+      getToolSchemaDisplayParts(
+        JSON.stringify({
+          type: "object",
+          title: "get_weather",
+          description: "Look up the current weather for a city.",
+          properties: { city: { type: "string" } },
+        })
+      )
+    ).toEqual({
+      name: "get_weather",
+      description: "Look up the current weather for a city.",
+    });
+  });
+
+  it("returns nulls for a schema with no recoverable identity", () => {
+    expect(
+      getToolSchemaDisplayParts(JSON.stringify({ type: "object" }))
+    ).toEqual({ name: null, description: null });
+  });
+
+  it("returns nulls for a payload that is not a JSON object", () => {
+    expect(getToolSchemaDisplayParts("not json")).toEqual({
+      name: null,
+      description: null,
+    });
+    expect(getToolSchemaDisplayParts('["a"]')).toEqual({
+      name: null,
+      description: null,
     });
   });
 });

--- a/js/app/src/pages/trace/span/utils.ts
+++ b/js/app/src/pages/trace/span/utils.ts
@@ -17,7 +17,7 @@ import type {
   AttributeToolCall,
 } from "@phoenix/openInference/tracing/types";
 import { isAttributeMessages } from "@phoenix/openInference/tracing/types";
-import { isStringArray } from "@phoenix/typeUtils";
+import { isStringArray, isStringKeyedObject } from "@phoenix/typeUtils";
 import {
   toContentPreview,
   toRecordPreview,
@@ -331,6 +331,55 @@ export function getToolAttributes(
     parameters: asToolAttributeString(
       toolAttributes[ToolAttributePostfixes.parameters]
     ),
+  };
+}
+
+/**
+ * The identity of a tool recovered from its `llm.tools.{i}.tool.json_schema`
+ * payload, for the tool card's header and description line.
+ */
+export type ToolSchemaDisplayParts = {
+  name: string | null;
+  description: string | null;
+};
+
+/**
+ * A non-empty string field of an untrusted parsed tool definition.
+ */
+function asDisplayString(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+/**
+ * Recover the tool's name and description from a `tool.json_schema` payload.
+ *
+ * The payload is the tool definition as the instrumented client sent it, so
+ * its shape is provider-specific: OpenAI Chat Completions nests the definition
+ * under `function` and AWS Bedrock under `toolSpec`, while Anthropic, Gemini,
+ * OpenAI Responses, and pydantic-ai keep `name`/`description` at the top
+ * level. Instrumentation that records only the bare parameters schema is
+ * covered by the JSON-schema `title`/`description` fallback.
+ */
+export function getToolSchemaDisplayParts(
+  toolSchema: string
+): ToolSchemaDisplayParts {
+  const { json } = safelyParseJSON(toolSchema);
+  if (!isStringKeyedObject(json)) {
+    return { name: null, description: null };
+  }
+  const definitions = [json, json.function, json.toolSpec];
+  for (const definition of definitions) {
+    if (!isStringKeyedObject(definition)) {
+      continue;
+    }
+    const name = asDisplayString(definition.name);
+    if (name != null) {
+      return { name, description: asDisplayString(definition.description) };
+    }
+  }
+  return {
+    name: asDisplayString(json.title),
+    description: asDisplayString(json.description),
   };
 }
 

--- a/src/phoenix/server/agents/pydantic_ai/openinference_model_wrapper.py
+++ b/src/phoenix/server/agents/pydantic_ai/openinference_model_wrapper.py
@@ -256,13 +256,21 @@ def _response_to_oi_message(msg: ModelResponse) -> Message:
 
 
 def _to_oi_tools(params: ModelRequestParameters) -> list[Tool]:
+    """Convert the request's tool definitions to OpenInference ``llm.tools`` entries.
+
+    Each ``tool.json_schema`` carries the full tool definition — name,
+    description, and parameters — rather than the bare parameters schema, so
+    the tools advertised to the model surface with their identity intact.
+    """
     tools: list[Tool] = []
     for tool_def in params.function_tools or []:
-        schema: dict[str, Any] = {**tool_def.parameters_json_schema}
-        schema.setdefault("title", tool_def.name)
+        definition: dict[str, Any] = {"name": tool_def.name}
         if tool_def.description:
-            schema.setdefault("description", tool_def.description)
-        tools.append({"json_schema": schema})
+            definition["description"] = tool_def.description
+        definition["parameters_json_schema"] = tool_def.parameters_json_schema
+        if tool_def.strict is not None:
+            definition["strict"] = tool_def.strict
+        tools.append({"json_schema": definition})
     return tools
 
 

--- a/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
+++ b/tests/unit/server/agents/pydantic_ai/test_openinference_model_wrapper.py
@@ -293,9 +293,13 @@ async def test_request_emits_llm_span_for_tool_call_response(
     tool_schema_attr = attributes.pop(f"{LLM_TOOLS}.0.{TOOL_JSON_SCHEMA}")
     assert isinstance(tool_schema_attr, str)
     tool_schema = json.loads(tool_schema_attr)
-    assert tool_schema["title"] == "get_weather"
+    assert tool_schema["name"] == "get_weather"
     assert tool_schema["description"] == "Look up the current weather for a city."
-    assert tool_schema["required"] == ["city"]
+    assert tool_schema["parameters_json_schema"] == {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
 
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "system"
     assert isinstance(attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}"), str)
@@ -581,9 +585,13 @@ async def test_request_emits_tool_return_message_in_history(
     tool_schema_attr = attributes.pop(f"{LLM_TOOLS}.0.{TOOL_JSON_SCHEMA}")
     assert isinstance(tool_schema_attr, str)
     tool_schema = json.loads(tool_schema_attr)
-    assert tool_schema["title"] == "get_weather"
+    assert tool_schema["name"] == "get_weather"
     assert tool_schema["description"] == "Look up the current weather for a city."
-    assert tool_schema["required"] == ["city"]
+    assert tool_schema["parameters_json_schema"] == {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
 
     # Message 0: system prompt.
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "system"


### PR DESCRIPTION
Fixes #15359

## Problem

PXI's model wrapper recorded only each mounted tool's bare parameters JSON schema in `llm.tools.{i}.tool.json_schema` (folding the tool's name and description into the schema's `title`/`description` fields). The trace view then rendered each tool as an anonymous JSON schema — the tools actually available to the LLM were not identifiable.

## Changes

**Backend** — `openinference_model_wrapper.py`
- `_to_oi_tools` now emits the full tool definition as `tool.json_schema`: `name`, `description` (when set), `parameters_json_schema`, and `strict` (when set). This matches how other OpenInference instrumentations record the definition the client advertised to the model, and the playground's canonical tool normalization already recognizes this shape (`{name, description, parameters_json_schema}`).

**Frontend** — trace span view
- New `getToolSchemaDisplayParts` helper recovers a tool's name/description from a `tool.json_schema` payload across the common provider shapes (pydantic-ai, OpenAI Chat Completions `function.*`, OpenAI Responses flat, Anthropic, AWS Bedrock `toolSpec.*`, Gemini), with a JSON-schema `title`/`description` fallback for instrumentations that still record bare parameter schemas.
- `LLMToolSchemasList` now renders the tool name in the card title (`Tool: get_weather`) and the description above the schema block, mirroring the existing `ToolMetadata` card for TOOL spans.

## Testing

- Updated `test_openinference_model_wrapper.py` assertions for the new definition shape (7 passed; full `tests/unit/server/agents` suite: 440 passed)
- Added `getToolSchemaDisplayParts` cases to `app/src/pages/trace/span/__tests__/utils.test.ts` (34 passed)
- `tsc`, oxlint, prettier, ruff, and mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)