### PR TITLE
feat(server): add POST /traces/transfer

### DIFF
--- a/.agents/skills/phoenix-rest-api/references/endpoint-patterns.md
+++ b/.agents/skills/phoenix-rest-api/references/endpoint-patterns.md
@@ -13,6 +13,7 @@ Keywords per [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) / [RFC 8174](htt
 - Query params for filtering/sorting/pagination. snake_case names.
 - Cursor-based pagination only. Response: `{"data": [...], "next_cursor": "..."}`.
 - All responses wrap payload in `"data"` key. snake_case field names.
+- Field names MUST be self-describing without reading the endpoint docs. Counts are named `<noun>_count` with the noun spelled out (`transferred_trace_count`, not `transferred` or `count`); IDs say what they identify (`destination_project_id`, not `id`). Bare verbs, adjectives, and abbreviations are not field names.
 
 ## Implementation
 

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -6328,10 +6328,10 @@ export interface components {
         /** TransferTracesRequestBody */
         TransferTracesRequestBody: {
             /**
-             * Trace Ids
-             * @description The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project.
+             * Trace Identifiers
+             * @description The traces to transfer. Each identifier is either a trace ID (GlobalID) or an OpenTelemetry trace_id (hex string). Must be non-empty, and all traces must currently belong to the same source project.
              */
-            trace_ids: string[];
+            trace_identifiers: string[];
             /**
              * Destination Project Identifier
              * @description The destination project: either project ID (GlobalID) or project name.

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -804,6 +804,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/traces/transfer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Transfer traces to a project
+         * @description Move traces into a different project. This re-parents the traces rather than copying them, so they no longer appear under their original project. All traces must currently belong to the same source project.
+         */
+        post: operations["transferTraces"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/traces/{trace_identifier}": {
         parameters: {
             query?: never;
@@ -6292,6 +6312,30 @@ export interface components {
              */
             end_time: string;
         };
+        /** TransferTracesData */
+        TransferTracesData: {
+            /** Transferred */
+            transferred: number;
+            /** Destination Project Id */
+            destination_project_id: string;
+        };
+        /** TransferTracesRequestBody */
+        TransferTracesRequestBody: {
+            /**
+             * Trace Ids
+             * @description The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project.
+             */
+            trace_ids: string[];
+            /**
+             * Destination Project Identifier
+             * @description The destination project: either project ID (GlobalID) or project name.
+             */
+            destination_project_identifier: string;
+        };
+        /** TransferTracesResponseBody */
+        TransferTracesResponseBody: {
+            data: components["schemas"]["TransferTracesData"];
+        };
         /**
          * TurnTraceContext
          * @description The trace identity a turn's spans are parented to.
@@ -9916,6 +9960,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    transferTraces: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransferTracesRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransferTracesResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Destination project or trace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -6314,9 +6314,15 @@ export interface components {
         };
         /** TransferTracesData */
         TransferTracesData: {
-            /** Transferred */
-            transferred: number;
-            /** Destination Project Id */
+            /**
+             * Transferred Trace Count
+             * @description The number of traces that were moved to the destination project.
+             */
+            transferred_trace_count: number;
+            /**
+             * Destination Project Id
+             * @description The ID (GlobalID) of the project the traces were moved to.
+             */
             destination_project_id: string;
         };
         /** TransferTracesRequestBody */

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -6328,10 +6328,10 @@ export interface components {
         /** TransferTracesRequestBody */
         TransferTracesRequestBody: {
             /**
-             * Trace Ids
-             * @description The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project.
+             * Trace Identifiers
+             * @description The traces to transfer. Each identifier is either a trace ID (GlobalID) or an OpenTelemetry trace_id (hex string). Must be non-empty, and all traces must currently belong to the same source project.
              */
-            trace_ids: string[];
+            trace_identifiers: string[];
             /**
              * Destination Project Identifier
              * @description The destination project: either project ID (GlobalID) or project name.

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -804,6 +804,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/traces/transfer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Transfer traces to a project
+         * @description Move traces into a different project. This re-parents the traces rather than copying them, so they no longer appear under their original project. All traces must currently belong to the same source project.
+         */
+        post: operations["transferTraces"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/traces/{trace_identifier}": {
         parameters: {
             query?: never;
@@ -6292,6 +6312,30 @@ export interface components {
              */
             end_time: string;
         };
+        /** TransferTracesData */
+        TransferTracesData: {
+            /** Transferred */
+            transferred: number;
+            /** Destination Project Id */
+            destination_project_id: string;
+        };
+        /** TransferTracesRequestBody */
+        TransferTracesRequestBody: {
+            /**
+             * Trace Ids
+             * @description The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project.
+             */
+            trace_ids: string[];
+            /**
+             * Destination Project Identifier
+             * @description The destination project: either project ID (GlobalID) or project name.
+             */
+            destination_project_identifier: string;
+        };
+        /** TransferTracesResponseBody */
+        TransferTracesResponseBody: {
+            data: components["schemas"]["TransferTracesData"];
+        };
         /**
          * TurnTraceContext
          * @description The trace identity a turn's spans are parented to.
@@ -9916,6 +9960,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    transferTraces: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransferTracesRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransferTracesResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Destination project or trace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -6314,9 +6314,15 @@ export interface components {
         };
         /** TransferTracesData */
         TransferTracesData: {
-            /** Transferred */
-            transferred: number;
-            /** Destination Project Id */
+            /**
+             * Transferred Trace Count
+             * @description The number of traces that were moved to the destination project.
+             */
+            transferred_trace_count: number;
+            /**
+             * Destination Project Id
+             * @description The ID (GlobalID) of the project the traces were moved to.
+             */
             destination_project_id: string;
         };
         /** TransferTracesRequestBody */

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -6328,10 +6328,10 @@ export interface components {
         /** TransferTracesRequestBody */
         TransferTracesRequestBody: {
             /**
-             * Trace Ids
-             * @description The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project.
+             * Trace Identifiers
+             * @description The traces to transfer. Each identifier is either a trace ID (GlobalID) or an OpenTelemetry trace_id (hex string). Must be non-empty, and all traces must currently belong to the same source project.
              */
-            trace_ids: string[];
+            trace_identifiers: string[];
             /**
              * Destination Project Identifier
              * @description The destination project: either project ID (GlobalID) or project name.

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -804,6 +804,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/traces/transfer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Transfer traces to a project
+         * @description Move traces into a different project. This re-parents the traces rather than copying them, so they no longer appear under their original project. All traces must currently belong to the same source project.
+         */
+        post: operations["transferTraces"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/traces/{trace_identifier}": {
         parameters: {
             query?: never;
@@ -6292,6 +6312,30 @@ export interface components {
              */
             end_time: string;
         };
+        /** TransferTracesData */
+        TransferTracesData: {
+            /** Transferred */
+            transferred: number;
+            /** Destination Project Id */
+            destination_project_id: string;
+        };
+        /** TransferTracesRequestBody */
+        TransferTracesRequestBody: {
+            /**
+             * Trace Ids
+             * @description The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project.
+             */
+            trace_ids: string[];
+            /**
+             * Destination Project Identifier
+             * @description The destination project: either project ID (GlobalID) or project name.
+             */
+            destination_project_identifier: string;
+        };
+        /** TransferTracesResponseBody */
+        TransferTracesResponseBody: {
+            data: components["schemas"]["TransferTracesData"];
+        };
         /**
          * TurnTraceContext
          * @description The trace identity a turn's spans are parented to.
@@ -9916,6 +9960,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    transferTraces: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransferTracesRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransferTracesResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Destination project or trace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -6314,9 +6314,15 @@ export interface components {
         };
         /** TransferTracesData */
         TransferTracesData: {
-            /** Transferred */
-            transferred: number;
-            /** Destination Project Id */
+            /**
+             * Transferred Trace Count
+             * @description The number of traces that were moved to the destination project.
+             */
+            transferred_trace_count: number;
+            /**
+             * Destination Project Id
+             * @description The ID (GlobalID) of the project the traces were moved to.
+             */
             destination_project_id: string;
         };
         /** TransferTracesRequestBody */

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1037,7 +1037,7 @@ class TraceSpanData(TypedDict):
 
 
 class TransferTracesData(TypedDict):
-    transferred: int
+    transferred_trace_count: int
     destination_project_id: str
 
 

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1042,7 +1042,7 @@ class TransferTracesData(TypedDict):
 
 
 class TransferTracesRequestBody(TypedDict):
-    trace_ids: Sequence[str]
+    trace_identifiers: Sequence[str]
     destination_project_identifier: str
 
 

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1036,6 +1036,20 @@ class TraceSpanData(TypedDict):
     end_time: str
 
 
+class TransferTracesData(TypedDict):
+    transferred: int
+    destination_project_id: str
+
+
+class TransferTracesRequestBody(TypedDict):
+    trace_ids: Sequence[str]
+    destination_project_identifier: str
+
+
+class TransferTracesResponseBody(TypedDict):
+    data: TransferTracesData
+
+
 class TurnTraceContext(TypedDict):
     traceId: str
     rootSpanId: str
@@ -1261,6 +1275,7 @@ class PhoenixToolCallCallbackProviderMetadata(TypedDict):
     toolInputEmittedAt: NotRequired[str]
     clientStartedAt: NotRequired[str]
     clientEndedAt: NotRequired[str]
+    outcome: NotRequired[str]
 
 
 class PhoenixToolCallProviderMetadata(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -20248,18 +20248,20 @@
       },
       "TransferTracesData": {
         "properties": {
-          "transferred": {
+          "transferred_trace_count": {
             "type": "integer",
-            "title": "Transferred"
+            "title": "Transferred Trace Count",
+            "description": "The number of traces that were moved to the destination project."
           },
           "destination_project_id": {
             "type": "string",
-            "title": "Destination Project Id"
+            "title": "Destination Project Id",
+            "description": "The ID (GlobalID) of the project the traces were moved to."
           }
         },
         "type": "object",
         "required": [
-          "transferred",
+          "transferred_trace_count",
           "destination_project_id"
         ],
         "title": "TransferTracesData"

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -20271,6 +20271,7 @@
               "type": "string"
             },
             "type": "array",
+            "minItems": 1,
             "title": "Trace Ids",
             "description": "The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project."
           },

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4924,6 +4924,68 @@
         }
       }
     },
+    "/v1/traces/transfer": {
+      "post": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Transfer traces to a project",
+        "description": "Move traces into a different project. This re-parents the traces rather than copying them, so they no longer appear under their original project. All traces must currently belong to the same source project.",
+        "operationId": "transferTraces",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferTracesRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferTracesResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Destination project or trace not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/traces/{trace_identifier}": {
       "delete": {
         "tags": [
@@ -20183,6 +20245,59 @@
           "end_time"
         ],
         "title": "TraceSpanData"
+      },
+      "TransferTracesData": {
+        "properties": {
+          "transferred": {
+            "type": "integer",
+            "title": "Transferred"
+          },
+          "destination_project_id": {
+            "type": "string",
+            "title": "Destination Project Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "transferred",
+          "destination_project_id"
+        ],
+        "title": "TransferTracesData"
+      },
+      "TransferTracesRequestBody": {
+        "properties": {
+          "trace_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Trace Ids",
+            "description": "The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project."
+          },
+          "destination_project_identifier": {
+            "type": "string",
+            "title": "Destination Project Identifier",
+            "description": "The destination project: either project ID (GlobalID) or project name."
+          }
+        },
+        "type": "object",
+        "required": [
+          "trace_ids",
+          "destination_project_identifier"
+        ],
+        "title": "TransferTracesRequestBody"
+      },
+      "TransferTracesResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TransferTracesData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "TransferTracesResponseBody"
       },
       "TurnTraceContext": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -20268,14 +20268,14 @@
       },
       "TransferTracesRequestBody": {
         "properties": {
-          "trace_ids": {
+          "trace_identifiers": {
             "items": {
               "type": "string"
             },
             "type": "array",
             "minItems": 1,
-            "title": "Trace Ids",
-            "description": "The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all traces must currently belong to the same source project."
+            "title": "Trace Identifiers",
+            "description": "The traces to transfer. Each identifier is either a trace ID (GlobalID) or an OpenTelemetry trace_id (hex string). Must be non-empty, and all traces must currently belong to the same source project."
           },
           "destination_project_identifier": {
             "type": "string",
@@ -20285,7 +20285,7 @@
         },
         "type": "object",
         "required": [
-          "trace_ids",
+          "trace_identifiers",
           "destination_project_identifier"
         ],
         "title": "TransferTracesRequestBody"

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -593,8 +593,12 @@ class TransferTracesRequestBody(V1RoutesBaseModel):
 
 
 class TransferTracesData(V1RoutesBaseModel):
-    transferred: int
-    destination_project_id: str
+    transferred_trace_count: int = Field(
+        description="The number of traces that were moved to the destination project."
+    )
+    destination_project_id: str = Field(
+        description="The ID (GlobalID) of the project the traces were moved to."
+    )
 
 
 class TransferTracesResponseBody(ResponseBody[TransferTracesData]):
@@ -664,7 +668,7 @@ async def transfer_traces(
     request.state.event_queue.put(SpanDeleteEvent(tuple({*source_project_rowids, project.id})))
     return TransferTracesResponseBody(
         data=TransferTracesData(
-            transferred=result.rowcount,
+            transferred_trace_count=result.rowcount,
             destination_project_id=str(GlobalID(ProjectNodeType.__name__, str(project.id))),
         )
     )

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -11,7 +11,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceResponse,
 )
 from pydantic import BeforeValidator, Field
-from sqlalchemy import delete, insert, or_, select
+from sqlalchemy import delete, insert, or_, select, update
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import State
 from starlette.requests import Request
@@ -579,6 +579,94 @@ async def _add_spans(
             for otlp_span in scope_span.spans:
                 span = await run_in_threadpool(decode_otlp_span, otlp_span)
                 await state.enqueue_span(span, project_name)
+
+
+class TransferTracesRequestBody(V1RoutesBaseModel):
+    trace_ids: list[str] = Field(
+        description="The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all "
+        "traces must currently belong to the same source project."
+    )
+    destination_project_identifier: str = Field(
+        description="The destination project: either project ID (GlobalID) or project name."
+    )
+
+
+class TransferTracesData(V1RoutesBaseModel):
+    transferred: int
+    destination_project_id: str
+
+
+class TransferTracesResponseBody(ResponseBody[TransferTracesData]):
+    pass
+
+
+@router.post(
+    "/traces/transfer",
+    dependencies=[
+        Depends(prevent_access_in_read_only_mode),
+        Depends(restrict_access_by_viewers),
+        Depends(is_not_locked),
+    ],
+    operation_id="transferTraces",
+    summary="Transfer traces to a project",
+    description=(
+        "Move traces into a different project. This re-parents the traces rather than copying "
+        "them, so they no longer appear under their original project. All traces must currently "
+        "belong to the same source project."
+    ),
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Destination project or trace not found"},
+            {"status_code": 422, "description": "Invalid request"},
+        ]
+    ),
+)
+async def transfer_traces(
+    request: Request,
+    request_body: TransferTracesRequestBody,
+) -> TransferTracesResponseBody:
+    if not request_body.trace_ids:
+        raise HTTPException(
+            detail="Must provide at least one trace ID to transfer",
+            status_code=422,
+        )
+    try:
+        trace_rowids = {
+            from_global_id_with_expected_type(GlobalID.from_id(trace_id), TraceNodeType.__name__)
+            for trace_id in request_body.trace_ids
+        }
+    except ValueError:
+        raise HTTPException(
+            detail="Invalid trace ID provided",
+            status_code=422,
+        )
+    async with request.app.state.db() as session:
+        project = await get_project_by_identifier(
+            session, request_body.destination_project_identifier
+        )
+        traces = (
+            await session.scalars(select(models.Trace).where(models.Trace.id.in_(trace_rowids)))
+        ).all()
+        if len(traces) < len(trace_rowids):
+            raise HTTPException(detail="Invalid trace IDs provided", status_code=404)
+        # Mirrors the transferTracesToProject mutation: a transfer moves traces out of exactly
+        # one source project, so a mixed-source request is ambiguous and is rejected.
+        if len({trace.project_rowid for trace in traces}) > 1:
+            raise HTTPException(
+                detail="Cannot transfer traces from multiple projects",
+                status_code=422,
+            )
+        await session.execute(
+            update(models.Trace)
+            .where(models.Trace.id.in_(trace_rowids))
+            .values(project_rowid=project.id)
+        )
+    return TransferTracesResponseBody(
+        data=TransferTracesData(
+            transferred=len(trace_rowids),
+            destination_project_id=str(GlobalID(ProjectNodeType.__name__, str(project.id))),
+        )
+    )
 
 
 @router.delete(

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -583,8 +583,9 @@ async def _add_spans(
 
 class TransferTracesRequestBody(V1RoutesBaseModel):
     trace_ids: list[str] = Field(
+        min_length=1,
         description="The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all "
-        "traces must currently belong to the same source project."
+        "traces must currently belong to the same source project.",
     )
     destination_project_identifier: str = Field(
         description="The destination project: either project ID (GlobalID) or project name."
@@ -625,11 +626,6 @@ async def transfer_traces(
     request: Request,
     request_body: TransferTracesRequestBody,
 ) -> TransferTracesResponseBody:
-    if not request_body.trace_ids:
-        raise HTTPException(
-            detail="Must provide at least one trace ID to transfer",
-            status_code=422,
-        )
     try:
         trace_rowids = {
             from_global_id_with_expected_type(GlobalID.from_id(trace_id), TraceNodeType.__name__)
@@ -644,26 +640,31 @@ async def transfer_traces(
         project = await get_project_by_identifier(
             session, request_body.destination_project_identifier
         )
-        traces = (
-            await session.scalars(select(models.Trace).where(models.Trace.id.in_(trace_rowids)))
+        source_project_rowids = (
+            await session.scalars(
+                select(models.Trace.project_rowid).where(models.Trace.id.in_(trace_rowids))
+            )
         ).all()
-        if len(traces) < len(trace_rowids):
-            raise HTTPException(detail="Invalid trace IDs provided", status_code=404)
+        if len(source_project_rowids) < len(trace_rowids):
+            raise HTTPException(detail="One or more traces not found", status_code=404)
         # Mirrors the transferTracesToProject mutation: a transfer moves traces out of exactly
         # one source project, so a mixed-source request is ambiguous and is rejected.
-        if len({trace.project_rowid for trace in traces}) > 1:
+        if len(set(source_project_rowids)) > 1:
             raise HTTPException(
                 detail="Cannot transfer traces from multiple projects",
                 status_code=422,
             )
-        await session.execute(
+        result = await session.execute(
             update(models.Trace)
             .where(models.Trace.id.in_(trace_rowids))
             .values(project_rowid=project.id)
         )
+    # Invalidate per-project cached aggregates (record counts, token counts/costs, latency
+    # quantiles, time ranges) for both the source and destination projects.
+    request.state.event_queue.put(SpanDeleteEvent(tuple({*source_project_rowids, project.id})))
     return TransferTracesResponseBody(
         data=TransferTracesData(
-            transferred=len(trace_rowids),
+            transferred=result.rowcount,
             destination_project_id=str(GlobalID(ProjectNodeType.__name__, str(project.id))),
         )
     )

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -582,10 +582,11 @@ async def _add_spans(
 
 
 class TransferTracesRequestBody(V1RoutesBaseModel):
-    trace_ids: list[str] = Field(
+    trace_identifiers: list[str] = Field(
         min_length=1,
-        description="The IDs (GlobalIDs) of the traces to transfer. Must be non-empty, and all "
-        "traces must currently belong to the same source project.",
+        description="The traces to transfer. Each identifier is either a trace ID (GlobalID) "
+        "or an OpenTelemetry trace_id (hex string). Must be non-empty, and all traces must "
+        "currently belong to the same source project.",
     )
     destination_project_identifier: str = Field(
         description="The destination project: either project ID (GlobalID) or project name."
@@ -630,37 +631,48 @@ async def transfer_traces(
     request: Request,
     request_body: TransferTracesRequestBody,
 ) -> TransferTracesResponseBody:
-    try:
-        trace_rowids = {
-            from_global_id_with_expected_type(GlobalID.from_id(trace_id), TraceNodeType.__name__)
-            for trace_id in request_body.trace_ids
-        }
-    except ValueError:
-        raise HTTPException(
-            detail="Invalid trace ID provided",
-            status_code=422,
-        )
+    # Each identifier may be a Trace GlobalID or an OpenTelemetry trace_id (hex string),
+    # mirroring DELETE /traces/{trace_identifier}.
+    trace_rowids: set[int] = set()
+    otel_trace_ids: set[str] = set()
+    for identifier in request_body.trace_identifiers:
+        try:
+            trace_rowids.add(
+                from_global_id_with_expected_type(
+                    GlobalID.from_id(identifier), TraceNodeType.__name__
+                )
+            )
+        except ValueError:
+            otel_trace_ids.add(identifier)
     async with request.app.state.db() as session:
         project = await get_project_by_identifier(
             session, request_body.destination_project_identifier
         )
-        source_project_rowids = (
-            await session.scalars(
-                select(models.Trace.project_rowid).where(models.Trace.id.in_(trace_rowids))
+        traces = (
+            await session.execute(
+                select(models.Trace.id, models.Trace.trace_id, models.Trace.project_rowid).where(
+                    or_(
+                        models.Trace.id.in_(trace_rowids),
+                        models.Trace.trace_id.in_(otel_trace_ids),
+                    )
+                )
             )
         ).all()
-        if len(source_project_rowids) < len(trace_rowids):
+        found_rowids = {trace.id for trace in traces}
+        found_otel_trace_ids = {trace.trace_id for trace in traces}
+        if not (trace_rowids <= found_rowids and otel_trace_ids <= found_otel_trace_ids):
             raise HTTPException(detail="One or more traces not found", status_code=404)
+        source_project_rowids = {trace.project_rowid for trace in traces}
         # Mirrors the transferTracesToProject mutation: a transfer moves traces out of exactly
         # one source project, so a mixed-source request is ambiguous and is rejected.
-        if len(set(source_project_rowids)) > 1:
+        if len(source_project_rowids) > 1:
             raise HTTPException(
                 detail="Cannot transfer traces from multiple projects",
                 status_code=422,
             )
         result = await session.execute(
             update(models.Trace)
-            .where(models.Trace.id.in_(trace_rowids))
+            .where(models.Trace.id.in_(found_rowids))
             .values(project_rowid=project.id)
         )
     # Invalidate per-project cached aggregates (record counts, token counts/costs, latency

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2274,6 +2274,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/trace_annotations"),
     (422, "POST", "v1/trace_notes"),
     (415, "POST", "v1/traces"),
+    (422, "POST", "v1/traces/transfer"),
     # PUT routes
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),
     (404, "PUT", "v1/projects/{0}/annotation_configs/{0}"),

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -628,7 +628,7 @@ async def _project_with_traces(
         project_rowid = await session.scalar(
             insert(models.Project).values(name=project_name).returning(models.Project.id)
         )
-        trace_rowids = []
+        trace_rowids: list[int] = []
         for i in range(num_traces):
             trace_rowid = await session.scalar(
                 insert(models.Trace)
@@ -640,6 +640,7 @@ async def _project_with_traces(
                 )
                 .returning(models.Trace.id)
             )
+            assert trace_rowid is not None
             trace_rowids.append(trace_rowid)
     assert project_rowid is not None
     return project_rowid, trace_rowids

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -662,7 +662,7 @@ async def test_transfer_traces_moves_traces_to_destination(
     )
     assert response.status_code == 200
     data = response.json()["data"]
-    assert data["transferred"] == 2
+    assert data["transferred_trace_count"] == 2
     assert data["destination_project_id"] == str(GlobalID("Project", str(dest_rowid)))
 
     async with db() as session:
@@ -690,7 +690,7 @@ async def test_transfer_traces_accepts_project_global_id(
         },
     )
     assert response.status_code == 200
-    assert response.json()["data"]["transferred"] == 1
+    assert response.json()["data"]["transferred_trace_count"] == 1
 
 
 async def test_transfer_traces_deduplicates_repeated_ids(
@@ -709,7 +709,7 @@ async def test_transfer_traces_deduplicates_repeated_ids(
         },
     )
     assert response.status_code == 200
-    assert response.json()["data"]["transferred"] == 1
+    assert response.json()["data"]["transferred_trace_count"] == 1
 
 
 async def test_transfer_traces_rejects_multiple_source_projects(

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -610,3 +610,180 @@ async def test_post_traces_resource_attribute_used_when_no_header(
         )
 
     assert project is not None, "Project from resource attribute should be created"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/traces/transfer
+# ---------------------------------------------------------------------------
+
+
+async def _project_with_traces(
+    db: DbSessionFactory,
+    project_name: str,
+    num_traces: int,
+    trace_id_prefix: str,
+) -> tuple[int, list[int]]:
+    """Create a project with `num_traces` traces; return (project_rowid, trace_rowids)."""
+    async with db() as session:
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name=project_name).returning(models.Project.id)
+        )
+        trace_rowids = []
+        for i in range(num_traces):
+            trace_rowid = await session.scalar(
+                insert(models.Trace)
+                .values(
+                    trace_id=f"{trace_id_prefix}{i:04d}",
+                    project_rowid=project_rowid,
+                    start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                    end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+                )
+                .returning(models.Trace.id)
+            )
+            trace_rowids.append(trace_rowid)
+    assert project_rowid is not None
+    return project_rowid, trace_rowids
+
+
+async def test_transfer_traces_moves_traces_to_destination(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    source_rowid, trace_rowids = await _project_with_traces(db, "src-proj", 2, "aaaa")
+    dest_rowid, _ = await _project_with_traces(db, "dst-proj", 1, "bbbb")
+
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": [str(GlobalID("Trace", str(rowid))) for rowid in trace_rowids],
+            "destination_project_identifier": "dst-proj",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["transferred"] == 2
+    assert data["destination_project_id"] == str(GlobalID("Project", str(dest_rowid)))
+
+    async with db() as session:
+        moved = (
+            await session.scalars(
+                select(models.Trace.project_rowid).where(models.Trace.id.in_(trace_rowids))
+            )
+        ).all()
+    assert set(moved) == {dest_rowid}, "traces should be re-parented to the destination"
+    assert source_rowid not in set(moved)
+
+
+async def test_transfer_traces_accepts_project_global_id(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    _, trace_rowids = await _project_with_traces(db, "src-gid", 1, "cccc")
+    dest_rowid, _ = await _project_with_traces(db, "dst-gid", 1, "dddd")
+
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": [str(GlobalID("Trace", str(trace_rowids[0])))],
+            "destination_project_identifier": str(GlobalID("Project", str(dest_rowid))),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["transferred"] == 1
+
+
+async def test_transfer_traces_deduplicates_repeated_ids(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    _, trace_rowids = await _project_with_traces(db, "src-dupe", 1, "eeee")
+    await _project_with_traces(db, "dst-dupe", 1, "ffff")
+    trace_gid = str(GlobalID("Trace", str(trace_rowids[0])))
+
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": [trace_gid, trace_gid],
+            "destination_project_identifier": "dst-dupe",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["transferred"] == 1
+
+
+async def test_transfer_traces_rejects_multiple_source_projects(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    _, traces_a = await _project_with_traces(db, "multi-a", 1, "1111")
+    _, traces_b = await _project_with_traces(db, "multi-b", 1, "2222")
+    await _project_with_traces(db, "multi-dst", 1, "3333")
+
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": [
+                str(GlobalID("Trace", str(traces_a[0]))),
+                str(GlobalID("Trace", str(traces_b[0]))),
+            ],
+            "destination_project_identifier": "multi-dst",
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_transfer_traces_empty_trace_ids(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    await _project_with_traces(db, "empty-dst", 1, "4444")
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={"trace_ids": [], "destination_project_identifier": "empty-dst"},
+    )
+    assert response.status_code == 422
+
+
+async def test_transfer_traces_unknown_trace(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    await _project_with_traces(db, "unknown-dst", 1, "5555")
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": [str(GlobalID("Trace", "99999"))],
+            "destination_project_identifier": "unknown-dst",
+        },
+    )
+    assert response.status_code == 404
+
+
+async def test_transfer_traces_unknown_destination_project(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    _, trace_rowids = await _project_with_traces(db, "src-nodst", 1, "6666")
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": [str(GlobalID("Trace", str(trace_rowids[0])))],
+            "destination_project_identifier": "does-not-exist",
+        },
+    )
+    assert response.status_code == 404
+
+
+async def test_transfer_traces_malformed_trace_id(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    await _project_with_traces(db, "malformed-dst", 1, "7777")
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_ids": ["not-a-global-id"],
+            "destination_project_identifier": "malformed-dst",
+        },
+    )
+    assert response.status_code == 422

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -656,7 +656,7 @@ async def test_transfer_traces_moves_traces_to_destination(
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": [str(GlobalID("Trace", str(rowid))) for rowid in trace_rowids],
+            "trace_identifiers": [str(GlobalID("Trace", str(rowid))) for rowid in trace_rowids],
             "destination_project_identifier": "dst-proj",
         },
     )
@@ -685,7 +685,7 @@ async def test_transfer_traces_accepts_project_global_id(
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": [str(GlobalID("Trace", str(trace_rowids[0])))],
+            "trace_identifiers": [str(GlobalID("Trace", str(trace_rowids[0])))],
             "destination_project_identifier": str(GlobalID("Project", str(dest_rowid))),
         },
     )
@@ -704,7 +704,7 @@ async def test_transfer_traces_deduplicates_repeated_ids(
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": [trace_gid, trace_gid],
+            "trace_identifiers": [trace_gid, trace_gid],
             "destination_project_identifier": "dst-dupe",
         },
     )
@@ -723,7 +723,7 @@ async def test_transfer_traces_rejects_multiple_source_projects(
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": [
+            "trace_identifiers": [
                 str(GlobalID("Trace", str(traces_a[0]))),
                 str(GlobalID("Trace", str(traces_b[0]))),
             ],
@@ -733,14 +733,14 @@ async def test_transfer_traces_rejects_multiple_source_projects(
     assert response.status_code == 422
 
 
-async def test_transfer_traces_empty_trace_ids(
+async def test_transfer_traces_empty_trace_identifiers(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
 ) -> None:
     await _project_with_traces(db, "empty-dst", 1, "4444")
     response = await httpx_client.post(
         "v1/traces/transfer",
-        json={"trace_ids": [], "destination_project_identifier": "empty-dst"},
+        json={"trace_identifiers": [], "destination_project_identifier": "empty-dst"},
     )
     assert response.status_code == 422
 
@@ -753,7 +753,7 @@ async def test_transfer_traces_unknown_trace(
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": [str(GlobalID("Trace", "99999"))],
+            "trace_identifiers": [str(GlobalID("Trace", "99999"))],
             "destination_project_identifier": "unknown-dst",
         },
     )
@@ -768,23 +768,52 @@ async def test_transfer_traces_unknown_destination_project(
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": [str(GlobalID("Trace", str(trace_rowids[0])))],
+            "trace_identifiers": [str(GlobalID("Trace", str(trace_rowids[0])))],
             "destination_project_identifier": "does-not-exist",
         },
     )
     assert response.status_code == 404
 
 
-async def test_transfer_traces_malformed_trace_id(
+async def test_transfer_traces_accepts_otel_trace_ids(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    source_rowid, trace_rowids = await _project_with_traces(db, "src-otel", 2, "abcd")
+    dest_rowid, _ = await _project_with_traces(db, "dst-otel", 1, "beef")
+
+    # Mix an OpenTelemetry trace_id with a GlobalID in a single request.
+    response = await httpx_client.post(
+        "v1/traces/transfer",
+        json={
+            "trace_identifiers": ["abcd0000", str(GlobalID("Trace", str(trace_rowids[1])))],
+            "destination_project_identifier": "dst-otel",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["transferred_trace_count"] == 2
+
+    async with db() as session:
+        moved = (
+            await session.scalars(
+                select(models.Trace.project_rowid).where(models.Trace.id.in_(trace_rowids))
+            )
+        ).all()
+    assert set(moved) == {dest_rowid}
+
+
+async def test_transfer_traces_unparseable_identifier(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
 ) -> None:
     await _project_with_traces(db, "malformed-dst", 1, "7777")
+    # An identifier that is not a GlobalID is treated as an OpenTelemetry trace_id;
+    # when no trace has it, the request is a 404.
     response = await httpx_client.post(
         "v1/traces/transfer",
         json={
-            "trace_ids": ["not-a-global-id"],
+            "trace_identifiers": ["not-a-global-id"],
             "destination_project_identifier": "malformed-dst",
         },
     )
-    assert response.status_code == 422
+    assert response.status_code == 404


### PR DESCRIPTION
Closes #12271

## Summary

Exposes the existing `transferTracesToProject` GraphQL mutation (`trace_mutations.py:76`) over REST as `POST /v1/traces/transfer`. This is a re-parenting operation — traces move into the destination project and leave their original one. There is no span-level transfer.

## API shape

```jsonc
// POST /v1/traces/transfer
{
  "trace_identifiers": ["<OTel trace_id (hex) or Trace GlobalID>", ...],
  "destination_project_identifier": "my-project" // or a Project GlobalID
}
// 200
{ "data": { "transferred_trace_count": 2, "destination_project_id": "<Project GlobalID>" } }
```

Naming and identifier semantics:

- **`trace_identifiers`** — each entry is either an OpenTelemetry trace_id (hex string) or a relay GlobalID, resolved the same way as `DELETE /traces/{trace_identifier}`, per the repo REST convention that identifiers SHOULD accept both forms. The two forms can be mixed in a single request.
- **`destination_project_identifier`** — project name or GlobalID, resolved through `get_project_by_identifier`, matching the `{project_identifier}` convention used by the other project-scoped routes.
- **`transferred_trace_count`** — the number of distinct traces moved. Duplicate identifiers (including a GlobalID and an OTel trace_id referring to the same trace) are collapsed before the update.
- **`destination_project_id`** — the resolved Project GlobalID.
- The route is registered before `/traces/{trace_identifier}` so the literal path cannot be shadowed if a `POST` is ever added to the parameterized route.

## Validation

Mirrors the mutation:

- at least one trace identifier is required (`422`)
- every trace identifier must resolve (`404`) — an unparseable identifier is treated as an unknown OTel trace_id
- **all traces must currently belong to a single source project** (`422`) — a mixed-source request is ambiguous
- the destination project must exist (`404`)

## Permissions

`prevent_access_in_read_only_mode`, `restrict_access_by_viewers` and `is_not_locked` — the REST equivalents of the mutation's `[IsNotReadOnly, IsNotViewer]` plus the locked check, matching the MEMBER+ requirement in the issue.

A `SpanDeleteEvent` is emitted for both the source and destination projects to invalidate per-project cached aggregates (record counts, token counts/costs, latency quantiles, time ranges).

## Tests

Nine tests in `tests/unit/server/api/routers/v1/test_traces.py`, all passing against SQLite:

- moves traces and re-parents them in the DB
- accepts OTel trace_ids, including mixed with GlobalIDs in one request
- accepts a project GlobalID as the destination identifier
- deduplicates repeated trace identifiers
- `422` traces spanning multiple source projects
- `422` empty `trace_identifiers`
- `404` unknown trace
- `404` unknown destination project
- `404` unparseable identifier (treated as an unknown OTel trace_id)

**I could not run the Postgres matrix locally** (no local Postgres/Docker), so that path is covered only by CI here.

## Generated files

`schemas/openapi.json` and the four generated clients were regenerated with the documented codegen flow. As in #15361, the regenerated Python client also picks up `outcome: NotRequired[str]` on `PhoenixToolCallCallbackProviderMetadata` — pre-existing drift on `main`, unrelated to this change.
