### PR TITLE
feat(server): add GET /datasets/{dataset_identifier}/splits

### DIFF
--- a/js/app/src/api/__generated__/v1.ts
+++ b/js/app/src/api/__generated__/v1.ts
@@ -430,7 +430,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List dataset splits */
+        get: operations["listDatasetSplits"];
         put?: never;
         /** Create a dataset split */
         post: operations["createDatasetSplit"];
@@ -3979,6 +3980,13 @@ export interface components {
         ListDatasetLabelsForDatasetResponseBody: {
             /** Data */
             data: components["schemas"]["DatasetLabel"][];
+        };
+        /** ListDatasetSplitsResponseBody */
+        ListDatasetSplitsResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetSplit"][];
+            /** Next Cursor */
+            next_cursor: string | null;
         };
         /** ListDatasetVersionsResponseBody */
         ListDatasetVersionsResponseBody: {
@@ -8955,6 +8963,61 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listDatasetSplits: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination */
+                cursor?: string | null;
+                /** @description The max number of dataset splits to return at a time. */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListDatasetSplitsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -430,7 +430,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List dataset splits */
+        get: operations["listDatasetSplits"];
         put?: never;
         /** Create a dataset split */
         post: operations["createDatasetSplit"];
@@ -3979,6 +3980,13 @@ export interface components {
         ListDatasetLabelsForDatasetResponseBody: {
             /** Data */
             data: components["schemas"]["DatasetLabel"][];
+        };
+        /** ListDatasetSplitsResponseBody */
+        ListDatasetSplitsResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetSplit"][];
+            /** Next Cursor */
+            next_cursor: string | null;
         };
         /** ListDatasetVersionsResponseBody */
         ListDatasetVersionsResponseBody: {
@@ -8955,6 +8963,61 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listDatasetSplits: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination */
+                cursor?: string | null;
+                /** @description The max number of dataset splits to return at a time. */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListDatasetSplitsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -430,7 +430,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List dataset splits */
+        get: operations["listDatasetSplits"];
         put?: never;
         /** Create a dataset split */
         post: operations["createDatasetSplit"];
@@ -3979,6 +3980,13 @@ export interface components {
         ListDatasetLabelsForDatasetResponseBody: {
             /** Data */
             data: components["schemas"]["DatasetLabel"][];
+        };
+        /** ListDatasetSplitsResponseBody */
+        ListDatasetSplitsResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetSplit"][];
+            /** Next Cursor */
+            next_cursor: string | null;
         };
         /** ListDatasetVersionsResponseBody */
         ListDatasetVersionsResponseBody: {
@@ -8955,6 +8963,61 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listDatasetSplits: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination */
+                cursor?: string | null;
+                /** @description The max number of dataset splits to return at a time. */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListDatasetSplitsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2966,6 +2966,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 1000,
               "exclusiveMinimum": 0,
               "description": "The max number of dataset splits to return at a time.",
               "default": 10,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2924,6 +2924,99 @@
       }
     },
     "/v1/datasets/{dataset_identifier}/splits": {
+      "get": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "List dataset splits",
+        "operationId": "listDatasetSplits",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Cursor for pagination",
+              "title": "Cursor"
+            },
+            "description": "Cursor for pagination"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "description": "The max number of dataset splits to return at a time.",
+              "default": 10,
+              "title": "Limit"
+            },
+            "description": "The max number of dataset splits to return at a time."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDatasetSplitsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid request"
+          }
+        }
+      },
       "post": {
         "tags": [
           "datasets"
@@ -15158,6 +15251,34 @@
           "data"
         ],
         "title": "ListDatasetLabelsForDatasetResponseBody"
+      },
+      "ListDatasetSplitsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetSplit"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_cursor"
+        ],
+        "title": "ListDatasetSplitsResponseBody"
       },
       "ListDatasetVersionsResponseBody": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -79,6 +79,25 @@ DATASET_VERSION_NODE_NAME = DatasetVersionNodeType.__name__
 DATASET_SPLIT_NODE_NAME = DatasetSplitNodeType.__name__
 DATASET_EXAMPLE_NODE_NAME = DatasetExampleNodeType.__name__
 
+
+def _parse_cursor_rowid(cursor: str, node_name: str) -> int:
+    """Parse a pagination cursor into a rowid for the given node type.
+
+    Raises 422 for malformed cursors, including ids outside the DB's integer
+    range, which would otherwise overflow at bind time and surface as a 500.
+    """
+    try:
+        rowid = from_global_id_with_expected_type(GlobalID.from_id(cursor), node_name)
+        if not 0 <= rowid < 2**63:
+            raise ValueError(cursor)
+    except ValueError:
+        raise HTTPException(
+            detail=f"Invalid cursor format: {cursor}",
+            status_code=422,
+        )
+    return rowid
+
+
 # Matches the dataset-split form's default color (app NewDatasetSplitForm).
 DEFAULT_DATASET_SPLIT_COLOR = "#33c5e8"
 
@@ -132,14 +151,9 @@ async def list_datasets(
         )
 
         if cursor:
-            try:
-                cursor_id = GlobalID.from_id(cursor).node_id
-                query = query.filter(models.Dataset.id <= int(cursor_id))
-            except ValueError:
-                raise HTTPException(
-                    detail=f"Invalid cursor format: {cursor}",
-                    status_code=422,
-                )
+            query = query.filter(
+                models.Dataset.id <= _parse_cursor_rowid(cursor, DATASET_NODE_NAME)
+            )
         if name:
             query = query.filter(models.Dataset.name == name)
 
@@ -315,15 +329,7 @@ async def list_dataset_versions(
         .limit(limit + 1)
     )
     if cursor:
-        try:
-            dataset_version_id = from_global_id_with_expected_type(
-                GlobalID.from_id(cursor), DATASET_VERSION_NODE_NAME
-            )
-        except ValueError:
-            raise HTTPException(
-                detail=f"Invalid cursor: {cursor}",
-                status_code=422,
-            )
+        dataset_version_id = _parse_cursor_rowid(cursor, DATASET_VERSION_NODE_NAME)
         max_dataset_version_id = (
             select(models.DatasetVersion.id)
             .where(models.DatasetVersion.id == dataset_version_id)
@@ -1629,10 +1635,16 @@ async def _dataset_scoped_example_counts(
     """
     if not dataset_split_ids:
         return {}
+    # Bound the latest-revision aggregation to the splits' members so it scales
+    # with their membership rather than the dataset's full revision history.
+    member_example_ids = select(models.DatasetSplitDatasetExample.dataset_example_id).where(
+        models.DatasetSplitDatasetExample.dataset_split_id.in_(dataset_split_ids)
+    )
     latest_revision_ids = (
         select(func.max(models.DatasetExampleRevision.id))
         .join(models.DatasetExample)
         .where(models.DatasetExample.dataset_id == dataset_id)
+        .where(models.DatasetExampleRevision.dataset_example_id.in_(member_example_ids))
         .group_by(models.DatasetExampleRevision.dataset_example_id)
     )
     rows = await session.execute(
@@ -1710,22 +1722,7 @@ async def list_dataset_splits(
 ) -> ListDatasetSplitsResponseBody:
     cursor_id: Optional[int] = None
     if cursor:
-        try:
-            cursor_id = from_global_id_with_expected_type(
-                GlobalID.from_id(cursor), DATASET_SPLIT_NODE_NAME
-            )
-        except ValueError:
-            raise HTTPException(
-                detail=f"Invalid cursor format: {cursor}",
-                status_code=422,
-            )
-        # Reject ids outside the DB's integer range; they would otherwise
-        # overflow at bind time and surface as a 500.
-        if not 0 <= cursor_id < 2**63:
-            raise HTTPException(
-                detail=f"Invalid cursor format: {cursor}",
-                status_code=422,
-            )
+        cursor_id = _parse_cursor_rowid(cursor, DATASET_SPLIT_NODE_NAME)
     async with request.app.state.db.read() as session:
         dataset = await get_dataset_by_identifier(session, dataset_identifier)
         # A split belongs to a dataset when at least one of its examples does. A split
@@ -1832,11 +1829,7 @@ async def create_dataset_split(
                 ],
             )
         await session.refresh(split)
-        example_count = (
-            await _dataset_scoped_example_count(session, split.id, dataset.id)
-            if example_rowids
-            else 0
-        )
+        example_count = await _dataset_scoped_example_count(session, split.id, dataset.id)
         data = _to_dataset_split(split, example_count=example_count)
     return CreateDatasetSplitResponseBody(data=data)
 

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -1534,6 +1534,10 @@ class CreateDatasetSplitRequestBody(V1RoutesBaseModel):
     )
 
 
+class ListDatasetSplitsResponseBody(PaginatedResponseBody[DatasetSplit]):
+    pass
+
+
 class CreateDatasetSplitResponseBody(ResponseBody[DatasetSplit]):
     pass
 
@@ -1641,6 +1645,80 @@ def _to_dataset_split(split: models.DatasetSplit, *, example_count: int) -> Data
         created_at=split.created_at,
         updated_at=split.updated_at,
     )
+
+
+@router.get(
+    "/datasets/{dataset_identifier}/splits",
+    operation_id="listDatasetSplits",
+    summary="List dataset splits",
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset not found"},
+            {"status_code": 422, "description": "Invalid request"},
+        ]
+    ),
+)
+async def list_dataset_splits(
+    request: Request,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+    cursor: Optional[str] = Query(
+        default=None,
+        description="Cursor for pagination",
+    ),
+    limit: int = Query(
+        default=10, description="The max number of dataset splits to return at a time.", gt=0
+    ),
+) -> ListDatasetSplitsResponseBody:
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        # A split belongs to a dataset when at least one of its examples does. The join is
+        # restricted to this dataset's examples, so the per-split count is dataset-scoped and
+        # matches what the create/update/delete endpoints report.
+        query = (
+            select(
+                models.DatasetSplit,
+                func.count(models.DatasetSplitDatasetExample.dataset_example_id).label(
+                    "example_count"
+                ),
+            )
+            .select_from(models.DatasetSplit)
+            .join(
+                models.DatasetSplitDatasetExample,
+                onclause=(
+                    models.DatasetSplit.id == models.DatasetSplitDatasetExample.dataset_split_id
+                ),
+            )
+            .join(
+                models.DatasetExample,
+                onclause=(
+                    models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id
+                ),
+            )
+            .where(models.DatasetExample.dataset_id == dataset.id)
+            .group_by(models.DatasetSplit.id)
+            .order_by(models.DatasetSplit.id.desc())
+        )
+        if cursor:
+            try:
+                cursor_id = from_global_id_with_expected_type(
+                    GlobalID.from_id(cursor), DATASET_SPLIT_NODE_NAME
+                )
+            except ValueError:
+                raise HTTPException(
+                    detail=f"Invalid cursor format: {cursor}",
+                    status_code=422,
+                )
+            query = query.where(models.DatasetSplit.id <= cursor_id)
+        rows = (await session.execute(query.limit(limit + 1))).all()
+
+    next_cursor = None
+    if len(rows) == limit + 1:
+        next_cursor = str(GlobalID(DATASET_SPLIT_NODE_NAME, str(rows[-1][0].id)))
+        rows = rows[:-1]
+    data = [_to_dataset_split(split, example_count=example_count) for split, example_count in rows]
+    return ListDatasetSplitsResponseBody(next_cursor=next_cursor, data=data)
 
 
 @router.post(

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -65,6 +65,7 @@ from .utils import (
     add_errors_to_responses,
     add_text_csv_content_to_responses,
     get_dataset_by_identifier,
+    parse_cursor_rowid,
 )
 
 csv.field_size_limit(
@@ -78,24 +79,6 @@ DATASET_NODE_NAME = DatasetNodeType.__name__
 DATASET_VERSION_NODE_NAME = DatasetVersionNodeType.__name__
 DATASET_SPLIT_NODE_NAME = DatasetSplitNodeType.__name__
 DATASET_EXAMPLE_NODE_NAME = DatasetExampleNodeType.__name__
-
-
-def _parse_cursor_rowid(cursor: str, node_name: str) -> int:
-    """Parse a pagination cursor into a rowid for the given node type.
-
-    Raises 422 for malformed cursors, including ids outside the DB's integer
-    range, which would otherwise overflow at bind time and surface as a 500.
-    """
-    try:
-        rowid = from_global_id_with_expected_type(GlobalID.from_id(cursor), node_name)
-        if not 0 <= rowid < 2**63:
-            raise ValueError(cursor)
-    except ValueError:
-        raise HTTPException(
-            detail=f"Invalid cursor format: {cursor}",
-            status_code=422,
-        )
-    return rowid
 
 
 # Matches the dataset-split form's default color (app NewDatasetSplitForm).
@@ -151,9 +134,7 @@ async def list_datasets(
         )
 
         if cursor:
-            query = query.filter(
-                models.Dataset.id <= _parse_cursor_rowid(cursor, DATASET_NODE_NAME)
-            )
+            query = query.filter(models.Dataset.id <= parse_cursor_rowid(cursor, DATASET_NODE_NAME))
         if name:
             query = query.filter(models.Dataset.name == name)
 
@@ -329,7 +310,7 @@ async def list_dataset_versions(
         .limit(limit + 1)
     )
     if cursor:
-        dataset_version_id = _parse_cursor_rowid(cursor, DATASET_VERSION_NODE_NAME)
+        dataset_version_id = parse_cursor_rowid(cursor, DATASET_VERSION_NODE_NAME)
         max_dataset_version_id = (
             select(models.DatasetVersion.id)
             .where(models.DatasetVersion.id == dataset_version_id)
@@ -1626,32 +1607,22 @@ async def _dataset_scoped_example_counts(
     dataset_split_ids: Sequence[int],
     dataset_id: int,
 ) -> dict[int, int]:
-    """Per-split count of the dataset's examples in each split.
+    """Per-split count of the dataset's live examples (latest revision not DELETE).
 
-    Only examples whose latest revision is not a DELETE are counted, so the
-    numbers agree with the example counts reported by the non-split dataset
-    surfaces (e.g. GET /datasets/{id}/examples). Splits absent from the result
-    have no live examples in the dataset.
+    Splits with no live examples in the dataset are absent from the result.
     """
     if not dataset_split_ids:
         return {}
-    # Bound the latest-revision aggregation to the splits' members so it scales
-    # with their membership rather than the dataset's full revision history.
     member_example_ids = select(models.DatasetSplitDatasetExample.dataset_example_id).where(
         models.DatasetSplitDatasetExample.dataset_split_id.in_(dataset_split_ids)
     )
     latest_revision_ids = (
         select(func.max(models.DatasetExampleRevision.id))
-        .join(models.DatasetExample)
-        .where(models.DatasetExample.dataset_id == dataset_id)
         .where(models.DatasetExampleRevision.dataset_example_id.in_(member_example_ids))
         .group_by(models.DatasetExampleRevision.dataset_example_id)
     )
     rows = await session.execute(
-        select(
-            models.DatasetSplitDatasetExample.dataset_split_id,
-            func.count(models.DatasetExample.id),
-        )
+        select(models.DatasetSplitDatasetExample.dataset_split_id, func.count())
         .select_from(models.DatasetSplitDatasetExample)
         .join(
             models.DatasetExample,
@@ -1720,39 +1691,29 @@ async def list_dataset_splits(
         le=1000,
     ),
 ) -> ListDatasetSplitsResponseBody:
-    cursor_id: Optional[int] = None
-    if cursor:
-        cursor_id = _parse_cursor_rowid(cursor, DATASET_SPLIT_NODE_NAME)
     async with request.app.state.db.read() as session:
         dataset = await get_dataset_by_identifier(session, dataset_identifier)
-        # A split belongs to a dataset when at least one of its examples does. A split
-        # with no examples at all belongs to no dataset yet and is listed under every
-        # dataset — otherwise a freshly created empty split would be invisible to GET
-        # until an example is added.
-        has_example_in_dataset = (
-            select(models.DatasetSplitDatasetExample.dataset_split_id)
-            .join(
-                models.DatasetExample,
-                models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
-            )
-            .where(models.DatasetSplitDatasetExample.dataset_split_id == models.DatasetSplit.id)
-            .where(models.DatasetExample.dataset_id == dataset.id)
-            .exists()
-        )
-        has_any_example = (
-            select(models.DatasetSplitDatasetExample.dataset_split_id)
-            .where(models.DatasetSplitDatasetExample.dataset_split_id == models.DatasetSplit.id)
-            .exists()
-        )
-        # Select the page of splits first so the count aggregation below is bounded by
-        # the page size rather than the dataset's entire split membership.
+        # A split is listed under a dataset when it has an example in that dataset,
+        # or when it has no examples at all.
+        split_ids_with_examples = select(models.DatasetSplitDatasetExample.dataset_split_id)
+        split_ids_in_dataset = split_ids_with_examples.join(
+            models.DatasetExample,
+            models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
+        ).where(models.DatasetExample.dataset_id == dataset.id)
         query = (
             select(models.DatasetSplit)
-            .where(or_(has_example_in_dataset, ~has_any_example))
+            .where(
+                or_(
+                    models.DatasetSplit.id.in_(split_ids_in_dataset),
+                    models.DatasetSplit.id.not_in(split_ids_with_examples),
+                )
+            )
             .order_by(models.DatasetSplit.id.desc())
         )
-        if cursor_id is not None:
-            query = query.where(models.DatasetSplit.id <= cursor_id)
+        if cursor:
+            query = query.where(
+                models.DatasetSplit.id <= parse_cursor_rowid(cursor, DATASET_SPLIT_NODE_NAME)
+            )
         splits = list(await session.scalars(query.limit(limit + 1)))
 
         next_cursor = None

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -19,7 +19,7 @@ from anyio import to_thread
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Query
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import Field
-from sqlalchemy import and_, case, delete, func, insert, or_, select
+from sqlalchemy import and_, case, delete, func, insert, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -1693,21 +1693,19 @@ async def list_dataset_splits(
 ) -> ListDatasetSplitsResponseBody:
     async with request.app.state.db.read() as session:
         dataset = await get_dataset_by_identifier(session, dataset_identifier)
-        # A split is listed under a dataset when it has an example in that dataset,
-        # or when it has no examples at all.
-        split_ids_with_examples = select(models.DatasetSplitDatasetExample.dataset_split_id)
-        split_ids_in_dataset = split_ids_with_examples.join(
-            models.DatasetExample,
-            models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
-        ).where(models.DatasetExample.dataset_id == dataset.id)
+        # A split belongs to a dataset through its examples: it is listed when at
+        # least one of its examples is in the dataset, matching GraphQL Dataset.splits.
+        split_ids_in_dataset = (
+            select(models.DatasetSplitDatasetExample.dataset_split_id)
+            .join(
+                models.DatasetExample,
+                models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
+            )
+            .where(models.DatasetExample.dataset_id == dataset.id)
+        )
         query = (
             select(models.DatasetSplit)
-            .where(
-                or_(
-                    models.DatasetSplit.id.in_(split_ids_in_dataset),
-                    models.DatasetSplit.id.not_in(split_ids_with_examples),
-                )
-            )
+            .where(models.DatasetSplit.id.in_(split_ids_in_dataset))
             .order_by(models.DatasetSplit.id.desc())
         )
         if cursor:

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -19,7 +19,7 @@ from anyio import to_thread
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Query
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import Field
-from sqlalchemy import and_, case, delete, func, insert, select
+from sqlalchemy import and_, case, delete, func, insert, or_, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -1615,23 +1615,57 @@ async def _resolve_dataset_example_rowids(
     return rowids
 
 
-async def _dataset_scoped_example_count(
+async def _dataset_scoped_example_counts(
     session: AsyncSession,
-    dataset_split_id: int,
+    dataset_split_ids: Sequence[int],
     dataset_id: int,
-) -> int:
-    """Count the split's examples that belong to the given dataset."""
-    count = await session.scalar(
-        select(func.count())
+) -> dict[int, int]:
+    """Per-split count of the dataset's examples in each split.
+
+    Only examples whose latest revision is not a DELETE are counted, so the
+    numbers agree with the example counts reported by the non-split dataset
+    surfaces (e.g. GET /datasets/{id}/examples). Splits absent from the result
+    have no live examples in the dataset.
+    """
+    if not dataset_split_ids:
+        return {}
+    latest_revision_ids = (
+        select(func.max(models.DatasetExampleRevision.id))
+        .join(models.DatasetExample)
+        .where(models.DatasetExample.dataset_id == dataset_id)
+        .group_by(models.DatasetExampleRevision.dataset_example_id)
+    )
+    rows = await session.execute(
+        select(
+            models.DatasetSplitDatasetExample.dataset_split_id,
+            func.count(models.DatasetExample.id),
+        )
         .select_from(models.DatasetSplitDatasetExample)
         .join(
             models.DatasetExample,
             models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
         )
-        .where(models.DatasetSplitDatasetExample.dataset_split_id == dataset_split_id)
+        .join(
+            models.DatasetExampleRevision,
+            models.DatasetExample.id == models.DatasetExampleRevision.dataset_example_id,
+        )
+        .where(models.DatasetSplitDatasetExample.dataset_split_id.in_(dataset_split_ids))
         .where(models.DatasetExample.dataset_id == dataset_id)
+        .where(models.DatasetExampleRevision.id.in_(latest_revision_ids))
+        .where(models.DatasetExampleRevision.revision_kind != "DELETE")
+        .group_by(models.DatasetSplitDatasetExample.dataset_split_id)
     )
-    return count or 0
+    return {split_id: example_count for split_id, example_count in rows}
+
+
+async def _dataset_scoped_example_count(
+    session: AsyncSession,
+    dataset_split_id: int,
+    dataset_id: int,
+) -> int:
+    """Count the split's live (not soft-deleted) examples in the given dataset."""
+    counts = await _dataset_scoped_example_counts(session, [dataset_split_id], dataset_id)
+    return counts.get(dataset_split_id, 0)
 
 
 def _to_dataset_split(split: models.DatasetSplit, *, example_count: int) -> DatasetSplit:
@@ -1668,56 +1702,70 @@ async def list_dataset_splits(
         description="Cursor for pagination",
     ),
     limit: int = Query(
-        default=10, description="The max number of dataset splits to return at a time.", gt=0
+        default=10,
+        description="The max number of dataset splits to return at a time.",
+        gt=0,
+        le=1000,
     ),
 ) -> ListDatasetSplitsResponseBody:
-    async with request.app.state.db() as session:
+    cursor_id: Optional[int] = None
+    if cursor:
+        try:
+            cursor_id = from_global_id_with_expected_type(
+                GlobalID.from_id(cursor), DATASET_SPLIT_NODE_NAME
+            )
+        except ValueError:
+            raise HTTPException(
+                detail=f"Invalid cursor format: {cursor}",
+                status_code=422,
+            )
+        # Reject ids outside the DB's integer range; they would otherwise
+        # overflow at bind time and surface as a 500.
+        if not 0 <= cursor_id < 2**63:
+            raise HTTPException(
+                detail=f"Invalid cursor format: {cursor}",
+                status_code=422,
+            )
+    async with request.app.state.db.read() as session:
         dataset = await get_dataset_by_identifier(session, dataset_identifier)
-        # A split belongs to a dataset when at least one of its examples does. The join is
-        # restricted to this dataset's examples, so the per-split count is dataset-scoped and
-        # matches what the create/update/delete endpoints report.
-        query = (
-            select(
-                models.DatasetSplit,
-                func.count(models.DatasetSplitDatasetExample.dataset_example_id).label(
-                    "example_count"
-                ),
-            )
-            .select_from(models.DatasetSplit)
-            .join(
-                models.DatasetSplitDatasetExample,
-                onclause=(
-                    models.DatasetSplit.id == models.DatasetSplitDatasetExample.dataset_split_id
-                ),
-            )
+        # A split belongs to a dataset when at least one of its examples does. A split
+        # with no examples at all belongs to no dataset yet and is listed under every
+        # dataset — otherwise a freshly created empty split would be invisible to GET
+        # until an example is added.
+        has_example_in_dataset = (
+            select(models.DatasetSplitDatasetExample.dataset_split_id)
             .join(
                 models.DatasetExample,
-                onclause=(
-                    models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id
-                ),
+                models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
             )
+            .where(models.DatasetSplitDatasetExample.dataset_split_id == models.DatasetSplit.id)
             .where(models.DatasetExample.dataset_id == dataset.id)
-            .group_by(models.DatasetSplit.id)
+            .exists()
+        )
+        has_any_example = (
+            select(models.DatasetSplitDatasetExample.dataset_split_id)
+            .where(models.DatasetSplitDatasetExample.dataset_split_id == models.DatasetSplit.id)
+            .exists()
+        )
+        # Select the page of splits first so the count aggregation below is bounded by
+        # the page size rather than the dataset's entire split membership.
+        query = (
+            select(models.DatasetSplit)
+            .where(or_(has_example_in_dataset, ~has_any_example))
             .order_by(models.DatasetSplit.id.desc())
         )
-        if cursor:
-            try:
-                cursor_id = from_global_id_with_expected_type(
-                    GlobalID.from_id(cursor), DATASET_SPLIT_NODE_NAME
-                )
-            except ValueError:
-                raise HTTPException(
-                    detail=f"Invalid cursor format: {cursor}",
-                    status_code=422,
-                )
+        if cursor_id is not None:
             query = query.where(models.DatasetSplit.id <= cursor_id)
-        rows = (await session.execute(query.limit(limit + 1))).all()
+        splits = list(await session.scalars(query.limit(limit + 1)))
 
-    next_cursor = None
-    if len(rows) == limit + 1:
-        next_cursor = str(GlobalID(DATASET_SPLIT_NODE_NAME, str(rows[-1][0].id)))
-        rows = rows[:-1]
-    data = [_to_dataset_split(split, example_count=example_count) for split, example_count in rows]
+        next_cursor = None
+        if len(splits) == limit + 1:
+            next_cursor = str(GlobalID(DATASET_SPLIT_NODE_NAME, str(splits[-1].id)))
+            splits = splits[:-1]
+        counts = await _dataset_scoped_example_counts(
+            session, [split.id for split in splits], dataset.id
+        )
+    data = [_to_dataset_split(split, example_count=counts.get(split.id, 0)) for split in splits]
     return ListDatasetSplitsResponseBody(next_cursor=next_cursor, data=data)
 
 
@@ -1784,7 +1832,12 @@ async def create_dataset_split(
                 ],
             )
         await session.refresh(split)
-        data = _to_dataset_split(split, example_count=len(example_rowids))
+        example_count = (
+            await _dataset_scoped_example_count(session, split.id, dataset.id)
+            if example_rowids
+            else 0
+        )
+        data = _to_dataset_split(split, example_count=example_count)
     return CreateDatasetSplitResponseBody(data=data)
 
 

--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -72,6 +72,29 @@ class PaginatedResponseBody(V1RoutesBaseModel, Generic[DataType]):
     next_cursor: Optional[str]
 
 
+# Rowid columns are 32-bit integers on Postgres; a wider value fails at bind time.
+MAX_CURSOR_ROWID = 2**31 - 1
+
+
+def parse_cursor_rowid(cursor: str, node_name: str) -> int:
+    """Parse a pagination cursor into a rowid for the given node type.
+
+    Raises 422 for malformed cursors and for ids outside the bindable range.
+    """
+    try:
+        rowid: Optional[int] = from_global_id_with_expected_type(
+            GlobalID.from_id(cursor), node_name
+        )
+    except ValueError:
+        rowid = None
+    if rowid is None or not 0 <= rowid <= MAX_CURSOR_ROWID:
+        raise HTTPException(
+            detail=f"Invalid cursor format: {cursor}",
+            status_code=422,
+        )
+    return rowid
+
+
 def add_errors_to_responses(
     errors: list[Union[StatusCode, StatusCodeWithDescription]],
     /,

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2204,6 +2204,7 @@ _COMMON_RESOURCE_ENDPOINTS = (
     (422, "GET", "v1/datasets/fake-id-{}/jsonl"),
     (422, "GET", "v1/datasets/fake-id-{}/jsonl/openai_ft"),
     (422, "GET", "v1/datasets/fake-id-{}/jsonl/openai_evals"),
+    (404, "GET", "v1/datasets/fake-id-{}/splits"),
     # Dataset labels
     (200, "GET", "v1/dataset_labels"),
     (422, "GET", "v1/dataset_labels/fake-id-{}"),

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4943,10 +4943,12 @@ async def test_list_dataset_splits_accepts_dataset_name(
     assert [s["name"] for s in response.json()["data"]] == ["by_name"]
 
 
-async def test_list_dataset_splits_excludes_splits_without_examples_in_dataset(
+async def test_list_dataset_splits_scopes_splits_through_example_membership(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    """A split is scoped to a dataset only through its examples."""
+    """A split with members is scoped to the datasets containing its examples. A
+    split with no examples at all belongs to no dataset yet and is listed under
+    every dataset, so the collection round-trips its own POST."""
     dataset_a, _ = await _create_dataset_with_examples(httpx_client, "ds_scope_a", 1)
     dataset_b, examples_b = await _create_dataset_with_examples(httpx_client, "ds_scope_b", 1)
     # Belongs to dataset B only.
@@ -4956,7 +4958,7 @@ async def test_list_dataset_splits_excludes_splits_without_examples_in_dataset(
             json={"name": "b_only", "example_ids": examples_b},
         )
     ).status_code == 201
-    # Has no examples at all, so it belongs to no dataset.
+    # Has no examples at all, so it is visible under both datasets.
     assert (
         await httpx_client.post(
             url=f"/v1/datasets/{dataset_a}/splits",
@@ -4964,12 +4966,73 @@ async def test_list_dataset_splits_excludes_splits_without_examples_in_dataset(
         )
     ).status_code == 201
 
-    response = await httpx_client.get(f"/v1/datasets/{dataset_a}/splits")
-    assert response.status_code == 200
-    assert response.json()["data"] == []
+    response_a = await httpx_client.get(f"/v1/datasets/{dataset_a}/splits")
+    assert response_a.status_code == 200
+    assert {s["name"]: s["example_count"] for s in response_a.json()["data"]} == {"empty_split": 0}
 
     response_b = await httpx_client.get(f"/v1/datasets/{dataset_b}/splits")
-    assert [s["name"] for s in response_b.json()["data"]] == ["b_only"]
+    assert {s["name"]: s["example_count"] for s in response_b.json()["data"]} == {
+        "b_only": 1,
+        "empty_split": 0,
+    }
+
+
+async def test_list_dataset_splits_excludes_soft_deleted_examples_from_counts(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Soft-deleting an example (DELETE revision) leaves its split membership rows in
+    place, but the reported example_count must drop to match the non-split surfaces
+    (e.g. GET /datasets/{id}/examples)."""
+    name = "ds_split_soft_delete"
+    examples = [
+        ExampleContent(input={"q": f"Q{i}"}, output={"a": f"A{i}"}, metadata={}) for i in range(3)
+    ]
+    await _append(httpx_client, name, examples)
+    async with db() as session:
+        dataset_rowid = await session.scalar(
+            select(models.Dataset.id).where(models.Dataset.name == name)
+        )
+    dataset_id = str(GlobalID("Dataset", str(dataset_rowid)))
+    examples_response = await httpx_client.get(f"/v1/datasets/{dataset_id}/examples")
+    example_ids = [e["node_id"] for e in examples_response.json()["data"]["examples"]]
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{name}/splits",
+        json={"name": "train", "example_ids": example_ids},
+    )
+    assert created.status_code == 201
+    assert created.json()["data"]["example_count"] == 3
+
+    # Soft-delete the last example with a DELETE revision while leaving its split
+    # membership row in place, as GraphQL deleteDatasetExamples does.
+    async with db() as session:
+        version = models.DatasetVersion(dataset_id=dataset_rowid, metadata_={})
+        session.add(version)
+        await session.flush()
+        session.add(
+            models.DatasetExampleRevision(
+                dataset_example_id=int(GlobalID.from_id(example_ids[-1]).node_id),
+                dataset_version_id=version.id,
+                input={},
+                output={},
+                metadata_={},
+                revision_kind="DELETE",
+            )
+        )
+
+    response = await httpx_client.get(f"/v1/datasets/{name}/splits")
+    assert response.status_code == 200
+    assert [s["example_count"] for s in response.json()["data"]] == [2]
+
+    # The membership rows are untouched — only the count filters out the deletion.
+    split_rowid = int(GlobalID.from_id(created.json()["data"]["id"]).node_id)
+    async with db() as session:
+        member_count = await session.scalar(
+            select(func.count())
+            .select_from(models.DatasetSplitDatasetExample)
+            .where(models.DatasetSplitDatasetExample.dataset_split_id == split_rowid)
+        )
+        assert member_count == 3
 
 
 async def test_list_dataset_splits_paginates(
@@ -4984,7 +5047,7 @@ async def test_list_dataset_splits_paginates(
             )
         ).status_code == 201
 
-    seen: list[str] = []
+    pages: list[dict[str, Any]] = []
     cursor: Optional[str] = None
     for _ in range(3):
         url = f"/v1/datasets/{dataset_id}/splits?limit=2"
@@ -4993,11 +5056,15 @@ async def test_list_dataset_splits_paginates(
         page = await httpx_client.get(url)
         assert page.status_code == 200
         body = page.json()
-        seen.extend(s["name"] for s in body["data"])
+        assert len(body["data"]) <= 2, "page exceeded requested limit"
+        pages.append(body)
         cursor = body["next_cursor"]
         if cursor is None:
             break
     assert cursor is None
+    assert [len(p["data"]) for p in pages] == [2, 1], "expected pages of sizes 2 and 1"
+    assert pages[0]["next_cursor"] is not None
+    seen = [s["name"] for p in pages for s in p["data"]]
     assert sorted(seen) == ["split_0", "split_1", "split_2"]
     assert len(seen) == len(set(seen)), "pagination returned duplicates"
 
@@ -5024,4 +5091,16 @@ async def test_list_dataset_splits_invalid_cursor(
 ) -> None:
     dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_bad_cursor", 1)
     response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits?cursor=not-a-global-id")
+    assert response.status_code == 422
+
+
+async def test_list_dataset_splits_out_of_range_cursor(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    """A cursor id beyond the DB's integer range must 422, not 500 at bind time."""
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_overflow_cursor", 1)
+    cursor = str(GlobalID("DatasetSplit", "99999999999999999999"))
+    response = await httpx_client.get(
+        f"/v1/datasets/{dataset_id}/splits", params={"cursor": cursor}
+    )
     assert response.status_code == 422

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4,7 +4,7 @@ import io
 import json
 from datetime import datetime, timezone
 from io import BytesIO, StringIO
-from typing import Any
+from typing import Any, Optional
 
 import httpx
 import pandas as pd
@@ -4898,4 +4898,130 @@ async def test_delete_dataset_split_invalid_id(
 ) -> None:
     dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_delete_422", 1)
     response = await httpx_client.delete(f"/v1/datasets/{dataset_id}/splits/not-a-global-id")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Dataset split list endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_list_dataset_splits_returns_splits_with_scoped_counts(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, example_ids = await _create_dataset_with_examples(httpx_client, "ds_list", 3)
+    for name, members in (("train", example_ids[:2]), ("test", example_ids[2:])):
+        created = await httpx_client.post(
+            url=f"/v1/datasets/{dataset_id}/splits",
+            json={"name": name, "example_ids": members},
+        )
+        assert created.status_code == 201
+
+    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["next_cursor"] is None
+    counts = {split["name"]: split["example_count"] for split in body["data"]}
+    assert counts == {"train": 2, "test": 1}
+    for split in body["data"]:
+        assert split["color"]
+        assert "created_at" in split and "updated_at" in split
+
+
+async def test_list_dataset_splits_accepts_dataset_name(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    _, example_ids = await _create_dataset_with_examples(httpx_client, "ds_list_by_name", 1)
+    created = await httpx_client.post(
+        url="/v1/datasets/ds_list_by_name/splits",
+        json={"name": "by_name", "example_ids": example_ids},
+    )
+    assert created.status_code == 201
+
+    response = await httpx_client.get("/v1/datasets/ds_list_by_name/splits")
+    assert response.status_code == 200
+    assert [s["name"] for s in response.json()["data"]] == ["by_name"]
+
+
+async def test_list_dataset_splits_excludes_splits_without_examples_in_dataset(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    """A split is scoped to a dataset only through its examples."""
+    dataset_a, _ = await _create_dataset_with_examples(httpx_client, "ds_scope_a", 1)
+    dataset_b, examples_b = await _create_dataset_with_examples(httpx_client, "ds_scope_b", 1)
+    # Belongs to dataset B only.
+    assert (
+        await httpx_client.post(
+            url=f"/v1/datasets/{dataset_b}/splits",
+            json={"name": "b_only", "example_ids": examples_b},
+        )
+    ).status_code == 201
+    # Has no examples at all, so it belongs to no dataset.
+    assert (
+        await httpx_client.post(
+            url=f"/v1/datasets/{dataset_a}/splits",
+            json={"name": "empty_split"},
+        )
+    ).status_code == 201
+
+    response = await httpx_client.get(f"/v1/datasets/{dataset_a}/splits")
+    assert response.status_code == 200
+    assert response.json()["data"] == []
+
+    response_b = await httpx_client.get(f"/v1/datasets/{dataset_b}/splits")
+    assert [s["name"] for s in response_b.json()["data"]] == ["b_only"]
+
+
+async def test_list_dataset_splits_paginates(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, example_ids = await _create_dataset_with_examples(httpx_client, "ds_page", 1)
+    for i in range(3):
+        assert (
+            await httpx_client.post(
+                url=f"/v1/datasets/{dataset_id}/splits",
+                json={"name": f"split_{i}", "example_ids": example_ids},
+            )
+        ).status_code == 201
+
+    seen: list[str] = []
+    cursor: Optional[str] = None
+    for _ in range(3):
+        url = f"/v1/datasets/{dataset_id}/splits?limit=2"
+        if cursor:
+            url += f"&cursor={cursor}"
+        page = await httpx_client.get(url)
+        assert page.status_code == 200
+        body = page.json()
+        seen.extend(s["name"] for s in body["data"])
+        cursor = body["next_cursor"]
+        if cursor is None:
+            break
+    assert cursor is None
+    assert sorted(seen) == ["split_0", "split_1", "split_2"]
+    assert len(seen) == len(set(seen)), "pagination returned duplicates"
+
+
+async def test_list_dataset_splits_empty(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_no_splits", 1)
+    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")
+    assert response.status_code == 200
+    assert response.json() == {"data": [], "next_cursor": None}
+
+
+async def test_list_dataset_splits_dataset_not_found(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    missing = str(GlobalID("Dataset", "99999"))
+    response = await httpx_client.get(f"/v1/datasets/{missing}/splits")
+    assert response.status_code == 404
+
+
+async def test_list_dataset_splits_invalid_cursor(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_bad_cursor", 1)
+    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits?cursor=not-a-global-id")
     assert response.status_code == 422

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4,7 +4,7 @@ import io
 import json
 from datetime import datetime, timezone
 from io import BytesIO, StringIO
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 import pandas as pd
@@ -4984,20 +4984,11 @@ async def test_list_dataset_splits_excludes_soft_deleted_examples_from_counts(
     """Soft-deleting an example (DELETE revision) leaves its split membership rows in
     place, but the reported example_count must drop to match the non-split surfaces
     (e.g. GET /datasets/{id}/examples)."""
-    name = "ds_split_soft_delete"
-    examples = [
-        ExampleContent(input={"q": f"Q{i}"}, output={"a": f"A{i}"}, metadata={}) for i in range(3)
-    ]
-    await _append(httpx_client, name, examples)
-    async with db() as session:
-        dataset_rowid = await session.scalar(
-            select(models.Dataset.id).where(models.Dataset.name == name)
-        )
-    dataset_id = str(GlobalID("Dataset", str(dataset_rowid)))
-    examples_response = await httpx_client.get(f"/v1/datasets/{dataset_id}/examples")
-    example_ids = [e["node_id"] for e in examples_response.json()["data"]["examples"]]
+    dataset_id, example_ids = await _create_dataset_with_examples(
+        httpx_client, "ds_split_soft_delete", 3
+    )
     created = await httpx_client.post(
-        url=f"/v1/datasets/{name}/splits",
+        url=f"/v1/datasets/{dataset_id}/splits",
         json={"name": "train", "example_ids": example_ids},
     )
     assert created.status_code == 201
@@ -5006,7 +4997,9 @@ async def test_list_dataset_splits_excludes_soft_deleted_examples_from_counts(
     # Soft-delete the last example with a DELETE revision while leaving its split
     # membership row in place, as GraphQL deleteDatasetExamples does.
     async with db() as session:
-        version = models.DatasetVersion(dataset_id=dataset_rowid, metadata_={})
+        version = models.DatasetVersion(
+            dataset_id=int(GlobalID.from_id(dataset_id).node_id), metadata_={}
+        )
         session.add(version)
         await session.flush()
         session.add(
@@ -5020,7 +5013,7 @@ async def test_list_dataset_splits_excludes_soft_deleted_examples_from_counts(
             )
         )
 
-    response = await httpx_client.get(f"/v1/datasets/{name}/splits")
+    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")
     assert response.status_code == 200
     assert [s["example_count"] for s in response.json()["data"]] == [2]
 
@@ -5047,26 +5040,21 @@ async def test_list_dataset_splits_paginates(
             )
         ).status_code == 201
 
-    pages: list[dict[str, Any]] = []
-    cursor: Optional[str] = None
-    for _ in range(3):
-        url = f"/v1/datasets/{dataset_id}/splits?limit=2"
-        if cursor:
-            url += f"&cursor={cursor}"
-        page = await httpx_client.get(url)
-        assert page.status_code == 200
-        body = page.json()
-        assert len(body["data"]) <= 2, "page exceeded requested limit"
-        pages.append(body)
-        cursor = body["next_cursor"]
-        if cursor is None:
-            break
-    assert cursor is None
-    assert [len(p["data"]) for p in pages] == [2, 1], "expected pages of sizes 2 and 1"
-    assert pages[0]["next_cursor"] is not None
-    seen = [s["name"] for p in pages for s in p["data"]]
-    assert sorted(seen) == ["split_0", "split_1", "split_2"]
-    assert len(seen) == len(set(seen)), "pagination returned duplicates"
+    url = f"/v1/datasets/{dataset_id}/splits"
+    first = await httpx_client.get(url, params={"limit": 2})
+    assert first.status_code == 200
+    first_page = first.json()
+    assert len(first_page["data"]) == 2
+    assert first_page["next_cursor"] is not None
+
+    second = await httpx_client.get(url, params={"limit": 2, "cursor": first_page["next_cursor"]})
+    assert second.status_code == 200
+    second_page = second.json()
+    assert len(second_page["data"]) == 1
+    assert second_page["next_cursor"] is None
+
+    names = [s["name"] for page in (first_page, second_page) for s in page["data"]]
+    assert sorted(names) == ["split_0", "split_1", "split_2"]
 
 
 async def test_list_dataset_splits_empty(

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -5028,6 +5028,43 @@ async def test_list_dataset_splits_excludes_soft_deleted_examples_from_counts(
         assert member_count == 3
 
 
+async def test_list_dataset_splits_all_examples_soft_deleted(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """When every in-dataset example of a split is soft-deleted, the split is still
+    listed -- membership, not example_count, decides inclusion -- but its count
+    drops to 0 rather than the split being hidden entirely."""
+    dataset_id, example_ids = await _create_dataset_with_examples(
+        httpx_client, "ds_all_soft_deleted", 1
+    )
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "all_gone", "example_ids": example_ids},
+    )
+    assert created.status_code == 201
+
+    async with db() as session:
+        version = models.DatasetVersion(
+            dataset_id=int(GlobalID.from_id(dataset_id).node_id), metadata_={}
+        )
+        session.add(version)
+        await session.flush()
+        session.add(
+            models.DatasetExampleRevision(
+                dataset_example_id=int(GlobalID.from_id(example_ids[0]).node_id),
+                dataset_version_id=version.id,
+                input={},
+                output={},
+                metadata_={},
+                revision_kind="DELETE",
+            )
+        )
+
+    body = (await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")).json()
+    assert {s["name"]: s["example_count"] for s in body["data"]} == {"all_gone": 0}
+
+
 async def test_list_dataset_splits_paginates(
     httpx_client: httpx.AsyncClient,
 ) -> None:

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4,7 +4,7 @@ import io
 import json
 from datetime import datetime, timezone
 from io import BytesIO, StringIO
-from typing import Any
+from typing import Any, Optional, cast
 
 import httpx
 import pandas as pd
@@ -4593,6 +4593,26 @@ async def _create_dataset_with_examples(
     return dataset_id, example_ids
 
 
+async def _soft_delete_example(db: DbSessionFactory, *, dataset_id: str, example_id: str) -> None:
+    """Soft-delete an example with a DELETE revision, leaving split memberships intact."""
+    async with db() as session:
+        version = models.DatasetVersion(
+            dataset_id=int(GlobalID.from_id(dataset_id).node_id), metadata_={}
+        )
+        session.add(version)
+        await session.flush()
+        session.add(
+            models.DatasetExampleRevision(
+                dataset_example_id=int(GlobalID.from_id(example_id).node_id),
+                dataset_version_id=version.id,
+                input={},
+                output={},
+                metadata_={},
+                revision_kind="DELETE",
+            )
+        )
+
+
 async def test_create_dataset_split_empty(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,
@@ -4906,23 +4926,40 @@ async def test_delete_dataset_split_invalid_id(
 # ---------------------------------------------------------------------------
 
 
+async def _create_split(
+    httpx_client: httpx.AsyncClient,
+    dataset_id: str,
+    name: str,
+    example_ids: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Create a split under the dataset and return its response payload."""
+    body: dict[str, Any] = {"name": name}
+    if example_ids is not None:
+        body["example_ids"] = example_ids
+    response = await httpx_client.post(url=f"/v1/datasets/{dataset_id}/splits", json=body)
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json()["data"])
+
+
+async def _list_split_counts(httpx_client: httpx.AsyncClient, dataset_id: str) -> dict[str, int]:
+    """Return {split name: example_count} for the dataset."""
+    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")
+    assert response.status_code == 200
+    return {s["name"]: s["example_count"] for s in response.json()["data"]}
+
+
 async def test_list_dataset_splits_returns_splits_with_scoped_counts(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     dataset_id, example_ids = await _create_dataset_with_examples(httpx_client, "ds_list", 3)
-    for name, members in (("train", example_ids[:2]), ("test", example_ids[2:])):
-        created = await httpx_client.post(
-            url=f"/v1/datasets/{dataset_id}/splits",
-            json={"name": name, "example_ids": members},
-        )
-        assert created.status_code == 201
+    await _create_split(httpx_client, dataset_id, "train", example_ids[:2])
+    await _create_split(httpx_client, dataset_id, "test", example_ids[2:])
 
     response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")
     assert response.status_code == 200
     body = response.json()
     assert body["next_cursor"] is None
-    counts = {split["name"]: split["example_count"] for split in body["data"]}
-    assert counts == {"train": 2, "test": 1}
+    assert {s["name"]: s["example_count"] for s in body["data"]} == {"train": 2, "test": 1}
     for split in body["data"]:
         assert split["color"]
         assert "created_at" in split and "updated_at" in split
@@ -4932,137 +4969,50 @@ async def test_list_dataset_splits_accepts_dataset_name(
     httpx_client: httpx.AsyncClient,
 ) -> None:
     _, example_ids = await _create_dataset_with_examples(httpx_client, "ds_list_by_name", 1)
-    created = await httpx_client.post(
-        url="/v1/datasets/ds_list_by_name/splits",
-        json={"name": "by_name", "example_ids": example_ids},
-    )
-    assert created.status_code == 201
-
-    response = await httpx_client.get("/v1/datasets/ds_list_by_name/splits")
-    assert response.status_code == 200
-    assert [s["name"] for s in response.json()["data"]] == ["by_name"]
+    await _create_split(httpx_client, "ds_list_by_name", "by_name", example_ids)
+    assert await _list_split_counts(httpx_client, "ds_list_by_name") == {"by_name": 1}
 
 
 async def test_list_dataset_splits_scopes_splits_through_example_membership(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    """A split with members is scoped to the datasets containing its examples. A
-    split with no examples at all belongs to no dataset yet and is listed under
-    every dataset, so the collection round-trips its own POST."""
+    """Populated splits are listed only under datasets holding their examples; empty
+    splits are listed under every dataset."""
     dataset_a, _ = await _create_dataset_with_examples(httpx_client, "ds_scope_a", 1)
     dataset_b, examples_b = await _create_dataset_with_examples(httpx_client, "ds_scope_b", 1)
-    # Belongs to dataset B only.
-    assert (
-        await httpx_client.post(
-            url=f"/v1/datasets/{dataset_b}/splits",
-            json={"name": "b_only", "example_ids": examples_b},
-        )
-    ).status_code == 201
-    # Has no examples at all, so it is visible under both datasets.
-    assert (
-        await httpx_client.post(
-            url=f"/v1/datasets/{dataset_a}/splits",
-            json={"name": "empty_split"},
-        )
-    ).status_code == 201
+    await _create_split(httpx_client, dataset_b, "b_only", examples_b)
+    await _create_split(httpx_client, dataset_a, "empty_split")
 
-    response_a = await httpx_client.get(f"/v1/datasets/{dataset_a}/splits")
-    assert response_a.status_code == 200
-    assert {s["name"]: s["example_count"] for s in response_a.json()["data"]} == {"empty_split": 0}
-
-    response_b = await httpx_client.get(f"/v1/datasets/{dataset_b}/splits")
-    assert {s["name"]: s["example_count"] for s in response_b.json()["data"]} == {
-        "b_only": 1,
-        "empty_split": 0,
-    }
+    assert await _list_split_counts(httpx_client, dataset_a) == {"empty_split": 0}
+    assert await _list_split_counts(httpx_client, dataset_b) == {"b_only": 1, "empty_split": 0}
 
 
+@pytest.mark.parametrize("num_examples, expected_count", [(3, 2), (1, 0)])
 async def test_list_dataset_splits_excludes_soft_deleted_examples_from_counts(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,
+    num_examples: int,
+    expected_count: int,
 ) -> None:
-    """Soft-deleting an example (DELETE revision) leaves its split membership rows in
-    place, but the reported example_count must drop to match the non-split surfaces
-    (e.g. GET /datasets/{id}/examples)."""
+    """Soft-deleted examples are excluded from example_count; the split stays listed."""
     dataset_id, example_ids = await _create_dataset_with_examples(
-        httpx_client, "ds_split_soft_delete", 3
+        httpx_client, "ds_split_soft_delete", num_examples
     )
-    created = await httpx_client.post(
-        url=f"/v1/datasets/{dataset_id}/splits",
-        json={"name": "train", "example_ids": example_ids},
-    )
-    assert created.status_code == 201
-    assert created.json()["data"]["example_count"] == 3
+    created = await _create_split(httpx_client, dataset_id, "train", example_ids)
+    assert created["example_count"] == num_examples
 
-    # Soft-delete the last example with a DELETE revision while leaving its split
-    # membership row in place, as GraphQL deleteDatasetExamples does.
-    async with db() as session:
-        version = models.DatasetVersion(
-            dataset_id=int(GlobalID.from_id(dataset_id).node_id), metadata_={}
-        )
-        session.add(version)
-        await session.flush()
-        session.add(
-            models.DatasetExampleRevision(
-                dataset_example_id=int(GlobalID.from_id(example_ids[-1]).node_id),
-                dataset_version_id=version.id,
-                input={},
-                output={},
-                metadata_={},
-                revision_kind="DELETE",
-            )
-        )
+    await _soft_delete_example(db, dataset_id=dataset_id, example_id=example_ids[-1])
 
-    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")
-    assert response.status_code == 200
-    assert [s["example_count"] for s in response.json()["data"]] == [2]
-
-    # The membership rows are untouched — only the count filters out the deletion.
-    split_rowid = int(GlobalID.from_id(created.json()["data"]["id"]).node_id)
+    assert await _list_split_counts(httpx_client, dataset_id) == {"train": expected_count}
+    # Membership rows survive the soft delete; only the count changes.
+    split_rowid = int(GlobalID.from_id(created["id"]).node_id)
     async with db() as session:
         member_count = await session.scalar(
             select(func.count())
             .select_from(models.DatasetSplitDatasetExample)
             .where(models.DatasetSplitDatasetExample.dataset_split_id == split_rowid)
         )
-        assert member_count == 3
-
-
-async def test_list_dataset_splits_all_examples_soft_deleted(
-    httpx_client: httpx.AsyncClient,
-    db: DbSessionFactory,
-) -> None:
-    """When every in-dataset example of a split is soft-deleted, the split is still
-    listed -- membership, not example_count, decides inclusion -- but its count
-    drops to 0 rather than the split being hidden entirely."""
-    dataset_id, example_ids = await _create_dataset_with_examples(
-        httpx_client, "ds_all_soft_deleted", 1
-    )
-    created = await httpx_client.post(
-        url=f"/v1/datasets/{dataset_id}/splits",
-        json={"name": "all_gone", "example_ids": example_ids},
-    )
-    assert created.status_code == 201
-
-    async with db() as session:
-        version = models.DatasetVersion(
-            dataset_id=int(GlobalID.from_id(dataset_id).node_id), metadata_={}
-        )
-        session.add(version)
-        await session.flush()
-        session.add(
-            models.DatasetExampleRevision(
-                dataset_example_id=int(GlobalID.from_id(example_ids[0]).node_id),
-                dataset_version_id=version.id,
-                input={},
-                output={},
-                metadata_={},
-                revision_kind="DELETE",
-            )
-        )
-
-    body = (await httpx_client.get(f"/v1/datasets/{dataset_id}/splits")).json()
-    assert {s["name"]: s["example_count"] for s in body["data"]} == {"all_gone": 0}
+    assert member_count == num_examples
 
 
 async def test_list_dataset_splits_paginates(
@@ -5070,12 +5020,7 @@ async def test_list_dataset_splits_paginates(
 ) -> None:
     dataset_id, example_ids = await _create_dataset_with_examples(httpx_client, "ds_page", 1)
     for i in range(3):
-        assert (
-            await httpx_client.post(
-                url=f"/v1/datasets/{dataset_id}/splits",
-                json={"name": f"split_{i}", "example_ids": example_ids},
-            )
-        ).status_code == 201
+        await _create_split(httpx_client, dataset_id, f"split_{i}", example_ids)
 
     url = f"/v1/datasets/{dataset_id}/splits"
     first = await httpx_client.get(url, params={"limit": 2})
@@ -5111,20 +5056,20 @@ async def test_list_dataset_splits_dataset_not_found(
     assert response.status_code == 404
 
 
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        "not-a-global-id",
+        str(GlobalID("Dataset", "1")),
+        # Ids the DB driver cannot bind as int32 must 422 rather than 500.
+        *(str(GlobalID("DatasetSplit", str(n))) for n in (2**31, 2**63, 10**20)),
+    ],
+)
 async def test_list_dataset_splits_invalid_cursor(
     httpx_client: httpx.AsyncClient,
+    cursor: str,
 ) -> None:
     dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_bad_cursor", 1)
-    response = await httpx_client.get(f"/v1/datasets/{dataset_id}/splits?cursor=not-a-global-id")
-    assert response.status_code == 422
-
-
-async def test_list_dataset_splits_out_of_range_cursor(
-    httpx_client: httpx.AsyncClient,
-) -> None:
-    """A cursor id beyond the DB's integer range must 422, not 500 at bind time."""
-    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_overflow_cursor", 1)
-    cursor = str(GlobalID("DatasetSplit", "99999999999999999999"))
     response = await httpx_client.get(
         f"/v1/datasets/{dataset_id}/splits", params={"cursor": cursor}
     )
@@ -5134,49 +5079,17 @@ async def test_list_dataset_splits_out_of_range_cursor(
 async def test_list_dataset_splits_counts_are_dataset_scoped_for_cross_dataset_split(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    """A split may span datasets; each dataset reports only its own examples.
-
-
-    A split is tied to a dataset only through its examples, and nothing binds a
-    split to a single dataset. Build a split holding one example from dataset A
-    and one from dataset B, then confirm each dataset's listing reports only the
-    count of its own examples (1 and 1) -- never the split's global total -- and
-    that the two dataset-scoped counts sum to the split's true size (2).
-    """
+    """A split spanning two datasets reports each dataset's own example count."""
     dataset_a, examples_a = await _create_dataset_with_examples(httpx_client, "ds_cross_a", 1)
     dataset_b, examples_b = await _create_dataset_with_examples(httpx_client, "ds_cross_b", 1)
-
-    # A split can only be seeded with examples from the dataset in the URL, so
-    # create it against A with A's example, then add B's example by PATCHing
-    # through dataset B. The split itself is bound to neither dataset.
-    created = await httpx_client.post(
-        url=f"/v1/datasets/{dataset_a}/splits",
-        json={"name": "cross_ds", "example_ids": examples_a},
-    )
-    assert created.status_code == 201
-    split_id = created.json()["data"]["id"]
-
+    # Seed with A's example, then add B's example by PATCHing through dataset B.
+    split_id = (await _create_split(httpx_client, dataset_a, "cross_ds", examples_a))["id"]
     patched = await httpx_client.patch(
         url=f"/v1/datasets/{dataset_b}/splits/{split_id}",
         json={"add_example_ids": examples_b},
     )
     assert patched.status_code == 200
-    # The update was issued through dataset B, so its response is B-scoped.
     assert patched.json()["data"]["example_count"] == 1
 
-    def _count(body: dict[str, Any]) -> int:
-        matches = [s for s in body["data"] if s["name"] == "cross_ds"]
-        assert len(matches) == 1, f"expected exactly one 'cross_ds' split, got {matches}"
-        return matches[0]["example_count"]
-
-    resp_a = await httpx_client.get(f"/v1/datasets/{dataset_a}/splits")
-    assert resp_a.status_code == 200
-    count_a = _count(resp_a.json())
-
-    resp_b = await httpx_client.get(f"/v1/datasets/{dataset_b}/splits")
-    assert resp_b.status_code == 200
-    count_b = _count(resp_b.json())
-
-    # Each dataset should only see its own example
-    assert count_a == 1
-    assert count_b == 1
+    assert await _list_split_counts(httpx_client, dataset_a) == {"cross_ds": 1}
+    assert await _list_split_counts(httpx_client, dataset_b) == {"cross_ds": 1}

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -5092,3 +5092,54 @@ async def test_list_dataset_splits_out_of_range_cursor(
         f"/v1/datasets/{dataset_id}/splits", params={"cursor": cursor}
     )
     assert response.status_code == 422
+
+
+async def test_list_dataset_splits_counts_are_dataset_scoped_for_cross_dataset_split(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    """A split may span datasets; each dataset reports only its own examples.
+
+
+    A split is tied to a dataset only through its examples, and nothing binds a
+    split to a single dataset. Build a split holding one example from dataset A
+    and one from dataset B, then confirm each dataset's listing reports only the
+    count of its own examples (1 and 1) -- never the split's global total -- and
+    that the two dataset-scoped counts sum to the split's true size (2).
+    """
+    dataset_a, examples_a = await _create_dataset_with_examples(httpx_client, "ds_cross_a", 1)
+    dataset_b, examples_b = await _create_dataset_with_examples(httpx_client, "ds_cross_b", 1)
+
+    # A split can only be seeded with examples from the dataset in the URL, so
+    # create it against A with A's example, then add B's example by PATCHing
+    # through dataset B. The split itself is bound to neither dataset.
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_a}/splits",
+        json={"name": "cross_ds", "example_ids": examples_a},
+    )
+    assert created.status_code == 201
+    split_id = created.json()["data"]["id"]
+
+    patched = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_b}/splits/{split_id}",
+        json={"add_example_ids": examples_b},
+    )
+    assert patched.status_code == 200
+    # The update was issued through dataset B, so its response is B-scoped.
+    assert patched.json()["data"]["example_count"] == 1
+
+    def _count(body: dict[str, Any]) -> int:
+        matches = [s for s in body["data"] if s["name"] == "cross_ds"]
+        assert len(matches) == 1, f"expected exactly one 'cross_ds' split, got {matches}"
+        return matches[0]["example_count"]
+
+    resp_a = await httpx_client.get(f"/v1/datasets/{dataset_a}/splits")
+    assert resp_a.status_code == 200
+    count_a = _count(resp_a.json())
+
+    resp_b = await httpx_client.get(f"/v1/datasets/{dataset_b}/splits")
+    assert resp_b.status_code == 200
+    count_b = _count(resp_b.json())
+
+    # Each dataset should only see its own example
+    assert count_a == 1
+    assert count_b == 1

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4976,15 +4976,15 @@ async def test_list_dataset_splits_accepts_dataset_name(
 async def test_list_dataset_splits_scopes_splits_through_example_membership(
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    """Populated splits are listed only under datasets holding their examples; empty
-    splits are listed under every dataset."""
+    """A split is listed only under datasets holding at least one of its examples, so
+    a split with no examples is listed under none."""
     dataset_a, _ = await _create_dataset_with_examples(httpx_client, "ds_scope_a", 1)
     dataset_b, examples_b = await _create_dataset_with_examples(httpx_client, "ds_scope_b", 1)
     await _create_split(httpx_client, dataset_b, "b_only", examples_b)
-    await _create_split(httpx_client, dataset_a, "empty_split")
+    await _create_split(httpx_client, dataset_a, "no_examples")
 
-    assert await _list_split_counts(httpx_client, dataset_a) == {"empty_split": 0}
-    assert await _list_split_counts(httpx_client, dataset_b) == {"b_only": 1, "empty_split": 0}
+    assert await _list_split_counts(httpx_client, dataset_a) == {}
+    assert await _list_split_counts(httpx_client, dataset_b) == {"b_only": 1}
 
 
 @pytest.mark.parametrize("num_examples, expected_count", [(3, 2), (1, 0)])


### PR DESCRIPTION
Closes #12090

## Summary

`POST`, `PATCH` and `DELETE` for dataset splits landed in #14046, but there was no way to **read** splits over REST. This completes the surface:

- `GET /v1/datasets/{dataset_identifier}/splits` lists the splits that hold at least one example of the dataset, newest first, with cursor pagination and an optional `name` filter.
- `GET /v1/datasets/{dataset_identifier}/splits/{split_identifier}` reads one split by ID or name.
- `PATCH` and `DELETE` now also accept a split name in place of the ID, so every segment of the path resolves the same way the dataset segment already does.

This unblocks the CLI roadmap in #11997.

## Scoping semantics

A split has no direct FK to a dataset; it is associated through its examples. The list matches the existing `Dataset.splits` GraphQL field (`DatasetDatasetSplitsDataLoader`): **a split is listed when at least one of its examples belongs to the dataset.** A split with no examples in the dataset is not listed, even if it was created under that dataset. The route description says so and points to the single-split `GET`, which reads any existing split under any dataset.

`example_count` is dataset-scoped and counts only live examples, so a split whose dataset examples were all soft-deleted is listed with a count of `0`. The count is computed in one grouped query rather than per split. Every `DatasetSplit` field now carries a schema description so these semantics are visible in the OpenAPI document and generated clients.

## Conventions followed

- **Pagination**: cursor over `DatasetSplit` GlobalIDs ordered by `id DESC`, matching `list_datasets` and `list_dataset_versions`. `limit` defaults to 10 and is capped at 1000. Cursor parsing is shared with those routes through `parse_cursor_rowid`, which rejects malformed cursors and ids outside the int32 range with `422` instead of a `500`.
- **Identifiers**: both path segments accept a name or a GlobalID. Split names are globally unique, so the name is a real natural key. Resolution lives in `get_dataset_split_by_identifier` next to the dataset one.
- **Errors**: `404` when the dataset or split does not exist, `422` for a malformed cursor or request body.
- Read routes carry no `is_not_locked` dependency.

## Behavior change on existing routes

`PATCH` and `DELETE` shipped in v19.20.0 with a `split_id` path parameter that only accepted a GlobalID. The URL shape and every previously valid call still work. Two things change:

- An identifier that is not a `DatasetSplit` GlobalID is now looked up as a name, so an unknown one returns `404` where a malformed ID returned `422`.
- The generated Python and TypeScript types rename the path parameter key from `split_id` to `split_identifier`.

## Tests

Added to `tests/unit/server/api/routers/v1/test_datasets.py`:

- list returns splits with dataset-scoped `example_count`
- list accepts a dataset name as the identifier
- list scopes splits through example membership, so an empty split is listed under no dataset
- list excludes soft-deleted examples from counts while keeping the split listed, including the all-deleted case
- list counts are dataset-scoped for a split spanning two datasets
- list paginates without duplicates or gaps
- list filters by `name`
- empty dataset returns `{"data": [], "next_cursor": null}`
- `404` unknown dataset, `422` malformed or out-of-range cursor
- single `GET` by ID and by name, with a scoped count that is `0` under a dataset the split has no examples in
- single `GET`, `PATCH`, `DELETE` return `404` for an unknown name
- `PATCH` and `DELETE` by name

All pass locally against SQLite. The Postgres matrix runs in CI.

## Generated files

`schemas/openapi.json` and the four generated clients were regenerated with `make openapi`.
