### PR TITLE
feat(agents): enable GraphQL mutations by default

### DIFF
--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -112,7 +112,6 @@ opens.
 | `--bypass-edits` | Apply edits without manual approval (see [You stay in control](#you-stay-in-control)). |
 | `--enable-web-access` | Allow PXI to consult the web for grounding. |
 | `--enable-subagents` | Allow the server to attach subagents (including the server-side bash tool). |
-| `--enable-graphql-mutations` | Allow PXI to run state-changing GraphQL mutations. |
 | `--ingest-traces` | Persist this session's PXI traces locally in Phoenix. |
 | `--export-remote-traces` | Export this session's PXI traces to a configured remote collector. |
 | `--attach-user-id` | Attach the authenticated Phoenix user to PXI traces (opt-in; see the **Privacy, safety & configuration** section below). |

--- a/evals/harbor/container_assets/run_server_agent.py
+++ b/evals/harbor/container_assets/run_server_agent.py
@@ -48,15 +48,6 @@ def _build_tracer_provider() -> TracerProvider | None:
     )
 
 
-def _resolve_allow_mutations(args: argparse.Namespace) -> bool:
-    if args.allow_mutations:
-        return True
-    if args.step_config is not None and args.step_config.is_file():
-        config = json.loads(args.step_config.read_text())
-        return bool(config.get("allow_mutations", False))
-    return False
-
-
 def _load_or_create_session_id(session_id_file: Path | None) -> str:
     if session_id_file is not None and session_id_file.is_file():
         if session_id := session_id_file.read_text().strip():
@@ -100,7 +91,6 @@ async def run(args: argparse.Namespace) -> None:
                 # Mirror the /agents route so the eval exercises the same base
                 # prompt production serves, not build_server_agent's default.
                 prompts=ServerAgentPrompts(base=AgentPrompts().base),
-                allow_mutations=_resolve_allow_mutations(args),
                 tracer_provider=tracer_provider,
             )
             trace_context = (
@@ -166,9 +156,10 @@ def main() -> None:
     parser.add_argument("--out-dir", type=Path, required=True)
     parser.add_argument("--history-file", type=Path, default=None)
     parser.add_argument("--session-id-file", type=Path, default=None)
+    # Accepted for forward compatibility: Harbor uploads each step's
+    # step-config.json and always passes it, but no keys are read today.
     parser.add_argument("--step-config", type=Path, default=None)
     parser.add_argument("--latest-symlink", type=Path, default=None)
-    parser.add_argument("--allow-mutations", action="store_true")
     asyncio.run(run(parser.parse_args()))
 
 

--- a/evals/harbor/tasks/regression-triage/steps/step_01_aggregate/workdir/step-config.json
+++ b/evals/harbor/tasks/regression-triage/steps/step_01_aggregate/workdir/step-config.json
@@ -1,1 +1,1 @@
-{"allow_mutations": false}
+{}

--- a/evals/harbor/tasks/regression-triage/steps/step_02_diagnose/workdir/step-config.json
+++ b/evals/harbor/tasks/regression-triage/steps/step_02_diagnose/workdir/step-config.json
@@ -1,1 +1,1 @@
-{"allow_mutations": false}
+{}

--- a/evals/harbor/tasks/regression-triage/steps/step_03_trace_drilldown/workdir/step-config.json
+++ b/evals/harbor/tasks/regression-triage/steps/step_03_trace_drilldown/workdir/step-config.json
@@ -1,1 +1,1 @@
-{"allow_mutations": false}
+{}

--- a/evals/harbor/tasks/regression-triage/steps/step_04_create_split/workdir/step-config.json
+++ b/evals/harbor/tasks/regression-triage/steps/step_04_create_split/workdir/step-config.json
@@ -1,1 +1,1 @@
-{"allow_mutations": true}
+{}

--- a/js/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/js/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -122,10 +122,6 @@ describe("buildAgentChatRequestBody", () => {
     });
 
     expect(body.contexts).toContainEqual({
-      type: "graphql",
-      mutationsEnabled: false,
-    });
-    expect(body.contexts).toContainEqual({
       type: "web_access",
       enabled: false,
     });

--- a/js/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/js/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -85,19 +85,6 @@ export type AgentChatRequestBodyPatch = Pick<
 >;
 
 /**
- * Build GraphQL context from the current capability snapshot.
- *
- * Forwards the user's mutations toggle to the backend as a typed context so
- * the agent's server-side instructions can render the matching guidance.
- */
-function buildGraphQLContext(capabilities: AgentCapabilities): AgentContext {
-  return {
-    type: "graphql",
-    mutationsEnabled: capabilities["graphql.mutations"] ?? false,
-  };
-}
-
-/**
  * Build web access context from the current capability snapshot.
  *
  * Forwards the user's web access toggle to the backend as a typed context.
@@ -143,7 +130,6 @@ export function buildAgentChatRequestBody({
     observability,
   });
   const requestContexts = [
-    buildGraphQLContext(capabilities),
     buildWebAccessContext(capabilities),
     buildSubagentsContext(capabilities),
     ...contexts,

--- a/js/app/src/agent/extensions/__tests__/capabilities.test.ts
+++ b/js/app/src/agent/extensions/__tests__/capabilities.test.ts
@@ -1,8 +1,4 @@
-import {
-  AGENT_CAPABILITY_DEFINITIONS,
-  createDefaultAgentCapabilities,
-  getAgentCapabilitiesForControlSurface,
-} from "@phoenix/agent/extensions/capabilities";
+import { createDefaultAgentCapabilities } from "@phoenix/agent/extensions/capabilities";
 
 describe("agent capabilities", () => {
   it("creates a fresh copy of the default capabilities", () => {
@@ -11,17 +7,5 @@ describe("agent capabilities", () => {
 
     expect(firstDefaults).toEqual(secondDefaults);
     expect(firstDefaults).not.toBe(secondDefaults);
-  });
-
-  it("filters capabilities by control surface", () => {
-    const debugMenuCapabilities = getAgentCapabilitiesForControlSurface(
-      "experimental-settings"
-    );
-
-    expect(debugMenuCapabilities).toEqual(
-      AGENT_CAPABILITY_DEFINITIONS.filter(
-        (definition) => definition.controlSurface === "experimental-settings"
-      )
-    );
   });
 });

--- a/js/app/src/agent/extensions/capabilities.ts
+++ b/js/app/src/agent/extensions/capabilities.ts
@@ -6,10 +6,7 @@
  * `defineClientActionTool` helpers in `./registry` and the registry aggregator
  * in `./toolRegistry`.
  */
-export type AgentCapabilityKey =
-  | "graphql.mutations"
-  | "subagents.enabled"
-  | "web.access";
+export type AgentCapabilityKey = "subagents.enabled" | "web.access";
 
 /** Describes one capability and how it should appear across the app. */
 export type AgentCapabilityDefinition = {
@@ -18,29 +15,18 @@ export type AgentCapabilityDefinition = {
   description: string;
   defaultValue: boolean;
   scope: "global" | "session";
-  controlSurface?: "experimental-settings";
 };
 
 /** Boolean runtime snapshot keyed by capability name. */
 export type AgentCapabilities = Record<AgentCapabilityKey, boolean>;
 
 const DEFAULT_AGENT_CAPABILITIES: AgentCapabilities = {
-  "graphql.mutations": false,
   "subagents.enabled": false,
   "web.access": false,
 };
 
 /** Ordered capability catalog used by the UI and runtime. */
 export const AGENT_CAPABILITY_DEFINITIONS: AgentCapabilityDefinition[] = [
-  {
-    key: "graphql.mutations",
-    label: "Dangerously enable mutations",
-    description:
-      "Allows the phoenix-gql bash command to execute GraphQL mutations in addition to queries.",
-    defaultValue: false,
-    scope: "global",
-    controlSurface: "experimental-settings",
-  },
   {
     key: "subagents.enabled",
     label: "Subagents",
@@ -89,13 +75,4 @@ export function getAgentCapabilityDefinition(
   key: AgentCapabilityKey
 ): AgentCapabilityDefinition {
   return AGENT_CAPABILITY_DEFINITIONS_BY_KEY[key];
-}
-
-/** Filters the capability catalog down to one UI control surface. */
-export function getAgentCapabilitiesForControlSurface(
-  controlSurface: NonNullable<AgentCapabilityDefinition["controlSurface"]>
-): AgentCapabilityDefinition[] {
-  return AGENT_CAPABILITY_DEFINITIONS.filter(
-    (definition) => definition.controlSurface === controlSurface
-  );
 }

--- a/js/app/src/api/__generated__/v1.ts
+++ b/js/app/src/api/__generated__/v1.ts
@@ -3508,7 +3508,11 @@ export interface components {
         };
         /**
          * GraphQLContext
-         * @description GraphQL runtime state.
+         * @description Deprecated: GraphQL mutations are always enabled.
+         *
+         *     Kept in the wire contract so requests from older clients that still send
+         *     this context (e.g. an installed phoenix-cli with `--enable-graphql-mutations`)
+         *     continue to validate. The value is ignored.
          */
         GraphQLContext: {
             /**

--- a/js/app/src/components/agent/AgentExperimentalSettings.tsx
+++ b/js/app/src/components/agent/AgentExperimentalSettings.tsx
@@ -1,10 +1,7 @@
 import { css } from "@emotion/react";
 
-import {
-  getAgentCapabilitiesForControlSurface,
-  getAgentCapabilityDefinition,
-} from "@phoenix/agent/extensions/capabilities";
-import { Flex, Switch, Text } from "@phoenix/components";
+import { getAgentCapabilityDefinition } from "@phoenix/agent/extensions/capabilities";
+import { Switch, Text } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import { useIsAdminOrAuthDisabled } from "@phoenix/contexts/ViewerContext";
 
@@ -42,46 +39,6 @@ const settingSwitchCSS = css`
     min-width: 0;
   }
 `;
-
-export function AgentExperimentalSettings() {
-  const store = useAgentStore();
-  const capabilities = useAgentContext((state) => state.capabilities);
-  const experimentalCapabilities = getAgentCapabilitiesForControlSurface(
-    "experimental-settings"
-  );
-
-  if (experimentalCapabilities.length === 0) {
-    return null;
-  }
-
-  return (
-    <Flex direction="column" gap="size-200">
-      <ul css={settingsListCSS}>
-        {experimentalCapabilities.map((definition) => (
-          <li key={definition.key} css={settingRowCSS}>
-            <Switch
-              isSelected={capabilities[definition.key]}
-              onChange={(enabled) => {
-                store
-                  .getState()
-                  .setCapability({ key: definition.key, enabled });
-              }}
-              labelPlacement="start"
-              css={settingSwitchCSS}
-            >
-              <span className="agent-settings__label">
-                <Text weight="heavy" size="M">
-                  {definition.label}
-                </Text>
-                <Text color="text-500">{definition.description}</Text>
-              </span>
-            </Switch>
-          </li>
-        ))}
-      </ul>
-    </Flex>
-  );
-}
 
 export function AgentWebAccessSettings() {
   const store = useAgentStore();

--- a/js/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/js/app/src/components/agent/__tests__/Chat.test.tsx
@@ -156,7 +156,6 @@ function renderChatView(
               },
             }}
             capabilities={{
-              "graphql.mutations": false,
               "subagents.enabled": false,
               "web.access": false,
             }}

--- a/js/app/src/components/agent/index.tsx
+++ b/js/app/src/components/agent/index.tsx
@@ -1,7 +1,6 @@
 export { AgentSettingsForm } from "./AgentSettingsForm";
 export { AgentObservabilitySettings } from "./AgentObservabilitySettings";
 export {
-  AgentExperimentalSettings,
   AgentSubagentsSettings,
   AgentWebAccessSettings,
 } from "./AgentExperimentalSettings";

--- a/js/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/js/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -14,7 +14,6 @@ import {
   Text,
 } from "@phoenix/components";
 import {
-  AgentExperimentalSettings,
   AgentObservabilitySettings,
   AgentSettingsForm,
   AgentSubagentsSettings,
@@ -46,7 +45,6 @@ function isServerAgentRuntimeEnabled(agentBashDisabled: boolean): boolean {
 
 const ADMIN_SECTION_ID = "admin-settings";
 const PERSONAL_SECTION_ID = "personal-settings";
-const EXPERIMENTAL_SECTION_ID = "experimental-settings";
 
 const sectionPanelCSS = css`
   padding: var(--global-dimension-size-200);
@@ -277,19 +275,6 @@ export function SettingsAgentsPage() {
               </div>
             </DisclosurePanel>
           </Disclosure>
-          {isServerAgentRuntimeEnabled(window.Config.agentBashDisabled) ? (
-            <Disclosure id={EXPERIMENTAL_SECTION_ID}>
-              <AssistantSettingsSectionTrigger
-                title="Experimental settings"
-                description="Early assistant capabilities that may change."
-              />
-              <DisclosurePanel>
-                <div css={sectionPanelCSS}>
-                  <AgentExperimentalSettings />
-                </div>
-              </DisclosurePanel>
-            </Disclosure>
-          ) : null}
         </DisclosureGroup>
       </Card>
       <SettingsAgentSessionsCard query={query} />

--- a/js/app/src/store/__tests__/agentStore.test.ts
+++ b/js/app/src/store/__tests__/agentStore.test.ts
@@ -456,7 +456,6 @@ describe("agentStore", () => {
   describe("persisted capabilities", () => {
     it("backfills missing capability keys when rehydrating persisted state", () => {
       const persistedCapabilities: Partial<AgentCapabilities> = {
-        "graphql.mutations": true,
         "web.access": true,
       };
       localStorage.setItem(
@@ -471,7 +470,6 @@ describe("agentStore", () => {
 
       expect(store.getState().capabilities).toEqual({
         ...createDefaultAgentCapabilities(),
-        "graphql.mutations": true,
         "web.access": true,
       });
     });

--- a/js/app/tests/pxi/fixtures.ts
+++ b/js/app/tests/pxi/fixtures.ts
@@ -76,7 +76,6 @@ async function installAgentDefaults({ page }: { page: Page }) {
               hasAcknowledgedConsent: false,
             },
             capabilities: {
-              "graphql.mutations": false,
               "web.access": false,
             },
           },

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -481,20 +481,18 @@ export function buildPxiHeaders({
 
 /**
  * Build the {@link PxiContext} list sent with every request, telling the server
- * agent the current local time and zone and which capabilities (GraphQL
- * mutations, web access, subagents) are enabled for the run. `now` and
- * `timeZone` default to the live clock/zone but are injectable for testing.
+ * agent the current local time and zone and which capabilities (web access,
+ * subagents) are enabled for the run. `now` and `timeZone` default to the
+ * live clock/zone but are injectable for testing.
  */
 export function buildPxiContexts({
   enableWebAccess,
   enableSubagents,
-  enableGraphqlMutations,
   now = new Date(),
   timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
 }: {
   enableWebAccess: boolean;
   enableSubagents: boolean;
-  enableGraphqlMutations: boolean;
   now?: Date;
   timeZone?: string;
 }): PxiContext[] {
@@ -503,10 +501,6 @@ export function buildPxiContexts({
       type: "app",
       currentDateTime: toLocalISOWithOffset(now),
       timeZone,
-    },
-    {
-      type: "graphql",
-      mutationsEnabled: enableGraphqlMutations,
     },
     {
       type: "web_access",
@@ -533,7 +527,6 @@ function buildPxiRequestBase({ options }: { options: PxiRuntimeOptions }) {
     contexts: buildPxiContexts({
       enableWebAccess: options.enableWebAccess,
       enableSubagents: options.enableSubagents,
-      enableGraphqlMutations: options.enableGraphqlMutations,
     }),
     model: options.modelSelection,
   };

--- a/js/packages/phoenix-cli/src/pxi/options.ts
+++ b/js/packages/phoenix-cli/src/pxi/options.ts
@@ -100,13 +100,6 @@ type RawPxiOptions = {
    */
   enableSubagents?: boolean;
   /**
-   * `--enable-graphql-mutations`: Allow the server agent's GraphQL *mutation*
-   * tools, not just reads — it can then change Phoenix state.
-   *
-   * @example true
-   */
-  enableGraphqlMutations?: boolean;
-  /**
    * `--bypass-edits`: Apply file edits without asking for approval, mapping to
    * a `"bypass"` (rather than `"manual"`) {@link PxiEditPermission}.
    *
@@ -253,7 +246,6 @@ export function resolvePxiRuntimeOptions({
     skipModelPreflight: Boolean(cliOptions.skipModelPreflight),
     enableWebAccess: Boolean(cliOptions.enableWebAccess),
     enableSubagents: Boolean(cliOptions.enableSubagents),
-    enableGraphqlMutations: Boolean(cliOptions.enableGraphqlMutations),
     editPermission,
     ingestTraces: Boolean(cliOptions.ingestTraces),
     exportRemoteTraces: Boolean(cliOptions.exportRemoteTraces),
@@ -290,10 +282,6 @@ export function createPxiProgram(): Command {
     )
     .option("--enable-web-access", "Enable PXI web access context")
     .option("--enable-subagents", "Enable PXI subagent context")
-    .option(
-      "--enable-graphql-mutations",
-      "Allow server-agent GraphQL mutation tools"
-    )
     .option("--bypass-edits", "Bypass manual edit approvals when supported")
     .option("--ingest-traces", "Persist local PXI traces in Phoenix")
     .option("--export-remote-traces", "Export PXI traces remotely")

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -51,13 +51,13 @@ export type ModelSelection = SchemasV1["AgentModelSelection"];
 /**
  * A capability/environment hint sent alongside the conversation so the server
  * agent knows what it is allowed to do and the world it is operating in — the
- * caller's local clock and time zone, whether GraphQL mutations are permitted,
- * and whether web access and subagents are enabled for this run. A subset of
- * the server's full `ChatContext` union: the rest are browser-only surfaces.
+ * caller's local clock and time zone, and whether web access and subagents
+ * are enabled for this run. A subset of the server's full `ChatContext`
+ * union: the rest are browser-only surfaces.
  */
 export type PxiContext = Extract<
   SchemasV1["ChatContext"],
-  { type: "app" | "graphql" | "web_access" | "subagents" }
+  { type: "app" | "web_access" | "subagents" }
 >;
 
 /**
@@ -106,7 +106,6 @@ export type PxiRuntimeOptions = {
   skipModelPreflight: boolean;
   enableWebAccess: boolean;
   enableSubagents: boolean;
-  enableGraphqlMutations: boolean;
   editPermission: PxiEditPermission;
   ingestTraces: boolean;
   exportRemoteTraces: boolean;

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -64,7 +64,6 @@ describe("PXI client", () => {
       model: "gpt-5.4",
       enableWebAccess: true,
       enableSubagents: true,
-      enableGraphqlMutations: true,
       bypassEdits: true,
       ingestTraces: true,
       exportRemoteTraces: true,
@@ -91,7 +90,6 @@ describe("PXI client", () => {
     });
     expect(request.contexts).toEqual(
       expect.arrayContaining([
-        { type: "graphql", mutationsEnabled: true },
         { type: "web_access", enabled: true },
         { type: "subagents", enabled: true },
       ])

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -3508,7 +3508,11 @@ export interface components {
         };
         /**
          * GraphQLContext
-         * @description GraphQL runtime state.
+         * @description Deprecated: GraphQL mutations are always enabled.
+         *
+         *     Kept in the wire contract so requests from older clients that still send
+         *     this context (e.g. an installed phoenix-cli with `--enable-graphql-mutations`)
+         *     continue to validate. The value is ignored.
          */
         GraphQLContext: {
             /**

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -3508,7 +3508,11 @@ export interface components {
         };
         /**
          * GraphQLContext
-         * @description GraphQL runtime state.
+         * @description Deprecated: GraphQL mutations are always enabled.
+         *
+         *     Kept in the wire contract so requests from older clients that still send
+         *     this context (e.g. an installed phoenix-cli with `--enable-graphql-mutations`)
+         *     continue to validate. The value is ignored.
          */
         GraphQLContext: {
             /**

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -13810,7 +13810,7 @@
           "mutationsEnabled"
         ],
         "title": "GraphQLContext",
-        "description": "GraphQL runtime state."
+        "description": "Deprecated: GraphQL mutations are always enabled.\n\nKept in the wire contract so requests from older clients that still send\nthis context (e.g. an installed phoenix-cli with `--enable-graphql-mutations`)\ncontinue to validate. The value is ignored."
       },
       "HTTPValidationError": {
         "properties": {

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -114,7 +114,6 @@ def build_agent(
     is_viewer: bool = False,
     schema: strawberry.Schema | None = None,
     build_graphql_context: Callable[[], Context] | None = None,
-    allow_mutations: bool = False,
     initial_bash_snapshot: bytes | None = None,
     on_bash_snapshot: Callable[[bytes], None] | None = None,
 ) -> AbstractAgent[AgentDependencies, AgentOutput]:
@@ -165,7 +164,6 @@ def build_agent(
             BashCapability[AgentDependencies](
                 schema=schema,
                 build_graphql_context=build_graphql_context,
-                allow_mutations=allow_mutations,
                 initial_snapshot=initial_bash_snapshot,
                 on_snapshot=on_bash_snapshot,
             )

--- a/src/phoenix/server/agents/capabilities/contexts/graphql_mutations.py
+++ b/src/phoenix/server/agents/capabilities/contexts/graphql_mutations.py
@@ -12,7 +12,7 @@ from phoenix.server.agents.types import AgentDependencies
 
 @dataclass
 class GraphQLMutationsCapability(AbstractDynamicCapability[AgentDependencies]):
-    """Always included so the model knows whether GraphQL mutations are available."""
+    """Always included so the model knows how to handle GraphQL mutations."""
 
     instructions: Template
 
@@ -20,9 +20,7 @@ class GraphQLMutationsCapability(AbstractDynamicCapability[AgentDependencies]):
         instructions = self.instructions
 
         def _instructions(ctx: RunContext[AgentDependencies]) -> str:
-            graphql = ctx.deps.contexts.graphql
-            enabled = graphql is not None and graphql.mutations_enabled
-            return instructions.render(enabled=enabled)
+            return instructions.render(edit_permission=ctx.deps.edit_permission)
 
         return _instructions
 

--- a/src/phoenix/server/agents/capabilities/tools/internal/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/bash.py
@@ -42,9 +42,9 @@ should not be assumed to work.
 other host binaries exist.
 - Language runtimes such as python, python3, and node are not available.
 - phoenix-gql is available for GraphQL operations against the Phoenix GraphQL API. \
-Run `phoenix-gql --help` for usage and current permissions. It is read-only by \
-default: only `query` operations are permitted, and mutations and subscriptions are \
-rejected unless mutations have been explicitly enabled.
+Run `phoenix-gql --help` for usage. Queries and mutations are permitted; \
+subscriptions are rejected. Mutations are still subject to server-side \
+authorization, so they may fail on read-only deployments or for viewer roles.
 
 Args:
     summary: Short, user-facing description of what this command does. Shown as the
@@ -115,19 +115,13 @@ def _format_graphql_errors(messages: list[str]) -> str:
     return f"GraphQL errors:\n{formatted}\n"
 
 
-# Annotated because jinja2's `Template.__new__` returns `t.Any`, which would
-# make the instance (and `.render()`) untyped under mypy.
-_HELP_TEXT_TEMPLATE: Template = Template(
-    """\
+_HELP_TEXT = """\
 Usage: phoenix-gql [query] [options] [query-or-file]
 
 Execute GraphQL operations against Phoenix.
 
-{% if mutations_enabled -%}
-Permissions: queries and mutations are ENABLED.
-{% else -%}
-Permissions: queries only (mutations are disabled).
-{% endif %}
+Permissions: queries and mutations are enabled (subscriptions are not supported).
+
 Recommended flow:
   1. start with a tiny query or an introspection query to confirm the schema
   2. add filters, sorting, and deeper fields only after the base query works
@@ -145,11 +139,6 @@ Examples:
   cat query.graphql | phoenix-gql --vars '{"id":"abc"}'
   phoenix-gql query.graphql --vars-file vars.json | jq '.data'
 """
-)
-
-
-def _get_help_text(mutations_enabled: bool) -> str:
-    return _HELP_TEXT_TEMPLATE.render(mutations_enabled=mutations_enabled)
 
 
 @dataclass
@@ -258,19 +247,16 @@ def create_phoenix_gql_builtin(
     *,
     schema: strawberry.Schema,
     build_graphql_context: Callable[[], Context],
-    allow_mutations: bool,
 ) -> Callable[[BuiltinContext], Awaitable[BuiltinResult]]:
     """Build the ``phoenix-gql`` custom shell command."""
-    allowed_operation_types = (
-        {OperationType.QUERY, OperationType.MUTATION} if allow_mutations else {OperationType.QUERY}
-    )
+    allowed_operation_types = {OperationType.QUERY, OperationType.MUTATION}
 
     async def phoenix_gql(ctx: BuiltinContext) -> BuiltinResult:
         try:
             parsed = _parse_args(list(ctx.argv))
 
             if parsed.show_help:
-                return BuiltinResult(stdout=_get_help_text(allow_mutations), stderr="", exit_code=0)
+                return BuiltinResult(stdout=_HELP_TEXT, stderr="", exit_code=0)
 
             query = _resolve_query_text(parsed, ctx)
 
@@ -278,9 +264,6 @@ def create_phoenix_gql_builtin(
 
             if GraphQLOperationType.SUBSCRIPTION in operation_types:
                 raise ValueError("Subscriptions are not supported by phoenix-gql")
-
-            if GraphQLOperationType.MUTATION in operation_types and not allow_mutations:
-                raise ValueError("Mutations are not permitted.")
 
             variables = _resolve_variables(parsed, ctx)
 
@@ -345,7 +328,6 @@ def _build_shell(
     *,
     schema: strawberry.Schema,
     build_graphql_context: Callable[[], Context],
-    allow_mutations: bool,
     initial_snapshot: Optional[bytes],
 ) -> Bash:
     """Build the virtual shell, restoring prior session state when available."""
@@ -353,7 +335,6 @@ def _build_shell(
         "phoenix-gql": create_phoenix_gql_builtin(
             schema=schema,
             build_graphql_context=build_graphql_context,
-            allow_mutations=allow_mutations,
         ),
     }
     if initial_snapshot is not None:
@@ -383,14 +364,12 @@ class BashToolset(FunctionToolset[AgentDepsT], Generic[AgentDepsT]):
         *,
         schema: strawberry.Schema,
         build_graphql_context: Callable[[], Context],
-        allow_mutations: bool,
         initial_snapshot: Optional[bytes] = None,
         on_snapshot: Optional[Callable[[bytes], None]] = None,
     ) -> None:
         shell = _build_shell(
             schema=schema,
             build_graphql_context=build_graphql_context,
-            allow_mutations=allow_mutations,
             initial_snapshot=initial_snapshot,
         )
 
@@ -434,7 +413,6 @@ class BashCapability(AbstractCapability[AgentDepsT], Generic[AgentDepsT]):
 
     schema: strawberry.Schema
     build_graphql_context: Callable[[], Context]
-    allow_mutations: bool = False
     initial_snapshot: Optional[bytes] = None
     on_snapshot: Optional[Callable[[bytes], None]] = None
 
@@ -442,7 +420,6 @@ class BashCapability(AbstractCapability[AgentDepsT], Generic[AgentDepsT]):
         return BashToolset[AgentDepsT](
             schema=self.schema,
             build_graphql_context=self.build_graphql_context,
-            allow_mutations=self.allow_mutations,
             initial_snapshot=self.initial_snapshot,
             on_snapshot=self.on_snapshot,
         )

--- a/src/phoenix/server/agents/context.py
+++ b/src/phoenix/server/agents/context.py
@@ -232,7 +232,12 @@ class DatasetContext(_ChatContextBase):
 
 
 class GraphQLContext(_ChatContextBase):
-    """GraphQL runtime state."""
+    """Deprecated: GraphQL mutations are always enabled.
+
+    Kept in the wire contract so requests from older clients that still send
+    this context (e.g. an installed phoenix-cli with `--enable-graphql-mutations`)
+    continue to validate. The value is ignored.
+    """
 
     type: Literal["graphql"]
     mutations_enabled: bool = Field(alias="mutationsEnabled")
@@ -289,7 +294,6 @@ class ResolvedContexts:
     code_evaluator: CodeEvaluatorContext | None = None
     llm_evaluator: LlmEvaluatorContext | None = None
     dataset: DatasetContext | None = None
-    graphql: GraphQLContext | None = None
     web_access: WebAccessContext | None = None
     subagents: SubagentsContext | None = None
 
@@ -321,7 +325,7 @@ def resolve_contexts(contexts: list[ChatContext]) -> ResolvedContexts:
         elif isinstance(context_value, AgentSpanContext):
             resolved.span = context_value
         elif isinstance(context_value, GraphQLContext):
-            resolved.graphql = context_value
+            pass  # deprecated: mutations are always enabled, the value is ignored
         elif isinstance(context_value, WebAccessContext):
             resolved.web_access = context_value
         elif isinstance(context_value, SubagentsContext):

--- a/src/phoenix/server/agents/prompts/context/GRAPHQL_MUTATIONS_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/context/GRAPHQL_MUTATIONS_INSTRUCTIONS.xml.j2
@@ -1,9 +1,8 @@
 <phoenix_gql_mutations_policy>
-{% if enabled %}
   <status>enabled</status>
-  <guidance>GraphQL mutations are enabled for phoenix-gql. Mutation operations may be executed when they are necessary and appropriate.</guidance>
+{% if edit_permission == "bypass" %}
+  <guidance>GraphQL mutations are enabled for phoenix-gql, and the user has auto-accept enabled. Execute mutations without a separate confirmation when they are necessary and appropriate. A mutation may still be rejected by server-side authorization (for example on a read-only deployment or for a viewer role); report such failures plainly.</guidance>
 {% else %}
-  <status>disabled</status>
-  <guidance>GraphQL mutations are disabled for phoenix-gql. Only read-only GraphQL queries are permitted.</guidance>
+  <guidance>GraphQL mutations are enabled for phoenix-gql, but mutations change the user's data, so confirm before you act: unless the user's most recent request explicitly asked for the exact change, describe what the mutation will do and get their approval first (the ask_user tool works well for this). Never chain destructive mutations such as deletes behind a single approval. A mutation may still be rejected by server-side authorization (for example on a read-only deployment or for a viewer role); report such failures plainly.</guidance>
 {% endif %}
 </phoenix_gql_mutations_policy>

--- a/src/phoenix/server/agents/server_agents.py
+++ b/src/phoenix/server/agents/server_agents.py
@@ -62,7 +62,6 @@ def build_server_agent(
     prompts: ServerAgentPrompts | None = None,
     docs_mcp_server: MCPToolset[None] | None = None,
     enable_web_access: bool = False,
-    allow_mutations: bool = False,
     read_only: bool = False,
     auth_enabled: bool = False,
     user_id: int | None = None,
@@ -83,7 +82,6 @@ def build_server_agent(
         BashCapability[None](
             schema=schema,
             build_graphql_context=build_graphql_context,
-            allow_mutations=allow_mutations,
             initial_snapshot=initial_bash_snapshot,
             on_snapshot=on_bash_snapshot,
         ),
@@ -130,7 +128,6 @@ def build_server_agent(
             event_queue=event_queue,
             docs_mcp_server=docs_mcp_server,
             enable_web_access=enable_web_access,
-            allow_mutations=allow_mutations,
             read_only=read_only,
             auth_enabled=auth_enabled,
             user_id=user_id,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -2794,9 +2794,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         request_user_id = int(phoenix_user.identity) if phoenix_user is not None else None
         is_viewer = phoenix_user.is_viewer if phoenix_user is not None else False
         subagents_enabled = _subagents_enabled(resolved_contexts)
-        graphql_mutations_enabled = (
-            resolved_contexts.graphql is not None and resolved_contexts.graphql.mutations_enabled
-        )
         phoenix_user_email: str | None = None
         initial_bash_snapshot: bytes | None = None
         try:
@@ -2939,7 +2936,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     prompts=ServerAgentPrompts(base=agent_prompts.base),
                     docs_mcp_server=request.app.state.docs_mcp_server,
                     enable_web_access=web_access_enabled,
-                    allow_mutations=graphql_mutations_enabled,
                     read_only=request.app.state.read_only,
                     auth_enabled=request.app.state.authentication_enabled,
                     user_id=request_user_id,
@@ -2982,7 +2978,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         event_queue=request.state.event_queue,
                         docs_mcp_server=request.app.state.docs_mcp_server,
                         enable_web_access=web_access_enabled,
-                        allow_mutations=graphql_mutations_enabled,
                         read_only=request.app.state.read_only,
                         auth_enabled=request.app.state.authentication_enabled,
                         user_id=request_user_id,
@@ -3037,7 +3032,6 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         if bash_enabled
                         else None
                     ),
-                    allow_mutations=graphql_mutations_enabled,
                     initial_bash_snapshot=initial_bash_snapshot,
                     on_bash_snapshot=_capture_bash_snapshot,
                 )

--- a/src/phoenix/server/api/routers/legacy_agents.py
+++ b/src/phoenix/server/api/routers/legacy_agents.py
@@ -181,9 +181,6 @@ def create_legacy_agents_router(authentication_enabled: bool) -> APIRouter:
         phoenix_user = user if isinstance(user, PhoenixUser) else None
         user_id = int(phoenix_user.identity) if phoenix_user is not None else None
         is_viewer = phoenix_user.is_viewer if phoenix_user is not None else False
-        graphql_mutations_enabled = (
-            resolved_contexts.graphql is not None and resolved_contexts.graphql.mutations_enabled
-        )
         recording = request.app.state.system_settings.agent_trace_recording
         ingest_traces, export_remote_traces = _resolve_trace_recording(
             record_local_traces=body.ingest_traces,
@@ -228,7 +225,6 @@ def create_legacy_agents_router(authentication_enabled: bool) -> APIRouter:
             prompts=ServerAgentPrompts(base=AgentPrompts().base),
             docs_mcp_server=request.app.state.docs_mcp_server,
             enable_web_access=web_access_enabled,
-            allow_mutations=graphql_mutations_enabled,
             read_only=request.app.state.read_only,
             auth_enabled=request.app.state.authentication_enabled,
             user_id=user_id,

--- a/tests/unit/pxi/evals/test_agent_task_inputs.py
+++ b/tests/unit/pxi/evals/test_agent_task_inputs.py
@@ -45,8 +45,7 @@ class TestBuildContexts:
         assert contexts.app is not None
         assert contexts.app.current_date_time == "2026-05-18T14:30:00-07:00"
         assert contexts.app.time_zone == "America/Los_Angeles"
-        assert contexts.graphql is not None
-        assert contexts.graphql.mutations_enabled is False
+        # The deprecated graphql context is accepted on the wire but ignored.
         assert contexts.project is not None
         assert contexts.project.project_node_id == "UHJvamVjdDoxMg=="
         assert contexts.project.span_filter == "span_kind == 'LLM' and parent_span is None"

--- a/tests/unit/server/agents/capabilities/tools/internal/test_bash.py
+++ b/tests/unit/server/agents/capabilities/tools/internal/test_bash.py
@@ -60,11 +60,11 @@ def _assert_execution_metadata(result: dict[str, Any], command: str) -> None:
     assert isinstance(result["stderrTruncated"], bool)
 
 
-def _build_run_bash(*, allow_mutations: bool) -> RunBash:
+@pytest.fixture
+def run_bash() -> RunBash:
     toolset = BashToolset(
         schema=strawberry.Schema(query=Query, mutation=Mutation),
         build_graphql_context=lambda: Mock(spec=Context),
-        allow_mutations=allow_mutations,
     )
     ctx: RunContext[None] = RunContext(deps=None, model=TestModel(), usage=RunUsage())
 
@@ -77,16 +77,6 @@ def _build_run_bash(*, allow_mutations: bool) -> RunBash:
         return result
 
     return run
-
-
-@pytest.fixture
-def run_bash() -> RunBash:
-    return _build_run_bash(allow_mutations=False)
-
-
-@pytest.fixture
-def run_bash_with_mutations() -> RunBash:
-    return _build_run_bash(allow_mutations=True)
 
 
 async def test_result_reports_execution_metadata(run_bash: RunBash) -> None:
@@ -174,26 +164,16 @@ async def test_query_from_file(run_bash: RunBash) -> None:
     assert result["stderr"] == ""
 
 
-async def test_mutation_rejected_when_disabled(run_bash: RunBash) -> None:
+async def test_mutation_executes(run_bash: RunBash) -> None:
     result = await run_bash("phoenix-gql 'mutation { deleteEverything }'")
-
-    assert result["exitCode"] == 1
-    assert result["stdout"] == ""
-    assert "Mutations are not permitted" in result["stderr"]
-
-
-async def test_mutation_allowed_when_enabled(run_bash_with_mutations: RunBash) -> None:
-    result = await run_bash_with_mutations("phoenix-gql 'mutation { deleteEverything }'")
 
     assert result["exitCode"] == 0
     assert json.loads(result["stdout"]) == {"data": {"deleteEverything": "deleted"}}
     assert result["stderr"] == ""
 
 
-async def test_subscription_rejected_even_when_mutations_enabled(
-    run_bash_with_mutations: RunBash,
-) -> None:
-    result = await run_bash_with_mutations("phoenix-gql 'subscription { hello }'")
+async def test_subscription_rejected(run_bash: RunBash) -> None:
+    result = await run_bash("phoenix-gql 'subscription { hello }'")
 
     assert result["exitCode"] == 1
     assert result["stdout"] == ""
@@ -219,19 +199,13 @@ async def test_unknown_option_errors(run_bash: RunBash) -> None:
     assert "Unknown option: --bogus" in result["stderr"]
 
 
-async def test_help_reflects_permissions(
-    run_bash: RunBash, run_bash_with_mutations: RunBash
-) -> None:
-    queries_only = await run_bash("phoenix-gql --help")
-    with_mutations = await run_bash_with_mutations("phoenix-gql --help")
+async def test_help_reports_permissions(run_bash: RunBash) -> None:
+    result = await run_bash("phoenix-gql --help")
 
-    assert queries_only["exitCode"] == 0
-    assert "Usage: phoenix-gql" in queries_only["stdout"]
-    assert "queries only (mutations are disabled)" in queries_only["stdout"]
-    assert queries_only["stderr"] == ""
-    assert with_mutations["exitCode"] == 0
-    assert "queries and mutations are ENABLED" in with_mutations["stdout"]
-    assert with_mutations["stderr"] == ""
+    assert result["exitCode"] == 0
+    assert "Usage: phoenix-gql" in result["stdout"]
+    assert "queries and mutations are enabled" in result["stdout"]
+    assert result["stderr"] == ""
 
 
 async def test_output_path_writes_file(run_bash: RunBash) -> None:


### PR DESCRIPTION
Removes the experimental setting that gated GraphQL mutations for the agent's `phoenix-gql` command and enables mutations by default, with prompt guidance to ask the user before executing one.

## Changes

**Server**
- `allow_mutations` is removed as a parameter throughout (`BashCapability`, `build_agent`, `build_server_agent`, both chat routers, and the harbor eval harness). `phoenix-gql` now accepts queries and mutations; subscriptions are still rejected. Server-side GraphQL authorization (read-only deployments, viewer roles) remains the enforcement point, so the tool-layer gate was redundant defense.
- The mutations prompt policy (`GRAPHQL_MUTATIONS_INSTRUCTIONS.xml.j2`) is rewritten: the agent must describe the mutation and get user approval (e.g. via `ask_user`) unless the user's most recent request explicitly asked for the exact change. When `edit_permission` is `bypass` (auto-accept), confirmation is skipped, matching the behavior of every other write tool.
- `GraphQLContext` stays in the wire contract as accepted-but-ignored so already-installed clients that still send `{type: "graphql", mutationsEnabled}` continue to validate. Removing it from the union can happen in a later release.

**Frontend**
- The `graphql.mutations` capability ("Dangerously enable mutations") is removed, along with the now-empty experimental settings section and the `controlSurface` machinery. Stale persisted capability keys are dropped on rehydrate by the existing normalizer. The `agent-experimental-settings` feature flag is left defined since it is the only flag and removing it would break the `FeatureFlag` type mechanism.
- Chat requests no longer send the `graphql` context.

**js CLI**
- `--enable-graphql-mutations` and the `graphql` context are removed.

## Testing
- `tests/unit/server/agents` (440 passed), mypy clean on changed server modules
- Frontend typecheck plus the affected vitest suites (82 passed)
- phoenix-cli typecheck and tests (41 passed)
- `make openapi` regenerated (description-only diff for the deprecated `GraphQLContext`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)