### PR TITLE
feat(online-evals): show evaluator config columns in the project evaluators table

### DIFF
--- a/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -1,11 +1,17 @@
 import { css } from "@emotion/react";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, ColumnSizingState } from "@tanstack/react-table";
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { startTransition, useCallback, useEffect, useMemo } from "react";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { graphql, readInlineData, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 
@@ -19,10 +25,19 @@ import {
   View,
 } from "@phoenix/components";
 import { CompactEmptyState } from "@phoenix/components/core/empty";
+import { PythonSVG, TypeScriptSVG } from "@phoenix/components/core/icon/Icons";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { EvaluatorKindToken } from "@phoenix/components/evaluators/EvaluatorKindToken";
+import { GenerativeProviderIcon } from "@phoenix/components/generative";
+import { SandboxConfigLabel } from "@phoenix/components/sandbox/SandboxConfigLabel";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
-import { selectableTableCSS } from "@phoenix/components/table/styles";
+import {
+  getCommonPinningStyles,
+  selectableTableCSS,
+} from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
+import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+import { PromptCell } from "@phoenix/pages/evaluators/PromptCell";
 import type { ProjectEvaluatorsTable_project$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql";
 import type { ProjectEvaluatorsTable_row$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql";
 import { ProjectEvaluatorActionMenu } from "@phoenix/pages/project/evaluators/ProjectEvaluatorActionMenu";
@@ -33,6 +48,7 @@ import {
   formatEvaluationTarget,
   formatSamplingRate,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import { isModelProvider } from "@phoenix/utils/generativeUtils";
 
 const PAGE_SIZE = 30;
 
@@ -52,8 +68,32 @@ const readRow = (row: ProjectEvaluatorsTable_row$key) => {
         filterCondition
         samplingRate
         enabled
+        updatedAt
         evaluator {
           kind
+          ... on LLMEvaluator {
+            prompt {
+              id
+              name
+            }
+            promptVersionTag {
+              name
+            }
+            promptVersion {
+              modelName
+              modelProvider
+            }
+          }
+          ... on CodeEvaluator {
+            language
+            sandboxConfig {
+              id
+              name
+              provider {
+                backendType
+              }
+            }
+          }
         }
       }
     `,
@@ -133,7 +173,8 @@ export function ProjectEvaluatorsTable({
   const columns = useMemo<ColumnDef<TableRow>[]>(
     () => [
       {
-        header: "Name",
+        header: "name",
+        size: 200,
         accessorKey: "name",
         cell: ({ getValue, row }) => (
           <Link to={paths.details(row.original.id)}>
@@ -142,14 +183,99 @@ export function ProjectEvaluatorsTable({
         ),
       },
       {
+        id: "kind",
+        header: "kind",
+        size: 80,
+        cell: ({ row }) => (
+          <EvaluatorKindToken kind={row.original.evaluator.kind} />
+        ),
+      },
+      {
+        id: "prompt",
+        header: "prompt",
+        size: 180,
+        cell: ({ row }) => {
+          const { prompt, promptVersionTag } = row.original.evaluator;
+          if (!prompt) {
+            return <Text color="text-700">—</Text>;
+          }
+          return (
+            <PromptCell
+              prompt={prompt}
+              promptVersionTag={promptVersionTag?.name}
+            />
+          );
+        },
+      },
+      {
+        id: "model",
+        header: "model",
+        size: 180,
+        cell: ({ row }) => {
+          const promptVersion = row.original.evaluator.promptVersion;
+          if (!promptVersion) {
+            return <Text color="text-700">—</Text>;
+          }
+          const { modelName, modelProvider } = promptVersion;
+          const providerIsValid = isModelProvider(modelProvider);
+          return (
+            <Flex direction="row" gap="size-100" alignItems="center">
+              {providerIsValid && (
+                <GenerativeProviderIcon provider={modelProvider} height={16} />
+              )}
+              <Text minWidth={0}>
+                <Truncate>{modelName}</Truncate>
+              </Text>
+            </Flex>
+          );
+        },
+      },
+      {
+        id: "language",
+        header: "language",
+        size: 110,
+        cell: ({ row }) => {
+          const language = row.original.evaluator.language;
+          if (!language) {
+            return <Text color="text-700">—</Text>;
+          }
+          return (
+            <Flex direction="row" gap="size-100" alignItems="center">
+              {language === "PYTHON" ? <PythonSVG /> : <TypeScriptSVG />}
+              <Text>{language === "PYTHON" ? "Python" : "TypeScript"}</Text>
+            </Flex>
+          );
+        },
+      },
+      {
+        id: "sandbox",
+        header: "sandbox",
+        size: 160,
+        cell: ({ row }) => {
+          const sandboxConfig = row.original.evaluator.sandboxConfig;
+          if (!sandboxConfig) {
+            return <Text color="text-700">—</Text>;
+          }
+          return (
+            <SandboxConfigLabel
+              sandboxConfigId={sandboxConfig.id}
+              name={sandboxConfig.name}
+              backendType={sandboxConfig.provider.backendType}
+            />
+          );
+        },
+      },
+      {
         id: "target",
-        header: "Target",
+        header: "target",
+        size: 110,
         cell: ({ row }) =>
           formatEvaluationTarget(row.original.evaluationTarget),
       },
       {
         id: "filter",
-        header: "Filter",
+        header: "filter",
+        size: 180,
         cell: ({ row }) => (
           <Text color={row.original.filterCondition ? undefined : "text-700"}>
             {row.original.filterCondition || "All spans"}
@@ -158,12 +284,21 @@ export function ProjectEvaluatorsTable({
       },
       {
         id: "sampling",
-        header: "Sampling",
+        header: "sampling",
+        size: 100,
         cell: ({ row }) => formatSamplingRate(row.original.samplingRate),
       },
       {
+        id: "updatedAt",
+        header: "last updated",
+        size: 160,
+        accessorKey: "updatedAt",
+        cell: TimestampCell,
+      },
+      {
         id: "enabled",
-        header: "Enabled",
+        header: "enabled",
+        size: 90,
         cell: ({ row }) => (
           <StopPropagation>
             <ProjectEvaluatorEnabledSwitch
@@ -176,7 +311,8 @@ export function ProjectEvaluatorsTable({
       },
       {
         id: "actions",
-        header: "Actions",
+        header: "actions",
+        size: 80,
         cell: ({ row }) => (
           <ProjectEvaluatorActionMenu
             projectEvaluatorId={row.original.id}
@@ -191,12 +327,42 @@ export function ProjectEvaluatorsTable({
     [projectId, openEditSlideover, paths]
   );
   // eslint-disable-next-line react-hooks-js/incompatible-library
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
   const table = useReactTable({
     columns,
     data: tableData,
+    state: {
+      columnPinning: {
+        right: ["enabled", "actions"],
+      },
+      columnSizing,
+    },
+    columnResizeMode: "onChange",
+    onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
   });
+  const { columnSizingInfo } = table.getState();
+  const getFlatHeaders = table.getFlatHeaders;
+  /**
+   * Calculate all column sizes at once at the root table level
+   * and pass them down as CSS variables to the <table> element.
+   * This avoids calling `column.getSize()` on every render for every cell.
+   * @see https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
+   */
+  const columnSizeVars = useMemo(() => {
+    const headers = getFlatHeaders();
+    const colSizes: { [key: string]: number } = {};
+    for (let i = 0; i < headers.length; i++) {
+      const header = headers[i]!;
+      colSizes[`--header-${header.id}-size`] = header.getSize();
+      colSizes[`--col-${header.column.id}-size`] = header.column.getSize();
+    }
+    return colSizes;
+    // Disabled lint as per tanstack docs linked above
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getFlatHeaders, columnSizingInfo, columnSizing]);
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
   const isFiltered = trimmedFilter.length > 0;
@@ -209,18 +375,51 @@ export function ProjectEvaluatorsTable({
   }
   return (
     <div css={scrollableAreaCSS}>
-      <table css={selectableTableCSS} aria-label="Project evaluators">
+      <table
+        css={selectableTableCSS}
+        aria-label="Project evaluators"
+        style={{
+          ...columnSizeVars,
+          width: table.getTotalSize(),
+          minWidth: "100%",
+        }}
+      >
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
+                <th
+                  key={header.id}
+                  colSpan={header.colSpan}
+                  style={{
+                    width: `calc(var(--header-${header.id}-size) * 1px)`,
+                    ...(header.column.getIsPinned()
+                      ? {
+                          ...getCommonPinningStyles(header.column),
+                          zIndex: 3,
+                        }
+                      : {}),
+                  }}
+                >
+                  {header.isPlaceholder ? null : (
+                    <>
+                      <div>
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                      </div>
+                      <div
+                        {...{
+                          onMouseDown: header.getResizeHandler(),
+                          onTouchStart: header.getResizeHandler(),
+                          className: `resizer ${
+                            header.column.getIsResizing() ? "isResizing" : ""
+                          }`,
+                        }}
+                      />
+                    </>
+                  )}
                 </th>
               ))}
             </tr>
@@ -241,11 +440,29 @@ export function ProjectEvaluatorsTable({
                 key={row.id}
                 onClick={() => navigate(paths.details(row.original.id))}
               >
-                {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
+                {row.getVisibleCells().map((cell) => {
+                  const colSizeVar = `--col-${cell.column.id}-size`;
+                  return (
+                    <td
+                      key={cell.id}
+                      style={{
+                        width: `calc(var(${colSizeVar}) * 1px)`,
+                        maxWidth: `calc(var(${colSizeVar}) * 1px)`,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        ...(cell.column.getIsPinned()
+                          ? getCommonPinningStyles(cell.column)
+                          : {}),
+                      }}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<73baeaaeec65037620cdccb76819f671>>
+ * @generated SignedSource<<e12a19b80833e77062a0bf9af6fa0112>>
  * @lightSyntaxTransform
  */
 
@@ -57,7 +57,14 @@ v4 = [
     "name": "first",
     "value": 30
   }
-];
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*:: as any*/),
@@ -136,13 +143,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*:: as any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
+                          (v5/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -174,6 +175,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": null,
                             "kind": "LinkedField",
                             "name": "evaluator",
@@ -186,6 +194,111 @@ return {
                                 "kind": "ScalarField",
                                 "name": "kind",
                                 "storageKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Prompt",
+                                    "kind": "LinkedField",
+                                    "name": "prompt",
+                                    "plural": false,
+                                    "selections": [
+                                      (v3/*:: as any*/),
+                                      (v5/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptVersionTag",
+                                    "kind": "LinkedField",
+                                    "name": "promptVersionTag",
+                                    "plural": false,
+                                    "selections": [
+                                      (v5/*:: as any*/),
+                                      (v3/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptVersion",
+                                    "kind": "LinkedField",
+                                    "name": "promptVersion",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "modelName",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "modelProvider",
+                                        "storageKey": null
+                                      },
+                                      (v3/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "LLMEvaluator",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "language",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SandboxConfig",
+                                    "kind": "LinkedField",
+                                    "name": "sandboxConfig",
+                                    "plural": false,
+                                    "selections": [
+                                      (v3/*:: as any*/),
+                                      (v5/*:: as any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "SandboxProvider",
+                                        "kind": "LinkedField",
+                                        "name": "provider",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "backendType",
+                                            "storageKey": null
+                                          },
+                                          (v3/*:: as any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "CodeEvaluator",
+                                "abstractKey": null
                               },
                               (v3/*:: as any*/)
                             ],
@@ -254,12 +367,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "60471dd4b202845e95f3b5db106eb8d4",
+    "cacheID": "5b5b40ba96125b7dc6ca3f622523945c",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsPageQuery(\n  $projectId: ID!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectEvaluatorsTable_project\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project on Project {\n  evaluators(first: 30) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  evaluator {\n    __typename\n    kind\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorsPageQuery(\n  $projectId: ID!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectEvaluatorsTable_project\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project on Project {\n  evaluators(first: 30) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fb7526f611a86bf3404cb887e325e60>>
+ * @generated SignedSource<<f963f58d9b2289a61ac65e26bf58fb29>>
  * @lightSyntaxTransform
  */
 
@@ -90,6 +90,13 @@ v4 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -162,13 +169,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v4/*:: as any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
+                          (v5/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -200,6 +201,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": null,
                             "kind": "LinkedField",
                             "name": "evaluator",
@@ -212,6 +220,111 @@ return {
                                 "kind": "ScalarField",
                                 "name": "kind",
                                 "storageKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Prompt",
+                                    "kind": "LinkedField",
+                                    "name": "prompt",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*:: as any*/),
+                                      (v5/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptVersionTag",
+                                    "kind": "LinkedField",
+                                    "name": "promptVersionTag",
+                                    "plural": false,
+                                    "selections": [
+                                      (v5/*:: as any*/),
+                                      (v4/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptVersion",
+                                    "kind": "LinkedField",
+                                    "name": "promptVersion",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "modelName",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "modelProvider",
+                                        "storageKey": null
+                                      },
+                                      (v4/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "LLMEvaluator",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "language",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SandboxConfig",
+                                    "kind": "LinkedField",
+                                    "name": "sandboxConfig",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*:: as any*/),
+                                      (v5/*:: as any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "SandboxProvider",
+                                        "kind": "LinkedField",
+                                        "name": "provider",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "backendType",
+                                            "storageKey": null
+                                          },
+                                          (v4/*:: as any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "CodeEvaluator",
+                                "abstractKey": null
                               },
                               (v4/*:: as any*/)
                             ],
@@ -280,12 +393,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "54db04379164fa924f78bc296643425d",
+    "cacheID": "8dac28f42c05bbd9a107d9c9ac894581",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsTablePaginationQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_G9cLv\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_G9cLv on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  evaluator {\n    __typename\n    kind\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_G9cLv\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_G9cLv on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<41257a23e83fe69735107a60219f9167>>
+ * @generated SignedSource<<b0a88ddf710d1e2f063786deb3d4cf87>>
  * @lightSyntaxTransform
  */
 
@@ -36,6 +36,13 @@ v1 = {
   "args": null,
   "kind": "ScalarField",
   "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
   "storageKey": null
 };
 return {
@@ -122,13 +129,7 @@ return {
                   "name": "ProjectEvaluatorsTable_row",
                   "selections": [
                     (v1/*:: as any*/),
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "name",
-                      "storageKey": null
-                    },
+                    (v2/*:: as any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -160,6 +161,13 @@ return {
                     {
                       "alias": null,
                       "args": null,
+                      "kind": "ScalarField",
+                      "name": "updatedAt",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
                       "concreteType": null,
                       "kind": "LinkedField",
                       "name": "evaluator",
@@ -171,6 +179,108 @@ return {
                           "kind": "ScalarField",
                           "name": "kind",
                           "storageKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Prompt",
+                              "kind": "LinkedField",
+                              "name": "prompt",
+                              "plural": false,
+                              "selections": [
+                                (v1/*:: as any*/),
+                                (v2/*:: as any*/)
+                              ],
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "PromptVersionTag",
+                              "kind": "LinkedField",
+                              "name": "promptVersionTag",
+                              "plural": false,
+                              "selections": [
+                                (v2/*:: as any*/)
+                              ],
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "PromptVersion",
+                              "kind": "LinkedField",
+                              "name": "promptVersion",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "modelName",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "modelProvider",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "type": "LLMEvaluator",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "language",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "SandboxConfig",
+                              "kind": "LinkedField",
+                              "name": "sandboxConfig",
+                              "plural": false,
+                              "selections": [
+                                (v1/*:: as any*/),
+                                (v2/*:: as any*/),
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "concreteType": "SandboxProvider",
+                                  "kind": "LinkedField",
+                                  "name": "provider",
+                                  "plural": false,
+                                  "selections": [
+                                    {
+                                      "alias": null,
+                                      "args": null,
+                                      "kind": "ScalarField",
+                                      "name": "backendType",
+                                      "storageKey": null
+                                    }
+                                  ],
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "type": "CodeEvaluator",
+                          "abstractKey": null
                         }
                       ],
                       "storageKey": null

--- a/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9ab93d3554044b11f6402dcfa60b4755>>
+ * @generated SignedSource<<965113e717b30e0088b141e1e6e4064f>>
  * @lightSyntaxTransform
  */
 
@@ -10,17 +10,40 @@
 import { ReaderInlineDataFragment } from 'relay-runtime';
 export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type Language = "PYTHON" | "TYPESCRIPT";
+export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "MONTY" | "VERCEL" | "WASM";
 import { FragmentRefs } from "relay-runtime";
 export type ProjectEvaluatorsTable_row$data = {
   readonly enabled: boolean;
   readonly evaluationTarget: EvaluationTarget;
   readonly evaluator: {
     readonly kind: EvaluatorKind;
+    readonly language?: Language;
+    readonly prompt?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly promptVersion?: {
+      readonly modelName: string;
+      readonly modelProvider: ModelProvider;
+    };
+    readonly promptVersionTag?: {
+      readonly name: string;
+    } | null;
+    readonly sandboxConfig?: {
+      readonly id: string;
+      readonly name: string;
+      readonly provider: {
+        readonly backendType: SandboxBackendType;
+      };
+    } | null;
   };
   readonly filterCondition: string;
   readonly id: string;
   readonly name: string;
   readonly samplingRate: number;
+  readonly updatedAt: string;
   readonly " $fragmentType": "ProjectEvaluatorsTable_row";
 };
 export type ProjectEvaluatorsTable_row$key = {
@@ -33,6 +56,6 @@ const node: ReaderInlineDataFragment = {
   "name": "ProjectEvaluatorsTable_row"
 };
 
-(node as any).hash = "b7cb83cf33e943187c0766746a2132f3";
+(node as any).hash = "b3af2600cc18279e0fae388fb2e9b0cf";
 
 export default node;

--- a/app/src/pages/project/evaluators/__generated__/refetchProjectEvaluatorsQuery.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/refetchProjectEvaluatorsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef6d6b684fecfeda42747ded6aa6f331>>
+ * @generated SignedSource<<2bc8813c52016fb4b575b3ca6d237f05>>
  * @lightSyntaxTransform
  */
 
@@ -105,24 +105,72 @@ v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "kind",
+  "name": "updatedAt",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "kind",
   "storageKey": null
 },
 v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Prompt",
+  "kind": "LinkedField",
+  "name": "prompt",
+  "plural": false,
+  "selections": [
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
+  ],
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "modelName",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "modelProvider",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "language",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "backendType",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v13 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -147,7 +195,7 @@ v13 = {
   ],
   "storageKey": null
 },
-v14 = [
+v20 = [
   {
     "kind": "Variable",
     "name": "first",
@@ -210,6 +258,7 @@ return {
                               (v7/*:: as any*/),
                               (v8/*:: as any*/),
                               (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -218,7 +267,73 @@ return {
                                 "name": "evaluator",
                                 "plural": false,
                                 "selections": [
-                                  (v10/*:: as any*/)
+                                  (v11/*:: as any*/),
+                                  {
+                                    "kind": "InlineFragment",
+                                    "selections": [
+                                      (v12/*:: as any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "PromptVersionTag",
+                                        "kind": "LinkedField",
+                                        "name": "promptVersionTag",
+                                        "plural": false,
+                                        "selections": [
+                                          (v5/*:: as any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "PromptVersion",
+                                        "kind": "LinkedField",
+                                        "name": "promptVersion",
+                                        "plural": false,
+                                        "selections": [
+                                          (v13/*:: as any*/),
+                                          (v14/*:: as any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "type": "LLMEvaluator",
+                                    "abstractKey": null
+                                  },
+                                  {
+                                    "kind": "InlineFragment",
+                                    "selections": [
+                                      (v15/*:: as any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "SandboxConfig",
+                                        "kind": "LinkedField",
+                                        "name": "sandboxConfig",
+                                        "plural": false,
+                                        "selections": [
+                                          (v4/*:: as any*/),
+                                          (v5/*:: as any*/),
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "SandboxProvider",
+                                            "kind": "LinkedField",
+                                            "name": "provider",
+                                            "plural": false,
+                                            "selections": [
+                                              (v16/*:: as any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "type": "CodeEvaluator",
+                                    "abstractKey": null
+                                  }
                                 ],
                                 "storageKey": null
                               }
@@ -226,15 +341,15 @@ return {
                             "args": null,
                             "argumentDefinitions": []
                           },
-                          (v11/*:: as any*/)
+                          (v17/*:: as any*/)
                         ],
                         "storageKey": null
                       },
-                      (v12/*:: as any*/)
+                      (v18/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v13/*:: as any*/)
+                  (v19/*:: as any*/)
                 ],
                 "storageKey": null
               }
@@ -266,14 +381,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v11/*:: as any*/),
+          (v17/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               (v3/*:: as any*/),
               {
                 "alias": null,
-                "args": (v14/*:: as any*/),
+                "args": (v20/*:: as any*/),
                 "concreteType": "ProjectEvaluatorConnection",
                 "kind": "LinkedField",
                 "name": "evaluators",
@@ -301,6 +416,7 @@ return {
                           (v7/*:: as any*/),
                           (v8/*:: as any*/),
                           (v9/*:: as any*/),
+                          (v10/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -309,27 +425,96 @@ return {
                             "name": "evaluator",
                             "plural": false,
                             "selections": [
+                              (v17/*:: as any*/),
                               (v11/*:: as any*/),
-                              (v10/*:: as any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v12/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptVersionTag",
+                                    "kind": "LinkedField",
+                                    "name": "promptVersionTag",
+                                    "plural": false,
+                                    "selections": [
+                                      (v5/*:: as any*/),
+                                      (v4/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "PromptVersion",
+                                    "kind": "LinkedField",
+                                    "name": "promptVersion",
+                                    "plural": false,
+                                    "selections": [
+                                      (v13/*:: as any*/),
+                                      (v14/*:: as any*/),
+                                      (v4/*:: as any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "LLMEvaluator",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v15/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SandboxConfig",
+                                    "kind": "LinkedField",
+                                    "name": "sandboxConfig",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*:: as any*/),
+                                      (v5/*:: as any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "SandboxProvider",
+                                        "kind": "LinkedField",
+                                        "name": "provider",
+                                        "plural": false,
+                                        "selections": [
+                                          (v16/*:: as any*/),
+                                          (v4/*:: as any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "CodeEvaluator",
+                                "abstractKey": null
+                              },
                               (v4/*:: as any*/)
                             ],
                             "storageKey": null
                           },
-                          (v11/*:: as any*/)
+                          (v17/*:: as any*/)
                         ],
                         "storageKey": null
                       },
-                      (v12/*:: as any*/)
+                      (v18/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v13/*:: as any*/)
+                  (v19/*:: as any*/)
                 ],
                 "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v14/*:: as any*/),
+                "args": (v20/*:: as any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "ProjectEvaluatorsTable_evaluators",
@@ -347,7 +532,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "82ed3e8b8cbae8b6f7e7e38d9740a2c2",
+    "cacheID": "dfcfa74eff5fd31277862cb0484845b5",
     "id": null,
     "metadata": {
       "connection": [
@@ -364,7 +549,7 @@ return {
     },
     "name": "refetchProjectEvaluatorsQuery",
     "operationKind": "query",
-    "text": "query refetchProjectEvaluatorsQuery(\n  $projectId: ID!\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      evaluators(first: $first) {\n        edges {\n          node {\n            ...ProjectEvaluatorsTable_row\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  evaluator {\n    __typename\n    kind\n    id\n  }\n}\n"
+    "text": "query refetchProjectEvaluatorsQuery(\n  $projectId: ID!\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      evaluators(first: $first) {\n        edges {\n          node {\n            ...ProjectEvaluatorsTable_row\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/UsersCard.tsx
+++ b/app/src/pages/settings/UsersCard.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from "react";
 import { Suspense, useMemo, useState } from "react";
-import { graphql, useLazyLoadQuery } from "react-relay";
+import {
+  fetchQuery,
+  graphql,
+  useLazyLoadQuery,
+  useRelayEnvironment,
+} from "react-relay";
 
 import {
   Alert,
@@ -19,7 +24,14 @@ import type { UsersCardQuery } from "./__generated__/UsersCardQuery.graphql";
 import { NewUserDialog } from "./NewUserDialog";
 import { UsersTable } from "./UsersTable";
 
+const usersCardQuery = graphql`
+  query UsersCardQuery {
+    ...UsersTable_users
+  }
+`;
+
 export function UsersCard() {
+  const environment = useRelayEnvironment();
   const [fetchKey, setFetchKey] = useState(0);
   const [dialog, setDialog] = useState<ReactNode>(null);
   const [error, setError] = useState<string | null>(null);
@@ -39,11 +51,7 @@ export function UsersCard() {
   }, []);
 
   const data = useLazyLoadQuery<UsersCardQuery>(
-    graphql`
-      query UsersCardQuery {
-        ...UsersTable_users
-      }
-    `,
+    usersCardQuery,
     {},
     {
       fetchKey: fetchKey,
@@ -73,7 +81,16 @@ export function UsersCard() {
                     title: "User added",
                     message: `User ${username} has been added.`,
                   });
-                  setFetchKey((prev) => prev + 1);
+                  // A fetchKey bump alone dedupes into any UsersCardQuery that
+                  // was already in flight when the user was created, and that
+                  // response predates the insert. Join such a fetch first so
+                  // the bump below always issues a fresh network request.
+                  const bump = () => setFetchKey((prev) => prev + 1);
+                  fetchQuery<UsersCardQuery>(
+                    environment,
+                    usersCardQuery,
+                    {}
+                  ).subscribe({ complete: bump, error: bump });
                 }}
                 onNewUserCreationError={(error) => {
                   const formattedError =

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -84,6 +84,7 @@ from phoenix.config import (
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.db.insertion.project_session import advance_project_session_liveness
 from phoenix.db.types.data_stream_protocol import (
     AssistantMessageMetadataUsage,
     AssistantMessageMetadataUsageCacheTokenDetails,
@@ -117,7 +118,6 @@ from phoenix.db.types.data_stream_protocol import (
     UIMessagePart,
 )
 from phoenix.db.types.db_helper_types import UNDEFINED
-from phoenix.db.insertion.project_session import advance_project_session_liveness
 from phoenix.server.agents.agent_factory import build_agent
 from phoenix.server.agents.capabilities import get_external_tool_definition
 from phoenix.server.agents.capabilities.skills import Skill


### PR DESCRIPTION

Brings the project evaluators table up to parity with the dataset and global evaluator tables so an evaluator's full configuration is visible at a glance.

<img width="1728" height="956" alt="Screenshot 2026-08-11 at 7 36 43 PM" src="https://github.com/user-attachments/assets/07b6a1f0-3f02-4284-890a-47ee3a30de43" />


- **New columns**: kind, prompt (with pinned version tag), model (with provider icon), language, sandbox, and last updated — reusing the same cell components as the other evaluator tables (`EvaluatorKindToken`, `PromptCell`, `GenerativeProviderIcon`, `SandboxConfigLabel`, `TimestampCell`). Kind-specific columns show an em-dash placeholder when not applicable.
- **Pinned right columns**: the enabled switch and actions menu stay visible while the table scrolls horizontally, via `columnPinning` + the shared `getCommonPinningStyles`.
- **Uniform row heights**: cells are constrained to a single line with ellipsis truncation.
- **Column resizing**: drag handles on every header using the performant CSS-variable pattern from the other evaluator tables.
- Headers are lowercase to match the rest of the evaluator tables.

The `ProjectEvaluatorsTable_row` fragment now selects the LLM evaluator's prompt/model and the code evaluator's language/sandbox config; Relay artifacts regenerated.

## Testing

- `pnpm run typecheck` passes
- oxlint / oxfmt clean (one pre-existing warning untouched)