### PR TITLE
refactor(playground): drop the reasoning-model Chat Completions clients

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1987,70 +1987,6 @@ class OpenAIResponsesAPIStreamingClient(OpenAIStreamingClient):
             yield chunk
 
 
-# Not in the catalog; reachable only via an explicit CHAT_COMPLETIONS api type.
-class OpenAIReasoningChatCompletionsClient(OpenAIStreamingClient):
-    @override
-    def _to_openai_chat_completion_message_param(
-        self,
-        message: PlaygroundMessage,
-    ) -> Optional["ChatCompletionMessageParam"]:
-        from openai.types.chat import (
-            ChatCompletionAssistantMessageParam,
-            ChatCompletionDeveloperMessageParam,
-            ChatCompletionMessageToolCallParam,
-            ChatCompletionToolMessageParam,
-            ChatCompletionUserMessageParam,
-        )
-        from openai.types.chat.chat_completion_message_function_tool_call_param import Function
-
-        role = message["role"]
-        content = message["content"]
-        tool_call_id = message.get("tool_call_id")
-        tool_calls = message.get("tool_calls")
-
-        if role is ChatCompletionMessageRole.USER:
-            return ChatCompletionUserMessageParam(
-                content=content,
-                role="user",
-            )
-        if role is ChatCompletionMessageRole.SYSTEM:
-            return ChatCompletionDeveloperMessageParam(
-                content=content,
-                role="developer",
-            )
-        if role is ChatCompletionMessageRole.AI:
-            if tool_calls is None:
-                return ChatCompletionAssistantMessageParam(
-                    content=content,
-                    role="assistant",
-                )
-            else:
-                return ChatCompletionAssistantMessageParam(
-                    content=content,
-                    role="assistant",
-                    tool_calls=[
-                        ChatCompletionMessageToolCallParam(
-                            type="function",
-                            id=tool_call["id"],
-                            function=Function(
-                                name=tool_call["function"]["name"],
-                                arguments=safe_json_dumps(tool_call["function"]["arguments"]),
-                            ),
-                        )
-                        for tool_call in tool_calls
-                    ],
-                )
-        if role is ChatCompletionMessageRole.TOOL:
-            if tool_call_id is None:
-                raise ValueError("tool_call_id is required for tool messages")
-            return ChatCompletionToolMessageParam(
-                content=content,
-                role="tool",
-                tool_call_id=tool_call_id,
-            )
-        assert_never(role)
-
-
 @register_llm_client(
     provider_key=GenerativeProviderKey.AZURE_OPENAI,
     model_names=[
@@ -2105,70 +2041,6 @@ class AzureOpenAIResponsesAPIStreamingClient(AzureOpenAIStreamingClient):
     def get_rate_limit_key(self) -> Hashable:
         """Azure has per-deployment rate limits (endpoint + model_name)."""
         return (self._client_factory.rate_limit_key, self.model_name)
-
-
-# Not in the catalog; reachable only via an explicit CHAT_COMPLETIONS api type.
-class AzureOpenAIReasoningChatCompletionsClient(AzureOpenAIStreamingClient):
-    @override
-    def _to_openai_chat_completion_message_param(
-        self,
-        message: PlaygroundMessage,
-    ) -> ChatCompletionMessageParam | None:
-        from openai.types.chat import (
-            ChatCompletionAssistantMessageParam,
-            ChatCompletionDeveloperMessageParam,
-            ChatCompletionMessageToolCallParam,
-            ChatCompletionToolMessageParam,
-            ChatCompletionUserMessageParam,
-        )
-        from openai.types.chat.chat_completion_message_function_tool_call_param import Function
-
-        role = message["role"]
-        content = message["content"]
-        tool_call_id = message.get("tool_call_id")
-        tool_calls = message.get("tool_calls")
-
-        if role is ChatCompletionMessageRole.USER:
-            return ChatCompletionUserMessageParam(
-                content=content,
-                role="user",
-            )
-        if role is ChatCompletionMessageRole.SYSTEM:
-            return ChatCompletionDeveloperMessageParam(
-                content=content,
-                role="developer",
-            )
-        if role is ChatCompletionMessageRole.AI:
-            if tool_calls is None:
-                return ChatCompletionAssistantMessageParam(
-                    content=content,
-                    role="assistant",
-                )
-            else:
-                return ChatCompletionAssistantMessageParam(
-                    content=content,
-                    role="assistant",
-                    tool_calls=[
-                        ChatCompletionMessageToolCallParam(
-                            type="function",
-                            id=tool_call["id"],
-                            function=Function(
-                                name=tool_call["function"]["name"],
-                                arguments=safe_json_dumps(tool_call["function"]["arguments"]),
-                            ),
-                        )
-                        for tool_call in tool_calls
-                    ],
-                )
-        if role is ChatCompletionMessageRole.TOOL:
-            if tool_call_id is None:
-                raise ValueError("tool_call_id is required for tool messages")
-            return ChatCompletionToolMessageParam(
-                content=content,
-                role="tool",
-                tool_call_id=tool_call_id,
-            )
-        assert_never(role)
 
 
 def _anthropic_beta_headers_for_tools(
@@ -3287,8 +3159,6 @@ def get_openai_client_class(
 
     if provider_key == GenerativeProviderKey.OPENAI:
         if openai_api_type == OpenAIApiType.CHAT_COMPLETIONS:
-            if model_name in OPENAI_REASONING_MODELS:
-                return OpenAIReasoningChatCompletionsClient
             return OpenAIStreamingClient
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return OpenAIResponsesAPIStreamingClient
@@ -3300,8 +3170,6 @@ def get_openai_client_class(
 
     elif provider_key == GenerativeProviderKey.AZURE_OPENAI:
         if openai_api_type == OpenAIApiType.CHAT_COMPLETIONS:
-            if model_name in OPENAI_REASONING_MODELS:
-                return AzureOpenAIReasoningChatCompletionsClient
             return AzureOpenAIStreamingClient
         elif openai_api_type == OpenAIApiType.RESPONSES:
             return AzureOpenAIResponsesAPIStreamingClient

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -40,12 +40,10 @@ from phoenix.server.api.helpers.playground_clients import (
     OPENAI_CHAT_COMPLETIONS_MODELS,
     OPENAI_REASONING_MODELS,
     AnthropicStreamingClient,
-    AzureOpenAIReasoningChatCompletionsClient,
     AzureOpenAIResponsesAPIStreamingClient,
     AzureOpenAIStreamingClient,
     GoogleStreamingClient,
     OpenAIBaseStreamingClient,
-    OpenAIReasoningChatCompletionsClient,
     OpenAIResponsesAPIStreamingClient,
     OpenAIStreamingClient,
     _get_builtin_provider_client,
@@ -683,15 +681,16 @@ class TestGetOpenAIClientClass:
         )
         assert client_class is OpenAIStreamingClient
 
-    def test_openai_chat_completions_reasoning_model_returns_reasoning_client(self) -> None:
-        """Reasoning models (o1, o3) with CHAT_COMPLETIONS should return reasoning client."""
+    def test_openai_chat_completions_reasoning_model_returns_streaming_client(self) -> None:
+        """Reasoning models need no Chat Completions specialization -- they accept
+        `system` and every other parameter the base client sends."""
         for model_name in ["o1", "o3", "o3-mini", "gpt-5.6-luna"]:
             client_class = get_openai_client_class(
                 GenerativeProviderKey.OPENAI,
                 model_name,
                 OpenAIApiType.CHAT_COMPLETIONS,
             )
-            assert client_class is OpenAIReasoningChatCompletionsClient, f"Failed for {model_name}"
+            assert client_class is OpenAIStreamingClient, f"Failed for {model_name}"
 
     def test_openai_responses_returns_responses_client(self) -> None:
         """RESPONSES API type should return OpenAIResponsesAPIStreamingClient."""
@@ -750,17 +749,15 @@ class TestGetOpenAIClientClass:
         )
         assert client_class is AzureOpenAIStreamingClient
 
-    def test_azure_chat_completions_reasoning_model_returns_reasoning_client(self) -> None:
-        """Azure reasoning models with CHAT_COMPLETIONS should return reasoning client."""
+    def test_azure_chat_completions_reasoning_model_returns_streaming_client(self) -> None:
+        """Azure reasoning models need no Chat Completions specialization either."""
         for model_name in ["o1", "gpt-5.6-luna"]:
             client_class = get_openai_client_class(
                 GenerativeProviderKey.AZURE_OPENAI,
                 model_name,
                 OpenAIApiType.CHAT_COMPLETIONS,
             )
-            assert client_class is AzureOpenAIReasoningChatCompletionsClient, (
-                f"Failed for {model_name}"
-            )
+            assert client_class is AzureOpenAIStreamingClient, f"Failed for {model_name}"
 
     def test_azure_responses_returns_azure_responses_client(self) -> None:
         """Azure with RESPONSES should return AzureOpenAIResponsesAPIStreamingClient."""
@@ -1020,22 +1017,22 @@ class TestDefaultApiTypeRouting:
         assert get_openai_client_class(provider_key, model_name, None) is expected_class
 
 
-class TestReasoningChatCompletionsMessages:
+class TestChatCompletionsMessageRoles:
     @pytest.mark.parametrize(
         "client_class",
-        [OpenAIReasoningChatCompletionsClient, AzureOpenAIReasoningChatCompletionsClient],
+        [OpenAIStreamingClient, AzureOpenAIStreamingClient],
     )
-    def test_system_messages_become_developer_messages(
+    def test_system_messages_keep_the_system_role(
         self, client_class: type[OpenAIBaseStreamingClient]
     ) -> None:
-        """Reasoning models take instructions on the `developer` role, not `system`."""
+        """`system` is sent as-is on every model, reasoning included.
+
+        Reasoning models accept `system` and treat it as a `developer` message, so
+        rewriting the role gains nothing and costs compatibility with the
+        OpenAI-compatible endpoints reachable through a custom base URL.
+        """
         message = create_playground_message(ChatCompletionMessageRole.SYSTEM, "be terse")
         param = client_class._to_openai_chat_completion_message_param(None, message)  # type: ignore[arg-type]
-        assert param == {"content": "be terse", "role": "developer"}
-
-    def test_non_reasoning_clients_keep_the_system_role(self) -> None:
-        message = create_playground_message(ChatCompletionMessageRole.SYSTEM, "be terse")
-        param = OpenAIStreamingClient._to_openai_chat_completion_message_param(None, message)  # type: ignore[arg-type]
         assert param == {"content": "be terse", "role": "system"}
 
 


### PR DESCRIPTION
Follow-up to #15362. Removes the two reasoning-model Chat Completions clients, whose only behavior was rewriting `system` messages to the `developer` role — something the OpenAI API has done on its own for every model we route.

## Background

`OpenAIReasoningChatCompletionsClient` and `AzureOpenAIReasoningChatCompletionsClient` were reachable only via an explicit `CHAT_COMPLETIONS` API type. Apart from `_to_openai_chat_completion_message_param`, which mapped `ChatCompletionMessageRole.SYSTEM` to `role: "developer"`, they were empty subclasses of the plain streaming clients.

That mapping was correct when written. `o1-preview` and `o1-mini` rejected the `system` role outright, and the `developer` role was introduced as its replacement.

## Why it is obsolete

Azure's reasoning-model reference (capability matrices, updated 2026-08-06) lists **System Messages: ✅** for every model in `OPENAI_REASONING_MODELS` — the whole `gpt-5.x` line through `gpt-5.6-sol/terra/luna`, and the o-series including `o1`, `o3`, `o3-mini`, `o3-pro`, `o4-mini`. The footnotes are explicit:

> The latest o\* series model support system messages to make migration easier. **When you use a system message with `o4-mini`, `o3`, `o3-mini`, and `o1` it will be treated as a developer message.** You should not use both a developer message and a system message in the same API request.

> Developer messages (`"role": "developer"`) are **functionally the same as system messages**.

So the API performs exactly the mapping this code performed. The two models that genuinely rejected `system` — `o1-preview` and `o1-mini` — have never been in `OPENAI_REASONING_MODELS`.

## Why sending `system` is the better default

Builtin OpenAI accepts a custom `base_url`, so these requests can reach OpenAI-compatible servers rather than `api.openai.com`. `system` is universally understood; `developer` is only implemented by servers tracking recent OpenAI releases. Rewriting the role traded a guaranteed-safe wire format for one that is not.

## Changes

- Delete `OpenAIReasoningChatCompletionsClient` and `AzureOpenAIReasoningChatCompletionsClient`.
- `get_openai_client_class` returns the plain streaming client for `CHAT_COMPLETIONS` on both providers, regardless of model name.
- Tests renamed and re-pointed; the role assertion now pins `system` in place rather than `developer`.

`-132` lines of source.

## Behavior delta

Measured over all 228 `(provider, api_type, model)` combinations, against the state of `main` **before** #15362:

```
52 of 228 changed:
  AzureOpenAIReasoningNonStreamingClient -> AzureOpenAIStreamingClient   (26 models)
  OpenAIReasoningNonStreamingClient      -> OpenAIStreamingClient        (26 models)
```

Every change is `CHAT_COMPLETIONS` on a reasoning model. The other 176 combinations are untouched.

The two halves are not equivalent, and the distinction matters for review:

| Provider | Effect |
|---|---|
| **OpenAI** | **No behavior change.** Its remap never executed — the method was named `_to_openai_chat_completion_param` while the request builder calls `_to_openai_chat_completion_message_param`, and there was no `@override` to catch it. The class was already indistinguishable from `OpenAIStreamingClient`. |
| **Azure** | **Real change.** Its override was correctly named and did run, so Azure requests now send `system` where they previously sent `developer`. Per the documentation above, the API maps that back to the same thing. |

## Verification

- 519 tests pass across `server/api/helpers/`, `test_subscriptions.py`, `test_create_llm_evaluator_from_inline.py`, `types/test_GenerativeProvider.py`
- `mypy` and `ruff` clean on changed files
- Routing delta confirmed exhaustively by snapshotting the full combination space before and after

## Sources

- [Azure OpenAI reasoning models — Microsoft Learn](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/reasoning) — capability matrices and footnotes on system/developer handling
- [Reasoning models — OpenAI API docs](https://developers.openai.com/api/docs/guides/reasoning)
- [O1 supports 'system' role, o1-mini does not? — OpenAI Developer Community](https://community.openai.com/t/o1-supports-system-role-o1-mini-does-not/1071954)

## Still open, not addressed here

- **The ten legacy names.** `OPENAI_CHAT_COMPLETIONS_MODELS` (`gpt-4o`, `gpt-4.1`, `gpt-3.5-turbo`, …) default to Chat Completions while every other name — including ones we have never seen — defaults to Responses. #15362 preserved this deliberately to stay behavior-neutral; it is an artifact of which names happened to be registered, not a decision anyone made.
- **Azure deployment aliases.** Azure model names are user-chosen, so a reasoning model deployed as e.g. `prod-evaluator` is not recognized and still falls to Chat Completions, where function tools plus `reasoning_effort` fail. Covered by a characterization test that documents it as a limitation. Closing it needs deployment metadata from Azure, not name matching.
- **Registry → plain data.** After #15362 the playground registry carries only the model catalog and dependency metadata. Converting it from decorators to a literal has no behavior value and touches GraphQL-visible surfaces, so it was left out.
