### PR TITLE
ci: bump claude-code-action to v1.0.191 to unbreak sandboxed Bash

### DIFF
--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run Claude Code
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-docs-gap-audit.yml
+++ b/.github/workflows/claude-docs-gap-audit.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Run Claude Code
         if: steps.guard.outputs.ready == 'true'
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-llms-txt.yml
+++ b/.github/workflows/claude-llms-txt.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-skills-audit.yml
+++ b/.github/workflows/claude-skills-audit.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Hand off to Claude (fix regressions)
         id: claude_fix
         if: steps.changes.outputs.changed == 'true' && steps.verify.outcome == 'failure'
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1.0.191
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:


### PR DESCRIPTION
## Summary

Every Bash call in our Claude workflows has been failing since **July 27**, when [#14769](https://github.com/Arize-ai/phoenix/pull/14769) bumped `claude-code-action` to v1.0.183 (which pins Claude Code CLI **2.1.220**):

```
bwrap: Can't create file at /home/.mcp.json: Permission denied
```

The jobs still conclude `success`, so nothing surfaced. This bumps all nine workflows to **v1.0.191** (CLI 2.1.228), which contains the upstream fix.

## What was actually broken

`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` turns on the CLI's bubblewrap sandbox for every Bash call. That sandbox masks sensitive dotfiles with `--ro-bind /dev/null <path>`, walking the ancestors of the working directory. On a runner, cwd is `/home/runner/work/phoenix/phoenix`, so the walk runs past `$HOME` up to `/home`. There is no `/home/.mcp.json`, and `/home` is read-only inside the sandbox, so bwrap cannot create the mount point and aborts the whole invocation — before the command runs.

Consequence: `echo hello` fails. So does everything else, including with `dangerouslyDisableSandbox: true`. In [run 31560224179](https://github.com/Arize-ai/phoenix/actions/runs/31560224179/job/94000837347) the error appears 57 times and the review agent ends with:

> I can't run this review — the Bash tool is non-functional in this environment. … No GitHub comment was posted.

The check was green.

## Evidence

| Run | Pinned CLI | `bwrap:` errors in log |
|---|---|---|
| Jul 16 | 2.1.173 | 0 — review posted inline comments |
| Jul 21 | 2.1.173 | 0 |
| Aug 1 | 2.1.220 | 19 |
| Aug 12 (×2) | 2.1.220 | 57 / 31 |

**185** `claude-code-review` runs have reported success since July 28; every one spot-checked reviewed nothing and posted nothing. The same env var is set in all nine workflows here, so `@claude`, implement-issue, and the scheduled audits hit the same wall on any Bash use.

## The fix

Claude Code **2.1.227** ([release notes](https://github.com/anthropics/claude-code/releases/tag/v2.1.227)):

> Fixed every Bash command failing under `claude-code-action` with `allowed_non_write_users` on GitHub-hosted runners

Nothing in 2.1.221–2.1.226 addresses it. Mapping releases to pinned CLI (from `src/entrypoints/run.ts`):

| Action release | Pinned CLI | |
|---|---|---|
| v1.0.183 (current) | 2.1.220 | broken |
| v1.0.189 | 2.1.226 | broken |
| v1.0.190 | 2.1.227 | first fixed |
| **v1.0.191** | **2.1.228** | this PR |

`v1.0.191` → commit `239e3a730883eeb5c53db12b0fc9573b3024b126`. Note the tag is annotated, so `git/refs/tags/v1.0.191` returns `16e2063a…` (the tag object) — that SHA would not resolve in `uses:`; the dereferenced commit above is the correct pin.

Diffing `action.yml` v1.0.183 → v1.0.191: **no breaking input changes**, only a new `conclusion` output. The 28 intervening commits are CLI bumps plus fixes (max-turns enforcement, null `files` on large PRs, credential redaction in published output).

`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"` and the `Install subprocess isolation deps` steps stay as they are — the sandbox hardening is the thing we want to keep, and the action only installs bubblewrap/socat itself when `allowed_non_write_users` is set, which we don't use. Disabling the scrub was the alternative fix; it's strictly worse now that upstream has shipped a real one.

## How to verify

**This PR is its own canary** — it triggers `claude-code-review.yml` on itself.

Pass condition: **a review comment is actually posted, and the job log contains zero `bwrap:` lines.** A green check does not count — green-while-dead is the entire bug.

One caveat worth naming: the upstream fix is documented against `allowed_non_write_users`, while we enable the sandbox by setting the env var directly. Same code path in principle, but unverified for our configuration, and no reporter has confirmed the fix on the tracking issues yet. If the canary still shows `bwrap:` lines, the fallback is `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"` on `claude-code-review.yml` only — that workflow runs on same-repo non-draft PRs, unlike `claude.yml` / `claude-implement-issue.yml`, which take input from anyone and should keep the sandbox.

## Follow-up worth considering (not in this PR)

The failure mode is silent: every Bash call died and the job still reported success. A startup smoke check, or asserting that the review posted something, would have caught this in July instead of after two weeks of green no-ops.

Upstream tracking: [claude-code#83129](https://github.com/anthropics/claude-code/issues/83129), [claude-code#83922](https://github.com/anthropics/claude-code/issues/83922), [claude-code-action#1547](https://github.com/anthropics/claude-code-action/issues/1547) — all still open.
