### PR TITLE
fix: route OpenAI reasoning models to the Responses API client

### DIFF
--- a/app/src/components/playground/model/ModelParametersConfigButton.tsx
+++ b/app/src/components/playground/model/ModelParametersConfigButton.tsx
@@ -116,6 +116,7 @@ export function ModelParametersConfigButton(
   const canConfigureRegion = provider === "AWS";
   const canConfigureOpenAIApiType =
     !usingCustomProvider &&
+    !disableEphemeralRouting &&
     (provider === "OPENAI" || provider === "AZURE_OPENAI");
 
   const showBaseUrl =
@@ -150,11 +151,10 @@ export function ModelParametersConfigButton(
               playgroundInstanceId={playgroundInstanceId}
             />
 
-            {/* OpenAI / Azure API type - built-in only: editable when ephemeral routing enabled, fixed default when disabled */}
+            {/* OpenAI / Azure API type - built-in only, and only where the selection is sent */}
             {canConfigureOpenAIApiType && (
               <OpenAIApiTypeConfigFormField
                 playgroundInstanceId={playgroundInstanceId}
-                displayDefaultOnly={disableEphemeralRouting}
               />
             )}
 

--- a/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
+++ b/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Flex,
   Label,
   ListBox,
   Popover,
@@ -8,7 +7,6 @@ import {
   SelectChevronUpDownIcon,
   SelectItem,
   SelectValue,
-  Text,
 } from "@phoenix/components";
 import { DEFAULT_OPENAI_API_TYPE } from "@phoenix/constants/generativeConstants";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
@@ -18,26 +16,20 @@ const API_TYPE_OPTIONS: { id: OpenAIApiType; label: string }[] = [
   { id: "RESPONSES", label: "Responses" },
 ];
 
-function getApiTypeLabel(apiType: OpenAIApiType): string {
-  return API_TYPE_OPTIONS.find((opt) => opt.id === apiType)?.label ?? apiType;
-}
-
 export type OpenAIApiTypeConfigFormFieldProps = {
   playgroundInstanceId: number;
-  /**
-   * When true, shows only the fixed default API type as static text (not editable).
-   * Does not read from instance/model or localStorage — used when ephemeral routing is disabled.
-   */
-  displayDefaultOnly?: boolean;
 };
 
 /**
  * Form field for selecting OpenAI/Azure API type (Chat Completions vs Responses).
  * Shown for built-in OpenAI and Azure OpenAI providers only.
+ *
+ * Only rendered where the selection is sent to the server. Surfaces that do not
+ * send one (evaluators) leave the choice to the server's per-model default, which
+ * this field cannot predict.
  */
 export function OpenAIApiTypeConfigFormField({
   playgroundInstanceId,
-  displayDefaultOnly = false,
 }: OpenAIApiTypeConfigFormFieldProps) {
   const instance = usePlaygroundContext((state) =>
     state.instances.find((instance) => instance.id === playgroundInstanceId)
@@ -46,16 +38,6 @@ export function OpenAIApiTypeConfigFormField({
 
   if (!instance) {
     return null;
-  }
-
-  // When ephemeral routing is disabled: always show the default API type, never use stored value
-  if (displayDefaultOnly) {
-    return (
-      <Flex direction="column" gap="size-50">
-        <Label>API Type</Label>
-        <Text size="S">{getApiTypeLabel(DEFAULT_OPENAI_API_TYPE)}</Text>
-      </Flex>
-    );
   }
 
   const value = instance.model.openaiApiType ?? DEFAULT_OPENAI_API_TYPE;

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2107,8 +2107,7 @@ class AzureOpenAIResponsesAPIStreamingClient(AzureOpenAIStreamingClient):
         return (self._client_factory.rate_limit_key, self.model_name)
 
 
-# Not registered; reachable only via an explicit CHAT_COMPLETIONS api type
-# (see get_openai_client_class).
+# Not in the catalog; reachable only via an explicit CHAT_COMPLETIONS api type.
 class AzureOpenAIReasoningChatCompletionsClient(AzureOpenAIStreamingClient):
     @override
     def _to_openai_chat_completion_message_param(
@@ -3265,17 +3264,11 @@ def get_openai_client_class(
     openai_api_type: Optional["OpenAIApiType"] = None,
 ) -> Optional[type["PlaygroundStreamingClient[Any]"]]:
     """
-    Get the appropriate OpenAI/Azure client class based on provider, model, and API type.
+    Select the OpenAI/Azure client class for a provider, model, and API type.
 
-    This function centralizes the logic for selecting the correct client class for
-    OpenAI and Azure OpenAI providers, ensuring consistency between parameter fetching
-    and client instantiation.
-
-    This is the source of truth for OpenAI/Azure client selection, including the
-    default when no API type is configured. The playground registry is not consulted:
-    it carries the model catalog, not routing.
-
-    For non-OpenAI providers, returns None (callers should fall back to the registry).
+    The source of truth for both parameter fetching and client instantiation,
+    including the default when no API type is configured. The playground registry
+    is not consulted: it carries the model catalog, not routing.
 
     Args:
         provider_key: The generative provider (OPENAI, AZURE_OPENAI, etc.)
@@ -3284,7 +3277,8 @@ def get_openai_client_class(
             the provider's default for that model applies.
 
     Returns:
-        The appropriate client class, or None if the provider is not OpenAI/Azure.
+        The client class, or None for non-OpenAI providers, whose callers fall
+        back to the registry.
     """
     from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 
@@ -3309,7 +3303,7 @@ def get_openai_client_class(
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return AzureOpenAIResponsesAPIStreamingClient
         # Unconfigured default: Chat Completions, since an Azure deployment may not
-        # expose /v1/responses. Reasoning models are routed there regardless -- they
+        # expose /v1/responses. Reasoning models go to Responses regardless -- they
         # cannot use /v1/chat/completions when function tools are present.
         if model_name in OPENAI_REASONING_MODELS:
             return AzureOpenAIResponsesAPIStreamingClient

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1956,7 +1956,6 @@ OPENAI_REASONING_MODELS = [
         PROVIDER_DEFAULT,
         *OPENAI_REASONING_MODELS,
     ],
-    override=True,  # intentionally replaces OpenAIStreamingClient as the provider default
 )
 class OpenAIResponsesAPIStreamingClient(OpenAIStreamingClient):
     """OpenAI Responses API (responses.create) client.
@@ -3040,7 +3039,6 @@ GEMINI_2_5_MODELS = [
 @register_llm_client(
     provider_key=GenerativeProviderKey.GOOGLE,
     model_names=GEMINI_2_5_MODELS,
-    override=True,  # intentionally replaces GoogleStreamingClient as the provider default
 )
 class Gemini25GoogleStreamingClient(GoogleStreamingClient):
     pass

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -613,7 +613,7 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient["AsyncOpenAI"]):
                     assert_never(tc.type)
             if tools.disable_parallel_tool_calls:
                 params["parallel_tool_calls"] = False
-            elif tools.tools:
+            if tools.tools:
                 resp_tool_list: list[ToolParam] = []
                 for tool in tools.tools:
                     if tool.type == "raw":
@@ -1948,6 +1948,12 @@ class OpenAIReasoningReasoningModelsMixin:
     provider_key=GenerativeProviderKey.OPENAI,
     model_names=[
         PROVIDER_DEFAULT,
+        # Reasoning models must default to the Responses API: OpenAI rejects
+        # function tools combined with reasoning_effort on /v1/chat/completions,
+        # and LLM evaluators always emit their output via a function tool.
+        # An explicit CHAT_COMPLETIONS connection config still selects
+        # OpenAIReasoningNonStreamingClient via get_openai_client_class.
+        *OPENAI_REASONING_MODELS,
     ],
 )
 class OpenAIResponsesAPIStreamingClient(
@@ -1982,10 +1988,9 @@ class OpenAIResponsesAPIStreamingClient(
             yield chunk
 
 
-@register_llm_client(
-    provider_key=GenerativeProviderKey.OPENAI,
-    model_names=OPENAI_REASONING_MODELS,
-)
+# Not registered in the playground registry: reasoning models resolve to
+# OpenAIResponsesAPIStreamingClient by default. This client is reachable only
+# through an explicit CHAT_COMPLETIONS api type (see get_openai_client_class).
 class OpenAIReasoningNonStreamingClient(
     OpenAIReasoningReasoningModelsMixin,
     OpenAIStreamingClient,
@@ -2110,10 +2115,10 @@ class AzureOpenAIResponsesAPIStreamingClient(
         return (self._client_factory.rate_limit_key, self.model_name)
 
 
-@register_llm_client(
-    provider_key=GenerativeProviderKey.AZURE_OPENAI,
-    model_names=OPENAI_REASONING_MODELS,
-)
+# Not registered in the playground registry: registering it here would
+# overwrite the AzureOpenAIResponsesAPIStreamingClient entries for the same
+# model names. Reachable only through an explicit CHAT_COMPLETIONS api type
+# (see get_openai_client_class).
 class AzureOpenAIReasoningNonStreamingClient(
     OpenAIReasoningReasoningModelsMixin,
     AzureOpenAIStreamingClient,

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1995,10 +1995,10 @@ class OpenAIResponsesAPIStreamingClient(OpenAIStreamingClient):
             yield chunk
 
 
-# Not registered; reachable only via an explicit CHAT_COMPLETIONS api type
-# (see get_openai_client_class).
+# Not in the catalog; reachable only via an explicit CHAT_COMPLETIONS api type.
 class OpenAIReasoningNonStreamingClient(OpenAIStreamingClient):
-    def _to_openai_chat_completion_param(
+    @override
+    def _to_openai_chat_completion_message_param(
         self,
         message: PlaygroundMessage,
     ) -> Optional["ChatCompletionMessageParam"]:

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -3266,10 +3266,12 @@ def get_openai_client_class(
     """
     Select the OpenAI/Azure client class for a provider, model, and API type.
 
-    The source of truth for parameter fetching and for client instantiation on both
-    the builtin and custom-provider paths, including the default when no API type is
-    configured. The playground registry is not consulted: it carries the model
-    catalog, not routing.
+    The source of truth for the builtin-provider path, including the default when no
+    API type is configured. The playground registry is not consulted: it carries the
+    model catalog, not routing.
+
+    Custom providers do not resolve through here -- their SDK type does not identify
+    the model family, so model-name-based specialization is not sound for them.
 
     Args:
         provider_key: The generative provider (OPENAI, AZURE_OPENAI, etc.)
@@ -4022,16 +4024,23 @@ async def _get_custom_provider_client(
     headers = dict(extra_headers) if extra_headers else None
     cfg = config.root
 
+    # The openai/azure_openai SDK configs serve any OpenAI-compatible endpoint --
+    # DeepSeek, xAI, Ollama, Groq, Together and others (see
+    # is_sdk_compatible_with_model_provider). A model name matching an OpenAI model
+    # does not mean OpenAI is behind it, so the reasoning-model specializations,
+    # which rewrite `system` to `developer`, are deliberately not applied here.
     if cfg.type == "openai":
         try:
             openai_client_factory = cfg.get_client_factory(extra_headers=headers)
         except Exception as e:
             raise BadRequest(f"Failed to create {cfg.type} client factory: {e}")
-        openai_client_class = get_openai_client_class(
-            GenerativeProviderKey.OPENAI, model_name, OpenAIApiType(cfg.openai_api_type)
-        )
-        assert openai_client_class is not None
-        return openai_client_class(
+        if cfg.openai_api_type == "responses":
+            return OpenAIResponsesAPIStreamingClient(
+                client_factory=openai_client_factory,
+                model_name=model_name,
+                provider=provider,
+            )
+        return OpenAIStreamingClient(
             client_factory=openai_client_factory,
             model_name=model_name,
             provider=provider,
@@ -4041,11 +4050,13 @@ async def _get_custom_provider_client(
             azure_openai_client_factory = cfg.get_client_factory(extra_headers=headers)
         except Exception as e:
             raise BadRequest(f"Failed to create {cfg.type} client factory: {e}")
-        azure_client_class = get_openai_client_class(
-            GenerativeProviderKey.AZURE_OPENAI, model_name, OpenAIApiType(cfg.openai_api_type)
-        )
-        assert azure_client_class is not None
-        return azure_client_class(
+        if cfg.openai_api_type == "responses":
+            return AzureOpenAIResponsesAPIStreamingClient(
+                client_factory=azure_openai_client_factory,
+                model_name=model_name,
+                provider=provider,
+            )
+        return AzureOpenAIStreamingClient(
             client_factory=azure_openai_client_factory,
             model_name=model_name,
             provider=provider,

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1887,20 +1887,30 @@ class BedrockStreamingClient(PlaygroundStreamingClient["BedrockRuntimeClient"]):
         return converse_messages
 
 
+OPENAI_CHAT_COMPLETIONS_MODELS = [
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "gpt-4o",
+    "chatgpt-4o-latest",
+    "gpt-4o-mini",
+    "gpt-4-turbo",
+    "gpt-4-turbo-preview",
+    "gpt-4",
+    "gpt-3.5-turbo",
+]
+"""Models that default to /v1/chat/completions when no API type is configured.
+
+Everything else — including model names Phoenix has never heard of — defaults to
+the Responses API. See ``get_openai_client_class``.
+"""
+
+
 @register_llm_client(
     provider_key=GenerativeProviderKey.OPENAI,
     model_names=[
         PROVIDER_DEFAULT,
-        "gpt-4.1",
-        "gpt-4.1-mini",
-        "gpt-4.1-nano",
-        "gpt-4o",
-        "chatgpt-4o-latest",
-        "gpt-4o-mini",
-        "gpt-4-turbo",
-        "gpt-4-turbo-preview",
-        "gpt-4",
-        "gpt-3.5-turbo",
+        *OPENAI_CHAT_COMPLETIONS_MODELS,
     ],
 )
 class OpenAIStreamingClient(OpenAIBaseStreamingClient):
@@ -3272,18 +3282,21 @@ def get_openai_client_class(
     OpenAI and Azure OpenAI providers, ensuring consistency between parameter fetching
     and client instantiation.
 
+    This is the source of truth for OpenAI/Azure client selection, including the
+    default when no API type is configured. The playground registry is not consulted:
+    it carries the model catalog, not routing.
+
     For non-OpenAI providers, returns None (callers should fall back to the registry).
 
     Args:
         provider_key: The generative provider (OPENAI, AZURE_OPENAI, etc.)
         model_name: The name of the model
         openai_api_type: The API type (CHAT_COMPLETIONS or RESPONSES). If None,
-            falls back to registry behavior.
+            the provider's default for that model applies.
 
     Returns:
         The appropriate client class, or None if the provider is not OpenAI/Azure.
     """
-    from phoenix.server.api.helpers.playground_registry import PLAYGROUND_CLIENT_REGISTRY
     from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 
     if provider_key == GenerativeProviderKey.OPENAI:
@@ -3293,8 +3306,14 @@ def get_openai_client_class(
             return OpenAIStreamingClient
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return OpenAIResponsesAPIStreamingClient
-        # If openai_api_type is None, fall back to registry
-        return PLAYGROUND_CLIENT_REGISTRY.get_client(provider_key, model_name)
+        # No API type configured. The Responses API is the default for everything
+        # except the legacy models that predate it: OpenAI rejects function tools
+        # combined with reasoning_effort on /v1/chat/completions, and LLM evaluators
+        # always emit their structured output via a function tool.
+        # See https://github.com/Arize-ai/phoenix/issues/15299.
+        if model_name in OPENAI_CHAT_COMPLETIONS_MODELS:
+            return OpenAIStreamingClient
+        return OpenAIResponsesAPIStreamingClient
 
     elif provider_key == GenerativeProviderKey.AZURE_OPENAI:
         if openai_api_type == OpenAIApiType.CHAT_COMPLETIONS:
@@ -3303,8 +3322,12 @@ def get_openai_client_class(
             return AzureOpenAIStreamingClient
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return AzureOpenAIResponsesAPIStreamingClient
-        # If openai_api_type is None, fall back to registry
-        return PLAYGROUND_CLIENT_REGISTRY.get_client(provider_key, model_name)
+        # No API type configured. Azure deployments are not guaranteed to expose
+        # /v1/responses, so only the reasoning models — which cannot work on
+        # /v1/chat/completions with tools — are routed there by default.
+        if model_name in OPENAI_REASONING_MODELS:
+            return AzureOpenAIResponsesAPIStreamingClient
+        return AzureOpenAIStreamingClient
 
     # For non-OpenAI providers, return None to signal caller should use registry
     return None

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1940,27 +1940,25 @@ OPENAI_REASONING_MODELS = [
 ]
 
 
-class OpenAIReasoningReasoningModelsMixin:
-    """Mixin class for OpenAI-style reasoning model clients (o1, o3 series)."""
-
-
 @register_llm_client(
     provider_key=GenerativeProviderKey.OPENAI,
     model_names=[
         PROVIDER_DEFAULT,
-        # Reasoning models must default to the Responses API: OpenAI rejects
-        # function tools combined with reasoning_effort on /v1/chat/completions,
-        # and LLM evaluators always emit their output via a function tool.
-        # An explicit CHAT_COMPLETIONS connection config still selects
-        # OpenAIReasoningNonStreamingClient via get_openai_client_class.
         *OPENAI_REASONING_MODELS,
     ],
+    override=True,  # intentionally replaces OpenAIStreamingClient as the provider default
 )
-class OpenAIResponsesAPIStreamingClient(
-    OpenAIReasoningReasoningModelsMixin,
-    OpenAIStreamingClient,
-):
-    """OpenAI Responses API (responses.create) for gpt-5.2, gpt-5.1, etc."""
+class OpenAIResponsesAPIStreamingClient(OpenAIStreamingClient):
+    """OpenAI Responses API (responses.create) client.
+
+    The provider default, and the default for all reasoning models: OpenAI
+    rejects function tools combined with reasoning_effort on
+    /v1/chat/completions, and LLM evaluators always emit their structured
+    output via a function tool (see
+    https://github.com/Arize-ai/phoenix/issues/15299). An explicit
+    CHAT_COMPLETIONS connection config still selects
+    OpenAIReasoningNonStreamingClient via get_openai_client_class.
+    """
 
     @override
     async def _chat_completion_create(
@@ -1988,13 +1986,9 @@ class OpenAIResponsesAPIStreamingClient(
             yield chunk
 
 
-# Not registered in the playground registry: reasoning models resolve to
-# OpenAIResponsesAPIStreamingClient by default. This client is reachable only
-# through an explicit CHAT_COMPLETIONS api type (see get_openai_client_class).
-class OpenAIReasoningNonStreamingClient(
-    OpenAIReasoningReasoningModelsMixin,
-    OpenAIStreamingClient,
-):
+# Not registered; reachable only via an explicit CHAT_COMPLETIONS api type
+# (see get_openai_client_class).
+class OpenAIReasoningNonStreamingClient(OpenAIStreamingClient):
     def _to_openai_chat_completion_param(
         self,
         message: PlaygroundMessage,
@@ -2078,10 +2072,7 @@ class AzureOpenAIStreamingClient(OpenAIBaseStreamingClient):
     provider_key=GenerativeProviderKey.AZURE_OPENAI,
     model_names=OPENAI_REASONING_MODELS,
 )
-class AzureOpenAIResponsesAPIStreamingClient(
-    OpenAIReasoningReasoningModelsMixin,
-    AzureOpenAIStreamingClient,
-):
+class AzureOpenAIResponsesAPIStreamingClient(AzureOpenAIStreamingClient):
     """Azure OpenAI Responses API (responses.create) for gpt-5.2, gpt-5.1, etc."""
 
     @override
@@ -2115,14 +2106,9 @@ class AzureOpenAIResponsesAPIStreamingClient(
         return (self._client_factory.rate_limit_key, self.model_name)
 
 
-# Not registered in the playground registry: registering it here would
-# overwrite the AzureOpenAIResponsesAPIStreamingClient entries for the same
-# model names. Reachable only through an explicit CHAT_COMPLETIONS api type
+# Not registered; reachable only via an explicit CHAT_COMPLETIONS api type
 # (see get_openai_client_class).
-class AzureOpenAIReasoningNonStreamingClient(
-    OpenAIReasoningReasoningModelsMixin,
-    AzureOpenAIStreamingClient,
-):
+class AzureOpenAIReasoningNonStreamingClient(AzureOpenAIStreamingClient):
     @override
     def _to_openai_chat_completion_message_param(
         self,
@@ -3044,6 +3030,7 @@ GEMINI_2_5_MODELS = [
 @register_llm_client(
     provider_key=GenerativeProviderKey.GOOGLE,
     model_names=GEMINI_2_5_MODELS,
+    override=True,  # intentionally replaces GoogleStreamingClient as the provider default
 )
 class Gemini25GoogleStreamingClient(GoogleStreamingClient):
     pass

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1899,11 +1899,8 @@ OPENAI_CHAT_COMPLETIONS_MODELS = [
     "gpt-4",
     "gpt-3.5-turbo",
 ]
-"""Models that default to /v1/chat/completions when no API type is configured.
-
-Everything else — including model names Phoenix has never heard of — defaults to
-the Responses API. See ``get_openai_client_class``.
-"""
+"""OpenAI models that default to /v1/chat/completions. Any other name, known or
+not, defaults to the Responses API. See ``get_openai_client_class``."""
 
 
 @register_llm_client(
@@ -1960,13 +1957,8 @@ OPENAI_REASONING_MODELS = [
 class OpenAIResponsesAPIStreamingClient(OpenAIStreamingClient):
     """OpenAI Responses API (responses.create) client.
 
-    The provider default, and the default for all reasoning models: OpenAI
-    rejects function tools combined with reasoning_effort on
-    /v1/chat/completions, and LLM evaluators always emit their structured
-    output via a function tool (see
-    https://github.com/Arize-ai/phoenix/issues/15299). An explicit
-    CHAT_COMPLETIONS connection config still selects
-    OpenAIReasoningNonStreamingClient via get_openai_client_class.
+    Encodes reasoning effort as ``reasoning: {"effort": ...}``, which is the only
+    form OpenAI accepts alongside function tools.
     """
 
     @override
@@ -1996,7 +1988,7 @@ class OpenAIResponsesAPIStreamingClient(OpenAIStreamingClient):
 
 
 # Not in the catalog; reachable only via an explicit CHAT_COMPLETIONS api type.
-class OpenAIReasoningNonStreamingClient(OpenAIStreamingClient):
+class OpenAIReasoningChatCompletionsClient(OpenAIStreamingClient):
     @override
     def _to_openai_chat_completion_message_param(
         self,
@@ -2117,7 +2109,7 @@ class AzureOpenAIResponsesAPIStreamingClient(AzureOpenAIStreamingClient):
 
 # Not registered; reachable only via an explicit CHAT_COMPLETIONS api type
 # (see get_openai_client_class).
-class AzureOpenAIReasoningNonStreamingClient(AzureOpenAIStreamingClient):
+class AzureOpenAIReasoningChatCompletionsClient(AzureOpenAIStreamingClient):
     @override
     def _to_openai_chat_completion_message_param(
         self,
@@ -3299,15 +3291,12 @@ def get_openai_client_class(
     if provider_key == GenerativeProviderKey.OPENAI:
         if openai_api_type == OpenAIApiType.CHAT_COMPLETIONS:
             if model_name in OPENAI_REASONING_MODELS:
-                return OpenAIReasoningNonStreamingClient
+                return OpenAIReasoningChatCompletionsClient
             return OpenAIStreamingClient
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return OpenAIResponsesAPIStreamingClient
-        # No API type configured. The Responses API is the default for everything
-        # except the legacy models that predate it: OpenAI rejects function tools
-        # combined with reasoning_effort on /v1/chat/completions, and LLM evaluators
-        # always emit their structured output via a function tool.
-        # See https://github.com/Arize-ai/phoenix/issues/15299.
+        # Unconfigured default: Responses, except the models predating it. Reasoning
+        # models cannot use /v1/chat/completions when function tools are present.
         if model_name in OPENAI_CHAT_COMPLETIONS_MODELS:
             return OpenAIStreamingClient
         return OpenAIResponsesAPIStreamingClient
@@ -3315,13 +3304,13 @@ def get_openai_client_class(
     elif provider_key == GenerativeProviderKey.AZURE_OPENAI:
         if openai_api_type == OpenAIApiType.CHAT_COMPLETIONS:
             if model_name in OPENAI_REASONING_MODELS:
-                return AzureOpenAIReasoningNonStreamingClient
+                return AzureOpenAIReasoningChatCompletionsClient
             return AzureOpenAIStreamingClient
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return AzureOpenAIResponsesAPIStreamingClient
-        # No API type configured. Azure deployments are not guaranteed to expose
-        # /v1/responses, so only the reasoning models — which cannot work on
-        # /v1/chat/completions with tools — are routed there by default.
+        # Unconfigured default: Chat Completions, since an Azure deployment may not
+        # expose /v1/responses. Reasoning models are routed there regardless -- they
+        # cannot use /v1/chat/completions when function tools are present.
         if model_name in OPENAI_REASONING_MODELS:
             return AzureOpenAIResponsesAPIStreamingClient
         return AzureOpenAIStreamingClient

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -3266,9 +3266,10 @@ def get_openai_client_class(
     """
     Select the OpenAI/Azure client class for a provider, model, and API type.
 
-    The source of truth for both parameter fetching and client instantiation,
-    including the default when no API type is configured. The playground registry
-    is not consulted: it carries the model catalog, not routing.
+    The source of truth for parameter fetching and for client instantiation on both
+    the builtin and custom-provider paths, including the default when no API type is
+    configured. The playground registry is not consulted: it carries the model
+    catalog, not routing.
 
     Args:
         provider_key: The generative provider (OPENAI, AZURE_OPENAI, etc.)
@@ -4026,13 +4027,11 @@ async def _get_custom_provider_client(
             openai_client_factory = cfg.get_client_factory(extra_headers=headers)
         except Exception as e:
             raise BadRequest(f"Failed to create {cfg.type} client factory: {e}")
-        if cfg.openai_api_type == "responses":
-            return OpenAIResponsesAPIStreamingClient(
-                client_factory=openai_client_factory,
-                model_name=model_name,
-                provider=provider,
-            )
-        return OpenAIStreamingClient(
+        openai_client_class = get_openai_client_class(
+            GenerativeProviderKey.OPENAI, model_name, OpenAIApiType(cfg.openai_api_type)
+        )
+        assert openai_client_class is not None
+        return openai_client_class(
             client_factory=openai_client_factory,
             model_name=model_name,
             provider=provider,
@@ -4042,13 +4041,11 @@ async def _get_custom_provider_client(
             azure_openai_client_factory = cfg.get_client_factory(extra_headers=headers)
         except Exception as e:
             raise BadRequest(f"Failed to create {cfg.type} client factory: {e}")
-        if cfg.openai_api_type == "responses":
-            return AzureOpenAIResponsesAPIStreamingClient(
-                client_factory=azure_openai_client_factory,
-                model_name=model_name,
-                provider=provider,
-            )
-        return AzureOpenAIStreamingClient(
+        azure_client_class = get_openai_client_class(
+            GenerativeProviderKey.AZURE_OPENAI, model_name, OpenAIApiType(cfg.openai_api_type)
+        )
+        assert azure_client_class is not None
+        return azure_client_class(
             client_factory=azure_openai_client_factory,
             model_name=model_name,
             provider=provider,

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -3029,7 +3029,6 @@ class GoogleStreamingClient(PlaygroundStreamingClient["GoogleAsyncClient"]):
 
 
 GEMINI_2_5_MODELS = [
-    PROVIDER_DEFAULT,
     "gemini-2.5-pro",  # Will be deprecated and will be shut down on June 17, 2026.
     "gemini-2.5-flash",  # Will be deprecated and will be shut down on June 17, 2026.
     "gemini-2.5-flash-lite",  # Will be deprecated and will be shut down on July 22, 2026.

--- a/src/phoenix/server/api/helpers/playground_registry.py
+++ b/src/phoenix/server/api/helpers/playground_registry.py
@@ -63,9 +63,9 @@ def register_llm_client(
 ) -> Callable[[type["PlaygroundStreamingClient[Any]"]], type["PlaygroundStreamingClient[Any]"]]:
     """Add a provider's models to the playground catalog.
 
-    This declares which model names the UI offers for a provider, and which client
-    supplies the provider's dependency metadata. It does not decide which client
-    serves a request -- see ``get_openai_client_class`` in ``playground_clients``.
+    Declares the model names the UI offers and the client supplying the provider's
+    dependency metadata. Does not select the client that serves a request -- see
+    ``get_openai_client_class`` in ``playground_clients``.
     """
 
     def decorator(

--- a/src/phoenix/server/api/helpers/playground_registry.py
+++ b/src/phoenix/server/api/helpers/playground_registry.py
@@ -60,20 +60,19 @@ PLAYGROUND_CLIENT_REGISTRY: PlaygroundClientRegistry = PlaygroundClientRegistry(
 def register_llm_client(
     provider_key: GenerativeProviderKey,
     model_names: Sequence[ModelName],
-    override: bool = False,
 ) -> Callable[[type["PlaygroundStreamingClient[Any]"]], type["PlaygroundStreamingClient[Any]"]]:
+    """Add a provider's models to the playground catalog.
+
+    This declares which model names the UI offers for a provider, and which client
+    supplies the provider's dependency metadata. It does not decide which client
+    serves a request -- see ``get_openai_client_class`` in ``playground_clients``.
+    """
+
     def decorator(
         cls: type["PlaygroundStreamingClient[Any]"],
     ) -> type["PlaygroundStreamingClient[Any]"]:
         provider_registry = PLAYGROUND_CLIENT_REGISTRY._registry.setdefault(provider_key, {})
         for model_name in model_names:
-            existing = provider_registry.get(model_name)
-            if existing is not None and existing is not cls and not override:
-                raise ValueError(
-                    f"LLM client for ({provider_key.name}, {model_name!r}) is already "
-                    f"registered to {existing.__name__}; refusing to silently overwrite "
-                    f"with {cls.__name__}. Pass override=True if this is intentional."
-                )
             provider_registry[model_name] = cls
         return cls
 

--- a/src/phoenix/server/api/helpers/playground_registry.py
+++ b/src/phoenix/server/api/helpers/playground_registry.py
@@ -60,12 +60,20 @@ PLAYGROUND_CLIENT_REGISTRY: PlaygroundClientRegistry = PlaygroundClientRegistry(
 def register_llm_client(
     provider_key: GenerativeProviderKey,
     model_names: Sequence[ModelName],
+    override: bool = False,
 ) -> Callable[[type["PlaygroundStreamingClient[Any]"]], type["PlaygroundStreamingClient[Any]"]]:
     def decorator(
         cls: type["PlaygroundStreamingClient[Any]"],
     ) -> type["PlaygroundStreamingClient[Any]"]:
         provider_registry = PLAYGROUND_CLIENT_REGISTRY._registry.setdefault(provider_key, {})
         for model_name in model_names:
+            existing = provider_registry.get(model_name)
+            if existing is not None and existing is not cls and not override:
+                raise ValueError(
+                    f"LLM client for ({provider_key.name}, {model_name!r}) is already "
+                    f"registered to {existing.__name__}; refusing to silently overwrite "
+                    f"with {cls.__name__}. Pass override=True if this is intentional."
+                )
             provider_registry[model_name] = cls
         return cls
 

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -801,12 +801,10 @@ class TestGetOpenAIClientClass:
 
 
 class TestReasoningModelClientRouting:
-    """Regression tests for https://github.com/Arize-ai/phoenix/issues/15299.
+    """Reasoning models must reach the Responses API when no API type is configured.
 
-    LLM evaluators emit structured output via a function tool, and OpenAI
-    reasoning models reject function tools combined with ``reasoning_effort``
-    on ``/v1/chat/completions``. When no API type is explicitly configured,
-    reasoning models must therefore route to the Responses API clients.
+    They reject function tools combined with ``reasoning_effort`` on
+    ``/v1/chat/completions``, and LLM evaluators always send a function tool.
     """
 
     @pytest.mark.parametrize(
@@ -884,11 +882,9 @@ class TestReasoningModelClientRouting:
 
 
 class TestDefaultApiTypeRouting:
-    """Routing with no configured API type is decided by ``get_openai_client_class``.
+    """``get_openai_client_class`` decides the client when no API type is configured.
 
-    The playground registry carries the model catalog, not routing. Keeping the two
-    separate is what prevents a stale catalog entry from shadowing a newer provider
-    default -- the shape of https://github.com/Arize-ai/phoenix/issues/15299.
+    The playground registry carries the model catalog, not routing.
     """
 
     def test_openai_defaults_to_responses_except_legacy_models(self) -> None:

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -40,12 +40,12 @@ from phoenix.server.api.helpers.playground_clients import (
     OPENAI_CHAT_COMPLETIONS_MODELS,
     OPENAI_REASONING_MODELS,
     AnthropicStreamingClient,
-    AzureOpenAIReasoningNonStreamingClient,
+    AzureOpenAIReasoningChatCompletionsClient,
     AzureOpenAIResponsesAPIStreamingClient,
     AzureOpenAIStreamingClient,
     GoogleStreamingClient,
     OpenAIBaseStreamingClient,
-    OpenAIReasoningNonStreamingClient,
+    OpenAIReasoningChatCompletionsClient,
     OpenAIResponsesAPIStreamingClient,
     OpenAIStreamingClient,
     _get_builtin_provider_client,
@@ -690,7 +690,7 @@ class TestGetOpenAIClientClass:
                 model_name,
                 OpenAIApiType.CHAT_COMPLETIONS,
             )
-            assert client_class is OpenAIReasoningNonStreamingClient, f"Failed for {model_name}"
+            assert client_class is OpenAIReasoningChatCompletionsClient, f"Failed for {model_name}"
 
     def test_openai_responses_returns_responses_client(self) -> None:
         """RESPONSES API type should return OpenAIResponsesAPIStreamingClient."""
@@ -757,7 +757,7 @@ class TestGetOpenAIClientClass:
                 model_name,
                 OpenAIApiType.CHAT_COMPLETIONS,
             )
-            assert client_class is AzureOpenAIReasoningNonStreamingClient, (
+            assert client_class is AzureOpenAIReasoningChatCompletionsClient, (
                 f"Failed for {model_name}"
             )
 
@@ -951,7 +951,7 @@ class TestDefaultApiTypeRouting:
 class TestReasoningChatCompletionsMessages:
     @pytest.mark.parametrize(
         "client_class",
-        [OpenAIReasoningNonStreamingClient, AzureOpenAIReasoningNonStreamingClient],
+        [OpenAIReasoningChatCompletionsClient, AzureOpenAIReasoningChatCompletionsClient],
     )
     def test_system_messages_become_developer_messages(
         self, client_class: type[OpenAIBaseStreamingClient]

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -49,6 +49,7 @@ from phoenix.server.api.helpers.playground_clients import (
     OpenAIResponsesAPIStreamingClient,
     OpenAIStreamingClient,
     _get_builtin_provider_client,
+    _get_custom_provider_client,
     _resolve_provider_api_key,
     get_openai_client_class,
 )
@@ -961,6 +962,48 @@ class TestReasoningChatCompletionsMessages:
         message = create_playground_message(ChatCompletionMessageRole.SYSTEM, "be terse")
         param = OpenAIStreamingClient._to_openai_chat_completion_message_param(None, message)  # type: ignore[arg-type]
         assert param == {"content": "be terse", "role": "system"}
+
+
+class TestCustomProviderClientSelection:
+    """Custom providers resolve through ``get_openai_client_class`` like builtins."""
+
+    @pytest.mark.parametrize(
+        "openai_api_type,model_name,expected_class",
+        [
+            ("responses", "gpt-4o", OpenAIResponsesAPIStreamingClient),
+            ("responses", "gpt-5.6-luna", OpenAIResponsesAPIStreamingClient),
+            ("chat_completions", "gpt-4o", OpenAIStreamingClient),
+            ("chat_completions", "gpt-5.6-luna", OpenAIReasoningChatCompletionsClient),
+        ],
+    )
+    async def test_openai_custom_provider_honors_api_type_and_model(
+        self,
+        openai_api_type: str,
+        model_name: str,
+        expected_class: type[OpenAIBaseStreamingClient],
+    ) -> None:
+        import phoenix.db.types.model_provider as mp
+
+        config = mp.GenerativeModelCustomerProviderConfig(
+            root=mp.OpenAICustomProviderConfig(
+                openai_authentication_method=mp.AuthenticationMethodApiKey(api_key="sk-test"),
+                openai_api_type=openai_api_type,
+            )
+        )
+        provider_record = models.GenerativeModelCustomProvider(
+            name="proxy",
+            provider="openai",
+            sdk="openai",
+            config=config.model_dump_json().encode(),
+        )
+
+        client = await _get_custom_provider_client(
+            provider_record=provider_record,
+            model_name=model_name,
+            extra_headers=None,
+            decrypt=_identity_decrypt,
+        )
+        assert type(client) is expected_class
 
 
 def _identity_decrypt(value: bytes) -> bytes:

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -37,6 +37,7 @@ from phoenix.db.types.prompts import (
 from phoenix.server.api.exceptions import BadRequest
 from phoenix.server.api.helpers.message_helpers import PlaygroundMessage, create_playground_message
 from phoenix.server.api.helpers.playground_clients import (
+    OPENAI_REASONING_MODELS,
     AnthropicStreamingClient,
     AzureOpenAIReasoningNonStreamingClient,
     AzureOpenAIResponsesAPIStreamingClient,
@@ -50,6 +51,7 @@ from phoenix.server.api.helpers.playground_clients import (
     _resolve_provider_api_key,
     get_openai_client_class,
 )
+from phoenix.server.api.helpers.playground_registry import PLAYGROUND_CLIENT_REGISTRY
 from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
 from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
@@ -789,6 +791,117 @@ class TestGetOpenAIClientClass:
             None,
         )
         assert client_class is None
+
+
+class TestReasoningModelClientRouting:
+    """Regression tests for https://github.com/Arize-ai/phoenix/issues/15299.
+
+    LLM evaluators emit structured output via a function tool, and OpenAI
+    reasoning models reject function tools combined with ``reasoning_effort``
+    on ``/v1/chat/completions``. When no API type is explicitly configured,
+    reasoning models must therefore route to the Responses API clients.
+    """
+
+    def test_openai_reasoning_models_default_to_responses_client(self) -> None:
+        for model_name in OPENAI_REASONING_MODELS:
+            client_class = get_openai_client_class(
+                GenerativeProviderKey.OPENAI,
+                model_name,
+                None,
+            )
+            assert client_class is OpenAIResponsesAPIStreamingClient, f"Failed for {model_name}"
+
+    def test_azure_reasoning_models_default_to_responses_client(self) -> None:
+        for model_name in OPENAI_REASONING_MODELS:
+            client_class = get_openai_client_class(
+                GenerativeProviderKey.AZURE_OPENAI,
+                model_name,
+                None,
+            )
+            assert client_class is AzureOpenAIResponsesAPIStreamingClient, (
+                f"Failed for {model_name}"
+            )
+
+    def test_registry_maps_reasoning_models_to_responses_clients(self) -> None:
+        for model_name in OPENAI_REASONING_MODELS:
+            assert (
+                PLAYGROUND_CLIENT_REGISTRY.get_client(GenerativeProviderKey.OPENAI, model_name)
+                is OpenAIResponsesAPIStreamingClient
+            ), f"Failed for {model_name}"
+            assert (
+                PLAYGROUND_CLIENT_REGISTRY.get_client(
+                    GenerativeProviderKey.AZURE_OPENAI, model_name
+                )
+                is AzureOpenAIResponsesAPIStreamingClient
+            ), f"Failed for {model_name}"
+
+    def test_explicit_chat_completions_still_selects_reasoning_chat_clients(self) -> None:
+        assert (
+            get_openai_client_class(
+                GenerativeProviderKey.OPENAI, "gpt-5.6-luna", OpenAIApiType.CHAT_COMPLETIONS
+            )
+            is OpenAIReasoningNonStreamingClient
+        )
+        assert (
+            get_openai_client_class(
+                GenerativeProviderKey.AZURE_OPENAI, "gpt-5.6-luna", OpenAIApiType.CHAT_COMPLETIONS
+            )
+            is AzureOpenAIReasoningNonStreamingClient
+        )
+
+    def test_response_params_keep_tools_and_map_reasoning_effort(self) -> None:
+        """Function tools + reasoning_effort + disabled parallel tool calls must all
+        survive translation into a Responses API request."""
+        from unittest.mock import MagicMock
+
+        client = object.__new__(OpenAIResponsesAPIStreamingClient)
+        client.model_name = "gpt-5.6-luna"
+
+        tools = PromptTools(
+            type="tools",
+            tools=[
+                PromptToolFunction(
+                    type="function",
+                    function=PromptToolFunctionDefinition(
+                        name="record_evaluation",
+                        description="Record the evaluation result",
+                        parameters={
+                            "type": "object",
+                            "properties": {"label": {"type": "string"}},
+                        },
+                    ),
+                )
+            ],
+            tool_choice=PromptToolChoiceSpecificFunctionTool(
+                type="specific_function", function_name="record_evaluation"
+            ),
+            disable_parallel_tool_calls=True,
+        )
+        invocation_parameters = PromptOpenAIInvocationParameters(
+            type="openai",
+            openai=PromptOpenAIInvocationParametersContent(reasoning_effort="high"),
+        )
+        messages: list[PlaygroundMessage] = [
+            create_playground_message(ChatCompletionMessageRole.USER, "Evaluate this span.")
+        ]
+
+        params, extra_body = client._openai_response_build_params(
+            messages=messages,
+            tools=tools,
+            response_format=None,
+            invocation_parameters=invocation_parameters,
+            span=MagicMock(),
+        )
+
+        assert extra_body is None
+        assert params["model"] == "gpt-5.6-luna"
+        assert params["parallel_tool_calls"] is False
+        tool_params = params.get("tools")
+        assert tool_params, "function tools were dropped from the Responses request"
+        assert tool_params[0]["name"] == "record_evaluation"
+        assert params["tool_choice"] == {"type": "function", "name": "record_evaluation"}
+        assert params["reasoning"] == {"effort": "high"}
+        assert "reasoning_effort" not in params
 
 
 def _identity_decrypt(value: bytes) -> bytes:

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -16,7 +16,7 @@ from openinference.semconv.trace import (
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import StatusCode, Tracer
+from opentelemetry.trace import INVALID_SPAN, StatusCode, Tracer
 from pydantic import SecretStr
 
 from phoenix.db import models
@@ -51,7 +51,6 @@ from phoenix.server.api.helpers.playground_clients import (
     _resolve_provider_api_key,
     get_openai_client_class,
 )
-from phoenix.server.api.helpers.playground_registry import PLAYGROUND_CLIENT_REGISTRY
 from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
 from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
 from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
@@ -680,7 +679,7 @@ class TestGetOpenAIClientClass:
 
     def test_openai_chat_completions_reasoning_model_returns_reasoning_client(self) -> None:
         """Reasoning models (o1, o3) with CHAT_COMPLETIONS should return reasoning client."""
-        for model_name in ["o1", "o3", "o3-mini"]:
+        for model_name in ["o1", "o3", "o3-mini", "gpt-5.6-luna"]:
             client_class = get_openai_client_class(
                 GenerativeProviderKey.OPENAI,
                 model_name,
@@ -747,12 +746,15 @@ class TestGetOpenAIClientClass:
 
     def test_azure_chat_completions_reasoning_model_returns_reasoning_client(self) -> None:
         """Azure reasoning models with CHAT_COMPLETIONS should return reasoning client."""
-        client_class = get_openai_client_class(
-            GenerativeProviderKey.AZURE_OPENAI,
-            "o1",
-            OpenAIApiType.CHAT_COMPLETIONS,
-        )
-        assert client_class is AzureOpenAIReasoningNonStreamingClient
+        for model_name in ["o1", "gpt-5.6-luna"]:
+            client_class = get_openai_client_class(
+                GenerativeProviderKey.AZURE_OPENAI,
+                model_name,
+                OpenAIApiType.CHAT_COMPLETIONS,
+            )
+            assert client_class is AzureOpenAIReasoningNonStreamingClient, (
+                f"Failed for {model_name}"
+            )
 
     def test_azure_responses_returns_azure_responses_client(self) -> None:
         """Azure with RESPONSES should return AzureOpenAIResponsesAPIStreamingClient."""
@@ -802,60 +804,32 @@ class TestReasoningModelClientRouting:
     reasoning models must therefore route to the Responses API clients.
     """
 
-    def test_openai_reasoning_models_default_to_responses_client(self) -> None:
+    @pytest.mark.parametrize(
+        "provider_key,expected_class",
+        [
+            (GenerativeProviderKey.OPENAI, OpenAIResponsesAPIStreamingClient),
+            (GenerativeProviderKey.AZURE_OPENAI, AzureOpenAIResponsesAPIStreamingClient),
+        ],
+    )
+    def test_reasoning_models_default_to_responses_client(
+        self,
+        provider_key: GenerativeProviderKey,
+        expected_class: type[OpenAIBaseStreamingClient],
+    ) -> None:
         for model_name in OPENAI_REASONING_MODELS:
-            client_class = get_openai_client_class(
-                GenerativeProviderKey.OPENAI,
-                model_name,
-                None,
-            )
-            assert client_class is OpenAIResponsesAPIStreamingClient, f"Failed for {model_name}"
-
-    def test_azure_reasoning_models_default_to_responses_client(self) -> None:
-        for model_name in OPENAI_REASONING_MODELS:
-            client_class = get_openai_client_class(
-                GenerativeProviderKey.AZURE_OPENAI,
-                model_name,
-                None,
-            )
-            assert client_class is AzureOpenAIResponsesAPIStreamingClient, (
-                f"Failed for {model_name}"
-            )
-
-    def test_registry_maps_reasoning_models_to_responses_clients(self) -> None:
-        for model_name in OPENAI_REASONING_MODELS:
-            assert (
-                PLAYGROUND_CLIENT_REGISTRY.get_client(GenerativeProviderKey.OPENAI, model_name)
-                is OpenAIResponsesAPIStreamingClient
-            ), f"Failed for {model_name}"
-            assert (
-                PLAYGROUND_CLIENT_REGISTRY.get_client(
-                    GenerativeProviderKey.AZURE_OPENAI, model_name
-                )
-                is AzureOpenAIResponsesAPIStreamingClient
-            ), f"Failed for {model_name}"
-
-    def test_explicit_chat_completions_still_selects_reasoning_chat_clients(self) -> None:
-        assert (
-            get_openai_client_class(
-                GenerativeProviderKey.OPENAI, "gpt-5.6-luna", OpenAIApiType.CHAT_COMPLETIONS
-            )
-            is OpenAIReasoningNonStreamingClient
-        )
-        assert (
-            get_openai_client_class(
-                GenerativeProviderKey.AZURE_OPENAI, "gpt-5.6-luna", OpenAIApiType.CHAT_COMPLETIONS
-            )
-            is AzureOpenAIReasoningNonStreamingClient
-        )
+            client_class = get_openai_client_class(provider_key, model_name, None)
+            assert client_class is expected_class, f"Failed for {model_name}"
 
     def test_response_params_keep_tools_and_map_reasoning_effort(self) -> None:
         """Function tools + reasoning_effort + disabled parallel tool calls must all
         survive translation into a Responses API request."""
-        from unittest.mock import MagicMock
-
-        client = object.__new__(OpenAIResponsesAPIStreamingClient)
-        client.model_name = "gpt-5.6-luna"
+        client = OpenAIResponsesAPIStreamingClient(
+            client_factory=LLMClientFactory(
+                lambda: AsyncOpenAI(api_key="sk-test"), ("openai", "test")
+            ),
+            model_name="gpt-5.6-luna",
+            provider="openai",
+        )
 
         tools = PromptTools(
             type="tools",
@@ -890,7 +864,7 @@ class TestReasoningModelClientRouting:
             tools=tools,
             response_format=None,
             invocation_parameters=invocation_parameters,
-            span=MagicMock(),
+            span=INVALID_SPAN,
         )
 
         assert extra_body is None

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -888,6 +888,68 @@ class TestDefaultApiTypeRouting:
     The playground registry carries the model catalog, not routing.
     """
 
+    @pytest.mark.parametrize(
+        "model_provider,model_name,expected_class",
+        [
+            # The exact configuration that produced the 400 in #15299: builtin
+            # provider, no connection config, reasoning model, function tool.
+            (ModelProvider.OPENAI, "gpt-5.6-luna", OpenAIResponsesAPIStreamingClient),
+            (ModelProvider.OPENAI, "o3", OpenAIResponsesAPIStreamingClient),
+            (ModelProvider.OPENAI, "gpt-4o", OpenAIStreamingClient),
+            (ModelProvider.OPENAI, "gpt-6-does-not-exist-yet", OpenAIResponsesAPIStreamingClient),
+        ],
+    )
+    async def test_builtin_client_without_connection_config(
+        self,
+        db: DbSessionFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        model_provider: ModelProvider,
+        model_name: str,
+        expected_class: type[OpenAIBaseStreamingClient],
+    ) -> None:
+        """End-to-end through the path evaluators take: connection=None.
+
+        The registry is poisoned for this model so the assertion fails if any part of
+        the builtin path starts consulting it again.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+
+        class WrongClient(OpenAIStreamingClient):
+            pass
+
+        provider_key = GenerativeProviderKey.from_model_provider(model_provider)
+        poisoned = dict(PLAYGROUND_CLIENT_REGISTRY._registry[provider_key])
+        poisoned[model_name] = WrongClient
+        poisoned[PROVIDER_DEFAULT] = WrongClient
+        monkeypatch.setitem(PLAYGROUND_CLIENT_REGISTRY._registry, provider_key, poisoned)
+
+        async with db() as session:
+            client = await _get_builtin_provider_client(
+                model_provider,
+                model_name,
+                None,
+                None,
+                session,
+                _identity_decrypt,
+            )
+        assert type(client) is expected_class
+
+    def test_legacy_model_list_is_exactly_the_pre_responses_models(self) -> None:
+        """Literal expectation: a name silently added or dropped changes routing."""
+        assert set(OPENAI_CHAT_COMPLETIONS_MODELS) == {
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4.1-nano",
+            "gpt-4o",
+            "chatgpt-4o-latest",
+            "gpt-4o-mini",
+            "gpt-4-turbo",
+            "gpt-4-turbo-preview",
+            "gpt-4",
+            "gpt-3.5-turbo",
+        }
+        assert not set(OPENAI_CHAT_COMPLETIONS_MODELS) & set(OPENAI_REASONING_MODELS)
+
     def test_openai_defaults_to_responses_except_legacy_models(self) -> None:
         for model_name in OPENAI_CHAT_COMPLETIONS_MODELS:
             assert (
@@ -906,11 +968,24 @@ class TestDefaultApiTypeRouting:
                 get_openai_client_class(GenerativeProviderKey.AZURE_OPENAI, model_name, None)
                 is AzureOpenAIResponsesAPIStreamingClient
             ), f"Failed for {model_name}"
-        for model_name in ["gpt-4o", "my-custom-deployment"]:
+        for model_name in ["gpt-4o"]:
             assert (
                 get_openai_client_class(GenerativeProviderKey.AZURE_OPENAI, model_name, None)
                 is AzureOpenAIStreamingClient
             ), f"Failed for {model_name}"
+
+    def test_azure_deployment_alias_is_not_recognized_as_a_reasoning_model(self) -> None:
+        """Known limitation, not desired behavior.
+
+        Azure model names are user-chosen deployment names, so a reasoning model
+        deployed under an alias is indistinguishable from any other deployment and
+        falls to Chat Completions -- where function tools plus reasoning_effort still
+        fail. Closing this needs deployment metadata from Azure, not name matching.
+        """
+        assert (
+            get_openai_client_class(GenerativeProviderKey.AZURE_OPENAI, "prod-evaluator", None)
+            is AzureOpenAIStreamingClient
+        )
 
     @pytest.mark.parametrize(
         "provider_key,model_name,expected_class",
@@ -965,7 +1040,13 @@ class TestReasoningChatCompletionsMessages:
 
 
 class TestCustomProviderClientSelection:
-    """Custom providers resolve through ``get_openai_client_class`` like builtins."""
+    """Custom providers select on API type alone, never on the model name.
+
+    The openai SDK config serves any OpenAI-compatible endpoint, so a name matching
+    an OpenAI model does not imply OpenAI semantics. Applying the reasoning clients
+    here would rewrite ``system`` to ``developer`` against providers that may not
+    accept it.
+    """
 
     @pytest.mark.parametrize(
         "openai_api_type,model_name,expected_class",
@@ -973,10 +1054,10 @@ class TestCustomProviderClientSelection:
             ("responses", "gpt-4o", OpenAIResponsesAPIStreamingClient),
             ("responses", "gpt-5.6-luna", OpenAIResponsesAPIStreamingClient),
             ("chat_completions", "gpt-4o", OpenAIStreamingClient),
-            ("chat_completions", "gpt-5.6-luna", OpenAIReasoningChatCompletionsClient),
+            ("chat_completions", "gpt-5.6-luna", OpenAIStreamingClient),
         ],
     )
-    async def test_openai_custom_provider_honors_api_type_and_model(
+    async def test_openai_custom_provider_selects_on_api_type_only(
         self,
         openai_api_type: str,
         model_name: str,

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -948,6 +948,25 @@ class TestDefaultApiTypeRouting:
         assert get_openai_client_class(provider_key, model_name, None) is expected_class
 
 
+class TestReasoningChatCompletionsMessages:
+    @pytest.mark.parametrize(
+        "client_class",
+        [OpenAIReasoningNonStreamingClient, AzureOpenAIReasoningNonStreamingClient],
+    )
+    def test_system_messages_become_developer_messages(
+        self, client_class: type[OpenAIBaseStreamingClient]
+    ) -> None:
+        """Reasoning models take instructions on the `developer` role, not `system`."""
+        message = create_playground_message(ChatCompletionMessageRole.SYSTEM, "be terse")
+        param = client_class._to_openai_chat_completion_message_param(None, message)  # type: ignore[arg-type]
+        assert param == {"content": "be terse", "role": "developer"}
+
+    def test_non_reasoning_clients_keep_the_system_role(self) -> None:
+        message = create_playground_message(ChatCompletionMessageRole.SYSTEM, "be terse")
+        param = OpenAIStreamingClient._to_openai_chat_completion_message_param(None, message)  # type: ignore[arg-type]
+        assert param == {"content": "be terse", "role": "system"}
+
+
 def _identity_decrypt(value: bytes) -> bytes:
     return value
 

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -37,6 +37,7 @@ from phoenix.db.types.prompts import (
 from phoenix.server.api.exceptions import BadRequest
 from phoenix.server.api.helpers.message_helpers import PlaygroundMessage, create_playground_message
 from phoenix.server.api.helpers.playground_clients import (
+    OPENAI_CHAT_COMPLETIONS_MODELS,
     OPENAI_REASONING_MODELS,
     AnthropicStreamingClient,
     AzureOpenAIReasoningNonStreamingClient,
@@ -50,6 +51,10 @@ from phoenix.server.api.helpers.playground_clients import (
     _get_builtin_provider_client,
     _resolve_provider_api_key,
     get_openai_client_class,
+)
+from phoenix.server.api.helpers.playground_registry import (
+    PLAYGROUND_CLIENT_REGISTRY,
+    PROVIDER_DEFAULT,
 )
 from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
 from phoenix.server.api.input_types.ModelClientOptionsInput import OpenAIApiType
@@ -876,6 +881,71 @@ class TestReasoningModelClientRouting:
         assert params["tool_choice"] == {"type": "function", "name": "record_evaluation"}
         assert params["reasoning"] == {"effort": "high"}
         assert "reasoning_effort" not in params
+
+
+class TestDefaultApiTypeRouting:
+    """Routing with no configured API type is decided by ``get_openai_client_class``.
+
+    The playground registry carries the model catalog, not routing. Keeping the two
+    separate is what prevents a stale catalog entry from shadowing a newer provider
+    default -- the shape of https://github.com/Arize-ai/phoenix/issues/15299.
+    """
+
+    def test_openai_defaults_to_responses_except_legacy_models(self) -> None:
+        for model_name in OPENAI_CHAT_COMPLETIONS_MODELS:
+            assert (
+                get_openai_client_class(GenerativeProviderKey.OPENAI, model_name, None)
+                is OpenAIStreamingClient
+            ), f"Failed for {model_name}"
+        for model_name in [*OPENAI_REASONING_MODELS, "gpt-6-does-not-exist-yet"]:
+            assert (
+                get_openai_client_class(GenerativeProviderKey.OPENAI, model_name, None)
+                is OpenAIResponsesAPIStreamingClient
+            ), f"Failed for {model_name}"
+
+    def test_azure_defaults_to_chat_completions_except_reasoning_models(self) -> None:
+        for model_name in OPENAI_REASONING_MODELS:
+            assert (
+                get_openai_client_class(GenerativeProviderKey.AZURE_OPENAI, model_name, None)
+                is AzureOpenAIResponsesAPIStreamingClient
+            ), f"Failed for {model_name}"
+        for model_name in ["gpt-4o", "my-custom-deployment"]:
+            assert (
+                get_openai_client_class(GenerativeProviderKey.AZURE_OPENAI, model_name, None)
+                is AzureOpenAIStreamingClient
+            ), f"Failed for {model_name}"
+
+    @pytest.mark.parametrize(
+        "provider_key,model_name,expected_class",
+        [
+            (GenerativeProviderKey.OPENAI, "gpt-5.6-luna", OpenAIResponsesAPIStreamingClient),
+            (GenerativeProviderKey.OPENAI, "gpt-4o", OpenAIStreamingClient),
+            (
+                GenerativeProviderKey.AZURE_OPENAI,
+                "gpt-5.6-luna",
+                AzureOpenAIResponsesAPIStreamingClient,
+            ),
+            (GenerativeProviderKey.AZURE_OPENAI, "gpt-4o", AzureOpenAIStreamingClient),
+        ],
+    )
+    def test_registry_entries_do_not_affect_routing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        provider_key: GenerativeProviderKey,
+        model_name: str,
+        expected_class: type[OpenAIBaseStreamingClient],
+    ) -> None:
+        """A wrong catalog entry must not be able to redirect a request."""
+
+        class WrongClient(OpenAIStreamingClient):
+            pass
+
+        provider_registry = dict(PLAYGROUND_CLIENT_REGISTRY._registry[provider_key])
+        provider_registry[model_name] = WrongClient
+        provider_registry[PROVIDER_DEFAULT] = WrongClient
+        monkeypatch.setitem(PLAYGROUND_CLIENT_REGISTRY._registry, provider_key, provider_registry)
+
+        assert get_openai_client_class(provider_key, model_name, None) is expected_class
 
 
 def _identity_decrypt(value: bytes) -> bytes:


### PR DESCRIPTION
Cherry-pick of the shared-code portion of #15355 onto `main` (see that PR for the full reviewer's guide). Related to #15299 — the issue was filed against the online-evals feature branch, but the buggy registrations live on `main` and affect the playground and experiment evaluators here.

## Problem

The playground client registry exact-match maps every model in `OPENAI_REASONING_MODELS` to `OpenAIReasoningNonStreamingClient` — a Chat Completions client that sends `reasoning_effort` at the request root. OpenAI rejects that combination whenever function tools are present:

```
Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions.
```

LLM evaluators always emit their structured output via a function tool, so any evaluator (and any playground run with tools) on these models fails. `OpenAIResponsesAPIStreamingClient`, which encodes the request correctly for `/v1/responses` (`reasoning: {"effort": ...}`), was registered only as the provider default and therefore unreachable for exactly the models that require it.

## Changes

- Register reasoning models to the Responses API clients (OpenAI + Azure). An explicit `CHAT_COMPLETIONS` connection config still selects the Chat Completions reasoning clients via `get_openai_client_class`.
- `elif tools.tools:` → `if tools.tools:` in `_openai_response_build_params` — `disable_parallel_tool_calls=True` silently dropped the entire tools list from Responses requests.
- `register_llm_client` now raises at import time on duplicate (provider, model) registration unless `override=True`. The Azure half of this bug existed because a later registration silently clobbered the Responses client entries for the same model names; the two intentional provider-default overrides (OpenAI Responses, Gemini 2.5) are marked explicitly.
- Delete the empty `OpenAIReasoningReasoningModelsMixin` (docstring-only, no behavior, no `isinstance` checks) and dedup the routing tests.
