### PR TITLE
fix(playground): validate assistant prefill for Anthropic 4.6+ models before running

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -121,6 +121,7 @@ import { PlaygroundToolCall } from "./PlaygroundToolCall";
 import {
   extractRootVariable,
   getChatCompletionOverDatasetInput,
+  validateChatCompletionInput,
 } from "./playgroundUtils";
 
 const PAGE_SIZE = 10;
@@ -1097,6 +1098,16 @@ export function PlaygroundDatasetExamplesTable({
       const { activeRunId } = instance;
       setInstanceExperiment(instance.id, null);
       if (activeRunId === null) {
+        continue;
+      }
+
+      const validationError = validateChatCompletionInput({
+        playgroundStore,
+        instanceId: instance.id,
+      });
+      if (validationError != null) {
+        markPlaygroundInstanceComplete(instance.id);
+        setApiError(validationError);
         continue;
       }
 

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -43,7 +43,11 @@ import { PlaygroundErrorWrap } from "./PlaygroundErrorWrap";
 import { PlaygroundOutputMoveButton } from "./PlaygroundOutputMoveButton";
 import type { PartialOutputToolCall } from "./PlaygroundToolCall";
 import { PlaygroundToolCall } from "./PlaygroundToolCall";
-import { getChatCompletionInput, isChatMessages } from "./playgroundUtils";
+import {
+  getChatCompletionInput,
+  isChatMessages,
+  validateChatCompletionInput,
+} from "./playgroundUtils";
 import { RunMetadataFooter } from "./RunMetadataFooter";
 import { TitleWithAlphabeticIndex } from "./TitleWithAlphabeticIndex";
 import type { PlaygroundInstanceProps } from "./types";
@@ -306,6 +310,26 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
       return undefined;
     }
     setApiError(null);
+    const validationError = validateChatCompletionInput({
+      playgroundStore,
+      instanceId,
+    });
+    if (validationError != null) {
+      const repetitionNumbers = Object.keys(
+        playgroundStore
+          .getState()
+          .instances.find((instance) => instance.id === instanceId)
+          ?.repetitions ?? {}
+      );
+      markPlaygroundInstanceComplete(props.playgroundInstanceId);
+      for (const repetitionNumber of repetitionNumbers) {
+        setRepetitionError(instanceId, parseInt(repetitionNumber), {
+          title: "Invalid message order",
+          message: validationError,
+        });
+      }
+      return undefined;
+    }
     const input = getChatCompletionInput({
       playgroundStore,
       instanceId,
@@ -361,6 +385,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
     playgroundStore,
     props.playgroundInstanceId,
     setRepetitionStatus,
+    setRepetitionError,
   ]);
 
   return (

--- a/app/src/pages/playground/__tests__/validateChatCompletionInput.test.ts
+++ b/app/src/pages/playground/__tests__/validateChatCompletionInput.test.ts
@@ -1,0 +1,338 @@
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+import { getDefaultInvocationConfig } from "@phoenix/pages/playground/providerAdapters";
+import {
+  ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS,
+  validateChatCompletionInput,
+} from "@phoenix/pages/playground/playgroundUtils";
+import type { ChatMessage, PlaygroundInstance } from "@phoenix/store";
+import { createPlaygroundStore } from "@phoenix/store";
+
+installTestStorage();
+
+function makeMessage(
+  id: number,
+  role: ChatMessageRole,
+  content = "message"
+): ChatMessage {
+  return { id, role, content };
+}
+
+function makeInstance({
+  id,
+  modelName,
+  provider,
+  messages,
+}: {
+  id: number;
+  modelName: string | null;
+  provider: ModelProvider;
+  messages: ChatMessage[];
+}): PlaygroundInstance {
+  return {
+    id,
+    template: { __type: "chat", messages },
+    tools: [],
+    model: {
+      provider,
+      modelName,
+      invocationParameters: getDefaultInvocationConfig(provider),
+    },
+    repetitions: {},
+    activeRunId: null,
+    selectedRepetitionNumber: 1,
+  };
+}
+
+function makeStore(instances: PlaygroundInstance[]) {
+  return createPlaygroundStore({
+    datasetId: null,
+    instances,
+    modelConfigByProvider: {},
+  });
+}
+
+function makeAnthropicInstance(modelName: string, messages: ChatMessage[]) {
+  return makeInstance({ id: 0, modelName, provider: "ANTHROPIC", messages });
+}
+
+describe("validateChatCompletionInput", () => {
+  it("returns an error for claude-opus-4-6 when the last message is an assistant message", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).not.toBeNull();
+    expect(error).toContain("claude-opus-4-6");
+    expect(error).toContain("conversation A");
+  });
+
+  it("returns an error for claude-sonnet-4-6 when the last message is an assistant message", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-sonnet-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).not.toBeNull();
+    expect(error).toContain("claude-sonnet-4-6");
+  });
+
+  it("returns an error for claude-opus-5 (adaptive family) when the last message is an assistant message", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-5", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).not.toBeNull();
+    expect(error).toContain("claude-opus-5");
+  });
+
+  it("allows assistant prefill for pre-4.6 models like claude-3-5-sonnet-latest", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-3-5-sonnet-latest", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("allows assistant prefill for claude-haiku-4-5", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-haiku-4-5", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("allows claude-opus-4-6 when the last message is a user message", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+        makeMessage(3, "user"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("allows claude-opus-4-6 when the last message is a tool message", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+        makeMessage(3, "tool"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("returns an error when the last non-system message is an assistant message", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+        makeMessage(3, "system"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).not.toBeNull();
+  });
+
+  it("allows claude-opus-4-6 for a [system, user] conversation", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "system"),
+        makeMessage(2, "user"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("allows claude-opus-4-6 for a [user, ai, user] conversation", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+        makeMessage(3, "user"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("ignores non-Anthropic providers regardless of the last message role", () => {
+    const store = makeStore([
+      makeInstance({
+        id: 0,
+        modelName: "gpt-4o",
+        provider: "OPENAI",
+        messages: [makeMessage(1, "user"), makeMessage(2, "ai")],
+      }),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("returns null when the conversation has no messages", () => {
+    const store = makeStore([makeAnthropicInstance("claude-opus-4-6", [])]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("names the offending conversation with an alphabetic label in a multi-instance playground", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(100, "system"),
+        makeMessage(101, "user"),
+      ]),
+      makeInstance({
+        id: 1,
+        modelName: "claude-opus-4-6",
+        provider: "ANTHROPIC",
+        messages: [makeMessage(200, "user"), makeMessage(201, "ai")],
+      }),
+      makeAnthropicInstance("claude-sonnet-4-6", [
+        makeMessage(300, "system"),
+        makeMessage(301, "user"),
+      ]),
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(400, "system"),
+        makeMessage(401, "user"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[1].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).not.toBeNull();
+    expect(error).toContain("conversation B");
+  });
+
+  it("enumerates exactly the Anthropic models that reject assistant prefill", () => {
+    expect(ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS).toEqual([
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-opus-4-7",
+      "claude-opus-4-8",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-fable-5",
+    ]);
+    expect(ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS).not.toContain(
+      "claude-haiku-4-5"
+    );
+    expect(ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS).not.toContain(
+      "claude-3-5-sonnet-latest"
+    );
+  });
+
+  it("ignores a disallowed model name when the provider is not ANTHROPIC", () => {
+    const store = makeStore([
+      makeInstance({
+        id: 0,
+        modelName: "claude-opus-4-6",
+        provider: "OPENAI",
+        messages: [makeMessage(1, "user"), makeMessage(2, "ai")],
+      }),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("returns an error for claude-opus-4-6 on [ai, system] (last non-system is ai)", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "ai"),
+        makeMessage(2, "system"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).not.toBeNull();
+  });
+
+  it("allows claude-opus-4-6 on [user, system] (last non-system is user)", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "system"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("returns null for a [system]-only conversation (no user/ai message to judge)", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [makeMessage(1, "system")]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("returns null when the instance has no model name", () => {
+    const store = makeStore([
+      makeInstance({
+        id: 0,
+        modelName: null,
+        provider: "ANTHROPIC",
+        messages: [makeMessage(1, "user"), makeMessage(2, "ai")],
+      }),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+
+  it("returns null for an unknown instance id", () => {
+    const store = makeStore([
+      makeAnthropicInstance("claude-opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId: 9999 });
+    expect(error).toBeNull();
+  });
+
+  it("matches model names exactly (case-sensitive), so a case variant is not flagged", () => {
+    // The blocklist is matched exactly; the Anthropic registry uses lowercase ids,
+    // so a differently-cased name is treated as a different (unsupported-by-gate) model.
+    const store = makeStore([
+      makeAnthropicInstance("Claude-Opus-4-6", [
+        makeMessage(1, "user"),
+        makeMessage(2, "ai"),
+      ]),
+    ]);
+    const instanceId = store.getState().instances[0].id;
+    const error = validateChatCompletionInput({ playgroundStore: store, instanceId });
+    expect(error).toBeNull();
+  });
+});

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -2093,6 +2093,66 @@ export function buildPromptVersionInput({
 }
 
 /**
+ * Anthropic models that reject assistant message prefill (a conversation whose
+ * final message is not a user or tool message). The Anthropic Messages API
+ * returns a 400 for these models when the last message has role "ai".
+ * Keep in sync with the Anthropic model lists in
+ * `src/phoenix/server/api/helpers/playground_clients.py`: this set is
+ * `ANTHROPIC_ADAPTIVE_THINKING_MODELS` plus `claude-opus-4-6` and
+ * `claude-sonnet-4-6`. It intentionally excludes models that still support
+ * assistant prefill (e.g. `claude-haiku-4-5`).
+ */
+export const ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS: readonly string[] = [
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-opus-4-7",
+  "claude-opus-4-8",
+  "claude-opus-5",
+  "claude-sonnet-5",
+  "claude-fable-5",
+];
+
+export function validateChatCompletionInput({
+  playgroundStore,
+  instanceId,
+}: {
+  playgroundStore: PlaygroundStore;
+  instanceId: number;
+}): string | null {
+  const { instances, allInstanceMessages } = playgroundStore.getState();
+  const instance = instances.find((i) => i.id === instanceId);
+  if (
+    instance == null ||
+    instance.template.__type !== "chat" ||
+    instance.model.provider !== "ANTHROPIC"
+  ) {
+    return null;
+  }
+  const modelName = instance.model.modelName;
+  if (
+    modelName == null ||
+    !ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS.includes(modelName)
+  ) {
+    return null;
+  }
+  const nonSystemMessages = instance.template.messageIds
+    .map((messageId) => allInstanceMessages[messageId])
+    .filter((message) => message != null && message.role !== "system");
+  const lastMessage = nonSystemMessages[nonSystemMessages.length - 1];
+  if (
+    lastMessage == null ||
+    lastMessage.role === "user" ||
+    lastMessage.role === "tool"
+  ) {
+    return null;
+  }
+  const conversationLabel = String.fromCharCode(
+    65 + instances.findIndex((i) => i.id === instanceId)
+  );
+  return `The model "${modelName}" used by conversation ${conversationLabel} does not support assistant message prefill. The final prompt message must have role "user" (or "tool").`;
+}
+
+/**
  * Gets chat completion input for running over variables.
  *
  * Builds the hub-and-spoke ChatCompletionInput shape where prompt content


### PR DESCRIPTION
resolves #11332

## Summary

Running a conversation in the Playground that ends with an assistant message against an Anthropic model that does not support assistant message prefill (e.g. `claude-opus-4-6`) currently fails with a raw provider 400 after the request is sent:

```
Error code: 400
invalid_request_error: This model does not support assistant message prefill. The conversation must end with a user message.
```

This change validates the conversation before the request is sent and surfaces a clear error that names the model and conversation, instead of the provider error appearing after the fact.

## Changes

- Add `ANTHROPIC_ASSISTANT_PREFILL_UNSUPPORTED_MODELS`, a constant list of Anthropic models that reject assistant message prefill (the 4.6+ generation).
- Add `validateChatCompletionInput`, a util that takes the playground store and returns an error message (or null) when the final non-system message of a conversation is not a user or tool message.
- Run the validation before starting a chat completion in the Playground output and before dataset example runs.
- Add unit tests covering the validation rule, provider gating, and the model list.

## Why this approach

Anthropic removed assistant message prefill support starting with the 4.6-generation models; older models still accept it. The check therefore needs to be model-aware and provider-aware. Keeping the affected models in a named constant makes the list easy to extend as more models are affected, and mirrors the existing Anthropic model-family constants on the server.

## Note on scope

- Only `ANTHROPIC` provider models are covered; Bedrock Converse model IDs use a different namespace and are out of scope.
- The list intentionally excludes models that still support prefill (e.g. `claude-haiku-4-5`).