### PR TITLE
chore(codegen): upgrade datamodel-code-generator to 0.72.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,9 +206,10 @@ codegen-python-client: ## Generate Python client types from OpenAPI
 		--use-default-kwarg \
 		--use-double-quotes \
 		--use-generic-container-types \
+		--no-use-union-operator \
 		--wrap-string-literal \
+		--formatters black isort \
 		--disable-timestamp
-	@$(UV) run python -c "import re; file = '$(PHOENIX_CLIENT_GENERATED)/v1/.dataclass.py'; lines = [re.sub(r'\\bSequence]', 'Sequence[Any]]', line) for line in open(file).readlines()]; open(file, 'w').writelines(lines)"
 	@$(UV) run python $(CURDIR)/packages/phoenix-client/scripts/codegen/transform.py $(PHOENIX_CLIENT_GENERATED)/v1
 	@$(UV) run ruff format $(PHOENIX_CLIENT_GENERATED)/v1
 	@$(UV) run ruff check --fix $(PHOENIX_CLIENT_GENERATED)/v1

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,11 @@ schema-openapi: ## Generate OpenAPI schema from Python
 	@echo -e "$(GREEN)✓ schemas/openapi.json$(NC)"
 
 codegen-python-client: ## Generate Python client types from OpenAPI
+# `--use-generic-container-types` emits Sequence/Mapping rather than list/dict.
+# Its help text claims it requires --target-python-version 3.11+, but it takes
+# effect at 3.10 and the containers it emits (from collections.abc) are
+# subscriptable from 3.9 onward. Dropping it would widen the client's public
+# types from Sequence/Mapping to list/dict, so keep it despite the help text.
 	@echo -e "$(CYAN)Generating Python client types...$(NC)"
 	@rm -f $(PHOENIX_CLIENT_GENERATED)/v1/__init__.py
 	@$(UV) run datamodel-codegen \

--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,6 @@ schema-openapi: ## Generate OpenAPI schema from Python
 	@echo -e "$(GREEN)✓ schemas/openapi.json$(NC)"
 
 codegen-python-client: ## Generate Python client types from OpenAPI
-# `--use-generic-container-types` emits Sequence/Mapping rather than list/dict.
-# Its help text claims it requires --target-python-version 3.11+, but it takes
-# effect at 3.10 and the containers it emits (from collections.abc) are
-# subscriptable from 3.9 onward. Dropping it would widen the client's public
-# types from Sequence/Mapping to list/dict, so keep it despite the help text.
 	@echo -e "$(CYAN)Generating Python client types...$(NC)"
 	@rm -f $(PHOENIX_CLIENT_GENERATED)/v1/__init__.py
 	@$(UV) run datamodel-codegen \

--- a/packages/phoenix-client/scripts/codegen/transform.py
+++ b/packages/phoenix-client/scripts/codegen/transform.py
@@ -98,7 +98,8 @@ class ConvertDataClassToTypedDict(ast.NodeTransformer):
           - Convert str fields to datetime based on STR_TO_DATETIME_ALTERATIONS.
           - Rename fields ending with "_" (like schema_ or json_) by stripping the underscore.
           - Convert default values on fields (when present) to a NotRequired[...] annotation.
-          - Change `type: str = "xyz"` into `type: Literal["xyz"]`.
+          - Change `type: str = "xyz"` (or `type: Literal["xyz"] = "xyz"`) into a
+            required `type: Literal["xyz"]`.
           - If a field is Optional[...] with a default value, remove the Optional.
         """
         # Convert str fields to datetime based on STR_TO_DATETIME_ALTERATIONS
@@ -146,23 +147,35 @@ class ConvertDataClassToTypedDict(ast.NodeTransformer):
 
         # If there is a default value, perform further transformations.
         if isinstance(node.value, ast.Constant):
-            # Convert `type: str = "xyz"` into `type: Literal["xyz"]`
-            if (
-                isinstance(node.target, ast.Name)
-                and node.target.id == "type"
-                and isinstance(node.annotation, ast.Name)
-                and node.annotation.id == "str"
-            ):
-                return ast.AnnAssign(
-                    target=node.target,
-                    annotation=ast.Subscript(
-                        value=ast.Name(id="Literal", ctx=ast.Load()),
-                        slice=node.value,
-                        ctx=ast.Load(),
-                    ),
-                    value=None,  # Remove default value
-                    simple=node.simple,
-                )
+            # The "type" discriminator carries a schema default, but the server
+            # always emits it, so keep it a *required* Literal: it is the tag
+            # consumers switch on. Drop the default without wrapping the field
+            # in NotRequired.
+            if isinstance(node.target, ast.Name) and node.target.id == "type":
+                # Convert `type: str = "xyz"` into `type: Literal["xyz"]`
+                if isinstance(node.annotation, ast.Name) and node.annotation.id == "str":
+                    return ast.AnnAssign(
+                        target=node.target,
+                        annotation=ast.Subscript(
+                            value=ast.Name(id="Literal", ctx=ast.Load()),
+                            slice=node.value,
+                            ctx=ast.Load(),
+                        ),
+                        value=None,  # Remove default value
+                        simple=node.simple,
+                    )
+                # Convert `type: Literal["xyz"] = "xyz"` into `type: Literal["xyz"]`
+                if (
+                    isinstance(node.annotation, ast.Subscript)
+                    and isinstance(node.annotation.value, ast.Name)
+                    and node.annotation.value.id == "Literal"
+                ):
+                    return ast.AnnAssign(
+                        target=node.target,
+                        annotation=node.annotation,
+                        value=None,  # Remove default value
+                        simple=node.simple,
+                    )
             # Convert an Optional annotation (with a default) to the inner type.
             if (
                 isinstance(node.annotation, ast.Subscript)
@@ -187,6 +200,33 @@ class ConvertDataClassToTypedDict(ast.NodeTransformer):
                 simple=node.simple,
             )
         return node
+
+
+def is_union_alias(node: ast.stmt) -> bool:
+    """
+    Detect a top-level union alias emitted by the code generator.
+
+    The generator emits these in two shapes depending on its version and flags:
+
+        Alias = Union[A, B]                 # bare assignment
+        Alias: TypeAlias = Union[A, B]      # annotated assignment
+
+    Both are dropped from the output, because the client exposes the member
+    TypedDicts directly rather than the union aliases.
+
+    Args:
+        node: A top-level statement from the generated module.
+
+    Returns:
+        True if the statement is a union alias.
+    """
+    if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+        return False
+    return (
+        isinstance(node.value, ast.Subscript)
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "Union"
+    )
 
 
 def transform_dataclass(code: str) -> ast.AST:
@@ -219,16 +259,7 @@ def transform_dataclass(code: str) -> ast.AST:
             break
 
     # Remove top-level Union type definitions
-    parsed_ast.body = [
-        node
-        for node in parsed_ast.body
-        if not (
-            isinstance(node, ast.Assign)
-            and isinstance(node.value, ast.Subscript)
-            and isinstance(node.value.value, ast.Name)
-            and node.value.value.id == "Union"
-        )
-    ]
+    parsed_ast.body = [node for node in parsed_ast.body if not is_union_alias(node)]
 
     transformer = ConvertDataClassToTypedDict()
     transformed_ast = transformer.visit(parsed_ast)
@@ -381,6 +412,39 @@ def topologically_sort_classes(
 
 
 # =============================================================================
+# Import pruning.
+# =============================================================================
+def prune_unused_imports(module: ast.Module) -> ast.Module:
+    """
+    Drop imported names that the transformed module no longer references.
+
+    Dropping the top-level union aliases can remove the last use of a name the
+    generator imported for them (e.g. `TypeAlias`). Ruff cannot clean this up
+    on its own: it declines to auto-fix unused imports in an `__init__.py`,
+    since they are frequently deliberate re-exports.
+
+    Args:
+        module: The fully transformed module.
+
+    Returns:
+        The module, with unreferenced imported names removed in place.
+    """
+    used: set[str] = {node.id for node in ast.walk(module) if isinstance(node, ast.Name)}
+
+    new_body: list[ast.stmt] = []
+    for stmt in module.body:
+        # `__future__` imports are directives, not referenced by name.
+        if isinstance(stmt, ast.ImportFrom) and stmt.module != "__future__":
+            names = [alias for alias in stmt.names if (alias.asname or alias.name) in used]
+            if not names:
+                continue
+            stmt = ast.ImportFrom(module=stmt.module, names=names, level=stmt.level)
+        new_body.append(stmt)
+    module.body = new_body
+    return module
+
+
+# =============================================================================
 # File rewriting logic.
 # =============================================================================
 def rewrite_file(
@@ -423,6 +487,7 @@ def rewrite_file(
     new_body: list[ast.stmt] = non_class_statements + sorted_classes
 
     new_module: ast.Module = ast.Module(body=new_body, type_ignores=[])
+    new_module = prune_unused_imports(new_module)
     new_module = ast.fix_missing_locations(new_module)
 
     output_code: str = ast.unparse(new_module)

--- a/packages/phoenix-client/scripts/codegen/transform.py
+++ b/packages/phoenix-client/scripts/codegen/transform.py
@@ -1,7 +1,7 @@
 import ast
 import sys
 from pathlib import Path
-from typing import Callable, Literal, Mapping, Sequence
+from typing import Callable, Literal, Mapping, Optional, Sequence
 
 # =============================================================================
 # String-to-DateTime field type conversions
@@ -42,16 +42,16 @@ class ConvertDataClassToTypedDict(ast.NodeTransformer):
     def __init__(self):
         self.current_class_name = None
 
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.AST:
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> Optional[ast.AST]:
         """
-        Replace the dataclasses import with a TypedDict import from typing.
+        Drop the dataclasses import, which the TypedDict output does not need.
+
+        The replacement `TypedDict` import is injected by `transform_dataclass`
+        rather than substituted here, so that it does not depend on the
+        generator happening to emit an import from `dataclasses`.
         """
         if node.module == "dataclasses":
-            return ast.ImportFrom(
-                module="typing",
-                names=[ast.alias(name="TypedDict", asname=None)],
-                level=0,
-            )
+            return None
         return node
 
     def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
@@ -241,9 +241,16 @@ def transform_dataclass(code: str) -> ast.AST:
         The transformed AST.
     """
     parsed_ast: ast.Module = ast.parse(code)
-    # Insert the imports for NotRequired and datetime before the first class.
+    # Insert the imports for TypedDict, NotRequired and datetime before the
+    # first class. Any of these that turn out to be unused are dropped again by
+    # `prune_unused_imports`.
     for index, node in enumerate(parsed_ast.body):
         if isinstance(node, ast.ClassDef):
+            import_typeddict = ast.ImportFrom(
+                module="typing",
+                names=[ast.alias(name="TypedDict", asname=None)],
+                level=0,
+            )
             import_notrequired = ast.ImportFrom(
                 module="typing_extensions",
                 names=[ast.alias(name="NotRequired", asname=None)],
@@ -254,8 +261,9 @@ def transform_dataclass(code: str) -> ast.AST:
                 names=[ast.alias(name="datetime", asname=None)],
                 level=0,
             )
-            parsed_ast.body.insert(index, import_notrequired)
-            parsed_ast.body.insert(index + 1, import_datetime)
+            parsed_ast.body.insert(index, import_typeddict)
+            parsed_ast.body.insert(index + 1, import_notrequired)
+            parsed_ast.body.insert(index + 2, import_datetime)
             break
 
     # Remove top-level Union type definitions
@@ -272,11 +280,19 @@ def transform_dataclass(code: str) -> ast.AST:
 
 # Mapping from a class name to a list of its parent class names.
 PARENTS: Mapping[str, Sequence[str]] = {
-    "Prompt": ["PromptData"],
-    "PromptVersion": ["PromptVersionData"],
-    "SpanAnnotation": ["SpanAnnotationData"],
+    "ApiKey": ["ApiKeyData"],
+    "CategoricalAnnotationConfig": ["CategoricalAnnotationConfigData"],
+    "ContinuousAnnotationConfig": ["ContinuousAnnotationConfigData"],
+    "FreeformAnnotationConfig": ["FreeformAnnotationConfigData"],
+    "LDAPUser": ["LDAPUserData"],
     "LocalUser": ["LocalUserData"],
     "OAuth2User": ["OAuth2UserData"],
+    "Prompt": ["PromptData"],
+    "PromptVersion": ["PromptVersionData"],
+    "PromptVersionTag": ["PromptVersionTagData"],
+    "SessionAnnotation": ["SessionAnnotationData"],
+    "SpanAnnotation": ["SpanAnnotationData"],
+    "TraceAnnotation": ["TraceAnnotationData"],
 }
 
 
@@ -337,19 +353,24 @@ def remove_inherited_fields(
             ast.Name(id=parent, ctx=ast.Load()) for parent in parent_map[class_name]
         ]
 
-        # Collect the field names defined in the class.
-        child_field_names: set[str] = {
+        # Collect the field names defined in the class. A class body may hold
+        # statements that are not fields (a docstring, for instance), so only
+        # the annotated assignments are considered.
+        child_fields: list[str] = [
             stmt.target.id
             for stmt in node.body
             if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
-        }
-        # Ensure every statement in the body is an AnnAssign.
-        assert len(child_field_names) == len(node.body), "Every field must be an AnnAssign"
+        ]
+        child_field_names: set[str] = set(child_fields)
+        assert len(child_fields) == len(child_field_names), (
+            f"{class_name} declares a duplicate field"
+        )
 
         # Collect all ancestor field names.
         ancestor_field_names: set[str] = get_ancestor_fields(class_name, class_nodes, parent_map)
-        assert ancestor_field_names < child_field_names, (
-            "Ancestor fields must be a subset of child fields"
+        assert ancestor_field_names <= child_field_names, (
+            f"Ancestor fields must be a subset of {class_name}'s fields, but "
+            f"{sorted(ancestor_field_names - child_field_names)} are missing from it"
         )
 
         # Remove any inherited field from the class body.
@@ -363,6 +384,10 @@ def remove_inherited_fields(
                 and stmt.target.id in inherited_fields
             )
         ]
+        # A class that adds nothing to its ancestors would be left with an
+        # empty body, which is not valid Python.
+        if not new_body:
+            new_body = [ast.Pass()]
         new_class_nodes[class_name] = ast.ClassDef(
             name=node.name,
             bases=bases,

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -46,18 +46,15 @@ class AnonymousUser(TypedDict):
     auth_method: Literal["ANONYMOUS"]
 
 
-class ApiKey(TypedDict):
-    id: str
-    name: str
-    created_at: str
-    description: NotRequired[str]
-    expires_at: NotRequired[str]
-
-
 class ApiKeyData(TypedDict):
     name: str
     description: NotRequired[str]
     expires_at: NotRequired[str]
+
+
+class ApiKey(ApiKeyData):
+    id: str
+    created_at: str
 
 
 class ApiKeyUser(TypedDict):
@@ -351,21 +348,17 @@ class InsertedTraceAnnotation(TypedDict):
     id: str
 
 
-class LDAPUser(TypedDict):
-    id: str
-    created_at: str
-    updated_at: str
-    email: str
-    username: str
-    role: Literal["SYSTEM", "ADMIN", "MEMBER", "VIEWER"]
-    auth_method: Literal["LDAP"]
-
-
 class LDAPUserData(TypedDict):
     email: str
     username: str
     role: Literal["SYSTEM", "ADMIN", "MEMBER", "VIEWER"]
     auth_method: Literal["LDAP"]
+
+
+class LDAPUser(LDAPUserData):
+    id: str
+    created_at: str
+    updated_at: str
 
 
 class ListAgentSessionsResponseBody(TypedDict):
@@ -725,15 +718,13 @@ class PromptVersionContext(TypedDict):
     promptVersionNodeId: str
 
 
-class PromptVersionTag(TypedDict):
-    name: str
-    id: str
-    description: NotRequired[str]
-
-
 class PromptVersionTagData(TypedDict):
     name: str
     description: NotRequired[str]
+
+
+class PromptVersionTag(PromptVersionTagData):
+    id: str
 
 
 class PromptXAIInvocationParametersContent(TypedDict):
@@ -765,20 +756,6 @@ class SecretKeyValue(TypedDict):
     value: Optional[str]
 
 
-class SessionAnnotation(TypedDict):
-    id: str
-    created_at: str
-    updated_at: str
-    source: Literal["API", "APP"]
-    user_id: Optional[str]
-    name: str
-    annotator_kind: Literal["LLM", "CODE", "HUMAN"]
-    session_id: str
-    result: NotRequired[AnnotationResult]
-    metadata: NotRequired[Mapping[str, Any]]
-    identifier: NotRequired[str]
-
-
 class SessionAnnotationData(TypedDict):
     name: str
     annotator_kind: Literal["LLM", "CODE", "HUMAN"]
@@ -786,6 +763,14 @@ class SessionAnnotationData(TypedDict):
     result: NotRequired[AnnotationResult]
     metadata: NotRequired[Mapping[str, Any]]
     identifier: NotRequired[str]
+
+
+class SessionAnnotation(SessionAnnotationData):
+    id: str
+    created_at: str
+    updated_at: str
+    source: Literal["API", "APP"]
+    user_id: Optional[str]
 
 
 class SessionAnnotationsResponseBody(TypedDict):
@@ -986,20 +971,6 @@ class ToolResultContentPart(TypedDict):
     tool_result: Optional[Union[bool, int, float, str, Mapping[str, Any], Sequence[Any]]]
 
 
-class TraceAnnotation(TypedDict):
-    id: str
-    created_at: str
-    updated_at: str
-    source: Literal["API", "APP"]
-    user_id: Optional[str]
-    name: str
-    annotator_kind: Literal["LLM", "CODE", "HUMAN"]
-    trace_id: str
-    result: NotRequired[AnnotationResult]
-    metadata: NotRequired[Mapping[str, Any]]
-    identifier: NotRequired[str]
-
-
 class TraceAnnotationData(TypedDict):
     name: str
     annotator_kind: Literal["LLM", "CODE", "HUMAN"]
@@ -1007,6 +978,14 @@ class TraceAnnotationData(TypedDict):
     result: NotRequired[AnnotationResult]
     metadata: NotRequired[Mapping[str, Any]]
     identifier: NotRequired[str]
+
+
+class TraceAnnotation(TraceAnnotationData):
+    id: str
+    created_at: str
+    updated_at: str
+    source: Literal["API", "APP"]
+    user_id: Optional[str]
 
 
 class TraceAnnotationsResponseBody(TypedDict):
@@ -1357,21 +1336,16 @@ class BuiltInProviderModelSelection(TypedDict):
     modelName: str
 
 
-class CategoricalAnnotationConfig(TypedDict):
-    type: Literal["CATEGORICAL"]
-    name: str
-    optimization_direction: Literal["MINIMIZE", "MAXIMIZE", "NONE"]
-    values: Sequence[CategoricalAnnotationValue]
-    id: str
-    description: NotRequired[str]
-
-
 class CategoricalAnnotationConfigData(TypedDict):
     type: Literal["CATEGORICAL"]
     name: str
     optimization_direction: Literal["MINIMIZE", "MAXIMIZE", "NONE"]
     values: Sequence[CategoricalAnnotationValue]
     description: NotRequired[str]
+
+
+class CategoricalAnnotationConfig(CategoricalAnnotationConfigData):
+    id: str
 
 
 class ChatCompletionChoice(TypedDict):
@@ -1385,16 +1359,6 @@ class ChatCompletionRequestMessage(TypedDict):
     content: Union[str, Sequence[ChatCompletionTextPart]]
 
 
-class ContinuousAnnotationConfig(TypedDict):
-    type: Literal["CONTINUOUS"]
-    name: str
-    optimization_direction: Literal["MINIMIZE", "MAXIMIZE", "NONE"]
-    id: str
-    description: NotRequired[str]
-    lower_bound: NotRequired[float]
-    upper_bound: NotRequired[float]
-
-
 class ContinuousAnnotationConfigData(TypedDict):
     type: Literal["CONTINUOUS"]
     name: str
@@ -1402,6 +1366,10 @@ class ContinuousAnnotationConfigData(TypedDict):
     description: NotRequired[str]
     lower_bound: NotRequired[float]
     upper_bound: NotRequired[float]
+
+
+class ContinuousAnnotationConfig(ContinuousAnnotationConfigData):
+    id: str
 
 
 class CreateAgentSessionResponseBody(TypedDict):
@@ -1554,17 +1522,6 @@ class DynamicToolOutputDeniedPart(TypedDict):
     approval: NotRequired[Union[ToolApprovalRequested, ToolApprovalResponded]]
 
 
-class FreeformAnnotationConfig(TypedDict):
-    type: Literal["FREEFORM"]
-    name: str
-    id: str
-    description: NotRequired[str]
-    optimization_direction: NotRequired[Literal["MINIMIZE", "MAXIMIZE", "NONE"]]
-    threshold: NotRequired[float]
-    lower_bound: NotRequired[float]
-    upper_bound: NotRequired[float]
-
-
 class FreeformAnnotationConfigData(TypedDict):
     type: Literal["FREEFORM"]
     name: str
@@ -1573,6 +1530,10 @@ class FreeformAnnotationConfigData(TypedDict):
     threshold: NotRequired[float]
     lower_bound: NotRequired[float]
     upper_bound: NotRequired[float]
+
+
+class FreeformAnnotationConfig(FreeformAnnotationConfigData):
+    id: str
 
 
 class GetAllUserApiKeysResponseBody(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict, Union
+from typing import Any, Literal, Optional, TypedDict, Union
 
 from typing_extensions import NotRequired
 
@@ -100,7 +101,7 @@ class ChatCompletionErrorResponse(TypedDict):
 
 class ChatCompletionMessage(TypedDict):
     content: str
-    role: NotRequired[str]
+    role: NotRequired[Literal["assistant"]]
 
 
 class ChatCompletionStreamOptions(TypedDict):
@@ -188,9 +189,9 @@ class CreatedApiKey(TypedDict):
 
 
 class CustomProviderModelSelection(TypedDict):
+    providerType: Literal["custom"]
     providerId: str
     modelName: str
-    providerType: Literal["custom"]
 
 
 class DataUIPart(TypedDict):
@@ -933,7 +934,7 @@ class ToolApprovalRespondedPart(TypedDict):
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["approval-responded"]]
     input: NotRequired[Any]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -950,7 +951,7 @@ class ToolInputAvailablePart(TypedDict):
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["input-available"]]
     input: NotRequired[Any]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -961,7 +962,7 @@ class ToolInputStreamingPart(TypedDict):
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["input-streaming"]]
     input: NotRequired[Any]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -972,7 +973,7 @@ class ToolOutputDeniedPart(TypedDict):
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-denied"]]
     input: NotRequired[Any]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -1163,7 +1164,7 @@ class PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputAvailablePart
     input: Any
     output: Any
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-available"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     resultProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -1178,7 +1179,7 @@ class PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputErrorPart(Typ
     input: Any
     errorText: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-error"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     resultProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -1189,7 +1190,7 @@ class PhoenixDbTypesDataStreamProtocolRequestTypesToolOutputAvailablePart(TypedD
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-available"]]
     input: NotRequired[Any]
     output: NotRequired[Any]
     providerExecuted: NotRequired[bool]
@@ -1204,7 +1205,7 @@ class PhoenixDbTypesDataStreamProtocolRequestTypesToolOutputErrorPart(TypedDict)
     toolCallId: str
     errorText: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-error"]]
     input: NotRequired[Any]
     rawInput: NotRequired[Any]
     providerExecuted: NotRequired[bool]
@@ -1220,7 +1221,7 @@ class PydanticAiUiVercelAiRequestTypesDynamicToolOutputAvailablePart(TypedDict):
     input: Any
     output: Any
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-available"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     preliminary: NotRequired[bool]
@@ -1234,7 +1235,7 @@ class PydanticAiUiVercelAiRequestTypesDynamicToolOutputErrorPart(TypedDict):
     input: Any
     errorText: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-error"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     approval: NotRequired[Union[ToolApprovalRequested, ToolApprovalResponded]]
@@ -1244,7 +1245,7 @@ class PydanticAiUiVercelAiRequestTypesToolOutputAvailablePart(TypedDict):
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-available"]]
     input: NotRequired[Any]
     output: NotRequired[Any]
     providerExecuted: NotRequired[bool]
@@ -1258,7 +1259,7 @@ class PydanticAiUiVercelAiRequestTypesToolOutputErrorPart(TypedDict):
     toolCallId: str
     errorText: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-error"]]
     input: NotRequired[Any]
     rawInput: NotRequired[Any]
     providerExecuted: NotRequired[bool]
@@ -1275,7 +1276,7 @@ class PhoenixToolCallCallbackProviderMetadata(TypedDict):
     toolInputEmittedAt: NotRequired[str]
     clientStartedAt: NotRequired[str]
     clientEndedAt: NotRequired[str]
-    outcome: NotRequired[str]
+    outcome: NotRequired[Literal["interrupted"]]
 
 
 class PhoenixToolCallProviderMetadata(TypedDict):
@@ -1287,7 +1288,7 @@ class SessionSummaryChunk(TypedDict):
     type: Literal["data-session-summary"]
     data: str
     id: NotRequired[str]
-    transient: NotRequired[bool]
+    transient: NotRequired[Literal[True]]
 
 
 class TranscriptPersistedData(TypedDict):
@@ -1336,6 +1337,7 @@ class AssistantMessageMetadataUsage(TypedDict):
 
 
 class BuiltInProviderModelSelection(TypedDict):
+    providerType: Literal["builtin"]
     provider: Literal[
         "OPENAI",
         "AZURE_OPENAI",
@@ -1353,7 +1355,6 @@ class BuiltInProviderModelSelection(TypedDict):
         "TOGETHER",
     ]
     modelName: str
-    providerType: Literal["builtin"]
 
 
 class CategoricalAnnotationConfig(TypedDict):
@@ -1499,7 +1500,7 @@ class DynamicToolApprovalRequestedPart(TypedDict):
     toolCallId: str
     input: Any
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["approval-requested"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     approval: NotRequired[Union[ToolApprovalRequested, ToolApprovalResponded]]
@@ -1511,7 +1512,7 @@ class DynamicToolApprovalRespondedPart(TypedDict):
     toolCallId: str
     input: Any
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["approval-responded"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     approval: NotRequired[Union[ToolApprovalRequested, ToolApprovalResponded]]
@@ -1523,7 +1524,7 @@ class DynamicToolInputAvailablePart(TypedDict):
     toolCallId: str
     input: Any
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["input-available"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     approval: NotRequired[Union[ToolApprovalRequested, ToolApprovalResponded]]
@@ -1534,7 +1535,7 @@ class DynamicToolInputStreamingPart(TypedDict):
     toolName: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["input-streaming"]]
     input: NotRequired[Any]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -1547,7 +1548,7 @@ class DynamicToolOutputDeniedPart(TypedDict):
     toolCallId: str
     input: Any
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["output-denied"]]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
     approval: NotRequired[Union[ToolApprovalRequested, ToolApprovalResponded]]
@@ -1849,7 +1850,7 @@ class ToolApprovalRequestedPart(TypedDict):
     type: str
     toolCallId: str
     title: NotRequired[str]
-    state: NotRequired[str]
+    state: NotRequired[Literal["approval-requested"]]
     input: NotRequired[Any]
     providerExecuted: NotRequired[bool]
     callProviderMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
@@ -1893,7 +1894,7 @@ class TranscriptPersistedChunk(TypedDict):
     type: Literal["data-transcript-persisted"]
     data: TranscriptPersistedData
     id: NotRequired[str]
-    transient: NotRequired[bool]
+    transient: NotRequired[Literal[True]]
 
 
 class AgentSessionData(TypedDict):
@@ -1917,7 +1918,7 @@ class ChatCompletion(TypedDict):
     model: str
     choices: Sequence[ChatCompletionChoice]
     usage: ChatCompletionUsage
-    object: NotRequired[str]
+    object: NotRequired[Literal["chat.completion"]]
 
 
 class CompactAgentSessionRequestBody(TypedDict):
@@ -2002,10 +2003,10 @@ class LegacyAssistantMetadataUIMessage(TypedDict):
 
 
 class LegacyChatRegenerateMessage(TypedDict):
+    trigger: Literal["regenerate-message"]
     id: str
     messages: Sequence[LegacyAssistantMetadataUIMessage]
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
-    trigger: Literal["regenerate-message"]
     messageId: NotRequired[str]
     ingestTraces: NotRequired[bool]
     exportRemoteTraces: NotRequired[bool]
@@ -2038,7 +2039,7 @@ class LegacyChatSubmitMessage(TypedDict):
     id: str
     messages: Sequence[LegacyAssistantMetadataUIMessage]
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
-    trigger: Literal["submit-message"]
+    trigger: NotRequired[Literal["submit-message"]]
     ingestTraces: NotRequired[bool]
     exportRemoteTraces: NotRequired[bool]
     attachUserId: NotRequired[bool]
@@ -2158,7 +2159,7 @@ class ChatRequestBody(TypedDict):
     ]
     editPermission: NotRequired[Literal["manual", "bypass"]]
     requestedSkills: NotRequired[Sequence[str]]
-    trigger: NotRequired[str]
+    trigger: NotRequired[Literal["submit-message"]]
     message: NotRequired[PhoenixUIMessage]
     toolOutputs: NotRequired[
         Sequence[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,7 @@ dev = [
   "jupyter>=1.1.1",
   "ruff>=0.15.2",
   "libcst>=1.8.6",
-  "datamodel-code-generator==0.32.0",
+  "datamodel-code-generator==0.72.2",
   "grpcio-tools>=1.78.0",
   "mypy-protobuf>=5.0.0",
   "jinja2>=3.1.6",

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ dev = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "check-wheel-contents" },
-    { name = "datamodel-code-generator", specifier = "==0.32.0" },
+    { name = "datamodel-code-generator", specifier = "==0.72.2" },
     { name = "daytona-sdk", specifier = ">=0.140.0" },
     { name = "debugpy" },
     { name = "deepdiff", specifier = "==8.6.2" },
@@ -1947,23 +1947,22 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.32.0"
+version = "0.72.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
-    { name = "black" },
+    { name = "black", marker = "sys_platform != 'emscripten'" },
     { name = "genson" },
     { name = "inflect" },
-    { name = "isort" },
+    { name = "isort", marker = "sys_platform != 'emscripten'" },
     { name = "jinja2" },
-    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.12'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/66/5ad66a2b5ff34ed67808570f7476261f6f1de3263d0764db9483384878b7/datamodel_code_generator-0.32.0.tar.gz", hash = "sha256:c6f84a6a7683ef9841940b0931aa1ee338b19950ba5b10c920f9c7ad6f5e5b72", size = 457172, upload-time = "2025-07-25T14:12:06.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/12becb81ac1492ed5f6e3afcb2426e0d665c5ae51fa24bbe951b408dd867/datamodel_code_generator-0.72.2.tar.gz", hash = "sha256:0e11564564ccf12e8ae89ca28b7848c795b40609e9f011e7b3434428eebd6f12", size = 1856918, upload-time = "2026-08-06T14:36:05.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/0a/ef2472343f7b2ec7257a646a21c3c29605939c2ff526959dc6ea2ac4ad7a/datamodel_code_generator-0.32.0-py3-none-any.whl", hash = "sha256:48f3cabbb792398112ee756b23a319e17b001ee534896b324893a98ff10e0a55", size = 120051, upload-time = "2025-07-25T14:12:04.969Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e5/a64c15b05307974cf9676a73ab9e11bed49656a1df16188685c73cb290ed/datamodel_code_generator-0.72.2-py3-none-any.whl", hash = "sha256:df75b3a3225085e098337538cb6895f12e4daca80c43dc15284102bd42948dfc", size = 514012, upload-time = "2026-08-06T14:36:03.785Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades the pinned `datamodel-code-generator` from 0.32.0 to 0.72.2, adapts the Python client codegen pipeline to its new output shape, and fixes two latent issues in the pipeline that the upgrade surfaced.

## Pipeline changes

The CLI flags all survived the jump; the breakage was in output shape.

- **`--no-use-union-operator`** — 0.72.2 defaults to PEP 604 unions. Keeping `Optional[...]`/`Union[...]` holds the emitted client surface stable rather than churning every nullable field. Happy to drop this and modernize instead if reviewers prefer.
- **`--formatters black isort`** — pins today's implicit default, silencing a `FutureWarning` about formatters becoming opt-in. Output is byte-identical.
- **Dropped the `\bSequence]` regex fixup** — it patched a 0.32.0 bug that emitted a bare `Sequence`; 0.72.2 emits `Sequence[Any]` correctly.
- **`transform.py`** — top-level union aliases are now emitted as `Alias: TypeAlias = Union[...]` (an `AnnAssign`) rather than a bare `Assign`, so the alias-stripping filter had stopped matching and left forward references at the top of the file (`F821`). It now matches both shapes, and prunes imports orphaned by that stripping, since ruff won't auto-fix `F401` in an `__init__.py`.

### The one regression worth a close look

0.72.2 emits `type: Literal["x"] = "x"` where 0.32.0 emitted `type: str = "x"`. That stopped matching the discriminator special case in `transform.py`, which **silently flipped 21 of 75 `type` discriminators to `NotRequired`** — with a green `make` run. Fixed by matching the new shape; back to 75 required, 0 `NotRequired`.

## Generated output delta

315 classes, none added, removed, or renamed.

- **24 fields narrow** from `str`/`bool` to `Literal[...]` (e.g. `role: NotRequired[Literal["assistant"]]`, `object: NotRequired[Literal["chat.completion"]]`, `transient: NotRequired[Literal[True]]`). Each traces to a `const` in the OpenAPI schema that 0.32.0 was discarding — these are fidelity improvements, not new constraints.
- **`LegacyChatSubmitMessage.trigger` becomes `NotRequired`**, matching the schema (`const` + `default`, absent from `required`). Its previous requiredness was a 0.32.0 artifact.
- **`Mapping`/`Sequence` now import from `collections.abc`** rather than `typing`. `--use-standard-collections` became default-enabled in 0.72.2; the `typing` spellings are deprecated aliases and the two are equivalent to type checkers. `--no-use-standard-collections` would revert this if preferred.

## Pipeline fixes (second commit)

Two pre-existing issues, independent of the version bump:

- **`PARENTS` was stale** — it declared 5 of the 13 `X`/`XData` pairs in the schema. `LDAPUser` was the giveaway, sitting undeclared beside a declared `LocalUser` and `OAuth2User`. The remaining 8 are now declared, so those types inherit rather than restate their parents' fields (output is 39 lines shorter). This is a readability/consistency change, **not** a typing change — TypedDict subtyping is structural, so `ApiKey` was already assignable to `ApiKeyData`. Each pair was checked for annotation equality first, since `remove_inherited_fields` drops fields by name and a differing annotation would silently retype a field.
- **Brittle assumptions hardened** — the ancestor-fields assertion relaxed from strict subset to subset (and reports which fields are missing when it fires); the now-reachable empty-body case guarded with `pass`; child fields collected from annotated assignments only, asserting on duplicates rather than body length, so a docstring in a class body no longer breaks generation; and the `TypedDict` import injected directly instead of being derived by rewriting the `dataclasses` import.

## Verification

- Codegen is **idempotent** — a second run is byte-identical.
- **Effective field sets and annotations unchanged** across all 315 classes after the inheritance change (verified by AST comparison resolving through bases).
- All 315 TypedDicts resolve via `typing.get_type_hints`.
- `mypy --strict` clean across 86 files; **635 phoenix-client tests pass** (run in a tox-equivalent isolated env).
- Root `mypy` reports 40 errors — **identical count on `main`**, all from a missing local `sqlean`, unrelated to this change.

Caveat: I could not faithfully reproduce CI's `pyright` leg locally (broken stubs, outdated pyright), though the generated file itself reports 0 errors under it.

## Known gaps not addressed here

Surfaced while reviewing the pipeline; each is independent and can be a follow-up:

1. **CI never runs `codegen-python-client`.** It drift-checks `schema-openapi`, `codegen-prompts`, DDL, and `uv.lock` (each `+ git diff --exit-code`), leaving schema→Python-client as the one unguarded edge. The exact version pin plus the `--formatters` pin in this PR are what make such a check deterministic.
2. **`transform.py` has no tests** — ~490 lines of AST surgery defining a public API surface, guarded only by generation-time asserts. The 21-discriminator flip above is exactly what tests would have caught.
3. **Eight public client type names embed server module paths** (e.g. `PhoenixDbTypesDataStreamProtocolRequestTypesDynamicToolOutputAvailablePart`), because FastAPI disambiguates duplicate model names as `phoenix__db__types__...`. A server-side module move silently renames a public client type. Fix belongs server-side.
4. **`Makefile` deletes the output before generating** (`rm -f .../v1/__init__.py`), so if the generator fails, the package's public module is left deleted.