### PR TITLE
feat(online-evals): session evaluators — creation, scope authoring, and scheduling

### DIFF
--- a/internal_docs/specs/online-evals.md
+++ b/internal_docs/specs/online-evals.md
@@ -294,9 +294,10 @@ not need to solve all levels at launch; a subset is still useful, and we can car
 the rest.
 
 The session filter DSL shipped in [#14101](https://github.com/Arize-ai/phoenix/pull/14101), closing
-[#14041](https://github.com/Arize-ai/phoenix/issues/14041). SESSION online-evaluation criteria do
-not consume it yet: filtered or sampled SESSION criteria are accepted but not scheduled.
-[#14038](https://github.com/Arize-ai/phoenix/issues/14038) owns the sampling half.
+[#14041](https://github.com/Arize-ai/phoenix/issues/14041). SESSION online evaluation applies this
+filter at the session's first eligible quiet period, then applies deterministic sampling to
+matches. A filter non-match or sampling miss is recorded permanently for that evaluator
+configuration, and later activity does not reopen the decision.
 
 Changing a filter affects only future artifacts; it does not backfill or re-run past data.
 
@@ -384,9 +385,10 @@ preserved for audit not by the annotation row (overwritten) but by the run recor
 ## Run Records and Audit
 
 The upsert-by-`identifier` mechanism in [Output](#output) is intentionally destructive: a re-run
-overwrites its own prior annotation, and a decision that produces *no* annotation (filtered out,
-sampled out, overload-dropped, pending, failed) writes nothing at all. Several requirements in
-this spec presuppose a durable record that the annotation tables cannot provide:
+overwrites its own prior annotation. SESSION filter and sampling declines are durable terminal
+work-unit states, but other decisions that produce *no* annotation (including span filter/sample
+misses and overload drops) still lack a complete cross-target run history. Several requirements
+in this spec presuppose a durable record that the annotation tables cannot provide:
 
 - **Audit** ("why is this annotation missing?") needs to tell filtered-out, sampled-out,
   overload-dropped, pending, failed, and succeeded apart — none of which an absent annotation row

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
+  Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is 10 seconds. Only SESSION scheduling honors a delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators are stored but not scheduled. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1010,7 +1010,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
+  Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is 10 seconds. Only SESSION scheduling honors a delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators are stored but not scheduled. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1036,7 +1036,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
+  Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is 10 seconds. Only SESSION scheduling honors a delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators are stored but not scheduled. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2705,27 +2705,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Create an LLM project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Only SESSION scheduling honors the evaluation delay, which a SPAN target rejects. The target is fixed at creation.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Update an LLM project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Only SESSION scheduling honors the evaluation delay, which a SPAN target rejects. The target is fixed at creation.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Only SESSION scheduling honors the evaluation delay, which a SPAN target rejects. The target is fixed at creation.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Create a CODE project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Only SESSION scheduling honors the evaluation delay, which a SPAN target rejects. The target is fixed at creation.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Only SESSION scheduling honors the evaluation delay, which a SPAN target rejects. The target is fixed at creation.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
@@ -3298,7 +3298,7 @@ type ProjectEvaluator implements Node {
   schedulabilityReason: ProjectEvaluatorSchedulabilityReason
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it. A later change to SESSION uses the stored value, but the target cannot change after evaluation work exists for this project evaluator.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation. Only SESSION scheduling honors this value: a SPAN evaluator cannot set one, and TRACE evaluators are not scheduled.
   """
   evaluationDelaySeconds: Int!
   inputMapping: EvaluatorInputMapping!
@@ -5198,7 +5198,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
+  Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is 10 seconds. Only SESSION scheduling honors a delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators are stored but not scheduled. Omit to preserve the current setting, or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -5219,7 +5219,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
+  Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is 10 seconds. Only SESSION scheduling honors a delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators are stored but not scheduled. Omit to preserve the current setting, or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -3378,6 +3378,11 @@ type ProjectSession implements Node {
   lastOutput: SpanIOValue
 
   """
+  The canonical input, output, and metadata context that online evaluators bind against when they run on this session. Null when the session's transcript exceeds the evaluation byte cap, which is the same reason a live evaluation of it would fail.
+  """
+  sessionEvaluationContext: JSON
+
+  """
   The first non-null "user.id" span attribute in the session, identifying the end user of the traced application.
   """
   userId: String

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -2705,27 +2705,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Create an LLM project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Update an LLM project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Create a CODE project evaluator. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
@@ -3285,7 +3285,7 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
+  SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per session at the first quiet period after the evaluation delay: it applies the session filter first, then deterministic sampling, and schedules admitted work asynchronously. A filter non-match or sampling miss is permanently declined for that evaluator configuration; later activity does not reopen the decision. TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   evaluationTarget: EvaluationTarget!
 
@@ -3343,8 +3343,6 @@ type ProjectEvaluatorMutationPayload {
 enum ProjectEvaluatorSchedulabilityReason {
   DISABLED
   TRACE_TARGET_UNSUPPORTED
-  SESSION_FILTER_UNSUPPORTED
-  SESSION_SAMPLING_UNSUPPORTED
 }
 
 enum ProjectEvaluatorSchedulabilityStatus {

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -3378,7 +3378,7 @@ type ProjectSession implements Node {
   lastOutput: SpanIOValue
 
   """
-  The canonical input, output, and metadata context that online evaluators bind against when they run on this session. Null when the session's transcript exceeds the evaluation byte cap, which is the same reason a live evaluation of it would fail.
+  The canonical input, output, and metadata context that online evaluators bind against when they run on this session. Null whenever a live evaluation would refuse this session: its content was trimmed after ingestion, it has no eligible root turn to transcribe, or no whole turn fits the evaluation byte cap. An over-cap transcript that still fits whole turns is truncated and returned, exactly as a live evaluation reads it.
   """
   sessionEvaluationContext: JSON
 

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -1903,6 +1903,11 @@ input EvaluatorPreviewItemInput {
   evaluator: EvaluatorPreviewInput!
   context: JSON!
   inputMapping: EvaluatorInputMappingInput!
+
+  """
+  Whether to enforce the execution limits an online evaluation runs under: the rendered LLM message cap and the sandbox payload cap. Set this when the preview stands in for a scheduled run, so a preview cannot succeed where the live evaluation would be rejected. The limits themselves come from the server's configuration, never from this request.
+  """
+  applyOnlineEvaluationLimits: Boolean! = false
 }
 
 input EvaluatorPreviewsInput {

--- a/js/app/src/components/evaluators/EvaluatorInputMapping.tsx
+++ b/js/app/src/components/evaluators/EvaluatorInputMapping.tsx
@@ -151,6 +151,7 @@ export const useFlattenedEvaluatorInputKeys = ({
     obj: evaluatorMappingSource.source,
     keepNonTerminalValues: true,
     formatIndices: true,
+    bracketNonIdentifierKeys: true,
   });
   return Object.keys(flat).map((key) => ({
     id: key,

--- a/js/app/src/components/evaluators/EvaluatorMappingSourceEditor.tsx
+++ b/js/app/src/components/evaluators/EvaluatorMappingSourceEditor.tsx
@@ -14,6 +14,7 @@ import type {
   EvaluatorMappingSource,
   EvaluatorMappingSourceGrain,
 } from "@phoenix/types";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 type EvaluatorMappingSourceFieldConfig<
   TGrain extends EvaluatorMappingSourceGrain,
@@ -83,6 +84,31 @@ const SPAN_FIELD_CONFIG: EvaluatorMappingSourceFieldConfig<"span">[] = [
   },
 ];
 
+const SESSION_FIELD_CONFIG: EvaluatorMappingSourceFieldConfig<"session">[] = [
+  {
+    field: "input",
+    label: "input",
+    description: "The matched session's transcript, one line per turn.",
+    tooltip:
+      "Every root span in the session, rendered as alternating User and Assistant turns under the transcript policy the evaluation runs with.",
+  },
+  {
+    field: "output",
+    label: "output",
+    description: "The last response in the matched session.",
+    tooltip:
+      "The output of the session's final turn, so an evaluator can judge how the conversation ended.",
+  },
+  {
+    field: "metadata",
+    label: "metadata",
+    description:
+      "From the matched session. Individual turns are under turns, and the transcript policy records what was truncated.",
+    tooltip:
+      "Each turn's input, output, metadata, and time are available for path mapping under metadata.turns.",
+  },
+];
+
 const editorContainerCSS = css`
   min-height: 60px;
   border-radius: var(--global-rounding-small);
@@ -104,20 +130,31 @@ type EvaluatorMappingSourceEditorProps = {
 export function EvaluatorMappingSourceEditor(
   props: EvaluatorMappingSourceEditorProps
 ) {
-  if (props.grain === "span") {
-    return (
-      <EvaluatorMappingSourceFields
-        {...props}
-        fieldConfig={SPAN_FIELD_CONFIG}
-      />
-    );
+  switch (props.grain) {
+    case "span":
+      return (
+        <EvaluatorMappingSourceFields
+          {...props}
+          fieldConfig={SPAN_FIELD_CONFIG}
+        />
+      );
+    case "session":
+      return (
+        <EvaluatorMappingSourceFields
+          {...props}
+          fieldConfig={SESSION_FIELD_CONFIG}
+        />
+      );
+    case "dataset":
+      return (
+        <EvaluatorMappingSourceFields
+          {...props}
+          fieldConfig={DATASET_FIELD_CONFIG}
+        />
+      );
+    default:
+      return assertUnreachable(props);
   }
-  return (
-    <EvaluatorMappingSourceFields
-      {...props}
-      fieldConfig={DATASET_FIELD_CONFIG}
-    />
-  );
 }
 
 function EvaluatorMappingSourceFields<

--- a/js/app/src/components/evaluators/EvaluatorMappingSourceEditor.tsx
+++ b/js/app/src/components/evaluators/EvaluatorMappingSourceEditor.tsx
@@ -88,24 +88,22 @@ const SESSION_FIELD_CONFIG: EvaluatorMappingSourceFieldConfig<"session">[] = [
   {
     field: "input",
     label: "input",
-    description: "The matched session's transcript, one line per turn.",
+    description: "From the matched session's transcript.",
     tooltip:
-      "Every root span in the session, rendered as alternating User and Assistant turns under the transcript policy the evaluation runs with.",
+      "This is the session's turns, rendered as alternating User and Assistant messages.",
   },
   {
     field: "output",
     label: "output",
-    description: "The last response in the matched session.",
-    tooltip:
-      "The output of the session's final turn, so an evaluator can judge how the conversation ended.",
+    description: "From the matched session's last response.",
+    tooltip: "This is the output of the session's final turn.",
   },
   {
     field: "metadata",
     label: "metadata",
-    description:
-      "From the matched session. Individual turns are under turns, and the transcript policy records what was truncated.",
+    description: "From the matched session. Session turns are under turns.",
     tooltip:
-      "Each turn's input, output, metadata, and time are available for path mapping under metadata.turns.",
+      "Session turns are available for path mapping under metadata.turns.",
   },
 ];
 

--- a/js/app/src/components/evaluators/__generated__/CodeEvaluatorTestSectionMutation.graphql.ts
+++ b/js/app/src/components/evaluators/__generated__/CodeEvaluatorTestSectionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c4285be75822b9be5988a347b88aa66>>
+ * @generated SignedSource<<a65bc955f8a81271d5d86a6ea358a453>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type EvaluatorPreviewsInput = {
   previews: ReadonlyArray<EvaluatorPreviewItemInput>;
 };
 export type EvaluatorPreviewItemInput = {
+  applyOnlineEvaluationLimits?: boolean;
   context: any;
   evaluator: EvaluatorPreviewInput;
   inputMapping: EvaluatorInputMappingInput;

--- a/js/app/src/components/evaluators/__generated__/EvaluatorOutputPreviewMutation.graphql.ts
+++ b/js/app/src/components/evaluators/__generated__/EvaluatorOutputPreviewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a9d2c215deb9a580c79d59b7bce228f9>>
+ * @generated SignedSource<<08f453480df1afb4581321d43563f1d6>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type EvaluatorPreviewsInput = {
   previews: ReadonlyArray<EvaluatorPreviewItemInput>;
 };
 export type EvaluatorPreviewItemInput = {
+  applyOnlineEvaluationLimits?: boolean;
   context: any;
   evaluator: EvaluatorPreviewInput;
   inputMapping: EvaluatorInputMappingInput;

--- a/js/app/src/pages/project/SessionFilterConditionField.tsx
+++ b/js/app/src/pages/project/SessionFilterConditionField.tsx
@@ -1,6 +1,7 @@
 import type { Completion, CompletionSection } from "@codemirror/autocomplete";
 import { snippetCompletion } from "@codemirror/autocomplete";
 import { useCallback, useMemo } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
 
 import {
   AIQueryDSLFilterField,
@@ -15,6 +16,7 @@ import {
 } from "@phoenix/components/filter";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
+import type { SessionFilterConditionFieldVocabularyQuery } from "./__generated__/SessionFilterConditionFieldVocabularyQuery.graphql";
 import {
   getSessionFilterLoopVariable,
   sessionFilterAIQueryDSL,
@@ -180,16 +182,90 @@ const sessionFilterAIQuery: DSLFilterAIQueryProps = {
   dsl: sessionFilterAIQueryDSL,
 };
 
+/** A project whose vocabulary has not loaded still filters, without typeahead. */
+export const EMPTY_SESSION_FILTER_VOCABULARY: readonly SessionFilterVocabularyTerm[] =
+  [];
+
+/**
+ * The project's session-filter autocomplete vocabulary. Suspends: the resolver
+ * scans annotation names and root-span attributes, so callers render the field
+ * with {@link EMPTY_SESSION_FILTER_VOCABULARY} until it arrives.
+ */
+export function useSessionFilterVocabulary(
+  projectId: string
+): readonly SessionFilterVocabularyTerm[] {
+  const data = useLazyLoadQuery<SessionFilterConditionFieldVocabularyQuery>(
+    graphql`
+      query SessionFilterConditionFieldVocabularyQuery($id: ID!) {
+        project: node(id: $id) {
+          ... on Project {
+            sessionFilterVocabulary {
+              name
+              type
+              description
+              category
+              iterableName
+            }
+          }
+        }
+      }
+    `,
+    { id: projectId }
+  );
+  return (
+    data.project?.sessionFilterVocabulary ?? EMPTY_SESSION_FILTER_VOCABULARY
+  );
+}
+
+/**
+ * Requires `SessionFiltersProvider`/`TracingProvider`; use
+ * {@link SessionFilterConditionFieldCore} outside them.
+ */
 export function SessionFilterConditionField(
   props: SessionFilterConditionFieldProps
 ) {
-  const {
-    onValidCondition,
-    vocabulary,
-    placeholder = "filter condition (e.g. num_traces >= 5)",
-  } = props;
+  const { onValidCondition, vocabulary, placeholder } = props;
   const { filterCondition, setFilterCondition } = useSessionFilters();
   const projectId = useTracingContext((state) => state.projectId);
+  return (
+    <SessionFilterConditionFieldCore
+      projectId={projectId}
+      vocabulary={vocabulary}
+      filterCondition={filterCondition}
+      onFilterConditionChange={setFilterCondition}
+      onValidCondition={onValidCondition}
+      placeholder={placeholder}
+    />
+  );
+}
+
+export type SessionFilterConditionFieldCoreProps = {
+  projectId: string;
+  vocabulary: readonly SessionFilterVocabularyTerm[];
+  filterCondition: string;
+  onFilterConditionChange: (condition: string) => void;
+  onValidCondition: (condition: string) => void;
+  /** An empty condition reports as valid (unfiltered). */
+  onValidityChange?: (isValid: boolean) => void;
+  placeholder?: string;
+};
+
+/**
+ * Takes all filter state as props, so it can mount outside
+ * `SessionFiltersProvider`/`TracingProvider`.
+ */
+export function SessionFilterConditionFieldCore(
+  props: SessionFilterConditionFieldCoreProps
+) {
+  const {
+    projectId,
+    vocabulary,
+    filterCondition,
+    onFilterConditionChange,
+    onValidCondition,
+    onValidityChange,
+    placeholder = "filter condition (e.g. num_traces >= 5)",
+  } = props;
 
   // Element fields are split out of the top-level vocabulary: offering
   // `latency_ms` bare would complete a condition the compiler rejects, since
@@ -299,7 +375,7 @@ export function SessionFilterConditionField(
       aria-label="Filter sessions"
       className="session-filter-condition-field"
       value={filterCondition}
-      onChange={setFilterCondition}
+      onChange={onFilterConditionChange}
       placeholder={placeholder}
       completions={completions}
       snippets={sessionFilterSnippets}
@@ -308,6 +384,7 @@ export function SessionFilterConditionField(
       getErrorRange={findDSLFilterComprehensionRange}
       validateCondition={validateCondition}
       onValidCondition={handleValidCondition}
+      onValidationStateChange={onValidityChange}
       aiQuery={sessionFilterAIQuery}
     />
   );

--- a/js/app/src/pages/project/SessionsTable.tsx
+++ b/js/app/src/pages/project/SessionsTable.tsx
@@ -20,7 +20,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay";
+import { graphql, usePaginationFragment } from "react-relay";
 import { Group, Panel } from "react-resizable-panels";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
@@ -63,14 +63,17 @@ import {
 } from "../../components/table";
 import type { SessionsTable_sessions$key } from "./__generated__/SessionsTable_sessions.graphql";
 import type { SessionsTableQuery } from "./__generated__/SessionsTableQuery.graphql";
-import type { SessionsTableSessionFilterVocabularyQuery } from "./__generated__/SessionsTableSessionFilterVocabularyQuery.graphql";
 import { DEFAULT_PAGE_SIZE } from "./constants";
 import {
   SessionInputValueTooltipCell,
   SessionOutputValueTooltipCell,
 } from "./IOValueTooltipCell";
 import { SessionColumnSelector } from "./SessionColumnSelector";
-import { SessionFilterConditionField } from "./SessionFilterConditionField";
+import {
+  EMPTY_SESSION_FILTER_VOCABULARY,
+  SessionFilterConditionField,
+  useSessionFilterVocabulary,
+} from "./SessionFilterConditionField";
 import { SessionsTableAside } from "./SessionsTableAside";
 import { SessionsTableEmpty } from "./SessionsTableEmpty";
 import { spansTableCSS } from "./styles";
@@ -98,8 +101,6 @@ const toolbarFilterFieldCSS = css`
   min-width: min(100%, 320px);
 `;
 
-const EMPTY_SESSION_FILTER_VOCABULARY = [] as const;
-
 /**
  * The filter field, once its per-project autocomplete vocabulary has loaded.
  * The vocabulary resolver scans annotation names and root-span attributes, so
@@ -112,29 +113,10 @@ function SessionFilterConditionFieldWithVocabulary({
   projectId: string;
   onValidCondition: (condition: string) => void;
 }) {
-  const data = useLazyLoadQuery<SessionsTableSessionFilterVocabularyQuery>(
-    graphql`
-      query SessionsTableSessionFilterVocabularyQuery($id: ID!) {
-        project: node(id: $id) {
-          ... on Project {
-            sessionFilterVocabulary {
-              name
-              type
-              description
-              category
-              iterableName
-            }
-          }
-        }
-      }
-    `,
-    { id: projectId }
-  );
+  const vocabulary = useSessionFilterVocabulary(projectId);
   return (
     <SessionFilterConditionField
-      vocabulary={
-        data.project?.sessionFilterVocabulary ?? EMPTY_SESSION_FILTER_VOCABULARY
-      }
+      vocabulary={vocabulary}
       onValidCondition={onValidCondition}
     />
   );

--- a/js/app/src/pages/project/__generated__/SessionFilterConditionFieldVocabularyQuery.graphql.ts
+++ b/js/app/src/pages/project/__generated__/SessionFilterConditionFieldVocabularyQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5c0ebefad8ef495498cc892298ebe2e9>>
+ * @generated SignedSource<<7923daf01db6a9098673be4ab855140d>>
  * @lightSyntaxTransform
  */
 
@@ -8,10 +8,10 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type SessionsTableSessionFilterVocabularyQuery$variables = {
+export type SessionFilterConditionFieldVocabularyQuery$variables = {
   id: string;
 };
-export type SessionsTableSessionFilterVocabularyQuery$data = {
+export type SessionFilterConditionFieldVocabularyQuery$data = {
   readonly project: {
     readonly sessionFilterVocabulary?: ReadonlyArray<{
       readonly category: string;
@@ -22,9 +22,9 @@ export type SessionsTableSessionFilterVocabularyQuery$data = {
     }>;
   };
 };
-export type SessionsTableSessionFilterVocabularyQuery = {
-  response: SessionsTableSessionFilterVocabularyQuery$data;
-  variables: SessionsTableSessionFilterVocabularyQuery$variables;
+export type SessionFilterConditionFieldVocabularyQuery = {
+  response: SessionFilterConditionFieldVocabularyQuery$data;
+  variables: SessionFilterConditionFieldVocabularyQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -100,7 +100,7 @@ return {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "SessionsTableSessionFilterVocabularyQuery",
+    "name": "SessionFilterConditionFieldVocabularyQuery",
     "selections": [
       {
         "alias": "project",
@@ -122,7 +122,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
-    "name": "SessionsTableSessionFilterVocabularyQuery",
+    "name": "SessionFilterConditionFieldVocabularyQuery",
     "selections": [
       {
         "alias": "project",
@@ -153,16 +153,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "40a2888a1d5ca2f41532e43b026a6e93",
+    "cacheID": "ce769f4e22791a7a2282a8d331116976",
     "id": null,
     "metadata": {},
-    "name": "SessionsTableSessionFilterVocabularyQuery",
+    "name": "SessionFilterConditionFieldVocabularyQuery",
     "operationKind": "query",
-    "text": "query SessionsTableSessionFilterVocabularyQuery(\n  $id: ID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      sessionFilterVocabulary {\n        name\n        type\n        description\n        category\n        iterableName\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query SessionFilterConditionFieldVocabularyQuery(\n  $id: ID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      sessionFilterVocabulary {\n        name\n        type\n        description\n        category\n        iterableName\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "99c0486b11805a81b0c04228d95040f7";
+(node as any).hash = "a315f91ed0f59f2866b1d6c32331eb61";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -188,6 +188,7 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
           // A null per-project mapping inherits the evaluator's own mapping.
           inputMapping: null,
           filterCondition: scope.filterCondition,
+          evaluationDelaySeconds: scope.evaluationDelaySeconds,
           enabled: true,
         },
       },

--- a/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -34,7 +34,10 @@ import type { CreateProjectCodeEvaluatorDialogContentMutation } from "@phoenix/p
 import type { CreateProjectCodeEvaluatorDialogContentQuery } from "@phoenix/pages/project/evaluators/__generated__/CreateProjectCodeEvaluatorDialogContentQuery.graphql";
 import { ProjectCodeEvaluatorFormSections } from "@phoenix/pages/project/evaluators/ProjectEvaluatorFormSections";
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
-import type { ProjectEvaluatorScope } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import {
+  toEvaluationDelayInput,
+  type ProjectEvaluatorScope,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { refetchProjectEvaluators } from "@phoenix/pages/project/evaluators/refetchProjectEvaluators";
 import type { CodeEvaluatorLanguage } from "@phoenix/types";
 
@@ -188,7 +191,7 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
           // A null per-project mapping inherits the evaluator's own mapping.
           inputMapping: null,
           filterCondition: scope.filterCondition,
-          evaluationDelaySeconds: scope.evaluationDelaySeconds,
+          ...toEvaluationDelayInput(scope),
           enabled: true,
         },
       },

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -32,6 +32,7 @@ import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/Pro
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
 import {
   DEFAULT_EVALUATION_DELAY_SECONDS,
+  toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { refetchProjectEvaluators } from "@phoenix/pages/project/evaluators/refetchProjectEvaluators";
@@ -42,6 +43,7 @@ import {
 import type { PlaygroundChatTemplate } from "@phoenix/store";
 import {
   DEFAULT_LLM_EVALUATOR_STORE_VALUES,
+  defaultEvaluatorMappingSourceState,
   type AnnotationConfig,
   type EvaluatorStoreProps,
 } from "@phoenix/store/evaluatorStore";
@@ -165,14 +167,9 @@ const CreateProjectEvaluatorDialog = ({
           kind: "CODE",
         },
         outputConfigs: [createDefaultFreeformOutputConfig("")],
-        evaluatorMappingSource: {
-          grain: "span",
-          source: {
-            input: {},
-            output: {},
-            metadata: { attributes: {} },
-          },
-        },
+        evaluatorMappingSource: defaultEvaluatorMappingSourceState(
+          toEvaluatorMappingSourceGrain(scope.targetType)
+        ),
       } satisfies EvaluatorStoreProps;
     }
     const copiedState =
@@ -208,14 +205,9 @@ const CreateProjectEvaluatorDialog = ({
           : outputConfigs[0]
             ? [{ ...outputConfigs[0], name: defaultEvaluatorName }]
             : [],
-      evaluatorMappingSource: {
-        grain: "span",
-        source: {
-          input: {},
-          output: {},
-          metadata: { attributes: {} },
-        },
-      },
+      evaluatorMappingSource: defaultEvaluatorMappingSourceState(
+        toEvaluatorMappingSourceGrain(scope.targetType)
+      ),
     } satisfies EvaluatorStoreProps;
   })();
 

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -30,7 +30,10 @@ import { ProjectLlmEvaluatorFormSections } from "@phoenix/pages/project/evaluato
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
 import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideover";
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
-import type { ProjectEvaluatorScope } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import {
+  DEFAULT_EVALUATION_DELAY_SECONDS,
+  type ProjectEvaluatorScope,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { refetchProjectEvaluators } from "@phoenix/pages/project/evaluators/refetchProjectEvaluators";
 import {
   useEvaluatorFormDirtyCheck,
@@ -147,6 +150,7 @@ const CreateProjectEvaluatorDialog = ({
     targetType: "SPAN",
     filterCondition: "",
     samplingRate: 1,
+    evaluationDelaySeconds: DEFAULT_EVALUATION_DELAY_SECONDS,
   });
 
   const initialState = (() => {
@@ -361,6 +365,7 @@ function AttachCodeProjectEvaluatorDialog({
               samplingRate: scope.samplingRate,
               evaluationTarget: scope.targetType,
               filterCondition: scope.filterCondition,
+              evaluationDelaySeconds: scope.evaluationDelaySeconds,
               enabled: true,
               inputMapping: null,
             },
@@ -452,6 +457,7 @@ function CreateLlmProjectEvaluatorDialog({
           evaluationTarget: scope.targetType,
           samplingRate: scope.samplingRate,
           filterCondition: scope.filterCondition,
+          evaluationDelaySeconds: scope.evaluationDelaySeconds,
           enabled: true,
         },
       });

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -32,6 +32,7 @@ import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/Pro
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
 import {
   DEFAULT_EVALUATION_DELAY_SECONDS,
+  toEvaluationDelayInput,
   toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
@@ -357,7 +358,7 @@ function AttachCodeProjectEvaluatorDialog({
               samplingRate: scope.samplingRate,
               evaluationTarget: scope.targetType,
               filterCondition: scope.filterCondition,
-              evaluationDelaySeconds: scope.evaluationDelaySeconds,
+              ...toEvaluationDelayInput(scope),
               enabled: true,
               inputMapping: null,
             },
@@ -449,7 +450,7 @@ function CreateLlmProjectEvaluatorDialog({
           evaluationTarget: scope.targetType,
           samplingRate: scope.samplingRate,
           filterCondition: scope.filterCondition,
-          evaluationDelaySeconds: scope.evaluationDelaySeconds,
+          ...toEvaluationDelayInput(scope),
           enabled: true,
         },
       });

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -113,6 +113,7 @@ export function useProjectEvaluator(projectEvaluatorId: string) {
             evaluationTarget
             filterCondition
             samplingRate
+            evaluationDelaySeconds
             enabled
             inputMapping {
               pathMapping
@@ -269,6 +270,7 @@ function getScope(evaluator: ProjectEvaluatorNode): ProjectEvaluatorScope {
     targetType: evaluator.evaluationTarget,
     filterCondition: evaluator.filterCondition,
     samplingRate: evaluator.samplingRate,
+    evaluationDelaySeconds: evaluator.evaluationDelaySeconds,
   };
 }
 
@@ -403,6 +405,7 @@ function EditLlmProjectEvaluatorContent({
             samplingRate: scope.samplingRate,
             evaluationTarget: scope.targetType,
             filterCondition: scope.filterCondition,
+            evaluationDelaySeconds: scope.evaluationDelaySeconds,
           },
         },
         onCompleted: () => {
@@ -637,6 +640,7 @@ function EditCodeProjectEvaluator({
                     samplingRate: scope.samplingRate,
                     evaluationTarget: scope.targetType,
                     filterCondition: scope.filterCondition,
+                    evaluationDelaySeconds: scope.evaluationDelaySeconds,
                   },
                 },
                 onCompleted: () => {

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -35,6 +35,7 @@ import { convertProjectEvaluatorOutputConfigs } from "@phoenix/pages/project/eva
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
 import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideover";
 import {
+  toEvaluationDelayInput,
   toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
@@ -406,7 +407,7 @@ function EditLlmProjectEvaluatorContent({
             samplingRate: scope.samplingRate,
             evaluationTarget: scope.targetType,
             filterCondition: scope.filterCondition,
-            evaluationDelaySeconds: scope.evaluationDelaySeconds,
+            ...toEvaluationDelayInput(scope),
           },
         },
         onCompleted: () => {
@@ -636,7 +637,7 @@ function EditCodeProjectEvaluator({
                     samplingRate: scope.samplingRate,
                     evaluationTarget: scope.targetType,
                     filterCondition: scope.filterCondition,
-                    evaluationDelaySeconds: scope.evaluationDelaySeconds,
+                    ...toEvaluationDelayInput(scope),
                   },
                 },
                 onCompleted: () => {

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -34,13 +34,17 @@ import { ProjectLlmEvaluatorFormSections } from "@phoenix/pages/project/evaluato
 import { convertProjectEvaluatorOutputConfigs } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
 import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideover";
-import type { ProjectEvaluatorScope } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import {
+  toEvaluatorMappingSourceGrain,
+  type ProjectEvaluatorScope,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import {
   useEvaluatorFormDirtyCheck,
   type EvaluatorFormDirtyCheck,
 } from "@phoenix/pages/project/evaluators/useEvaluatorFormDirtyCheck";
 import {
   DEFAULT_LLM_EVALUATOR_STORE_VALUES,
+  defaultEvaluatorMappingSourceState,
   type EvaluatorStoreInstance,
   type EvaluatorStoreProps,
 } from "@phoenix/store/evaluatorStore";
@@ -361,14 +365,11 @@ function EditLlmProjectEvaluatorContent({
     outputConfigs: outputConfigs.length
       ? outputConfigs
       : DEFAULT_LLM_EVALUATOR_STORE_VALUES.outputConfigs,
-    evaluatorMappingSource: {
-      grain: "span" as const,
-      source: {
-        input: {},
-        output: {},
-        metadata: { attributes: {} },
-      },
-    },
+    // The persisted target decides the mapping vocabulary before any recorded
+    // record loads; a session evaluator must never open speaking span.
+    evaluatorMappingSource: defaultEvaluatorMappingSourceState(
+      toEvaluatorMappingSourceGrain(scope.targetType)
+    ),
   } satisfies EvaluatorStoreProps;
 
   const submit = (
@@ -536,14 +537,9 @@ function EditCodeProjectEvaluator({
     },
     outputConfigs: loadedOutputConfigs,
     showPromptPreview: false,
-    evaluatorMappingSource: {
-      grain: "span",
-      source: {
-        input: {},
-        output: {},
-        metadata: { attributes: {} },
-      },
-    },
+    evaluatorMappingSource: defaultEvaluatorMappingSourceState(
+      toEvaluatorMappingSourceGrain(scope.targetType)
+    ),
   };
   return (
     <EvaluatorStoreProvider initialState={initialState}>

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorFormSections.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorFormSections.tsx
@@ -39,7 +39,9 @@ export const ProjectLlmEvaluatorFormSections = ({
               Evaluator Scope
             </Heading>
             <Text color="text-500" size="S">
-              Choose what gets evaluated and how much of it.
+              {scope.targetType === "SESSION"
+                ? "Select which sessions this evaluator runs on and how often."
+                : "Select which spans this evaluator runs on and how often."}
             </Text>
           </Flex>
           <ProjectEvaluatorScopeFieldGroup

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
@@ -87,10 +87,10 @@ function getSchedulabilityExplanation(
 ): string {
   switch (reason) {
     case "DISABLED":
-      return "This evaluator is disabled. Enable it to resume scheduling.";
+      return "Enable this evaluator to resume scheduling.";
     case "TRACE_TARGET_UNSUPPORTED":
-      return "Trace evaluators are saved but are not scheduled yet.";
+      return "Trace evaluators are not scheduled yet.";
     default:
-      return "This evaluator does not meet the current scheduling requirements.";
+      return "This evaluator does not meet the scheduling requirements.";
   }
 }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
@@ -90,10 +90,6 @@ function getSchedulabilityExplanation(
       return "This evaluator is disabled. Enable it to resume scheduling.";
     case "TRACE_TARGET_UNSUPPORTED":
       return "Trace evaluators are saved but are not scheduled yet.";
-    case "SESSION_FILTER_UNSUPPORTED":
-      return "Session evaluators with a filter are saved but never scheduled. Clear the filter to schedule this evaluator.";
-    case "SESSION_SAMPLING_UNSUPPORTED":
-      return "Session evaluators with a sampling rate below 100% are saved but never scheduled. Set sampling to 100% to schedule this evaluator.";
     default:
       return "This evaluator does not meet the current scheduling requirements.";
   }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeDetails.tsx
@@ -1,11 +1,16 @@
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import { Flex, Heading, Text } from "@phoenix/components";
+import { Alert, Flex, Heading, Text } from "@phoenix/components";
 import { evaluatorDetailsCardCSS } from "@phoenix/components/evaluators/EvaluatorDetailsSection";
-import type { ProjectEvaluatorScopeDetails_projectEvaluator$key } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql";
+import type {
+  ProjectEvaluatorScopeDetails_projectEvaluator$data,
+  ProjectEvaluatorScopeDetails_projectEvaluator$key,
+} from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql";
 import {
+  formatEvaluationDelay,
   formatEvaluationTarget,
+  formatEvaluationTargetPlural,
   formatSamplingRate,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
@@ -25,10 +30,14 @@ export function ProjectEvaluatorScopeDetails({
         evaluationTarget
         filterCondition
         samplingRate
+        evaluationDelaySeconds
+        schedulabilityStatus
+        schedulabilityReason
       }
     `,
     projectEvaluatorRef
   );
+  const isSessionTarget = projectEvaluator.evaluationTarget === "SESSION";
 
   return (
     <Flex direction="column" gap="size-100">
@@ -46,15 +55,46 @@ export function ProjectEvaluatorScopeDetails({
                 {projectEvaluator.filterCondition}
               </Text>
             ) : (
-              "All spans"
+              `All ${formatEvaluationTargetPlural(projectEvaluator.evaluationTarget)}`
             )}
           </Text>
           <Text size="S">
             <Text weight="heavy">Sampling Rate:</Text>{" "}
             {formatSamplingRate(projectEvaluator.samplingRate)}
           </Text>
+          {isSessionTarget ? (
+            <Text size="S">
+              <Text weight="heavy">Evaluation Delay:</Text>{" "}
+              {formatEvaluationDelay(projectEvaluator.evaluationDelaySeconds)}
+            </Text>
+          ) : null}
+          {projectEvaluator.schedulabilityStatus === "NOT_SCHEDULABLE" ? (
+            <Alert variant="warning" title="This evaluator is not scheduled">
+              {getSchedulabilityExplanation(
+                projectEvaluator.schedulabilityReason
+              )}
+            </Alert>
+          ) : null}
         </Flex>
       </div>
     </Flex>
   );
+}
+
+/** Every reason the server can report, including ones this build predates. */
+function getSchedulabilityExplanation(
+  reason: ProjectEvaluatorScopeDetails_projectEvaluator$data["schedulabilityReason"]
+): string {
+  switch (reason) {
+    case "DISABLED":
+      return "This evaluator is disabled. Enable it to resume scheduling.";
+    case "TRACE_TARGET_UNSUPPORTED":
+      return "Trace evaluators are saved but are not scheduled yet.";
+    case "SESSION_FILTER_UNSUPPORTED":
+      return "Session evaluators with a filter are saved but never scheduled. Clear the filter to schedule this evaluator.";
+    case "SESSION_SAMPLING_UNSUPPORTED":
+      return "Session evaluators with a sampling rate below 100% are saved but never scheduled. Set sampling to 100% to schedule this evaluator.";
+    default:
+      return "This evaluator does not meet the current scheduling requirements.";
+  }
 }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -87,6 +87,11 @@ export const ProjectEvaluatorScopeFieldGroup = ({
         ) : null}
         {children}
       </Flex>
+      {isSessionTarget ? (
+        <Text size="XS" color="text-500">
+          Sessions are evaluated after this many seconds of inactivity.
+        </Text>
+      ) : null}
       {/* Remounted per target so the draft condition does not survive a switch
           into a language that cannot parse it. */}
       <ProjectEvaluatorFilterField
@@ -99,13 +104,6 @@ export const ProjectEvaluatorScopeFieldGroup = ({
         }
         onValidityChange={onFilterValidityChange}
       />
-      {isSessionTarget ? (
-        <Text size="XS" color="text-500">
-          Each matching session is evaluated once, after it stays quiet for the
-          evaluation delay. Later activity in the session does not schedule
-          another evaluation.
-        </Text>
-      ) : null}
     </Flex>
   );
 };
@@ -285,6 +283,7 @@ const ProjectEvaluatorFilterField = ({
           onFilterConditionChange={setDraft}
           onValidCondition={applyValidCondition}
           onValidityChange={onValidityChange}
+          placeholder="num_traces >= 5"
         />
       ) : (
         <SpanFilterConditionFieldCore

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -31,8 +31,9 @@ import {
 } from "@phoenix/pages/project/SpanFilterConditionField";
 
 /**
- * The target, sampling, and filter fields wired to a scope object. `children`
- * renders additional fields in the first row after sampling.
+ * The target, sampling, delay, and filter fields wired to a scope object.
+ * `children` renders additional fields at the end of the first row, after
+ * every setting the scope persists.
  */
 export const ProjectEvaluatorScopeFieldGroup = ({
   projectId,
@@ -76,7 +77,6 @@ export const ProjectEvaluatorScopeFieldGroup = ({
           value={scope.samplingRate}
           onChange={(samplingRate) => onScopeChange({ ...scope, samplingRate })}
         />
-        {children}
         {isSessionTarget ? (
           <ProjectEvaluatorEvaluationDelayField
             value={scope.evaluationDelaySeconds}
@@ -85,6 +85,7 @@ export const ProjectEvaluatorScopeFieldGroup = ({
             }
           />
         ) : null}
+        {children}
       </Flex>
       {/* Remounted per target so the draft condition does not survive a switch
           into a language that cannot parse it. */}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { Suspense, useState } from "react";
 
 import {
-  Alert,
   Flex,
   Input,
   NumberField,
@@ -14,7 +13,6 @@ import {
   Text,
 } from "@phoenix/components";
 import {
-  getSessionScopeUnschedulableReason,
   isProjectEvaluatorTarget,
   MIN_EVALUATION_DELAY_SECONDS,
   toProjectEvaluatorSamplingFraction,
@@ -55,7 +53,6 @@ export const ProjectEvaluatorScopeFieldGroup = ({
   children?: ReactNode;
 }) => {
   const isSessionTarget = scope.targetType === "SESSION";
-  const unschedulableReason = getSessionScopeUnschedulableReason(scope);
   // Spans and sessions are filtered in different languages, so a condition
   // written for one target cannot carry over to the other.
   const handleTargetChange = (targetType: ProjectEvaluatorTarget) => {
@@ -101,17 +98,10 @@ export const ProjectEvaluatorScopeFieldGroup = ({
       />
       {isSessionTarget ? (
         <Text size="XS" color="text-500">
-          Every session in this project is evaluated once, after it stays quiet
-          for the evaluation delay. Later activity in the session does not
-          schedule another evaluation.
+          Each matching session is evaluated once, after it stays quiet for the
+          evaluation delay. Later activity in the session does not schedule
+          another evaluation.
         </Text>
-      ) : null}
-      {unschedulableReason ? (
-        <Alert variant="warning" title="This evaluator will not run">
-          {unschedulableReason === "filter"
-            ? "Session evaluators with a filter are saved but never scheduled. Clear the session filter to schedule this evaluator."
-            : "Session evaluators with a sampling rate below 100% are saved but never scheduled. Set sampling to 100% to schedule this evaluator."}
-        </Alert>
       ) : null}
     </Flex>
   );

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -97,6 +97,7 @@ export const ProjectEvaluatorScopeFieldGroup = ({
       {showFilterField ? (
         <ProjectEvaluatorSpanFilterField
           projectId={projectId}
+          targetType={scope.targetType}
           value={scope.filterCondition}
           onChange={(filterCondition) =>
             onScopeChange({ ...scope, filterCondition })
@@ -265,12 +266,15 @@ const samplingSliderFillCSS = css`
  */
 const ProjectEvaluatorSpanFilterField = ({
   projectId,
+  targetType,
   value,
   onChange,
   onValidityChange,
   showHint = true,
 }: {
   projectId: string;
+  /** Names the records the condition selects, in the label and the hint. */
+  targetType: ProjectEvaluatorTarget;
   value: string;
   onChange: (filterCondition: string) => void;
   onValidityChange?: (isValid: boolean) => void;
@@ -289,7 +293,7 @@ const ProjectEvaluatorSpanFilterField = ({
   return (
     <Flex direction="column" gap="size-50">
       <Text size="XS" weight="heavy" color="text-700">
-        Span filter
+        {targetType === "SESSION" ? "Session filter" : "Span filter"}
       </Text>
       <SpanFilterConditionFieldCore
         projectId={projectId}
@@ -301,7 +305,9 @@ const ProjectEvaluatorSpanFilterField = ({
       />
       {showHint ? (
         <Text size="XS" color="text-500">
-          Leave empty to evaluate every span.
+          {targetType === "SESSION"
+            ? "Leave empty to evaluate every session."
+            : "Leave empty to evaluate every span."}
         </Text>
       ) : null}
     </Flex>

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -69,6 +69,14 @@ export const ProjectEvaluatorScopeFieldGroup = ({
           onChange={handleTargetChange}
           isDisabled={isTargetDisabled}
         />
+        <ProjectEvaluatorSamplingField
+          // A filled slider takes the whole row, which would wrap the delay
+          // field onto a line of its own.
+          fill={fillSampling && !isSessionTarget}
+          value={scope.samplingRate}
+          onChange={(samplingRate) => onScopeChange({ ...scope, samplingRate })}
+        />
+        {children}
         {isSessionTarget ? (
           <ProjectEvaluatorEvaluationDelayField
             value={scope.evaluationDelaySeconds}
@@ -77,12 +85,6 @@ export const ProjectEvaluatorScopeFieldGroup = ({
             }
           />
         ) : null}
-        <ProjectEvaluatorSamplingField
-          fill={fillSampling}
-          value={scope.samplingRate}
-          onChange={(samplingRate) => onScopeChange({ ...scope, samplingRate })}
-        />
-        {children}
       </Flex>
       {/* Remounted per target so the draft condition does not survive a switch
           into a language that cannot parse it. */}
@@ -120,9 +122,10 @@ const ProjectEvaluatorEvaluationDelayField = ({
       <Text size="XS" weight="heavy" color="text-700">
         Evaluation delay
       </Text>
+      {/* Stays at the default M size so it lines up with the segmented
+          control, slider, and select sharing this row. */}
       <NumberField
         aria-label="Evaluation delay in seconds"
-        size="S"
         step={1}
         minValue={MIN_EVALUATION_DELAY_SECONDS}
         value={value}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
 import {
   Alert,
@@ -22,13 +22,19 @@ import {
   type ProjectEvaluatorTarget,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import {
+  EMPTY_SESSION_FILTER_VOCABULARY,
+  SessionFilterConditionFieldCore,
+  type SessionFilterConditionFieldCoreProps,
+  useSessionFilterVocabulary,
+} from "@phoenix/pages/project/SessionFilterConditionField";
+import {
   SpanFilterConditionFieldCore,
   type SpanFilterValidConditionArgs,
 } from "@phoenix/pages/project/SpanFilterConditionField";
 
 /**
- * The target, sampling, and span-filter fields wired to a scope object.
- * `children` renders additional fields in the first row after sampling.
+ * The target, sampling, and filter fields wired to a scope object. `children`
+ * renders additional fields in the first row after sampling.
  */
 export const ProjectEvaluatorScopeFieldGroup = ({
   projectId,
@@ -50,22 +56,13 @@ export const ProjectEvaluatorScopeFieldGroup = ({
 }) => {
   const isSessionTarget = scope.targetType === "SESSION";
   const unschedulableReason = getSessionScopeUnschedulableReason(scope);
-  // A session evaluator only runs unfiltered and unsampled, so those controls
-  // stay hidden unless a stored value is holding this evaluator back, in which
-  // case they are the only way to clear it.
-  const showSamplingField = !isSessionTarget || scope.samplingRate !== 1;
-  const showFilterField = !isSessionTarget || scope.filterCondition !== "";
+  // Spans and sessions are filtered in different languages, so a condition
+  // written for one target cannot carry over to the other.
   const handleTargetChange = (targetType: ProjectEvaluatorTarget) => {
-    if (targetType === "SESSION") {
-      onScopeChange({
-        ...scope,
-        targetType,
-        filterCondition: "",
-        samplingRate: 1,
-      });
+    if (targetType === scope.targetType) {
       return;
     }
-    onScopeChange({ ...scope, targetType });
+    onScopeChange({ ...scope, targetType, filterCondition: "" });
   };
   return (
     <Flex direction="column" gap="size-200">
@@ -83,29 +80,25 @@ export const ProjectEvaluatorScopeFieldGroup = ({
             }
           />
         ) : null}
-        {showSamplingField ? (
-          <ProjectEvaluatorSamplingField
-            fill={fillSampling}
-            value={scope.samplingRate}
-            onChange={(samplingRate) =>
-              onScopeChange({ ...scope, samplingRate })
-            }
-          />
-        ) : null}
+        <ProjectEvaluatorSamplingField
+          fill={fillSampling}
+          value={scope.samplingRate}
+          onChange={(samplingRate) => onScopeChange({ ...scope, samplingRate })}
+        />
         {children}
       </Flex>
-      {showFilterField ? (
-        <ProjectEvaluatorSpanFilterField
-          projectId={projectId}
-          targetType={scope.targetType}
-          value={scope.filterCondition}
-          onChange={(filterCondition) =>
-            onScopeChange({ ...scope, filterCondition })
-          }
-          onValidityChange={onFilterValidityChange}
-          showHint={!isSessionTarget}
-        />
-      ) : null}
+      {/* Remounted per target so the draft condition does not survive a switch
+          into a language that cannot parse it. */}
+      <ProjectEvaluatorFilterField
+        key={scope.targetType}
+        projectId={projectId}
+        targetType={scope.targetType}
+        value={scope.filterCondition}
+        onChange={(filterCondition) =>
+          onScopeChange({ ...scope, filterCondition })
+        }
+        onValidityChange={onFilterValidityChange}
+      />
       {isSessionTarget ? (
         <Text size="XS" color="text-500">
           Every session in this project is evaluated once, after it stays quiet
@@ -116,7 +109,7 @@ export const ProjectEvaluatorScopeFieldGroup = ({
       {unschedulableReason ? (
         <Alert variant="warning" title="This evaluator will not run">
           {unschedulableReason === "filter"
-            ? "Session evaluators with a filter are saved but never scheduled. Clear the span filter to schedule this evaluator."
+            ? "Session evaluators with a filter are saved but never scheduled. Clear the session filter to schedule this evaluator."
             : "Session evaluators with a sampling rate below 100% are saved but never scheduled. Set sampling to 100% to schedule this evaluator."}
         </Alert>
       ) : null}
@@ -261,30 +254,26 @@ const samplingSliderFillCSS = css`
 `;
 
 /**
- * The span filter with its own draft state: only validated conditions are
- * lifted into the committed scope via `onChange`.
+ * The filter for whichever records the target names, with its own draft state:
+ * only validated conditions are lifted into the committed scope via `onChange`.
  */
-const ProjectEvaluatorSpanFilterField = ({
+const ProjectEvaluatorFilterField = ({
   projectId,
   targetType,
   value,
   onChange,
   onValidityChange,
-  showHint = true,
 }: {
   projectId: string;
-  /** Names the records the condition selects, in the label and the hint. */
+  /** Picks the filter language, and names the records in the label and hint. */
   targetType: ProjectEvaluatorTarget;
   value: string;
   onChange: (filterCondition: string) => void;
   onValidityChange?: (isValid: boolean) => void;
-  /** Hidden where an empty filter is the only schedulable value. */
-  showHint?: boolean;
 }) => {
+  const isSessionTarget = targetType === "SESSION";
   const [draft, setDraft] = useState(value);
-  const handleValidCondition = ({
-    condition: filterCondition,
-  }: SpanFilterValidConditionArgs) => {
+  const applyValidCondition = (filterCondition: string) => {
     if (filterCondition === value) {
       return;
     }
@@ -293,23 +282,61 @@ const ProjectEvaluatorSpanFilterField = ({
   return (
     <Flex direction="column" gap="size-50">
       <Text size="XS" weight="heavy" color="text-700">
-        {targetType === "SESSION" ? "Session filter" : "Span filter"}
+        {isSessionTarget ? "Session filter" : "Span filter"}
       </Text>
-      <SpanFilterConditionFieldCore
-        projectId={projectId}
-        filterCondition={draft}
-        onFilterConditionChange={setDraft}
-        onValidCondition={handleValidCondition}
-        onValidityChange={onValidityChange}
-        placeholder="span_kind == 'LLM'"
-      />
-      {showHint ? (
-        <Text size="XS" color="text-500">
-          {targetType === "SESSION"
-            ? "Leave empty to evaluate every session."
-            : "Leave empty to evaluate every span."}
-        </Text>
-      ) : null}
+      {isSessionTarget ? (
+        <SessionScopeFilterField
+          projectId={projectId}
+          filterCondition={draft}
+          onFilterConditionChange={setDraft}
+          onValidCondition={applyValidCondition}
+          onValidityChange={onValidityChange}
+        />
+      ) : (
+        <SpanFilterConditionFieldCore
+          projectId={projectId}
+          filterCondition={draft}
+          onFilterConditionChange={setDraft}
+          onValidCondition={({ condition }: SpanFilterValidConditionArgs) =>
+            applyValidCondition(condition)
+          }
+          onValidityChange={onValidityChange}
+          placeholder="span_kind == 'LLM'"
+        />
+      )}
+      <Text size="XS" color="text-500">
+        {isSessionTarget
+          ? "Leave empty to evaluate every session."
+          : "Leave empty to evaluate every span."}
+      </Text>
     </Flex>
   );
 };
+
+/**
+ * Autocomplete data must not gate the field, so it filters with an empty
+ * vocabulary until the project's vocabulary arrives.
+ */
+function SessionScopeFilterField(
+  props: Omit<SessionFilterConditionFieldCoreProps, "vocabulary">
+) {
+  return (
+    <Suspense
+      fallback={
+        <SessionFilterConditionFieldCore
+          {...props}
+          vocabulary={EMPTY_SESSION_FILTER_VOCABULARY}
+        />
+      }
+    >
+      <SessionScopeFilterFieldWithVocabulary {...props} />
+    </Suspense>
+  );
+}
+
+function SessionScopeFilterFieldWithVocabulary(
+  props: Omit<SessionFilterConditionFieldCoreProps, "vocabulary">
+) {
+  const vocabulary = useSessionFilterVocabulary(props.projectId);
+  return <SessionFilterConditionFieldCore {...props} vocabulary={vocabulary} />;
+}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -3,7 +3,10 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 
 import {
+  Alert,
   Flex,
+  Input,
+  NumberField,
   SegmentedControl,
   SegmentedControlItem,
   Slider,
@@ -11,7 +14,9 @@ import {
   Text,
 } from "@phoenix/components";
 import {
+  getSessionScopeUnschedulableReason,
   isProjectEvaluatorTarget,
+  MIN_EVALUATION_DELAY_SECONDS,
   toProjectEvaluatorSamplingFraction,
   type ProjectEvaluatorScope,
   type ProjectEvaluatorTarget,
@@ -43,29 +48,107 @@ export const ProjectEvaluatorScopeFieldGroup = ({
   fillSampling?: boolean;
   children?: ReactNode;
 }) => {
+  const isSessionTarget = scope.targetType === "SESSION";
+  const unschedulableReason = getSessionScopeUnschedulableReason(scope);
+  // A session evaluator only runs unfiltered and unsampled, so those controls
+  // stay hidden unless a stored value is holding this evaluator back, in which
+  // case they are the only way to clear it.
+  const showSamplingField = !isSessionTarget || scope.samplingRate !== 1;
+  const showFilterField = !isSessionTarget || scope.filterCondition !== "";
+  const handleTargetChange = (targetType: ProjectEvaluatorTarget) => {
+    if (targetType === "SESSION") {
+      onScopeChange({
+        ...scope,
+        targetType,
+        filterCondition: "",
+        samplingRate: 1,
+      });
+      return;
+    }
+    onScopeChange({ ...scope, targetType });
+  };
   return (
     <Flex direction="column" gap="size-200">
       <Flex direction="row" gap="size-400" wrap alignItems="start">
         <ProjectEvaluatorTargetField
           value={scope.targetType}
-          onChange={(targetType) => onScopeChange({ ...scope, targetType })}
+          onChange={handleTargetChange}
           isDisabled={isTargetDisabled}
         />
-        <ProjectEvaluatorSamplingField
-          fill={fillSampling}
-          value={scope.samplingRate}
-          onChange={(samplingRate) => onScopeChange({ ...scope, samplingRate })}
-        />
+        {isSessionTarget ? (
+          <ProjectEvaluatorEvaluationDelayField
+            value={scope.evaluationDelaySeconds}
+            onChange={(evaluationDelaySeconds) =>
+              onScopeChange({ ...scope, evaluationDelaySeconds })
+            }
+          />
+        ) : null}
+        {showSamplingField ? (
+          <ProjectEvaluatorSamplingField
+            fill={fillSampling}
+            value={scope.samplingRate}
+            onChange={(samplingRate) =>
+              onScopeChange({ ...scope, samplingRate })
+            }
+          />
+        ) : null}
         {children}
       </Flex>
-      <ProjectEvaluatorSpanFilterField
-        projectId={projectId}
-        value={scope.filterCondition}
-        onChange={(filterCondition) =>
-          onScopeChange({ ...scope, filterCondition })
-        }
-        onValidityChange={onFilterValidityChange}
-      />
+      {showFilterField ? (
+        <ProjectEvaluatorSpanFilterField
+          projectId={projectId}
+          value={scope.filterCondition}
+          onChange={(filterCondition) =>
+            onScopeChange({ ...scope, filterCondition })
+          }
+          onValidityChange={onFilterValidityChange}
+          showHint={!isSessionTarget}
+        />
+      ) : null}
+      {isSessionTarget ? (
+        <Text size="XS" color="text-500">
+          Every session in this project is evaluated once, after it stays quiet
+          for the evaluation delay. Later activity in the session does not
+          schedule another evaluation.
+        </Text>
+      ) : null}
+      {unschedulableReason ? (
+        <Alert variant="warning" title="This evaluator will not run">
+          {unschedulableReason === "filter"
+            ? "Session evaluators with a filter are saved but never scheduled. Clear the span filter to schedule this evaluator."
+            : "Session evaluators with a sampling rate below 100% are saved but never scheduled. Set sampling to 100% to schedule this evaluator."}
+        </Alert>
+      ) : null}
+    </Flex>
+  );
+};
+
+const ProjectEvaluatorEvaluationDelayField = ({
+  value,
+  onChange,
+}: {
+  /** Seconds a session must stay quiet before its evaluation is scheduled. */
+  value: number;
+  onChange: (evaluationDelaySeconds: number) => void;
+}) => {
+  return (
+    <Flex direction="column" gap="size-50">
+      <Text size="XS" weight="heavy" color="text-700">
+        Evaluation delay
+      </Text>
+      <NumberField
+        aria-label="Evaluation delay in seconds"
+        size="S"
+        step={1}
+        minValue={MIN_EVALUATION_DELAY_SECONDS}
+        value={value}
+        onChange={onChange}
+        css={css`
+          width: 140px;
+        `}
+      >
+        <Input />
+      </NumberField>
     </Flex>
   );
 };
@@ -96,7 +179,7 @@ const ProjectEvaluatorTargetField = ({
         <SegmentedControlItem id="SPAN" isDisabled={isDisabled}>
           Span
         </SegmentedControlItem>
-        <SegmentedControlItem id="SESSION" isDisabled>
+        <SegmentedControlItem id="SESSION" isDisabled={isDisabled}>
           Session
         </SegmentedControlItem>
       </SegmentedControl>
@@ -185,11 +268,14 @@ const ProjectEvaluatorSpanFilterField = ({
   value,
   onChange,
   onValidityChange,
+  showHint = true,
 }: {
   projectId: string;
   value: string;
   onChange: (filterCondition: string) => void;
   onValidityChange?: (isValid: boolean) => void;
+  /** Hidden where an empty filter is the only schedulable value. */
+  showHint?: boolean;
 }) => {
   const [draft, setDraft] = useState(value);
   const handleValidCondition = ({
@@ -213,9 +299,11 @@ const ProjectEvaluatorSpanFilterField = ({
         onValidityChange={onValidityChange}
         placeholder="span_kind == 'LLM'"
       />
-      <Text size="XS" color="text-500">
-        Leave empty to evaluate every span.
-      </Text>
+      {showHint ? (
+        <Text size="XS" color="text-500">
+          Leave empty to evaluate every span.
+        </Text>
+      ) : null}
     </Flex>
   );
 };

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -51,6 +51,7 @@ import {
   useEvaluatorStoreInstance,
 } from "@phoenix/contexts/EvaluatorContext";
 import { usePlaygroundStore } from "@phoenix/contexts/PlaygroundContext";
+import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
 import { toGqlCredentials } from "@phoenix/pages/playground/playgroundUtils";
 import type { ProjectEvaluatorScopePanelCountQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelCountQuery.graphql";
 import type {
@@ -58,6 +59,8 @@ import type {
   InlineLLMEvaluatorInput,
   ProjectEvaluatorScopePanelPreviewMutation,
 } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelPreviewMutation.graphql";
+import type { ProjectEvaluatorScopePanelSessionCountQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionCountQuery.graphql";
+import type { ProjectEvaluatorScopePanelSessionsQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionsQuery.graphql";
 import type { ProjectEvaluatorScopePanelSpansQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSpansQuery.graphql";
 import { ProjectEvaluatorScopeFieldGroup } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeFields";
 import {
@@ -192,7 +195,7 @@ export const ProjectEvaluatorScopePanel = (
               <Heading level={2}>Scope</Heading>
               <Text color="text-500" size="S">
                 {isSessionTarget
-                  ? "Choose when this evaluator runs on each session."
+                  ? "Choose which sessions this evaluator runs on and when."
                   : "Choose what gets evaluated and how much of it."}
               </Text>
             </Flex>
@@ -208,7 +211,50 @@ export const ProjectEvaluatorScopePanel = (
           </>
         ) : null}
         {isSessionTarget ? (
-          <SessionInputNote />
+          <>
+            <SessionInputNote />
+            <Flex direction="column" gap="size-25">
+              {props.showScopeFields !== false ? (
+                <Heading level={2}>Matching sessions</Heading>
+              ) : (
+                <Flex
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  gap="size-200"
+                >
+                  <Heading level={2} weight="heavy">
+                    Matching Sessions
+                  </Heading>
+                  <TimeWindowSegmentedControl
+                    size="S"
+                    value={timeWindow.presetId}
+                    onChange={setTimeWindow}
+                  />
+                </Flex>
+              )}
+              <Suspense
+                fallback={
+                  <Text size="S" color="text-500">
+                    Counting matching sessions…
+                  </Text>
+                }
+              >
+                <MatchedSessionCountLine
+                  projectId={projectId}
+                  filterCondition={scope.filterCondition}
+                  timeWindow={timeWindow}
+                />
+              </Suspense>
+            </Flex>
+            <Suspense fallback={<Loading />}>
+              <SessionList
+                projectId={projectId}
+                filterCondition={scope.filterCondition}
+                timeWindow={timeWindow}
+              />
+            </Suspense>
+          </>
         ) : (
           <>
             <Flex direction="column" gap="size-25">
@@ -291,10 +337,7 @@ export const ProjectEvaluatorScopePanel = (
   );
 };
 
-/**
- * Sessions have no span-shaped preview, so name the bindings the evaluator will
- * actually receive rather than testing it against a span that it will never see.
- */
+/** Names the bindings a session evaluator receives, which no span vocabulary covers. */
 function SessionInputNote() {
   return (
     <Flex direction="column" gap="size-25">
@@ -426,17 +469,15 @@ function ScopeEditorCard({
         onFilterValidityChange={onFilterValidityChange}
         isTargetDisabled={isTargetDisabled}
       >
-        {scope.targetType === "SESSION" ? null : (
-          <Flex direction="column" gap="size-50">
-            <Text size="XS" weight="heavy" color="text-700">
-              Preview window
-            </Text>
-            <TimeWindowSegmentedControl
-              value={timeWindow.presetId}
-              onChange={onTimeWindowChange}
-            />
-          </Flex>
-        )}
+        <Flex direction="column" gap="size-50">
+          <Text size="XS" weight="heavy" color="text-700">
+            Preview window
+          </Text>
+          <TimeWindowSegmentedControl
+            value={timeWindow.presetId}
+            onChange={onTimeWindowChange}
+          />
+        </Flex>
       </ProjectEvaluatorScopeFieldGroup>
     </div>
   );
@@ -466,6 +507,195 @@ function MatchedSpanCountLine({
     </Text>
   );
 }
+
+function MatchedSessionCountLine({
+  projectId,
+  filterCondition,
+  timeWindow,
+}: {
+  projectId: string;
+  filterCondition: string;
+  timeWindow: TimeWindow;
+}) {
+  const { startIso, prose } = timeWindow;
+  const data = useLazyLoadQuery<ProjectEvaluatorScopePanelSessionCountQuery>(
+    graphql`
+      query ProjectEvaluatorScopePanelSessionCountQuery(
+        $projectId: ID!
+        $timeRange: TimeRange!
+        $sessionFilterCondition: String
+      ) {
+        project: node(id: $projectId) {
+          ... on Project {
+            sessionCount(
+              timeRange: $timeRange
+              sessionFilterCondition: $sessionFilterCondition
+            )
+          }
+        }
+      }
+    `,
+    {
+      projectId,
+      timeRange: { start: startIso },
+      sessionFilterCondition: filterCondition.trim() || null,
+    },
+    { fetchPolicy: "store-and-network" }
+  );
+  const matchedCount = data.project?.sessionCount ?? 0;
+  const hasMatches = matchedCount > 0;
+  return (
+    <Text size="S" color="text-500">
+      {hasMatches
+        ? `${matchedCount.toLocaleString()} session${matchedCount === 1 ? "" : "s"} matched ${prose}. The most recent are shown below.`
+        : `No sessions matched this scope ${prose}.`}
+    </Text>
+  );
+}
+
+const SESSION_LIST_PAGE_SIZE = 5;
+
+/**
+ * The sessions this evaluator would run on. A session carries no evaluation
+ * context to bind against, so each row names the session rather than previewing
+ * a run of the evaluator against it.
+ */
+function SessionList({
+  projectId,
+  filterCondition,
+  timeWindow,
+}: {
+  projectId: string;
+  filterCondition: string;
+  timeWindow: TimeWindow;
+}) {
+  const { shortDateTimeFormatter } = useTimeFormatters();
+  const [limit, setLimit] = useState(SESSION_LIST_PAGE_SIZE);
+  // A transition keeps the current rows visible instead of collapsing the list
+  // to its Suspense fallback while the wider page loads.
+  const [isShowingMore, startShowMoreTransition] = useTransition();
+  const data = useLazyLoadQuery<ProjectEvaluatorScopePanelSessionsQuery>(
+    graphql`
+      query ProjectEvaluatorScopePanelSessionsQuery(
+        $projectId: ID!
+        $sessionFilterCondition: String
+        $timeRange: TimeRange
+        $first: Int!
+      ) {
+        project: node(id: $projectId) {
+          ... on Project {
+            sessions(
+              first: $first
+              sort: { col: startTime, dir: desc }
+              sessionFilterCondition: $sessionFilterCondition
+              timeRange: $timeRange
+            ) {
+              edges {
+                session: node {
+                  id
+                  sessionId
+                  startTime
+                  numTraces
+                  tokenUsage {
+                    total
+                  }
+                  firstInput {
+                    truncatedValue
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      projectId,
+      sessionFilterCondition: filterCondition.trim() || null,
+      timeRange: { start: timeWindow.startIso },
+      first: limit,
+    },
+    { fetchPolicy: "store-and-network" }
+  );
+  const sessions = data.project?.sessions?.edges.map(({ session }) => session);
+  const hasMoreSessions = data.project?.sessions?.pageInfo.hasNextPage ?? false;
+  if (!sessions?.length) {
+    return null;
+  }
+  return (
+    <div css={runListCSS}>
+      <ul aria-label="Recent matching sessions" className="span-run-list__rows">
+        {sessions.map((session) => (
+          <li key={session.id} css={sessionRowCSS}>
+            <span className="session-row__name">{session.sessionId}</span>
+            <span className="session-row__snippet">
+              {session.firstInput?.truncatedValue ?? ""}
+            </span>
+            <span className="session-row__metric">
+              {session.numTraces.toLocaleString()} trace
+              {session.numTraces === 1 ? "" : "s"}
+            </span>
+            <span className="session-row__metric">
+              {session.tokenUsage.total.toLocaleString()} tokens
+            </span>
+            <span className="session-row__time">
+              {shortDateTimeFormatter(new Date(session.startTime))}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {hasMoreSessions ? (
+        <Flex justifyContent="center">
+          <LoadMoreButton
+            isLoadingNext={isShowingMore}
+            onLoadMore={() =>
+              startShowMoreTransition(() => {
+                setLimit((current) => current + SESSION_LIST_PAGE_SIZE);
+              })
+            }
+          />
+        </Flex>
+      ) : null}
+    </div>
+  );
+}
+
+const sessionRowCSS = css`
+  display: flex;
+  align-items: center;
+  gap: var(--global-dimension-size-100);
+  padding: var(--global-dimension-size-75) var(--global-dimension-size-100);
+  .session-row__name {
+    flex: none;
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--global-font-family-code, monospace);
+    font-size: var(--global-font-size-xs);
+    font-weight: 600;
+    color: var(--global-text-color-900);
+  }
+  .session-row__snippet {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--global-font-size-xs);
+    color: var(--global-text-color-500);
+  }
+  .session-row__metric,
+  .session-row__time {
+    flex: none;
+    font-variant-numeric: tabular-nums;
+    font-size: var(--global-font-size-xs);
+    color: var(--global-text-color-500);
+  }
+`;
 
 const scopeEditorCardCSS = css`
   border: 1px solid var(--global-border-color-default);

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -205,8 +205,8 @@ export const ProjectEvaluatorScopePanel = (
               <Heading level={2}>Scope</Heading>
               <Text color="text-500" size="S">
                 {isSessionTarget
-                  ? "Choose which sessions this evaluator runs on and when."
-                  : "Choose what gets evaluated and how much of it."}
+                  ? "Select which sessions this evaluator runs on and how often."
+                  : "Select which spans this evaluator runs on and how often."}
               </Text>
             </Flex>
             <ScopeEditorCard
@@ -386,9 +386,9 @@ function SessionInputNote() {
     <Flex direction="column" gap="size-25">
       <Heading level={2}>Session input</Heading>
       <Text color="text-500" size="S">
-        Your evaluator receives the session transcript as <code>input</code> and
-        the last response in the session as <code>output</code>. Individual
-        turns are available under <code>metadata.turns</code>.
+        Your evaluator receives the transcript as <code>input</code>, the last
+        response as <code>output</code>, and the turns under{" "}
+        <code>metadata.turns</code>.
       </Text>
     </Flex>
   );
@@ -698,10 +698,7 @@ function SessionRunList({
         isSample: false,
         unavailableReason:
           session.sessionEvaluationContext == null
-            ? "There is no transcript to evaluate: this session has no complete " +
-              "turn that fits the evaluation byte cap, or its content was " +
-              "trimmed after ingestion. A live evaluation would not run this " +
-              "session either."
+            ? "This session has no evaluable transcript."
             : undefined,
         metric: formatSessionMetric(
           session.numTraces,

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -51,7 +51,6 @@ import {
   useEvaluatorStoreInstance,
 } from "@phoenix/contexts/EvaluatorContext";
 import { usePlaygroundStore } from "@phoenix/contexts/PlaygroundContext";
-import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
 import { toGqlCredentials } from "@phoenix/pages/playground/playgroundUtils";
 import type { ProjectEvaluatorScopePanelCountQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelCountQuery.graphql";
 import type {
@@ -65,6 +64,7 @@ import type { ProjectEvaluatorScopePanelSpansQuery } from "@phoenix/pages/projec
 import { ProjectEvaluatorScopeFieldGroup } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeFields";
 import {
   getProjectEvaluatorMappingDiagnostics,
+  toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { getSampleSpanEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSpanEvaluationContext";
@@ -170,18 +170,27 @@ export const ProjectEvaluatorScopePanel = (
     props;
   const [timeWindow, setTimeWindow] = useState(() => makeTimeWindow("7d"));
   const isSessionTarget = scope.targetType === "SESSION";
-  // The run list below the Suspense boundary owns the spans and the run
+  // Span and session contexts are structurally identical, so the store cannot
+  // infer the grain from one; changing the target has to say so.
+  const evaluatorStore = useEvaluatorStoreInstance();
+  const mappingSourceGrain = toEvaluatorMappingSourceGrain(scope.targetType);
+  useEffect(() => {
+    evaluatorStore
+      .getState()
+      .setEvaluatorMappingSourceGrain(mappingSourceGrain);
+  }, [evaluatorStore, mappingSourceGrain]);
+  // The run list below the Suspense boundary owns the records and the run
   // machinery; it hands the header's Test All button the latest run-all
   // closure through this ref and reports readiness through the state.
-  const runAllSpansRef = useRef<() => void>(() => {});
-  const [canRunAllSpans, setCanRunAllSpans] = useState(false);
+  const runAllRecordsRef = useRef<() => void>(() => {});
+  const [canRunAllRecords, setCanRunAllRecords] = useState(false);
   const testAllButton = (
     <Button
       size="S"
       variant="primary"
       leadingVisual={<Icon svg={<Icons.PlayCircle />} />}
-      isDisabled={!canRunAllSpans}
-      onPress={() => runAllSpansRef.current()}
+      isDisabled={!canRunAllRecords}
+      onPress={() => runAllRecordsRef.current()}
     >
       Test All
     </Button>
@@ -215,23 +224,40 @@ export const ProjectEvaluatorScopePanel = (
             <SessionInputNote />
             <Flex direction="column" gap="size-25">
               {props.showScopeFields !== false ? (
-                <Heading level={2}>Matching sessions</Heading>
-              ) : (
                 <Flex
                   direction="row"
                   justifyContent="space-between"
                   alignItems="center"
                   gap="size-200"
                 >
-                  <Heading level={2} weight="heavy">
-                    Matching Sessions
-                  </Heading>
-                  <TimeWindowSegmentedControl
-                    size="S"
-                    value={timeWindow.presetId}
-                    onChange={setTimeWindow}
-                  />
+                  <Heading level={2}>Matching sessions</Heading>
+                  {testAllButton}
                 </Flex>
+              ) : (
+                <>
+                  <Flex
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap="size-200"
+                  >
+                    <Heading level={2} weight="heavy">
+                      Test with a Session
+                    </Heading>
+                    <Flex direction="row" alignItems="center" gap="size-100">
+                      <TimeWindowSegmentedControl
+                        size="S"
+                        value={timeWindow.presetId}
+                        onChange={setTimeWindow}
+                      />
+                      {testAllButton}
+                    </Flex>
+                  </Flex>
+                  <Text color="text-500">
+                    Test your evaluator on recent sessions that match your
+                    scope.
+                  </Text>
+                </>
               )}
               <Suspense
                 fallback={
@@ -248,11 +274,27 @@ export const ProjectEvaluatorScopePanel = (
               </Suspense>
             </Flex>
             <Suspense fallback={<Loading />}>
-              <SessionList
-                projectId={projectId}
-                filterCondition={scope.filterCondition}
-                timeWindow={timeWindow}
-              />
+              {codeEvaluatorId || inlineCode ? (
+                <SessionRunList
+                  projectId={projectId}
+                  filterCondition={scope.filterCondition}
+                  timeWindow={timeWindow}
+                  codeEvaluatorId={codeEvaluatorId}
+                  inlineCode={inlineCode}
+                  requiredVariables={requiredVariables}
+                  runAllRecordsRef={runAllRecordsRef}
+                  onCanRunAllChange={setCanRunAllRecords}
+                />
+              ) : (
+                <LlmSessionRunList
+                  projectId={projectId}
+                  filterCondition={scope.filterCondition}
+                  timeWindow={timeWindow}
+                  requiredVariables={requiredVariables}
+                  runAllRecordsRef={runAllRecordsRef}
+                  onCanRunAllChange={setCanRunAllRecords}
+                />
+              )}
             </Suspense>
           </>
         ) : (
@@ -316,8 +358,8 @@ export const ProjectEvaluatorScopePanel = (
                   codeEvaluatorId={codeEvaluatorId}
                   inlineCode={inlineCode}
                   requiredVariables={requiredVariables}
-                  runAllSpansRef={runAllSpansRef}
-                  onCanRunAllChange={setCanRunAllSpans}
+                  runAllRecordsRef={runAllRecordsRef}
+                  onCanRunAllChange={setCanRunAllRecords}
                 />
               ) : (
                 <LlmSpanRunList
@@ -325,8 +367,8 @@ export const ProjectEvaluatorScopePanel = (
                   filterCondition={scope.filterCondition}
                   timeWindow={timeWindow}
                   requiredVariables={requiredVariables}
-                  runAllSpansRef={runAllSpansRef}
-                  onCanRunAllChange={setCanRunAllSpans}
+                  runAllRecordsRef={runAllRecordsRef}
+                  onCanRunAllChange={setCanRunAllRecords}
                 />
               )}
             </Suspense>
@@ -344,8 +386,8 @@ function SessionInputNote() {
       <Heading level={2}>Session input</Heading>
       <Text color="text-500" size="S">
         Your evaluator receives the session transcript as <code>input</code> and
-        the last response in the session as <code>output</code>. Testing against
-        a recorded session is not available yet.
+        the last response in the session as <code>output</code>. Individual
+        turns are available under <code>metadata.turns</code>.
       </Text>
     </Flex>
   );
@@ -555,21 +597,46 @@ function MatchedSessionCountLine({
 
 const SESSION_LIST_PAGE_SIZE = 5;
 
+function formatSessionMetric(numTraces: number, totalTokens: number): string {
+  const traces = `${numTraces.toLocaleString()} trace${numTraces === 1 ? "" : "s"}`;
+  return `${traces} · ${totalTokens.toLocaleString()} tokens`;
+}
+
+function LlmSessionRunList(
+  props: Omit<
+    Parameters<typeof SessionRunList>[0],
+    "codeEvaluatorId" | "inlineCode" | "playgroundStore"
+  >
+) {
+  const playgroundStore = usePlaygroundStore();
+  return <SessionRunList {...props} playgroundStore={playgroundStore} />;
+}
+
 /**
- * The sessions this evaluator would run on. A session carries no evaluation
- * context to bind against, so each row names the session rather than previewing
- * a run of the evaluator against it.
+ * The sessions this evaluator would run on, each carrying the same evaluation
+ * context a live session evaluation binds against, so a row can be tested.
  */
-function SessionList({
+function SessionRunList({
   projectId,
   filterCondition,
   timeWindow,
+  codeEvaluatorId,
+  inlineCode,
+  playgroundStore,
+  requiredVariables,
+  runAllRecordsRef,
+  onCanRunAllChange,
 }: {
   projectId: string;
   filterCondition: string;
   timeWindow: TimeWindow;
+  codeEvaluatorId?: string;
+  inlineCode?: ProjectEvaluatorInlineCode;
+  playgroundStore?: ReturnType<typeof usePlaygroundStore>;
+  requiredVariables?: string[];
+  runAllRecordsRef?: { current: () => void };
+  onCanRunAllChange?: (canRunAll: boolean) => void;
 }) {
-  const { shortDateTimeFormatter } = useTimeFormatters();
   const [limit, setLimit] = useState(SESSION_LIST_PAGE_SIZE);
   // A transition keeps the current rows visible instead of collapsing the list
   // to its Suspense fallback while the wider page loads.
@@ -594,14 +661,11 @@ function SessionList({
                 session: node {
                   id
                   sessionId
-                  startTime
                   numTraces
                   tokenUsage {
                     total
                   }
-                  firstInput {
-                    truncatedValue
-                  }
+                  sessionEvaluationContext
                 }
               }
               pageInfo {
@@ -621,81 +685,46 @@ function SessionList({
     { fetchPolicy: "store-and-network" }
   );
   const sessions = data.project?.sessions?.edges.map(({ session }) => session);
-  const hasMoreSessions = data.project?.sessions?.pageInfo.hasNextPage ?? false;
   if (!sessions?.length) {
     return null;
   }
   return (
-    <div css={runListCSS}>
-      <ul aria-label="Recent matching sessions" className="span-run-list__rows">
-        {sessions.map((session) => (
-          <li key={session.id} css={sessionRowCSS}>
-            <span className="session-row__name">{session.sessionId}</span>
-            <span className="session-row__snippet">
-              {session.firstInput?.truncatedValue ?? ""}
-            </span>
-            <span className="session-row__metric">
-              {session.numTraces.toLocaleString()} trace
-              {session.numTraces === 1 ? "" : "s"}
-            </span>
-            <span className="session-row__metric">
-              {session.tokenUsage.total.toLocaleString()} tokens
-            </span>
-            <span className="session-row__time">
-              {shortDateTimeFormatter(new Date(session.startTime))}
-            </span>
-          </li>
-        ))}
-      </ul>
-      {hasMoreSessions ? (
-        <Flex justifyContent="center">
-          <LoadMoreButton
-            isLoadingNext={isShowingMore}
-            onLoadMore={() =>
-              startShowMoreTransition(() => {
-                setLimit((current) => current + SESSION_LIST_PAGE_SIZE);
-              })
-            }
-          />
-        </Flex>
-      ) : null}
-    </div>
+    <RecordedRunList
+      rows={sessions.map((session) => ({
+        key: session.id,
+        name: session.sessionId,
+        context: session.sessionEvaluationContext,
+        isSample: false,
+        unavailableReason:
+          session.sessionEvaluationContext == null
+            ? "There is no transcript to evaluate: this session has no complete " +
+              "turn that fits the evaluation byte cap, or its content was " +
+              "trimmed after ingestion. A live evaluation would not run this " +
+              "session either."
+            : undefined,
+        metric: formatSessionMetric(
+          session.numTraces,
+          session.tokenUsage.total
+        ),
+      }))}
+      recordNoun="session"
+      listLabel="Recent matching sessions"
+      hasMore={data.project?.sessions?.pageInfo.hasNextPage ?? false}
+      isLoadingMore={isShowingMore}
+      onLoadMore={() =>
+        startShowMoreTransition(() => {
+          setLimit((current) => current + SESSION_LIST_PAGE_SIZE);
+        })
+      }
+      codeEvaluatorId={codeEvaluatorId}
+      inlineCode={inlineCode}
+      playgroundStore={playgroundStore}
+      requiredVariables={requiredVariables}
+      runAllRecordsRef={runAllRecordsRef}
+      onCanRunAllChange={onCanRunAllChange}
+    />
   );
 }
-
-const sessionRowCSS = css`
-  display: flex;
-  align-items: center;
-  gap: var(--global-dimension-size-100);
-  padding: var(--global-dimension-size-75) var(--global-dimension-size-100);
-  .session-row__name {
-    flex: none;
-    max-width: 200px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-family: var(--global-font-family-code, monospace);
-    font-size: var(--global-font-size-xs);
-    font-weight: 600;
-    color: var(--global-text-color-900);
-  }
-  .session-row__snippet {
-    flex: 1 1 auto;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: var(--global-font-size-xs);
-    color: var(--global-text-color-500);
-  }
-  .session-row__metric,
-  .session-row__time {
-    flex: none;
-    font-variant-numeric: tabular-nums;
-    font-size: var(--global-font-size-xs);
-    color: var(--global-text-color-500);
-  }
-`;
 
 const scopeEditorCardCSS = css`
   border: 1px solid var(--global-border-color-default);
@@ -703,7 +732,7 @@ const scopeEditorCardCSS = css`
   padding: var(--global-dimension-size-200);
 `;
 
-type SpanRunResult = {
+type RecordedRunResult = {
   readonly evaluatorName: string;
   readonly annotation: {
     readonly name: string;
@@ -714,18 +743,30 @@ type SpanRunResult = {
   readonly error: string | null;
 };
 
-type SpanRun =
+type RecordedRun =
   | { status: "running" }
-  | { status: "done"; results: SpanRunResult[] }
+  | { status: "done"; results: RecordedRunResult[] }
   | { status: "error"; message: string };
 
-type SpanListRow = {
+/** One recorded span or session, with the context an evaluator binds against. */
+type RecordedRunListRow = {
   key: string;
   name: string;
-  spanKind: string;
+  /** Prefixes the card title on a span row; a session has no kind. */
+  spanKind?: string;
   context: unknown;
   isSample: boolean;
+  /** An at-a-glance measure of the record, such as a session's trace count. */
+  metric?: string;
+  /**
+   * Why this record has no context to bind against. Set only when the server
+   * cannot produce one, in which case a live evaluation would fail the same way.
+   */
+  unavailableReason?: string;
 };
+
+/** Names the kind of record a row holds, for prose and accessible labels. */
+type RecordedRunNoun = "span" | "session";
 
 const SAMPLE_ROW_KEY = "__sample__";
 
@@ -749,7 +790,7 @@ function SpanRunList({
   inlineCode,
   playgroundStore,
   requiredVariables,
-  runAllSpansRef,
+  runAllRecordsRef,
   onCanRunAllChange,
 }: {
   projectId: string;
@@ -759,8 +800,7 @@ function SpanRunList({
   inlineCode?: ProjectEvaluatorInlineCode;
   playgroundStore?: ReturnType<typeof usePlaygroundStore>;
   requiredVariables?: string[];
-  /** Receives the latest run-every-loaded-span closure for the header button. */
-  runAllSpansRef?: { current: () => void };
+  runAllRecordsRef?: { current: () => void };
   onCanRunAllChange?: (canRunAll: boolean) => void;
 }) {
   const [limit, setLimit] = useState(SPAN_LIST_PAGE_SIZE);
@@ -808,10 +848,9 @@ function SpanRunList({
     { fetchPolicy: "store-and-network" }
   );
   const spans = data.project?.spans?.edges.map(({ span }) => span) ?? [];
-  const hasMoreSpans = data.project?.spans?.pageInfo.hasNextPage ?? false;
   const sample =
     spans.length === 0 ? getSampleSpanEvaluationContext(filterCondition) : null;
-  const rows: SpanListRow[] = spans.length
+  const rows: RecordedRunListRow[] = spans.length
     ? spans.map((span) => ({
         key: span.id,
         name: span.name,
@@ -830,6 +869,60 @@ function SpanRunList({
           },
         ]
       : [];
+  return (
+    <RecordedRunList
+      rows={rows}
+      recordNoun="span"
+      listLabel="Recent matching spans"
+      hasMore={data.project?.spans?.pageInfo.hasNextPage ?? false}
+      isLoadingMore={isShowingMore}
+      onLoadMore={() =>
+        startShowMoreTransition(() => {
+          setLimit((current) => current + SPAN_LIST_PAGE_SIZE);
+        })
+      }
+      codeEvaluatorId={codeEvaluatorId}
+      inlineCode={inlineCode}
+      playgroundStore={playgroundStore}
+      requiredVariables={requiredVariables}
+      runAllRecordsRef={runAllRecordsRef}
+      onCanRunAllChange={onCanRunAllChange}
+    />
+  );
+}
+
+/**
+ * The recorded records an evaluator can be tested against. The active row is the
+ * mapping source, so the input mapping is authored against a real context.
+ */
+function RecordedRunList({
+  rows,
+  recordNoun,
+  listLabel,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  codeEvaluatorId,
+  inlineCode,
+  playgroundStore,
+  requiredVariables,
+  runAllRecordsRef,
+  onCanRunAllChange,
+}: {
+  rows: RecordedRunListRow[];
+  recordNoun: RecordedRunNoun;
+  listLabel: string;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+  codeEvaluatorId?: string;
+  inlineCode?: ProjectEvaluatorInlineCode;
+  playgroundStore?: ReturnType<typeof usePlaygroundStore>;
+  requiredVariables?: string[];
+  /** Receives the latest run-every-loaded-record closure for the header button. */
+  runAllRecordsRef?: { current: () => void };
+  onCanRunAllChange?: (canRunAll: boolean) => void;
+}) {
   // `undefined` is no explicit choice yet (the newest row opens); `null` is an
   // explicit collapse-all.
   const [expandedKey, setExpandedKey] = useState<string | null | undefined>(
@@ -850,67 +943,68 @@ function SpanRunList({
   const activeRowKey = activeRow?.key ?? null;
   const syncMappingSource = useEffectEvent(() => {
     const context = activeRow?.context;
-    if (context && isSpanEvaluatorMappingSource(context)) {
+    if (context && hasEvaluatorMappingSourceShape(context)) {
       evaluatorStore.getState().setEvaluatorMappingSource(context);
     }
   });
   useEffect(() => {
     syncMappingSource();
   }, [activeRowKey]);
-  const { runs, runOnSpan, isRunnable } = useEvaluatorPreviewRuns({
+  const { runs, runOnContext, isRunnable } = useEvaluatorPreviewRuns({
     codeEvaluatorId,
     inlineCode,
     playgroundStore,
   });
-  // No dependency array: rows and runOnSpan are rebuilt every render, so the
+  // A row the server could not build a context for would bind against nothing.
+  const runnableRows = rows.filter(
+    ({ unavailableReason }) => !unavailableReason
+  );
+  // No dependency array: rows and runOnContext are rebuilt every render, so the
   // ref is refreshed each render to keep the header's Test All button current.
   useEffect(() => {
-    if (runAllSpansRef) {
-      runAllSpansRef.current = () => {
-        for (const row of rows) {
-          runOnSpan(row.key, row.context);
+    if (runAllRecordsRef) {
+      runAllRecordsRef.current = () => {
+        for (const row of runnableRows) {
+          runOnContext(row.key, row.context);
         }
       };
     }
   });
-  const canRunAllSpans = isRunnable && rows.length > 0;
+  const canRunAllRecords = isRunnable && runnableRows.length > 0;
   useEffect(() => {
-    onCanRunAllChange?.(canRunAllSpans);
+    onCanRunAllChange?.(canRunAllRecords);
     return () => onCanRunAllChange?.(false);
-  }, [canRunAllSpans, onCanRunAllChange]);
+  }, [canRunAllRecords, onCanRunAllChange]);
   return (
     <div css={runListCSS}>
       {rows[0]?.isSample ? (
         <Text size="S" color="text-500">
-          Use this sample span to test your evaluator.
+          Use this sample {recordNoun} to test your evaluator.
         </Text>
       ) : null}
-      <ul aria-label="Recent matching spans" className="span-run-list__rows">
+      <ul aria-label={listLabel} className="run-list__rows">
         {rows.map((row) => (
-          <SpanRunRow
+          <RecordedRunRow
             key={row.key}
             row={row}
+            recordNoun={recordNoun}
             isExpanded={expandedRowKey === row.key}
             onToggleExpanded={() =>
               setExpandedKey(expandedRowKey === row.key ? null : row.key)
             }
             run={runs[row.key]}
             isRunnable={isRunnable}
-            onRun={() => runOnSpan(row.key, row.context)}
+            onRun={() => runOnContext(row.key, row.context)}
             pathMapping={pathMapping}
             requiredVariables={requiredVariables}
           />
         ))}
       </ul>
-      {hasMoreSpans ? (
+      {hasMore ? (
         <Flex justifyContent="center">
           <LoadMoreButton
-            isLoadingNext={isShowingMore}
-            onLoadMore={() =>
-              startShowMoreTransition(() => {
-                setLimit((current) => current + SPAN_LIST_PAGE_SIZE);
-              })
-            }
+            isLoadingNext={isLoadingMore}
+            onLoadMore={onLoadMore}
           />
         </Flex>
       ) : null}
@@ -922,7 +1016,7 @@ const runListCSS = css`
   display: flex;
   flex-direction: column;
   gap: var(--global-dimension-size-100);
-  .span-run-list__rows {
+  .run-list__rows {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -932,8 +1026,9 @@ const runListCSS = css`
   }
 `;
 
-function SpanRunRow({
+function RecordedRunRow({
   row,
+  recordNoun,
   isExpanded,
   onToggleExpanded,
   run,
@@ -942,16 +1037,18 @@ function SpanRunRow({
   pathMapping,
   requiredVariables,
 }: {
-  row: SpanListRow;
+  row: RecordedRunListRow;
+  recordNoun: RecordedRunNoun;
   isExpanded: boolean;
   onToggleExpanded: () => void;
-  run: SpanRun | undefined;
+  run: RecordedRun | undefined;
   isRunnable: boolean;
   onRun: () => void;
   pathMapping: Record<string, string>;
   requiredVariables?: string[];
 }) {
   const isRunning = run?.status === "running";
+  const isUnavailable = row.unavailableReason != null;
   return (
     <li>
       <Card
@@ -960,11 +1057,19 @@ function SpanRunRow({
         onOpenChange={onToggleExpanded}
         title={
           <>
-            <SpanKindToken spanKind={row.spanKind} size="S" />
+            {row.spanKind ? (
+              <SpanKindToken spanKind={row.spanKind} size="S" />
+            ) : null}
             {row.name}
           </>
         }
-        titleExtra={row.isSample ? <Token size="S">sample</Token> : null}
+        titleExtra={
+          row.isSample ? (
+            <Token size="S">sample</Token>
+          ) : row.metric ? (
+            <Token size="S">{row.metric}</Token>
+          ) : null
+        }
         headerContent={
           <CardCollapsedPreview>
             {getContextSnippet(row.context)}
@@ -972,23 +1077,23 @@ function SpanRunRow({
         }
         extra={
           <Flex direction="row" alignItems="center" gap="size-100" flex="none">
-            <SpanRunResultChip run={run} />
+            <RecordedRunResultChip run={run} />
             <Button
               size="S"
               variant="primary"
               aria-label={
-                // Recent spans commonly share a name; suffix the span id so
+                // Recent records commonly share a name; suffix the record id so
                 // each row's button has a distinct accessible name.
                 row.isSample
                   ? `Test evaluator on ${row.name}`
-                  : `Test evaluator on ${row.name}, span ${row.key.slice(-8)}`
+                  : `Test evaluator on ${row.name}, ${recordNoun} ${row.key.slice(-8)}`
               }
               leadingVisual={
                 <Icon
                   svg={isRunning ? <Icons.Loading /> : <Icons.PlayCircle />}
                 />
               }
-              isDisabled={!isRunnable || isRunning}
+              isDisabled={!isRunnable || isRunning || isUnavailable}
               isPending={isRunning}
               onPress={onRun}
             >
@@ -999,31 +1104,38 @@ function SpanRunRow({
       >
         {isExpanded ? (
           <View padding="size-200">
-            <Flex direction="column" gap="size-100">
-              <SpanRunDetail run={run} />
-              <Tabs defaultSelectedKey="bindings">
-                <TabList>
-                  <Tab id="bindings">Bindings</Tab>
-                  <Tab id="context">Context</Tab>
-                </TabList>
-                <TabPanel id="bindings">
-                  <BindingPreview
-                    context={row.context}
-                    pathMapping={pathMapping}
-                    requiredVariables={requiredVariables}
-                    isSampleContext={row.isSample}
-                  />
-                </TabPanel>
-                <TabPanel id="context">
-                  <div css={contextViewerCSS}>
-                    <JSONBlock
-                      value={JSON.stringify(row.context, null, 2)}
-                      basicSetup={{ lineNumbers: false }}
+            {row.unavailableReason ? (
+              <Alert variant="warning" title="No evaluation context">
+                {row.unavailableReason}
+              </Alert>
+            ) : (
+              <Flex direction="column" gap="size-100">
+                <RecordedRunDetail run={run} />
+                <Tabs defaultSelectedKey="bindings">
+                  <TabList>
+                    <Tab id="bindings">Bindings</Tab>
+                    <Tab id="context">Context</Tab>
+                  </TabList>
+                  <TabPanel id="bindings">
+                    <BindingPreview
+                      context={row.context}
+                      recordNoun={recordNoun}
+                      pathMapping={pathMapping}
+                      requiredVariables={requiredVariables}
+                      isSampleContext={row.isSample}
                     />
-                  </div>
-                </TabPanel>
-              </Tabs>
-            </Flex>
+                  </TabPanel>
+                  <TabPanel id="context">
+                    <div css={contextViewerCSS}>
+                      <JSONBlock
+                        value={JSON.stringify(row.context, null, 2)}
+                        basicSetup={{ lineNumbers: false }}
+                      />
+                    </div>
+                  </TabPanel>
+                </Tabs>
+              </Flex>
+            )}
           </View>
         ) : null}
       </Card>
@@ -1035,7 +1147,7 @@ function SpanRunRow({
  * The collapsed-row result summary: the same annotation button and details
  * popover the dataset evaluator's test panel renders.
  */
-function SpanRunResultChip({ run }: { run: SpanRun | undefined }) {
+function RecordedRunResultChip({ run }: { run: RecordedRun | undefined }) {
   if (run == null || run.status === "running") {
     return null;
   }
@@ -1076,7 +1188,7 @@ const resultAnnotationCSS = css`
  * The expanded-row result: the dataset evaluator's "Evaluator Annotation
  * Preview" card, with the same skeleton while a test is in flight.
  */
-function SpanRunDetail({ run }: { run: SpanRun | undefined }) {
+function RecordedRunDetail({ run }: { run: RecordedRun | undefined }) {
   if (run == null) {
     return null;
   }
@@ -1132,11 +1244,13 @@ type BindingRow = {
 
 function BindingPreview({
   context,
+  recordNoun,
   pathMapping,
   requiredVariables,
   isSampleContext,
 }: {
   context: unknown;
+  recordNoun: RecordedRunNoun;
   pathMapping: Record<string, string>;
   requiredVariables?: string[];
   isSampleContext: boolean;
@@ -1202,7 +1316,7 @@ function BindingPreview({
             variant="danger"
             title={`${variable} does not resolve`}
           >
-            No value at {path} on this span.
+            No value at {path} on this {recordNoun}.
           </Alert>
         ) : status === "unverified" ? (
           <Alert
@@ -1214,7 +1328,8 @@ function BindingPreview({
           </Alert>
         ) : status === "optional-missing" ? (
           <Text key={variable} size="S" color="text-500">
-            <code>{variable}</code> is optional and is not present on this span.
+            <code>{variable}</code> is optional and is not present on this{" "}
+            {recordNoun}.
           </Text>
         ) : null
       )}
@@ -1376,11 +1491,14 @@ function getBoundValueSnippet(value: unknown): string {
   return toContentPreview(value, { maxLength: 120 }) ?? "";
 }
 
-function isSpanEvaluatorMappingSource(
+/**
+ * Span and session contexts share this shape, so this cannot tell them apart —
+ * the store's grain does. Only `metadata` is guaranteed to be an object by the
+ * server context shape; `input`/`output` are raw attribute values.
+ */
+function hasEvaluatorMappingSourceShape(
   value: unknown
-): value is EvaluatorMappingSource<"span"> {
-  // Only `metadata` is guaranteed to be an object by the server context shape;
-  // `input`/`output` are raw attribute values.
+): value is EvaluatorMappingSource<"span" | "session"> {
   return isStringKeyedObject(value) && isStringKeyedObject(value.metadata);
 }
 
@@ -1395,7 +1513,7 @@ function useEvaluatorPreviewRuns({
 }) {
   const evaluatorStore = useEvaluatorStoreInstance();
   const credentials = useCredentialsContext((state) => state);
-  const [runs, setRuns] = useState<Record<string, SpanRun>>({});
+  const [runs, setRuns] = useState<Record<string, RecordedRun>>({});
   const [previewEvaluator] =
     useMutation<ProjectEvaluatorScopePanelPreviewMutation>(graphql`
       mutation ProjectEvaluatorScopePanelPreviewMutation(
@@ -1421,7 +1539,7 @@ function useEvaluatorPreviewRuns({
     inlineCode != null ||
     getOutputConfigValidationErrors(outputConfigs).length === 0;
 
-  const runOnSpan = (spanKey: string, spanContext: unknown) => {
+  const runOnContext = (rowKey: string, context: unknown) => {
     const state = evaluatorStore.getState();
     let evaluator:
       | { codeEvaluatorId: string }
@@ -1466,13 +1584,13 @@ function useEvaluatorPreviewRuns({
         },
       };
     }
-    setRuns((current) => ({ ...current, [spanKey]: { status: "running" } }));
+    setRuns((current) => ({ ...current, [rowKey]: { status: "running" } }));
     previewEvaluator({
       variables: {
         input: {
           previews: [
             {
-              context: spanContext,
+              context,
               evaluator,
               inputMapping: state.evaluator.inputMapping,
             },
@@ -1484,7 +1602,7 @@ function useEvaluatorPreviewRuns({
         if (errors?.length) {
           setRuns((current) => ({
             ...current,
-            [spanKey]: {
+            [rowKey]: {
               status: "error",
               message: errors.map(({ message }) => message).join("\n"),
             },
@@ -1493,7 +1611,7 @@ function useEvaluatorPreviewRuns({
         }
         setRuns((current) => ({
           ...current,
-          [spanKey]: {
+          [rowKey]: {
             status: "done",
             results: [...response.evaluatorPreviews.results],
           },
@@ -1502,7 +1620,7 @@ function useEvaluatorPreviewRuns({
       onError(mutationError) {
         setRuns((current) => ({
           ...current,
-          [spanKey]: {
+          [rowKey]: {
             status: "error",
             message:
               getErrorMessagesFromRelayMutationError(mutationError)?.join(
@@ -1514,5 +1632,5 @@ function useEvaluatorPreviewRuns({
     });
   };
 
-  return { runs, runOnSpan, isRunnable };
+  return { runs, runOnContext, isRunnable };
 }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -4,6 +4,7 @@ import {
   Suspense,
   useEffect,
   useEffectEvent,
+  useMemo,
   useRef,
   useState,
   useTransition,
@@ -939,8 +940,17 @@ function RecordedRunList({
   const pathMapping = useEvaluatorStore(
     (state) => state.evaluator.inputMapping.pathMapping
   );
-  // Key the effect on the row key: the row object is rebuilt every render.
+  // The row object is rebuilt every render, and a session keeps its key while
+  // its context changes under it — a refresh, a preview-window change, or a
+  // load-more can all return a new transcript for the same row. Key the effect
+  // on what the context says, so the mapping source follows the value the Run
+  // actually sends rather than the one the row opened with.
   const activeRowKey = activeRow?.key ?? null;
+  const activeRowContext = activeRow?.context;
+  const activeRowContextIdentity = useMemo(
+    () => (activeRowContext == null ? null : JSON.stringify(activeRowContext)),
+    [activeRowContext]
+  );
   const syncMappingSource = useEffectEvent(() => {
     const context = activeRow?.context;
     if (context && hasEvaluatorMappingSourceShape(context)) {
@@ -949,7 +959,7 @@ function RecordedRunList({
   });
   useEffect(() => {
     syncMappingSource();
-  }, [activeRowKey]);
+  }, [activeRowKey, activeRowContextIdentity]);
   const { runs, runOnContext, isRunnable } = useEvaluatorPreviewRuns({
     codeEvaluatorId,
     inlineCode,

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -1593,6 +1593,9 @@ function useEvaluatorPreviewRuns({
               context,
               evaluator,
               inputMapping: state.evaluator.inputMapping,
+              // Every row here stands in for a scheduled run, span or
+              // session, so the run has to fail wherever the live one would.
+              applyOnlineEvaluationLimits: true,
             },
           ],
           credentials: toGqlCredentials(credentials),

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -166,6 +166,7 @@ export const ProjectEvaluatorScopePanel = (
   const { projectId, scope, codeEvaluatorId, inlineCode, requiredVariables } =
     props;
   const [timeWindow, setTimeWindow] = useState(() => makeTimeWindow("7d"));
+  const isSessionTarget = scope.targetType === "SESSION";
   // The run list below the Suspense boundary owns the spans and the run
   // machinery; it hands the header's Test All button the latest run-all
   // closure through this ref and reports readiness through the state.
@@ -190,7 +191,9 @@ export const ProjectEvaluatorScopePanel = (
             <Flex direction="column" gap="size-25">
               <Heading level={2}>Scope</Heading>
               <Text color="text-500" size="S">
-                Choose what gets evaluated and how much of it.
+                {isSessionTarget
+                  ? "Choose when this evaluator runs on each session."
+                  : "Choose what gets evaluated and how much of it."}
               </Text>
             </Flex>
             <ScopeEditorCard
@@ -204,83 +207,106 @@ export const ProjectEvaluatorScopePanel = (
             />
           </>
         ) : null}
-        <Flex direction="column" gap="size-25">
-          {props.showScopeFields !== false ? (
-            <Flex
-              direction="row"
-              justifyContent="space-between"
-              alignItems="center"
-              gap="size-200"
-            >
-              <Heading level={2}>Matching spans</Heading>
-              {testAllButton}
-            </Flex>
-          ) : (
-            <>
-              <Flex
-                direction="row"
-                justifyContent="space-between"
-                alignItems="center"
-                gap="size-200"
-              >
-                <Heading level={2} weight="heavy">
-                  Test with a Span
-                </Heading>
-                <Flex direction="row" alignItems="center" gap="size-100">
-                  <TimeWindowSegmentedControl
-                    size="S"
-                    value={timeWindow.presetId}
-                    onChange={setTimeWindow}
-                  />
+        {isSessionTarget ? (
+          <SessionInputNote />
+        ) : (
+          <>
+            <Flex direction="column" gap="size-25">
+              {props.showScopeFields !== false ? (
+                <Flex
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  gap="size-200"
+                >
+                  <Heading level={2}>Matching spans</Heading>
                   {testAllButton}
                 </Flex>
-              </Flex>
-              <Text color="text-500">
-                Test your evaluator on recent spans that match your scope.
-              </Text>
-            </>
-          )}
-          <Suspense
-            fallback={
-              <Text size="S" color="text-500">
-                Counting matching spans…
-              </Text>
-            }
-          >
-            <MatchedSpanCountLine
-              projectId={projectId}
-              filterCondition={scope.filterCondition}
-              timeWindow={timeWindow}
-            />
-          </Suspense>
-        </Flex>
-        <Suspense fallback={<Loading />}>
-          {codeEvaluatorId || inlineCode ? (
-            <SpanRunList
-              projectId={projectId}
-              filterCondition={scope.filterCondition}
-              timeWindow={timeWindow}
-              codeEvaluatorId={codeEvaluatorId}
-              inlineCode={inlineCode}
-              requiredVariables={requiredVariables}
-              runAllSpansRef={runAllSpansRef}
-              onCanRunAllChange={setCanRunAllSpans}
-            />
-          ) : (
-            <LlmSpanRunList
-              projectId={projectId}
-              filterCondition={scope.filterCondition}
-              timeWindow={timeWindow}
-              requiredVariables={requiredVariables}
-              runAllSpansRef={runAllSpansRef}
-              onCanRunAllChange={setCanRunAllSpans}
-            />
-          )}
-        </Suspense>
+              ) : (
+                <>
+                  <Flex
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap="size-200"
+                  >
+                    <Heading level={2} weight="heavy">
+                      Test with a Span
+                    </Heading>
+                    <Flex direction="row" alignItems="center" gap="size-100">
+                      <TimeWindowSegmentedControl
+                        size="S"
+                        value={timeWindow.presetId}
+                        onChange={setTimeWindow}
+                      />
+                      {testAllButton}
+                    </Flex>
+                  </Flex>
+                  <Text color="text-500">
+                    Test your evaluator on recent spans that match your scope.
+                  </Text>
+                </>
+              )}
+              <Suspense
+                fallback={
+                  <Text size="S" color="text-500">
+                    Counting matching spans…
+                  </Text>
+                }
+              >
+                <MatchedSpanCountLine
+                  projectId={projectId}
+                  filterCondition={scope.filterCondition}
+                  timeWindow={timeWindow}
+                />
+              </Suspense>
+            </Flex>
+            <Suspense fallback={<Loading />}>
+              {codeEvaluatorId || inlineCode ? (
+                <SpanRunList
+                  projectId={projectId}
+                  filterCondition={scope.filterCondition}
+                  timeWindow={timeWindow}
+                  codeEvaluatorId={codeEvaluatorId}
+                  inlineCode={inlineCode}
+                  requiredVariables={requiredVariables}
+                  runAllSpansRef={runAllSpansRef}
+                  onCanRunAllChange={setCanRunAllSpans}
+                />
+              ) : (
+                <LlmSpanRunList
+                  projectId={projectId}
+                  filterCondition={scope.filterCondition}
+                  timeWindow={timeWindow}
+                  requiredVariables={requiredVariables}
+                  runAllSpansRef={runAllSpansRef}
+                  onCanRunAllChange={setCanRunAllSpans}
+                />
+              )}
+            </Suspense>
+          </>
+        )}
       </div>
     </div>
   );
 };
+
+/**
+ * Sessions have no span-shaped preview, so name the bindings the evaluator will
+ * actually receive rather than testing it against a span that it will never see.
+ */
+function SessionInputNote() {
+  return (
+    <Flex direction="column" gap="size-25">
+      <Heading level={2}>Session input</Heading>
+      <Text color="text-500" size="S">
+        Your evaluator receives the session transcript as <code>input</code> and
+        the last response in the session as <code>output</code>. Testing against
+        a recorded session is not available yet.
+      </Text>
+    </Flex>
+  );
+}
 
 const panelCSS = css`
   display: flex;
@@ -400,15 +426,17 @@ function ScopeEditorCard({
         onFilterValidityChange={onFilterValidityChange}
         isTargetDisabled={isTargetDisabled}
       >
-        <Flex direction="column" gap="size-50">
-          <Text size="XS" weight="heavy" color="text-700">
-            Preview window
-          </Text>
-          <TimeWindowSegmentedControl
-            value={timeWindow.presetId}
-            onChange={onTimeWindowChange}
-          />
-        </Flex>
+        {scope.targetType === "SESSION" ? null : (
+          <Flex direction="column" gap="size-50">
+            <Text size="XS" weight="heavy" color="text-700">
+              Preview window
+            </Text>
+            <TimeWindowSegmentedControl
+              value={timeWindow.presetId}
+              onChange={onTimeWindowChange}
+            />
+          </Flex>
+        )}
       </ProjectEvaluatorScopeFieldGroup>
     </div>
   );

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -278,7 +278,7 @@ export function ProjectEvaluatorsTable({
             <Text>{formatEvaluationTarget(row.original.evaluationTarget)}</Text>
             {row.original.enabled &&
             row.original.schedulabilityStatus === "NOT_SCHEDULABLE" ? (
-              <span title="This evaluator is not scheduled. Open it for details.">
+              <span title="This evaluator is not scheduled.">
                 <Icon svg={<Icons.AlertTriangle />} color="warning" />
               </span>
             ) : null}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -46,6 +46,7 @@ import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/proj
 import { ProjectEvaluatorsEmptyState } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsEmptyState";
 import {
   formatEvaluationTarget,
+  formatEvaluationTargetPlural,
   formatSamplingRate,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { isModelProvider } from "@phoenix/utils/generativeUtils";
@@ -67,6 +68,7 @@ const readRow = (row: ProjectEvaluatorsTable_row$key) => {
         evaluationTarget
         filterCondition
         samplingRate
+        schedulabilityStatus
         enabled
         updatedAt
         evaluator {
@@ -269,8 +271,19 @@ export function ProjectEvaluatorsTable({
         id: "target",
         header: "target",
         size: 110,
-        cell: ({ row }) =>
-          formatEvaluationTarget(row.original.evaluationTarget),
+        // A disabled evaluator already reads as not running from its own
+        // column, so only flag scope-driven reasons here.
+        cell: ({ row }) => (
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <Text>{formatEvaluationTarget(row.original.evaluationTarget)}</Text>
+            {row.original.enabled &&
+            row.original.schedulabilityStatus === "NOT_SCHEDULABLE" ? (
+              <span title="This evaluator is not scheduled. Open it for details.">
+                <Icon svg={<Icons.AlertTriangle />} color="warning" />
+              </span>
+            ) : null}
+          </Flex>
+        ),
       },
       {
         id: "filter",
@@ -278,7 +291,8 @@ export function ProjectEvaluatorsTable({
         size: 180,
         cell: ({ row }) => (
           <Text color={row.original.filterCondition ? undefined : "text-700"}>
-            {row.original.filterCondition || "All spans"}
+            {row.original.filterCondition ||
+              `All ${formatEvaluationTargetPlural(row.original.evaluationTarget)}`}
           </Text>
         ),
       },

--- a/js/app/src/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<220a9d4d6ba6d6561c6833553c0a4f64>>
+ * @generated SignedSource<<c5988aca628cd586c70a583642a02c97>>
  * @lightSyntaxTransform
  */
 
@@ -25,6 +25,7 @@ export type EditProjectEvaluatorSlideoverQuery$data = {
   readonly projectEvaluator: {
     readonly __typename: "ProjectEvaluator";
     readonly enabled: boolean;
+    readonly evaluationDelaySeconds: number;
     readonly evaluationTarget: EvaluationTarget;
     readonly evaluator: {
       readonly description: string | null;
@@ -207,10 +208,17 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "evaluationDelaySeconds",
   "storageKey": null
 },
 v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "enabled",
+  "storageKey": null
+},
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "EvaluatorInputMapping",
@@ -235,45 +243,45 @@ v9 = {
   ],
   "storageKey": null
 },
-v10 = [
+v11 = [
   (v3/*:: as any*/)
 ],
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "Project",
   "kind": "LinkedField",
   "name": "project",
   "plural": false,
-  "selections": (v10/*:: as any*/),
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "kind",
+  "selections": (v11/*:: as any*/),
   "storageKey": null
 },
 v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "description",
+  "name": "kind",
   "storageKey": null
 },
 v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "optimizationDirection",
+  "name": "description",
   "storageKey": null
 },
 v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v16 = {
   "kind": "InlineFragment",
   "selections": [
     (v4/*:: as any*/),
-    (v14/*:: as any*/),
+    (v15/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -303,36 +311,36 @@ v15 = {
   "type": "CategoricalAnnotationConfig",
   "abstractKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v18 = {
-  "kind": "InlineFragment",
-  "selections": [
-    (v4/*:: as any*/),
-    (v14/*:: as any*/),
-    (v16/*:: as any*/),
-    (v17/*:: as any*/)
-  ],
-  "type": "ContinuousAnnotationConfig",
-  "abstractKey": null
-},
 v19 = {
   "kind": "InlineFragment",
   "selections": [
     (v4/*:: as any*/),
-    (v14/*:: as any*/),
+    (v15/*:: as any*/),
+    (v17/*:: as any*/),
+    (v18/*:: as any*/)
+  ],
+  "type": "ContinuousAnnotationConfig",
+  "abstractKey": null
+},
+v20 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v4/*:: as any*/),
+    (v15/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -340,13 +348,13 @@ v19 = {
       "name": "threshold",
       "storageKey": null
     },
-    (v16/*:: as any*/),
-    (v17/*:: as any*/)
+    (v17/*:: as any*/),
+    (v18/*:: as any*/)
   ],
   "type": "FreeformAnnotationConfig",
   "abstractKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -355,41 +363,41 @@ v20 = {
   "plural": true,
   "selections": [
     (v2/*:: as any*/),
-    (v15/*:: as any*/),
-    (v18/*:: as any*/),
-    (v19/*:: as any*/)
+    (v16/*:: as any*/),
+    (v19/*:: as any*/),
+    (v20/*:: as any*/)
   ],
   "storageKey": null
 },
-v21 = [
+v22 = [
   (v3/*:: as any*/),
   (v4/*:: as any*/)
 ],
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "Prompt",
   "kind": "LinkedField",
   "name": "prompt",
   "plural": false,
-  "selections": (v21/*:: as any*/),
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "templateFormat",
+  "selections": (v22/*:: as any*/),
   "storageKey": null
 },
 v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "parameters",
+  "name": "templateFormat",
   "storageKey": null
 },
 v25 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "parameters",
+  "storageKey": null
+},
+v26 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -403,59 +411,59 @@ v25 = {
   "type": "PromptToolRaw",
   "abstractKey": null
 },
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "modelName",
   "storageKey": null
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "modelProvider",
   "storageKey": null
 },
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "temperature",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "frequencyPenalty",
   "storageKey": null
 },
-v30 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "presencePenalty",
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "topP",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extraBody",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "kind": "InlineFragment",
   "selections": [
-    (v28/*:: as any*/),
+    (v29/*:: as any*/),
     {
       "alias": "openaiMaxTokens",
       "args": null,
@@ -470,9 +478,9 @@ v33 = {
       "name": "maxCompletionTokens",
       "storageKey": null
     },
-    (v29/*:: as any*/),
     (v30/*:: as any*/),
     (v31/*:: as any*/),
+    (v32/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -494,19 +502,19 @@ v33 = {
       "name": "reasoningEffort",
       "storageKey": null
     },
-    (v32/*:: as any*/)
+    (v33/*:: as any*/)
   ],
   "type": "PromptOpenAIInvocationParameters",
   "abstractKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "stopSequences",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -516,9 +524,9 @@ v35 = {
       "name": "maxTokens",
       "storageKey": null
     },
-    (v28/*:: as any*/),
-    (v31/*:: as any*/),
-    (v34/*:: as any*/),
+    (v29/*:: as any*/),
+    (v32/*:: as any*/),
+    (v35/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -598,15 +606,15 @@ v35 = {
       ],
       "storageKey": null
     },
-    (v32/*:: as any*/)
+    (v33/*:: as any*/)
   ],
   "type": "PromptAnthropicInvocationParameters",
   "abstractKey": null
 },
-v36 = {
+v37 = {
   "kind": "InlineFragment",
   "selections": [
-    (v28/*:: as any*/),
+    (v29/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -614,10 +622,10 @@ v36 = {
       "name": "maxOutputTokens",
       "storageKey": null
     },
-    (v34/*:: as any*/),
-    (v30/*:: as any*/),
-    (v29/*:: as any*/),
+    (v35/*:: as any*/),
     (v31/*:: as any*/),
+    (v30/*:: as any*/),
+    (v32/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -661,7 +669,7 @@ v36 = {
   "type": "PromptGoogleInvocationParameters",
   "abstractKey": null
 },
-v37 = {
+v38 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -671,31 +679,31 @@ v37 = {
       "name": "maxTokens",
       "storageKey": null
     },
-    (v28/*:: as any*/),
-    (v31/*:: as any*/),
-    (v34/*:: as any*/)
+    (v29/*:: as any*/),
+    (v32/*:: as any*/),
+    (v35/*:: as any*/)
   ],
   "type": "PromptAwsInvocationParameters",
   "abstractKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "concreteType": "GenerativeModelCustomProvider",
   "kind": "LinkedField",
   "name": "customProvider",
   "plural": false,
-  "selections": (v21/*:: as any*/),
+  "selections": (v22/*:: as any*/),
   "storageKey": null
 },
-v39 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "strict",
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": null,
   "args": null,
   "concreteType": "PromptResponseFormatJSONSchema",
@@ -712,7 +720,7 @@ v40 = {
       "plural": false,
       "selections": [
         (v4/*:: as any*/),
-        (v13/*:: as any*/),
+        (v14/*:: as any*/),
         {
           "alias": null,
           "args": null,
@@ -720,21 +728,21 @@ v40 = {
           "name": "schema",
           "storageKey": null
         },
-        (v39/*:: as any*/)
+        (v40/*:: as any*/)
       ],
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v41 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "toolCallId",
   "storageKey": null
 },
-v42 = {
+v43 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -806,7 +814,7 @@ v42 = {
                       "name": "toolCall",
                       "plural": false,
                       "selections": [
-                        (v41/*:: as any*/),
+                        (v42/*:: as any*/),
                         {
                           "alias": null,
                           "args": null,
@@ -844,7 +852,7 @@ v42 = {
                       "name": "toolResult",
                       "plural": false,
                       "selections": [
-                        (v41/*:: as any*/),
+                        (v42/*:: as any*/),
                         {
                           "alias": null,
                           "args": null,
@@ -886,7 +894,7 @@ v42 = {
   ],
   "storageKey": null
 },
-v43 = {
+v44 = {
   "alias": null,
   "args": null,
   "concreteType": "PromptToolChoice",
@@ -911,52 +919,52 @@ v43 = {
   ],
   "storageKey": null
 },
-v44 = {
+v45 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "disableParallelToolCalls",
   "storageKey": null
 },
-v45 = {
+v46 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "sourceCode",
   "storageKey": null
 },
-v46 = {
+v47 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "language",
   "storageKey": null
 },
-v47 = {
+v48 = {
   "alias": null,
   "args": null,
   "concreteType": "SandboxConfig",
   "kind": "LinkedField",
   "name": "sandboxConfig",
   "plural": false,
-  "selections": (v10/*:: as any*/),
-  "storageKey": null
-},
-v48 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "backendType",
+  "selections": (v11/*:: as any*/),
   "storageKey": null
 },
 v49 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "supportedLanguages",
+  "name": "backendType",
   "storageKey": null
 },
 v50 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "supportedLanguages",
+  "storageKey": null
+},
+v51 = {
   "alias": null,
   "args": null,
   "concreteType": "SandboxConfig",
@@ -966,8 +974,8 @@ v50 = {
   "selections": [
     (v3/*:: as any*/),
     (v4/*:: as any*/),
-    (v13/*:: as any*/),
-    (v46/*:: as any*/),
+    (v14/*:: as any*/),
+    (v47/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -1044,7 +1052,7 @@ v50 = {
   ],
   "storageKey": null
 },
-v51 = {
+v52 = {
   "alias": null,
   "args": null,
   "concreteType": "SandboxBackendInfo",
@@ -1052,7 +1060,7 @@ v51 = {
   "name": "sandboxBackends",
   "plural": true,
   "selections": [
-    (v48/*:: as any*/),
+    (v49/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -1084,7 +1092,7 @@ v51 = {
   ],
   "storageKey": null
 },
-v52 = {
+v53 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -1093,12 +1101,12 @@ v52 = {
   "plural": true,
   "selections": [
     (v2/*:: as any*/),
-    (v15/*:: as any*/),
-    (v18/*:: as any*/),
+    (v16/*:: as any*/),
     (v19/*:: as any*/),
+    (v20/*:: as any*/),
     {
       "kind": "InlineFragment",
-      "selections": (v10/*:: as any*/),
+      "selections": (v11/*:: as any*/),
       "type": "Node",
       "abstractKey": "__isNode"
     }
@@ -1131,7 +1139,8 @@ return {
               (v7/*:: as any*/),
               (v8/*:: as any*/),
               (v9/*:: as any*/),
-              (v11/*:: as any*/),
+              (v10/*:: as any*/),
+              (v12/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1141,14 +1150,14 @@ return {
                 "plural": false,
                 "selections": [
                   (v3/*:: as any*/),
-                  (v12/*:: as any*/),
-                  (v4/*:: as any*/),
                   (v13/*:: as any*/),
+                  (v4/*:: as any*/),
+                  (v14/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v20/*:: as any*/),
-                      (v22/*:: as any*/),
+                      (v21/*:: as any*/),
+                      (v23/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1169,7 +1178,7 @@ return {
                         "name": "promptVersion",
                         "plural": false,
                         "selections": [
-                          (v23/*:: as any*/),
+                          (v24/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1198,7 +1207,7 @@ return {
                                         "name": "function",
                                         "plural": false,
                                         "selections": [
-                                          (v24/*:: as any*/)
+                                          (v25/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -1206,7 +1215,7 @@ return {
                                     "type": "PromptToolFunction",
                                     "abstractKey": null
                                   },
-                                  (v25/*:: as any*/)
+                                  (v26/*:: as any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1218,8 +1227,8 @@ return {
                             "name": "fetchPlaygroundPrompt_promptVersionToInstance_promptVersion",
                             "selections": [
                               (v3/*:: as any*/),
-                              (v26/*:: as any*/),
                               (v27/*:: as any*/),
+                              (v28/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1233,10 +1242,10 @@ return {
                                     "name": "PromptInvocationParametersReadableFragment",
                                     "selections": [
                                       (v2/*:: as any*/),
-                                      (v33/*:: as any*/),
-                                      (v35/*:: as any*/),
+                                      (v34/*:: as any*/),
                                       (v36/*:: as any*/),
-                                      (v37/*:: as any*/)
+                                      (v37/*:: as any*/),
+                                      (v38/*:: as any*/)
                                     ],
                                     "args": null,
                                     "argumentDefinitions": []
@@ -1244,9 +1253,9 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v38/*:: as any*/),
-                              (v40/*:: as any*/),
-                              (v42/*:: as any*/),
+                              (v39/*:: as any*/),
+                              (v41/*:: as any*/),
+                              (v43/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1276,9 +1285,9 @@ return {
                                             "plural": false,
                                             "selections": [
                                               (v4/*:: as any*/),
-                                              (v13/*:: as any*/),
-                                              (v24/*:: as any*/),
-                                              (v39/*:: as any*/)
+                                              (v14/*:: as any*/),
+                                              (v25/*:: as any*/),
+                                              (v40/*:: as any*/)
                                             ],
                                             "storageKey": null
                                           }
@@ -1286,12 +1295,12 @@ return {
                                         "type": "PromptToolFunction",
                                         "abstractKey": null
                                       },
-                                      (v25/*:: as any*/)
+                                      (v26/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v43/*:: as any*/),
-                                  (v44/*:: as any*/)
+                                  (v44/*:: as any*/),
+                                  (v45/*:: as any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1309,11 +1318,11 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v45/*:: as any*/),
                       (v46/*:: as any*/),
                       (v47/*:: as any*/),
-                      (v9/*:: as any*/),
-                      (v20/*:: as any*/)
+                      (v48/*:: as any*/),
+                      (v10/*:: as any*/),
+                      (v21/*:: as any*/)
                     ],
                     "type": "CodeEvaluator",
                     "abstractKey": null
@@ -1336,14 +1345,14 @@ return {
         "name": "sandboxProviders",
         "plural": true,
         "selections": [
-          (v48/*:: as any*/),
           (v49/*:: as any*/),
-          (v8/*:: as any*/),
-          (v50/*:: as any*/)
+          (v50/*:: as any*/),
+          (v9/*:: as any*/),
+          (v51/*:: as any*/)
         ],
         "storageKey": null
       },
-      (v51/*:: as any*/)
+      (v52/*:: as any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -1373,7 +1382,8 @@ return {
               (v7/*:: as any*/),
               (v8/*:: as any*/),
               (v9/*:: as any*/),
-              (v11/*:: as any*/),
+              (v10/*:: as any*/),
+              (v12/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1384,14 +1394,14 @@ return {
                 "selections": [
                   (v2/*:: as any*/),
                   (v3/*:: as any*/),
-                  (v12/*:: as any*/),
-                  (v4/*:: as any*/),
                   (v13/*:: as any*/),
+                  (v4/*:: as any*/),
+                  (v14/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v52/*:: as any*/),
-                      (v22/*:: as any*/),
+                      (v53/*:: as any*/),
+                      (v23/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1413,7 +1423,7 @@ return {
                         "name": "promptVersion",
                         "plural": false,
                         "selections": [
-                          (v23/*:: as any*/),
+                          (v24/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1442,10 +1452,10 @@ return {
                                         "name": "function",
                                         "plural": false,
                                         "selections": [
-                                          (v24/*:: as any*/),
+                                          (v25/*:: as any*/),
                                           (v4/*:: as any*/),
-                                          (v13/*:: as any*/),
-                                          (v39/*:: as any*/)
+                                          (v14/*:: as any*/),
+                                          (v40/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -1453,18 +1463,18 @@ return {
                                     "type": "PromptToolFunction",
                                     "abstractKey": null
                                   },
-                                  (v25/*:: as any*/)
+                                  (v26/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v43/*:: as any*/),
-                              (v44/*:: as any*/)
+                              (v44/*:: as any*/),
+                              (v45/*:: as any*/)
                             ],
                             "storageKey": null
                           },
                           (v3/*:: as any*/),
-                          (v26/*:: as any*/),
                           (v27/*:: as any*/),
+                          (v28/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1478,16 +1488,16 @@ return {
                                 "kind": "TypeDiscriminator",
                                 "abstractKey": "__isPromptInvocationParameters"
                               },
-                              (v33/*:: as any*/),
-                              (v35/*:: as any*/),
+                              (v34/*:: as any*/),
                               (v36/*:: as any*/),
-                              (v37/*:: as any*/)
+                              (v37/*:: as any*/),
+                              (v38/*:: as any*/)
                             ],
                             "storageKey": null
                           },
-                          (v38/*:: as any*/),
-                          (v40/*:: as any*/),
-                          (v42/*:: as any*/)
+                          (v39/*:: as any*/),
+                          (v41/*:: as any*/),
+                          (v43/*:: as any*/)
                         ],
                         "storageKey": null
                       }
@@ -1498,11 +1508,11 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v45/*:: as any*/),
                       (v46/*:: as any*/),
                       (v47/*:: as any*/),
-                      (v9/*:: as any*/),
-                      (v52/*:: as any*/)
+                      (v48/*:: as any*/),
+                      (v10/*:: as any*/),
+                      (v53/*:: as any*/)
                     ],
                     "type": "CodeEvaluator",
                     "abstractKey": null
@@ -1525,28 +1535,28 @@ return {
         "name": "sandboxProviders",
         "plural": true,
         "selections": [
-          (v48/*:: as any*/),
           (v49/*:: as any*/),
-          (v8/*:: as any*/),
           (v50/*:: as any*/),
+          (v9/*:: as any*/),
+          (v51/*:: as any*/),
           (v3/*:: as any*/)
         ],
         "storageKey": null
       },
-      (v51/*:: as any*/)
+      (v52/*:: as any*/)
     ]
   },
   "params": {
-    "cacheID": "67e0ca582fd01065d11e59105a952b62",
+    "cacheID": "dfbc42a734e7929d5f33c7a835070839",
     "id": null,
     "metadata": {},
     "name": "EditProjectEvaluatorSlideoverQuery",
     "operationKind": "query",
-    "text": "query EditProjectEvaluatorSlideoverQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      evaluationTarget\n      filterCondition\n      samplingRate\n      enabled\n      inputMapping {\n        pathMapping\n        literalMapping\n      }\n      project {\n        id\n      }\n      evaluator {\n        __typename\n        id\n        kind\n        name\n        description\n        ... on LLMEvaluator {\n          outputConfigs {\n            __typename\n            ... on CategoricalAnnotationConfig {\n              name\n              optimizationDirection\n              values {\n                label\n                score\n              }\n            }\n            ... on ContinuousAnnotationConfig {\n              name\n              optimizationDirection\n              lowerBound\n              upperBound\n            }\n            ... on FreeformAnnotationConfig {\n              name\n              optimizationDirection\n              threshold\n              lowerBound\n              upperBound\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n          }\n          prompt {\n            id\n            name\n          }\n          promptVersionTag {\n            name\n            id\n          }\n          promptVersion {\n            templateFormat\n            tools {\n              tools {\n                __typename\n                ... on PromptToolFunction {\n                  function {\n                    parameters\n                  }\n                }\n                ... on PromptToolRaw {\n                  raw\n                }\n              }\n            }\n            ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n            id\n          }\n        }\n        ... on CodeEvaluator {\n          sourceCode\n          language\n          sandboxConfig {\n            id\n          }\n          inputMapping {\n            pathMapping\n            literalMapping\n          }\n          outputConfigs {\n            __typename\n            ... on CategoricalAnnotationConfig {\n              name\n              optimizationDirection\n              values {\n                label\n                score\n              }\n            }\n            ... on ContinuousAnnotationConfig {\n              name\n              optimizationDirection\n              lowerBound\n              upperBound\n            }\n            ... on FreeformAnnotationConfig {\n              name\n              optimizationDirection\n              threshold\n              lowerBound\n              upperBound\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  sandboxProviders {\n    backendType\n    supportedLanguages\n    enabled\n    configs {\n      id\n      name\n      description\n      language\n      timeout\n      config {\n        envVars {\n          name\n          secretKey\n        }\n        internetAccess {\n          mode\n        }\n        dependencies {\n          packages\n        }\n      }\n    }\n    id\n  }\n  sandboxBackends {\n    backendType\n    status\n    supportsEnvVars\n    internetAccess\n    supportsDependencies\n  }\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters {\n    __typename\n    ...PromptInvocationParametersReadableFragment\n  }\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      __typename\n      ... on PromptToolFunction {\n        function {\n          name\n          description\n          parameters\n          strict\n        }\n      }\n      ... on PromptToolRaw {\n        raw\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
+    "text": "query EditProjectEvaluatorSlideoverQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      evaluationTarget\n      filterCondition\n      samplingRate\n      evaluationDelaySeconds\n      enabled\n      inputMapping {\n        pathMapping\n        literalMapping\n      }\n      project {\n        id\n      }\n      evaluator {\n        __typename\n        id\n        kind\n        name\n        description\n        ... on LLMEvaluator {\n          outputConfigs {\n            __typename\n            ... on CategoricalAnnotationConfig {\n              name\n              optimizationDirection\n              values {\n                label\n                score\n              }\n            }\n            ... on ContinuousAnnotationConfig {\n              name\n              optimizationDirection\n              lowerBound\n              upperBound\n            }\n            ... on FreeformAnnotationConfig {\n              name\n              optimizationDirection\n              threshold\n              lowerBound\n              upperBound\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n          }\n          prompt {\n            id\n            name\n          }\n          promptVersionTag {\n            name\n            id\n          }\n          promptVersion {\n            templateFormat\n            tools {\n              tools {\n                __typename\n                ... on PromptToolFunction {\n                  function {\n                    parameters\n                  }\n                }\n                ... on PromptToolRaw {\n                  raw\n                }\n              }\n            }\n            ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n            id\n          }\n        }\n        ... on CodeEvaluator {\n          sourceCode\n          language\n          sandboxConfig {\n            id\n          }\n          inputMapping {\n            pathMapping\n            literalMapping\n          }\n          outputConfigs {\n            __typename\n            ... on CategoricalAnnotationConfig {\n              name\n              optimizationDirection\n              values {\n                label\n                score\n              }\n            }\n            ... on ContinuousAnnotationConfig {\n              name\n              optimizationDirection\n              lowerBound\n              upperBound\n            }\n            ... on FreeformAnnotationConfig {\n              name\n              optimizationDirection\n              threshold\n              lowerBound\n              upperBound\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  sandboxProviders {\n    backendType\n    supportedLanguages\n    enabled\n    configs {\n      id\n      name\n      description\n      language\n      timeout\n      config {\n        envVars {\n          name\n          secretKey\n        }\n        internetAccess {\n          mode\n        }\n        dependencies {\n          packages\n        }\n      }\n    }\n    id\n  }\n  sandboxBackends {\n    backendType\n    status\n    supportsEnvVars\n    internetAccess\n    supportsDependencies\n  }\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters {\n    __typename\n    ...PromptInvocationParametersReadableFragment\n  }\n  customProvider {\n    id\n    name\n  }\n  responseFormat {\n    jsonSchema {\n      name\n      description\n      schema\n      strict\n    }\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    tools {\n      __typename\n      ... on PromptToolFunction {\n        function {\n          name\n          description\n          parameters\n          strict\n        }\n      }\n      ... on PromptToolRaw {\n        raw\n      }\n    }\n    toolChoice {\n      type\n      functionName\n    }\n    disableParallelToolCalls\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f74c869b6c67a90c71c373d687a45af2";
+(node as any).hash = "10089195314ab608b30a38c1cfe6f77c";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<263d3240e8057ed789c4eb1d86d7cfd9>>
+ * @generated SignedSource<<fe16753be59bfb99d4f2104ad3013d02>>
  * @lightSyntaxTransform
  */
 
@@ -9,11 +9,16 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
+export type ProjectEvaluatorSchedulabilityReason = "DISABLED" | "SESSION_FILTER_UNSUPPORTED" | "SESSION_SAMPLING_UNSUPPORTED" | "TRACE_TARGET_UNSUPPORTED";
+export type ProjectEvaluatorSchedulabilityStatus = "NOT_SCHEDULABLE" | "SCHEDULABLE";
 import { FragmentRefs } from "relay-runtime";
 export type ProjectEvaluatorScopeDetails_projectEvaluator$data = {
+  readonly evaluationDelaySeconds: number;
   readonly evaluationTarget: EvaluationTarget;
   readonly filterCondition: string;
   readonly samplingRate: number;
+  readonly schedulabilityReason: ProjectEvaluatorSchedulabilityReason | null;
+  readonly schedulabilityStatus: ProjectEvaluatorSchedulabilityStatus;
   readonly " $fragmentType": "ProjectEvaluatorScopeDetails_projectEvaluator";
 };
 export type ProjectEvaluatorScopeDetails_projectEvaluator$key = {
@@ -47,12 +52,33 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "samplingRate",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "evaluationDelaySeconds",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "schedulabilityStatus",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "schedulabilityReason",
+      "storageKey": null
     }
   ],
   "type": "ProjectEvaluator",
   "abstractKey": null
 };
 
-(node as any).hash = "206d2fc44e707d0e5030e443056ed522";
+(node as any).hash = "0d20a79f97199a3b9a330e4d26df794c";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopeDetails_projectEvaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fe16753be59bfb99d4f2104ad3013d02>>
+ * @generated SignedSource<<24b7ef4ebb95475966c437948f62eb85>>
  * @lightSyntaxTransform
  */
 
@@ -9,7 +9,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
-export type ProjectEvaluatorSchedulabilityReason = "DISABLED" | "SESSION_FILTER_UNSUPPORTED" | "SESSION_SAMPLING_UNSUPPORTED" | "TRACE_TARGET_UNSUPPORTED";
+export type ProjectEvaluatorSchedulabilityReason = "DISABLED" | "TRACE_TARGET_UNSUPPORTED";
 export type ProjectEvaluatorSchedulabilityStatus = "NOT_SCHEDULABLE" | "SCHEDULABLE";
 import { FragmentRefs } from "relay-runtime";
 export type ProjectEvaluatorScopeDetails_projectEvaluator$data = {

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelPreviewMutation.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelPreviewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<555849633b41b6fd7bb8933afe7995fc>>
+ * @generated SignedSource<<ee77a3b0f3dba3b26cbae4373dd94b63>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type EvaluatorPreviewsInput = {
   previews: ReadonlyArray<EvaluatorPreviewItemInput>;
 };
 export type EvaluatorPreviewItemInput = {
+  applyOnlineEvaluationLimits?: boolean;
   context: any;
   evaluator: EvaluatorPreviewInput;
   inputMapping: EvaluatorInputMappingInput;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionCountQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionCountQuery.graphql.ts
@@ -1,0 +1,156 @@
+/**
+ * @generated SignedSource<<bb02554f50c42217dcccba1a213a0453>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectEvaluatorScopePanelSessionCountQuery$variables = {
+  projectId: string;
+  sessionFilterCondition?: string | null;
+  timeRange: TimeRange;
+};
+export type ProjectEvaluatorScopePanelSessionCountQuery$data = {
+  readonly project: {
+    readonly sessionCount?: number;
+  };
+};
+export type ProjectEvaluatorScopePanelSessionCountQuery = {
+  response: ProjectEvaluatorScopePanelSessionCountQuery$data;
+  variables: ProjectEvaluatorScopePanelSessionCountQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "projectId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "sessionFilterCondition"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "sessionFilterCondition",
+          "variableName": "sessionFilterCondition"
+        },
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "sessionCount",
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*:: as any*/),
+      (v1/*:: as any*/),
+      (v2/*:: as any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectEvaluatorScopePanelSessionCountQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v3/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*:: as any*/),
+      (v2/*:: as any*/),
+      (v1/*:: as any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectEvaluatorScopePanelSessionCountQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v3/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v4/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0f883731aef898932f41642f94ab1b98",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectEvaluatorScopePanelSessionCountQuery",
+    "operationKind": "query",
+    "text": "query ProjectEvaluatorScopePanelSessionCountQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $sessionFilterCondition: String\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionCount(timeRange: $timeRange, sessionFilterCondition: $sessionFilterCondition)\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1999d47a6289158fc5d94ef12348cdc8";
+
+export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionsQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionsQuery.graphql.ts
@@ -1,0 +1,298 @@
+/**
+ * @generated SignedSource<<a895b65b8ecfbcec1caf4919298e0497>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectEvaluatorScopePanelSessionsQuery$variables = {
+  first: number;
+  projectId: string;
+  sessionFilterCondition?: string | null;
+  timeRange?: TimeRange | null;
+};
+export type ProjectEvaluatorScopePanelSessionsQuery$data = {
+  readonly project: {
+    readonly sessions?: {
+      readonly edges: ReadonlyArray<{
+        readonly session: {
+          readonly firstInput: {
+            readonly truncatedValue: string;
+          } | null;
+          readonly id: string;
+          readonly numTraces: number;
+          readonly sessionId: string;
+          readonly startTime: string;
+          readonly tokenUsage: {
+            readonly total: number;
+          };
+        };
+      }>;
+      readonly pageInfo: {
+        readonly hasNextPage: boolean;
+      };
+    };
+  };
+};
+export type ProjectEvaluatorScopePanelSessionsQuery = {
+  response: ProjectEvaluatorScopePanelSessionsQuery$data;
+  variables: ProjectEvaluatorScopePanelSessionsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "projectId"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "sessionFilterCondition"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "first",
+          "variableName": "first"
+        },
+        {
+          "kind": "Variable",
+          "name": "sessionFilterCondition",
+          "variableName": "sessionFilterCondition"
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": {
+            "col": "startTime",
+            "dir": "desc"
+          }
+        },
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "concreteType": "ProjectSessionConnection",
+      "kind": "LinkedField",
+      "name": "sessions",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ProjectSessionEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "session",
+              "args": null,
+              "concreteType": "ProjectSession",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v5/*:: as any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "sessionId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "startTime",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "numTraces",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "TokenUsage",
+                  "kind": "LinkedField",
+                  "name": "tokenUsage",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "total",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SpanIOValue",
+                  "kind": "LinkedField",
+                  "name": "firstInput",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "truncatedValue",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*:: as any*/),
+      (v1/*:: as any*/),
+      (v2/*:: as any*/),
+      (v3/*:: as any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectEvaluatorScopePanelSessionsQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v4/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*:: as any*/),
+      (v2/*:: as any*/),
+      (v3/*:: as any*/),
+      (v0/*:: as any*/)
+    ],
+    "kind": "Operation",
+    "name": "ProjectEvaluatorScopePanelSessionsQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v4/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v6/*:: as any*/),
+          (v5/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c3285ef32e61e6794ca284cbe249f502",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectEvaluatorScopePanelSessionsQuery",
+    "operationKind": "query",
+    "text": "query ProjectEvaluatorScopePanelSessionsQuery(\n  $projectId: ID!\n  $sessionFilterCondition: String\n  $timeRange: TimeRange\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessions(first: $first, sort: {col: startTime, dir: desc}, sessionFilterCondition: $sessionFilterCondition, timeRange: $timeRange) {\n        edges {\n          session: node {\n            id\n            sessionId\n            startTime\n            numTraces\n            tokenUsage {\n              total\n            }\n            firstInput {\n              truncatedValue\n            }\n          }\n        }\n        pageInfo {\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ee5c5a49ca766853e567c468c4328bd3";
+
+export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionsQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a895b65b8ecfbcec1caf4919298e0497>>
+ * @generated SignedSource<<f0d8a9b00c875796c563e88e9bb84691>>
  * @lightSyntaxTransform
  */
 
@@ -23,13 +23,10 @@ export type ProjectEvaluatorScopePanelSessionsQuery$data = {
     readonly sessions?: {
       readonly edges: ReadonlyArray<{
         readonly session: {
-          readonly firstInput: {
-            readonly truncatedValue: string;
-          } | null;
           readonly id: string;
           readonly numTraces: number;
+          readonly sessionEvaluationContext: any | null;
           readonly sessionId: string;
-          readonly startTime: string;
           readonly tokenUsage: {
             readonly total: number;
           };
@@ -144,13 +141,6 @@ v6 = {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "startTime",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
                   "name": "numTraces",
                   "storageKey": null
                 },
@@ -175,19 +165,8 @@ v6 = {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "SpanIOValue",
-                  "kind": "LinkedField",
-                  "name": "firstInput",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "truncatedValue",
-                      "storageKey": null
-                    }
-                  ],
+                  "kind": "ScalarField",
+                  "name": "sessionEvaluationContext",
                   "storageKey": null
                 }
               ],
@@ -283,16 +262,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c3285ef32e61e6794ca284cbe249f502",
+    "cacheID": "876e6b96743fcc3ec98e7dd1783fdc1a",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorScopePanelSessionsQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorScopePanelSessionsQuery(\n  $projectId: ID!\n  $sessionFilterCondition: String\n  $timeRange: TimeRange\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessions(first: $first, sort: {col: startTime, dir: desc}, sessionFilterCondition: $sessionFilterCondition, timeRange: $timeRange) {\n        edges {\n          session: node {\n            id\n            sessionId\n            startTime\n            numTraces\n            tokenUsage {\n              total\n            }\n            firstInput {\n              truncatedValue\n            }\n          }\n        }\n        pageInfo {\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorScopePanelSessionsQuery(\n  $projectId: ID!\n  $sessionFilterCondition: String\n  $timeRange: TimeRange\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessions(first: $first, sort: {col: startTime, dir: desc}, sessionFilterCondition: $sessionFilterCondition, timeRange: $timeRange) {\n        edges {\n          session: node {\n            id\n            sessionId\n            numTraces\n            tokenUsage {\n              total\n            }\n            sessionEvaluationContext\n          }\n        }\n        pageInfo {\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ee5c5a49ca766853e567c468c4328bd3";
+(node as any).hash = "f5834cfe7302b23d3823bcce1b2c51d0";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e12a19b80833e77062a0bf9af6fa0112>>
+ * @generated SignedSource<<10137666c146b5b676a2ffba87f6cef5>>
  * @lightSyntaxTransform
  */
 
@@ -163,6 +163,13 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "samplingRate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "schedulabilityStatus",
                             "storageKey": null
                           },
                           {
@@ -367,12 +374,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5b5b40ba96125b7dc6ca3f622523945c",
+    "cacheID": "537d95b7766f38e79540bddd86f29132",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsPageQuery(\n  $projectId: ID!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectEvaluatorsTable_project\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project on Project {\n  evaluators(first: 30) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorsPageQuery(\n  $projectId: ID!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectEvaluatorsTable_project\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project on Project {\n  evaluators(first: 30) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f963f58d9b2289a61ac65e26bf58fb29>>
+ * @generated SignedSource<<bfe1eaca9c2398cfc99c594a2d0938c8>>
  * @lightSyntaxTransform
  */
 
@@ -189,6 +189,13 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "samplingRate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "schedulabilityStatus",
                             "storageKey": null
                           },
                           {
@@ -393,12 +400,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8dac28f42c05bbd9a107d9c9ac894581",
+    "cacheID": "508095f24ede7dbf2ecae095b2b923f9",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsTablePaginationQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_G9cLv\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_G9cLv on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_G9cLv\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_G9cLv on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b0a88ddf710d1e2f063786deb3d4cf87>>
+ * @generated SignedSource<<3c1690467bc572080dbb176d4933b48d>>
  * @lightSyntaxTransform
  */
 
@@ -149,6 +149,13 @@ return {
                       "args": null,
                       "kind": "ScalarField",
                       "name": "samplingRate",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "schedulabilityStatus",
                       "storageKey": null
                     },
                     {

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_row.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<965113e717b30e0088b141e1e6e4064f>>
+ * @generated SignedSource<<d0985a906ef92bb8aa795a775e3c6a21>>
  * @lightSyntaxTransform
  */
 
@@ -12,6 +12,7 @@ export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
+export type ProjectEvaluatorSchedulabilityStatus = "NOT_SCHEDULABLE" | "SCHEDULABLE";
 export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "MONTY" | "VERCEL" | "WASM";
 import { FragmentRefs } from "relay-runtime";
 export type ProjectEvaluatorsTable_row$data = {
@@ -43,6 +44,7 @@ export type ProjectEvaluatorsTable_row$data = {
   readonly id: string;
   readonly name: string;
   readonly samplingRate: number;
+  readonly schedulabilityStatus: ProjectEvaluatorSchedulabilityStatus;
   readonly updatedAt: string;
   readonly " $fragmentType": "ProjectEvaluatorsTable_row";
 };
@@ -56,6 +58,6 @@ const node: ReaderInlineDataFragment = {
   "name": "ProjectEvaluatorsTable_row"
 };
 
-(node as any).hash = "b3af2600cc18279e0fae388fb2e9b0cf";
+(node as any).hash = "346865c8849e012c4362648a61cfd77d";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d8be6762e6535732a53ffabc13e1517d>>
+ * @generated SignedSource<<cf128f0721cde6a49d9e915ace33e832>>
  * @lightSyntaxTransform
  */
 
@@ -865,6 +865,27 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "evaluationDelaySeconds",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "schedulabilityStatus",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "schedulabilityReason",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "EvaluatorInputMapping",
                 "kind": "LinkedField",
                 "name": "inputMapping",
@@ -897,12 +918,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f18f52daf4c636d1195c47b43012f779",
+    "cacheID": "b906ae5fd99d9e416df75cc525562da6",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorDetailsLoaderQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorDetailsLoaderQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      enabled\n      evaluator {\n        __typename\n        kind\n        description\n        id\n      }\n      ...ProjectEvaluatorScopeDetails_projectEvaluator\n      ...LLMProjectEvaluatorDetails_projectEvaluator\n    }\n    id\n  }\n}\n\nfragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        invocationParameters {\n          __typename\n          ...PromptInvocationParametersReadableFragment\n        }\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n          }\n        }\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorScopeDetails_projectEvaluator on ProjectEvaluator {\n  evaluationTarget\n  filterCondition\n  samplingRate\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n"
+    "text": "query projectEvaluatorDetailsLoaderQuery(\n  $projectEvaluatorId: ID!\n) {\n  projectEvaluator: node(id: $projectEvaluatorId) {\n    __typename\n    ... on ProjectEvaluator {\n      id\n      name\n      enabled\n      evaluator {\n        __typename\n        kind\n        description\n        id\n      }\n      ...ProjectEvaluatorScopeDetails_projectEvaluator\n      ...LLMProjectEvaluatorDetails_projectEvaluator\n    }\n    id\n  }\n}\n\nfragment LLMProjectEvaluatorDetails_projectEvaluator on ProjectEvaluator {\n  inputMapping {\n    literalMapping\n    pathMapping\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        invocationParameters {\n          __typename\n          ...PromptInvocationParametersReadableFragment\n        }\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n          }\n        }\n        ...PromptChatMessagesCard__main\n        id\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorScopeDetails_projectEvaluator on ProjectEvaluator {\n  evaluationTarget\n  filterCondition\n  samplingRate\n  evaluationDelaySeconds\n  schedulabilityStatus\n  schedulabilityReason\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptInvocationParametersReadableFragment on PromptInvocationParameters {\n  __isPromptInvocationParameters: __typename\n  __typename\n  ... on PromptOpenAIInvocationParameters {\n    temperature\n    openaiMaxTokens: maxTokens\n    maxCompletionTokens\n    frequencyPenalty\n    presencePenalty\n    topP\n    seed\n    stop\n    reasoningEffort\n    extraBody\n  }\n  ... on PromptAnthropicInvocationParameters {\n    anthropicMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n    outputConfig {\n      effort\n    }\n    thinking {\n      __typename\n      ... on PromptAnthropicThinkingDisabled {\n        disabled\n      }\n      ... on PromptAnthropicThinkingEnabled {\n        budgetTokens\n        enabledDisplay: display\n      }\n      ... on PromptAnthropicThinkingAdaptive {\n        adaptiveDisplay: display\n      }\n    }\n    extraBody\n  }\n  ... on PromptGoogleInvocationParameters {\n    temperature\n    maxOutputTokens\n    stopSequences\n    presencePenalty\n    frequencyPenalty\n    topP\n    topK\n    thinkingConfig {\n      thinkingBudget\n      thinkingLevel\n      includeThoughts\n    }\n  }\n  ... on PromptAwsInvocationParameters {\n    awsMaxTokens: maxTokens\n    temperature\n    topP\n    stopSequences\n  }\n}\n"
   }
 };
 })();

--- a/js/app/src/pages/project/evaluators/__generated__/refetchProjectEvaluatorsQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/refetchProjectEvaluatorsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2bc8813c52016fb4b575b3ca6d237f05>>
+ * @generated SignedSource<<aa0736c60f8f0a3d8ba2264143dfdc0d>>
  * @lightSyntaxTransform
  */
 
@@ -98,24 +98,31 @@ v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "enabled",
+  "name": "schedulabilityStatus",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "updatedAt",
+  "name": "enabled",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "kind",
+  "name": "updatedAt",
   "storageKey": null
 },
 v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "kind",
+  "storageKey": null
+},
+v13 = {
   "alias": null,
   "args": null,
   "concreteType": "Prompt",
@@ -128,49 +135,49 @@ v12 = {
   ],
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "modelName",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "modelProvider",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "language",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "backendType",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -195,7 +202,7 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = [
+v21 = [
   {
     "kind": "Variable",
     "name": "first",
@@ -259,6 +266,7 @@ return {
                               (v8/*:: as any*/),
                               (v9/*:: as any*/),
                               (v10/*:: as any*/),
+                              (v11/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -267,11 +275,11 @@ return {
                                 "name": "evaluator",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*:: as any*/),
+                                  (v12/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v12/*:: as any*/),
+                                      (v13/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -292,8 +300,8 @@ return {
                                         "name": "promptVersion",
                                         "plural": false,
                                         "selections": [
-                                          (v13/*:: as any*/),
-                                          (v14/*:: as any*/)
+                                          (v14/*:: as any*/),
+                                          (v15/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -304,7 +312,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v15/*:: as any*/),
+                                      (v16/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -323,7 +331,7 @@ return {
                                             "name": "provider",
                                             "plural": false,
                                             "selections": [
-                                              (v16/*:: as any*/)
+                                              (v17/*:: as any*/)
                                             ],
                                             "storageKey": null
                                           }
@@ -341,15 +349,15 @@ return {
                             "args": null,
                             "argumentDefinitions": []
                           },
-                          (v17/*:: as any*/)
+                          (v18/*:: as any*/)
                         ],
                         "storageKey": null
                       },
-                      (v18/*:: as any*/)
+                      (v19/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v19/*:: as any*/)
+                  (v20/*:: as any*/)
                 ],
                 "storageKey": null
               }
@@ -381,14 +389,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v17/*:: as any*/),
+          (v18/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               (v3/*:: as any*/),
               {
                 "alias": null,
-                "args": (v20/*:: as any*/),
+                "args": (v21/*:: as any*/),
                 "concreteType": "ProjectEvaluatorConnection",
                 "kind": "LinkedField",
                 "name": "evaluators",
@@ -417,6 +425,7 @@ return {
                           (v8/*:: as any*/),
                           (v9/*:: as any*/),
                           (v10/*:: as any*/),
+                          (v11/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -425,12 +434,12 @@ return {
                             "name": "evaluator",
                             "plural": false,
                             "selections": [
-                              (v17/*:: as any*/),
-                              (v11/*:: as any*/),
+                              (v18/*:: as any*/),
+                              (v12/*:: as any*/),
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v12/*:: as any*/),
+                                  (v13/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -452,8 +461,8 @@ return {
                                     "name": "promptVersion",
                                     "plural": false,
                                     "selections": [
-                                      (v13/*:: as any*/),
                                       (v14/*:: as any*/),
+                                      (v15/*:: as any*/),
                                       (v4/*:: as any*/)
                                     ],
                                     "storageKey": null
@@ -465,7 +474,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v15/*:: as any*/),
+                                  (v16/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -484,7 +493,7 @@ return {
                                         "name": "provider",
                                         "plural": false,
                                         "selections": [
-                                          (v16/*:: as any*/),
+                                          (v17/*:: as any*/),
                                           (v4/*:: as any*/)
                                         ],
                                         "storageKey": null
@@ -500,21 +509,21 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v17/*:: as any*/)
+                          (v18/*:: as any*/)
                         ],
                         "storageKey": null
                       },
-                      (v18/*:: as any*/)
+                      (v19/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v19/*:: as any*/)
+                  (v20/*:: as any*/)
                 ],
                 "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v20/*:: as any*/),
+                "args": (v21/*:: as any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "ProjectEvaluatorsTable_evaluators",
@@ -532,7 +541,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dfcfa74eff5fd31277862cb0484845b5",
+    "cacheID": "a8a0624336b39d26761c6034b223f7ed",
     "id": null,
     "metadata": {
       "connection": [
@@ -549,7 +558,7 @@ return {
     },
     "name": "refetchProjectEvaluatorsQuery",
     "operationKind": "query",
-    "text": "query refetchProjectEvaluatorsQuery(\n  $projectId: ID!\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      evaluators(first: $first) {\n        edges {\n          node {\n            ...ProjectEvaluatorsTable_row\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query refetchProjectEvaluatorsQuery(\n  $projectId: ID!\n  $first: Int!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      evaluators(first: $first) {\n        edges {\n          node {\n            ...ProjectEvaluatorsTable_row\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
@@ -1,7 +1,9 @@
 import {
   dropReferencePathMappings,
   getProjectEvaluatorMappingDiagnostics,
+  getSessionScopeUnschedulableReason,
   toProjectEvaluatorSamplingFraction,
+  type ProjectEvaluatorScope,
 } from "../projectEvaluatorTypes";
 
 describe("dropReferencePathMappings", () => {
@@ -35,6 +37,39 @@ describe("toProjectEvaluatorSamplingFraction", () => {
     [150, 1],
   ])("clamps %s percent to %s", (percent, expected) => {
     expect(toProjectEvaluatorSamplingFraction(percent)).toBe(expected);
+  });
+});
+
+describe("getSessionScopeUnschedulableReason", () => {
+  const sessionScope: ProjectEvaluatorScope = {
+    targetType: "SESSION",
+    filterCondition: "",
+    samplingRate: 1,
+    evaluationDelaySeconds: 300,
+  };
+
+  it.each<[string, Partial<ProjectEvaluatorScope>, string | null]>([
+    ["an unfiltered, unsampled session scope", {}, null],
+    [
+      "a filtered session scope",
+      { filterCondition: "name == 'chat'" },
+      "filter",
+    ],
+    ["a sampled session scope", { samplingRate: 0.5 }, "sampling"],
+    [
+      "a filtered and sampled session scope",
+      { filterCondition: "name == 'chat'", samplingRate: 0.5 },
+      "filter",
+    ],
+    [
+      "a filtered span scope",
+      { targetType: "SPAN", filterCondition: "a" },
+      null,
+    ],
+  ])("reports %s as %s", (_label, overrides, expected) => {
+    expect(
+      getSessionScopeUnschedulableReason({ ...sessionScope, ...overrides })
+    ).toBe(expected);
   });
 });
 

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
@@ -1,9 +1,7 @@
 import {
   dropReferencePathMappings,
   getProjectEvaluatorMappingDiagnostics,
-  getSessionScopeUnschedulableReason,
   toProjectEvaluatorSamplingFraction,
-  type ProjectEvaluatorScope,
 } from "../projectEvaluatorTypes";
 
 describe("dropReferencePathMappings", () => {
@@ -37,39 +35,6 @@ describe("toProjectEvaluatorSamplingFraction", () => {
     [150, 1],
   ])("clamps %s percent to %s", (percent, expected) => {
     expect(toProjectEvaluatorSamplingFraction(percent)).toBe(expected);
-  });
-});
-
-describe("getSessionScopeUnschedulableReason", () => {
-  const sessionScope: ProjectEvaluatorScope = {
-    targetType: "SESSION",
-    filterCondition: "",
-    samplingRate: 1,
-    evaluationDelaySeconds: 300,
-  };
-
-  it.each<[string, Partial<ProjectEvaluatorScope>, string | null]>([
-    ["an unfiltered, unsampled session scope", {}, null],
-    [
-      "a filtered session scope",
-      { filterCondition: "name == 'chat'" },
-      "filter",
-    ],
-    ["a sampled session scope", { samplingRate: 0.5 }, "sampling"],
-    [
-      "a filtered and sampled session scope",
-      { filterCondition: "name == 'chat'", samplingRate: 0.5 },
-      "filter",
-    ],
-    [
-      "a filtered span scope",
-      { targetType: "SPAN", filterCondition: "a" },
-      null,
-    ],
-  ])("reports %s as %s", (_label, overrides, expected) => {
-    expect(
-      getSessionScopeUnschedulableReason({ ...sessionScope, ...overrides })
-    ).toBe(expected);
   });
 });
 

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
@@ -45,15 +45,17 @@ describe("getProjectEvaluatorMappingDiagnostics", () => {
         context: {
           input: { question: "What is Phoenix?" },
           answer: "An AI observability platform",
+          metadata: { "custom-key": "tagged" },
           unrelated: true,
         },
         pathMapping: {
           question: "input.question",
           missing: "output.missing",
-          complex: "metadata['custom-key']",
+          bracketed: "metadata['custom-key']",
+          complex: "metadata[*]",
           unrelated: "unrelated",
         },
-        variables: ["question", "answer", "missing", "complex"],
+        variables: ["question", "answer", "missing", "bracketed", "complex"],
       })
     ).toEqual([
       {
@@ -68,8 +70,13 @@ describe("getProjectEvaluatorMappingDiagnostics", () => {
         status: "missing",
       },
       {
-        variable: "complex",
+        variable: "bracketed",
         path: "metadata['custom-key']",
+        status: "resolved",
+      },
+      {
+        variable: "complex",
+        path: "metadata[*]",
         status: "unverified",
       },
     ]);

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -4,7 +4,7 @@ import type {
   EvaluatorMappingSourceGrain,
 } from "@phoenix/types";
 import { assertUnreachable } from "@phoenix/typeUtils";
-import { getValueAtPath } from "@phoenix/utils/objectUtils";
+import { getValueAtPath, parsePathSegments } from "@phoenix/utils/objectUtils";
 
 /** A span evaluation context has no counterpart to a dataset `reference`. */
 export function dropReferencePathMappings(
@@ -113,11 +113,6 @@ export type ProjectEvaluatorMappingDiagnostic = {
   status: "resolved" | "missing" | "optional-missing" | "unverified";
 };
 
-// Only dot-separated bare JSONPath identifiers resolve client-side; anything
-// else (hyphens, brackets, quotes) is left to server validation.
-const SIMPLE_MAPPING_PATH_PATTERN =
-  /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
-
 export function getProjectEvaluatorMappingDiagnostics({
   context,
   pathMapping,
@@ -132,7 +127,8 @@ export function getProjectEvaluatorMappingDiagnostics({
   const requiredVariableNames = new Set(requiredVariables);
   return variables.map((variable) => {
     const path = pathMapping[variable] ?? variable;
-    if (!SIMPLE_MAPPING_PATH_PATTERN.test(path)) {
+    // Wildcards and slices only the server can resolve are left to it.
+    if (parsePathSegments(path) === null) {
       return { variable, path, status: "unverified" };
     }
     return {

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -42,9 +42,22 @@ export type ProjectEvaluatorScope = {
   targetType: ProjectEvaluatorTarget;
   filterCondition: string;
   samplingRate: number;
-  /** Only session evaluators use this; other targets store it unused. */
+  /** Only session evaluators schedule off this; see `toEvaluationDelayInput`. */
   evaluationDelaySeconds: number;
 };
+
+/**
+ * The delay half of a create or update input, spread in by every mutation that
+ * carries a scope. Only session scheduling waits out a delay, and the server
+ * rejects one sent for a span evaluator, so non-session targets send nothing.
+ */
+export function toEvaluationDelayInput(scope: ProjectEvaluatorScope): {
+  evaluationDelaySeconds?: number;
+} {
+  return scope.targetType === "SESSION"
+    ? { evaluationDelaySeconds: scope.evaluationDelaySeconds }
+    : {};
+}
 
 export const isProjectEvaluatorTarget = (
   value: string

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -70,28 +70,6 @@ export function formatEvaluationDelay(seconds: number): string {
   return `${minutes.toLocaleString()} minute${minutes === 1 ? "" : "s"}`;
 }
 
-/**
- * Why a session evaluator would be stored but never scheduled. Mirrors the
- * server's SESSION schedulability conditions, in their order, so the form can
- * warn before submit; a saved evaluator reports the server's own verdict.
- */
-export type SessionScopeUnschedulableReason = "filter" | "sampling";
-
-export function getSessionScopeUnschedulableReason(
-  scope: ProjectEvaluatorScope
-): SessionScopeUnschedulableReason | null {
-  if (scope.targetType !== "SESSION") {
-    return null;
-  }
-  if (scope.filterCondition !== "") {
-    return "filter";
-  }
-  if (scope.samplingRate !== 1) {
-    return "sampling";
-  }
-  return null;
-}
-
 // Hoisted: Intl.NumberFormat construction does locale resolution, and the
 // evaluators table calls this per row per render.
 const samplingRateFormatter = new Intl.NumberFormat(undefined, {

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -1,5 +1,9 @@
 import type { EvaluationTarget } from "@phoenix/pages/project/evaluators/__generated__/createProjectLlmEvaluatorMutation.graphql";
-import type { EvaluatorInputMapping } from "@phoenix/types";
+import type {
+  EvaluatorInputMapping,
+  EvaluatorMappingSourceGrain,
+} from "@phoenix/types";
+import { assertUnreachable } from "@phoenix/typeUtils";
 import { getValueAtPath } from "@phoenix/utils/objectUtils";
 
 /** A span evaluation context has no counterpart to a dataset `reference`. */
@@ -46,6 +50,27 @@ export const isProjectEvaluatorTarget = (
   value: string
 ): value is ProjectEvaluatorTarget =>
   PROJECT_EVALUATOR_TARGETS.includes(value as ProjectEvaluatorTarget);
+
+/**
+ * Which mapping-source vocabulary the records of an evaluated target speak.
+ *
+ * Span and session sources are structurally identical, so this is the only thing
+ * that can tell them apart; every place that builds or resets a project
+ * evaluator's mapping source goes through here.
+ */
+export function toEvaluatorMappingSourceGrain(
+  target: ProjectEvaluatorTarget
+): EvaluatorMappingSourceGrain {
+  switch (target) {
+    case "SESSION":
+      return "session";
+    case "SPAN":
+    case "TRACE":
+      return "span";
+    default:
+      return assertUnreachable(target);
+  }
+}
 
 export function toProjectEvaluatorSamplingFraction(percent: number): number {
   return Math.min(100, Math.max(0, percent)) / 100;

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -28,10 +28,18 @@ export const PROJECT_EVALUATOR_TARGETS = [
 
 export type ProjectEvaluatorTarget = (typeof PROJECT_EVALUATOR_TARGETS)[number];
 
+/** The server rejects anything shorter. */
+export const MIN_EVALUATION_DELAY_SECONDS = 10;
+
+/** What the server stores when a create omits the delay. */
+export const DEFAULT_EVALUATION_DELAY_SECONDS = 300;
+
 export type ProjectEvaluatorScope = {
   targetType: ProjectEvaluatorTarget;
   filterCondition: string;
   samplingRate: number;
+  /** Only session evaluators use this; other targets store it unused. */
+  evaluationDelaySeconds: number;
 };
 
 export const isProjectEvaluatorTarget = (
@@ -46,6 +54,42 @@ export function toProjectEvaluatorSamplingFraction(percent: number): number {
 /** "SPAN" -> "Span", for display in the evaluators table and details page. */
 export function formatEvaluationTarget(target: EvaluationTarget): string {
   return `${target.charAt(0)}${target.slice(1).toLowerCase()}`;
+}
+
+/** "SPAN" -> "spans", for prose that names what an evaluator runs on. */
+export function formatEvaluationTargetPlural(target: EvaluationTarget): string {
+  return `${target.toLowerCase()}s`;
+}
+
+/** "300" -> "5 minutes"; whole minutes read better than raw seconds. */
+export function formatEvaluationDelay(seconds: number): string {
+  if (seconds < 60 || seconds % 60 !== 0) {
+    return `${seconds.toLocaleString()} second${seconds === 1 ? "" : "s"}`;
+  }
+  const minutes = seconds / 60;
+  return `${minutes.toLocaleString()} minute${minutes === 1 ? "" : "s"}`;
+}
+
+/**
+ * Why a session evaluator would be stored but never scheduled. Mirrors the
+ * server's SESSION schedulability conditions, in their order, so the form can
+ * warn before submit; a saved evaluator reports the server's own verdict.
+ */
+export type SessionScopeUnschedulableReason = "filter" | "sampling";
+
+export function getSessionScopeUnschedulableReason(
+  scope: ProjectEvaluatorScope
+): SessionScopeUnschedulableReason | null {
+  if (scope.targetType !== "SESSION") {
+    return null;
+  }
+  if (scope.filterCondition !== "") {
+    return "filter";
+  }
+  if (scope.samplingRate !== 1) {
+    return "sampling";
+  }
+  return null;
 }
 
 // Hoisted: Intl.NumberFormat construction does locale resolution, and the

--- a/js/app/src/store/__tests__/evaluatorStore.test.ts
+++ b/js/app/src/store/__tests__/evaluatorStore.test.ts
@@ -1,5 +1,6 @@
 import {
   createEvaluatorStore,
+  SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT,
   type EvaluatorStoreProps,
 } from "../evaluatorStore";
 
@@ -76,6 +77,52 @@ describe("evaluatorStore mapping source grain", () => {
     expect(store.getState().evaluator.inputMapping).toEqual({
       literalMapping: {},
       pathMapping: {},
+    });
+  });
+
+  it("keeps a recorded session context under the session grain", () => {
+    const store = createFreeformStore({
+      evaluatorMappingSource: {
+        grain: "session",
+        source: SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT,
+      },
+    });
+
+    store.getState().setEvaluatorMappingSource({
+      input: "User: hi\nAssistant: hello",
+      output: "hello",
+      metadata: { turns: [{ input: "hi", output: "hello" }] },
+    });
+
+    // A dataset fallthrough would coerce input/output to objects and add
+    // `reference`, silently renaming what the evaluator binds against.
+    expect(store.getState().evaluatorMappingSource).toEqual({
+      grain: "session",
+      source: {
+        input: "User: hi\nAssistant: hello",
+        output: "hello",
+        metadata: { turns: [{ input: "hi", output: "hello" }] },
+      },
+    });
+  });
+
+  it("resets the source to the new grain's default when the grain changes", () => {
+    const store = createFreeformStore({
+      evaluatorMappingSource: {
+        grain: "span",
+        source: {
+          input: "What is Phoenix?",
+          output: "An AI observability platform",
+          metadata: { attributes: { "openinference.span.kind": "LLM" } },
+        },
+      },
+    });
+
+    store.getState().setEvaluatorMappingSourceGrain("session");
+
+    expect(store.getState().evaluatorMappingSource).toEqual({
+      grain: "session",
+      source: SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT,
     });
   });
 

--- a/js/app/src/store/evaluatorStore.tsx
+++ b/js/app/src/store/evaluatorStore.tsx
@@ -12,11 +12,12 @@ import type {
   EvaluatorKind,
   EvaluatorMappingSource,
   EvaluatorMappingSourceField,
+  EvaluatorMappingSourceGrain,
   EvaluatorOptimizationDirection,
   FreeformEvaluatorAnnotationConfig,
 } from "@phoenix/types";
 import type { DeepPartial } from "@phoenix/typeUtils";
-import { isStringKeyedObject } from "@phoenix/typeUtils";
+import { assertUnreachable, isStringKeyedObject } from "@phoenix/typeUtils";
 import { compressObject } from "@phoenix/utils/objectUtils";
 
 /**
@@ -35,6 +36,10 @@ export type EvaluatorMappingSourceState =
   | {
       grain: "span";
       source: EvaluatorMappingSource<"span">;
+    }
+  | {
+      grain: "session";
+      source: EvaluatorMappingSource<"session">;
     };
 
 export type EvaluatorStoreProps = {
@@ -95,6 +100,15 @@ export type EvaluatorStoreActions = {
   setEvaluatorMappingSource: (
     evaluatorMappingSource: EvaluatorMappingSource
   ) => void;
+  /**
+   * Switches which kind of record the mapping source describes, resetting it to
+   * that grain's default.
+   *
+   * Span and session sources are structurally identical, so no setter can infer
+   * the grain from a source. Callers that change the evaluated target must say
+   * so explicitly, or mapping vocabulary silently keeps naming the old record.
+   */
+  setEvaluatorMappingSourceGrain: (grain: EvaluatorMappingSourceGrain) => void;
   /** Sets a single field of the evaluator mapping source. */
   setEvaluatorMappingSourceField: (
     params:
@@ -106,6 +120,11 @@ export type EvaluatorStoreActions = {
       | {
           grain: "span";
           field: EvaluatorMappingSourceField<"span">;
+          value: Record<string, unknown>;
+        }
+      | {
+          grain: "session";
+          field: EvaluatorMappingSourceField<"session">;
           value: Record<string, unknown>;
         }
   ) => void;
@@ -219,6 +238,32 @@ export const SPAN_EVALUATOR_MAPPING_SOURCE_DEFAULT: EvaluatorMappingSource<"span
       attributes: {},
     },
   };
+
+/** Stands in until a recorded session's server-computed context arrives. */
+export const SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT: EvaluatorMappingSource<"session"> =
+  {
+    input: "",
+    output: "",
+    metadata: {
+      turns: [],
+    },
+  };
+
+/** The mapping source a grain starts from before any record is selected. */
+export function defaultEvaluatorMappingSourceState(
+  grain: EvaluatorMappingSourceGrain
+): EvaluatorMappingSourceState {
+  switch (grain) {
+    case "dataset":
+      return { grain, source: EVALUATOR_MAPPING_SOURCE_DEFAULT };
+    case "span":
+      return { grain, source: SPAN_EVALUATOR_MAPPING_SOURCE_DEFAULT };
+    case "session":
+      return { grain, source: SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT };
+    default:
+      return assertUnreachable(grain);
+  }
+}
 
 /**
  * Default value for the evaluator mapping source as a string.
@@ -460,30 +505,55 @@ export const createEvaluatorStore = (
           },
           setEvaluatorMappingSource(evaluatorMappingSource) {
             const { input, output, metadata } = evaluatorMappingSource;
-            const currentMappingSource = get().evaluatorMappingSource;
+            const { grain } = get().evaluatorMappingSource;
+            let nextEvaluatorMappingSource: EvaluatorMappingSourceState;
+            switch (grain) {
+              case "span":
+                nextEvaluatorMappingSource = {
+                  grain: "span",
+                  source: { input, output, metadata },
+                };
+                break;
+              case "session":
+                nextEvaluatorMappingSource = {
+                  grain: "session",
+                  source: { input, output, metadata },
+                };
+                break;
+              case "dataset":
+                nextEvaluatorMappingSource = {
+                  grain: "dataset",
+                  source: {
+                    input: isStringKeyedObject(input) ? input : {},
+                    output: isStringKeyedObject(output) ? output : {},
+                    reference:
+                      "reference" in evaluatorMappingSource
+                        ? evaluatorMappingSource.reference
+                        : {},
+                    metadata,
+                  },
+                };
+                break;
+              default:
+                assertUnreachable(grain);
+            }
+            set(
+              { evaluatorMappingSource: nextEvaluatorMappingSource },
+              undefined,
+              "setEvaluatorMappingSource"
+            );
+          },
+          setEvaluatorMappingSourceGrain(grain) {
+            if (get().evaluatorMappingSource.grain === grain) {
+              return;
+            }
             set(
               {
                 evaluatorMappingSource:
-                  currentMappingSource.grain === "span"
-                    ? {
-                        grain: "span",
-                        source: { input, output, metadata },
-                      }
-                    : {
-                        grain: "dataset",
-                        source: {
-                          input: isStringKeyedObject(input) ? input : {},
-                          output: isStringKeyedObject(output) ? output : {},
-                          reference:
-                            "reference" in evaluatorMappingSource
-                              ? evaluatorMappingSource.reference
-                              : {},
-                          metadata,
-                        },
-                      },
+                  defaultEvaluatorMappingSourceState(grain),
               },
               undefined,
-              "setEvaluatorMappingSource"
+              "setEvaluatorMappingSourceGrain"
             );
           },
           setEvaluatorMappingSourceField(params) {
@@ -492,22 +562,38 @@ export const createEvaluatorStore = (
               evaluatorMappingSource.grain === params.grain,
               "Evaluator mapping source grain must match the field grain"
             );
-            const nextEvaluatorMappingSource =
-              evaluatorMappingSource.grain === "dataset"
-                ? {
-                    grain: "dataset" as const,
-                    source: {
-                      ...evaluatorMappingSource.source,
-                      [params.field]: params.value,
-                    },
-                  }
-                : {
-                    grain: "span" as const,
-                    source: {
-                      ...evaluatorMappingSource.source,
-                      [params.field]: params.value,
-                    },
-                  };
+            let nextEvaluatorMappingSource: EvaluatorMappingSourceState;
+            switch (evaluatorMappingSource.grain) {
+              case "dataset":
+                nextEvaluatorMappingSource = {
+                  grain: "dataset",
+                  source: {
+                    ...evaluatorMappingSource.source,
+                    [params.field]: params.value,
+                  },
+                };
+                break;
+              case "span":
+                nextEvaluatorMappingSource = {
+                  grain: "span",
+                  source: {
+                    ...evaluatorMappingSource.source,
+                    [params.field]: params.value,
+                  },
+                };
+                break;
+              case "session":
+                nextEvaluatorMappingSource = {
+                  grain: "session",
+                  source: {
+                    ...evaluatorMappingSource.source,
+                    [params.field]: params.value,
+                  },
+                };
+                break;
+              default:
+                assertUnreachable(evaluatorMappingSource);
+            }
             set(
               { evaluatorMappingSource: nextEvaluatorMappingSource },
               undefined,

--- a/js/app/src/types/evaluators.ts
+++ b/js/app/src/types/evaluators.ts
@@ -178,11 +178,27 @@ export type SpanEvaluatorMappingSource = {
   metadata: Record<string, unknown>;
 };
 
-export type EvaluatorMappingSourceGrain = "dataset" | "span";
+/**
+ * As produced by the server: `input` is the session transcript, `output` is the
+ * last response in the session, and `metadata` holds the ordered turns and the
+ * transcript policy that assembled them.
+ *
+ * Structurally identical to a span source, but semantically distinct: the two
+ * grains name different records and offer different mapping vocabulary, so the
+ * grain a source belongs to can never be inferred from its shape.
+ */
+export type SessionEvaluatorMappingSource = {
+  input: unknown;
+  output: unknown;
+  metadata: Record<string, unknown>;
+};
+
+export type EvaluatorMappingSourceGrain = "dataset" | "span" | "session";
 
 export type EvaluatorMappingSourceByGrain = {
   dataset: DatasetEvaluatorMappingSource;
   span: SpanEvaluatorMappingSource;
+  session: SessionEvaluatorMappingSource;
 };
 
 export type EvaluatorMappingSource<

--- a/js/app/src/utils/__tests__/jsonUtils.test.ts
+++ b/js/app/src/utils/__tests__/jsonUtils.test.ts
@@ -149,6 +149,25 @@ describe("flattenObject", () => {
         "metadata.turns": 3,
       });
     });
+
+    it("escapes quotes and backslashes so the segment ends where the key does", () => {
+      expect(
+        flattenObject({
+          obj: {
+            metadata: {
+              "a'b": 1,
+              "a\\b": 2,
+              "a\\'b": 3,
+            },
+          },
+          bracketNonIdentifierKeys: true,
+        })
+      ).toEqual({
+        "metadata['a\\'b']": 1,
+        "metadata['a\\\\b']": 2,
+        "metadata['a\\\\\\'b']": 3,
+      });
+    });
   });
 
   describe("parentKey parameter", () => {

--- a/js/app/src/utils/__tests__/jsonUtils.test.ts
+++ b/js/app/src/utils/__tests__/jsonUtils.test.ts
@@ -130,6 +130,27 @@ describe("flattenObject", () => {
     });
   });
 
+  describe("bracketNonIdentifierKeys parameter", () => {
+    it("brackets keys that dot notation cannot address", () => {
+      expect(
+        flattenObject({
+          obj: {
+            metadata: {
+              "phoenix.online_eval.transcript_policy": { version: 2 },
+              "custom-key": 1,
+              turns: 3,
+            },
+          },
+          bracketNonIdentifierKeys: true,
+        })
+      ).toEqual({
+        "metadata['phoenix.online_eval.transcript_policy'].version": 2,
+        "metadata['custom-key']": 1,
+        "metadata.turns": 3,
+      });
+    });
+  });
+
   describe("parentKey parameter", () => {
     it("uses no parent key by default", () => {
       expect(flattenObject({ obj: { a: 1 } })).toEqual({ a: 1 });

--- a/js/app/src/utils/__tests__/objectUtils.test.ts
+++ b/js/app/src/utils/__tests__/objectUtils.test.ts
@@ -1,3 +1,4 @@
+import { flattenObject } from "../jsonUtils";
 import {
   compressObject,
   extractPathsFromDatasetExamples,
@@ -297,6 +298,23 @@ describe("getValueAtPath", () => {
     ).toBeUndefined();
     // Syntax only the server resolves stays unresolved here.
     expect(getValueAtPath(context, "metadata[*]")).toBeUndefined();
+  });
+
+  it("resolves every path the mapping dropdown offers for quoted keys", () => {
+    const context = {
+      metadata: {
+        "a'b": 1,
+        "a\\b": 2,
+        "a\\'b": 3,
+      },
+    };
+    const offeredPaths = Object.keys(
+      flattenObject({ obj: context, bracketNonIdentifierKeys: true })
+    );
+
+    expect(
+      offeredPaths.map((path) => getValueAtPath(context, path))
+    ).toStrictEqual([1, 2, 3]);
   });
 });
 

--- a/js/app/src/utils/__tests__/objectUtils.test.ts
+++ b/js/app/src/utils/__tests__/objectUtils.test.ts
@@ -2,6 +2,7 @@ import {
   compressObject,
   extractPathsFromDatasetExamples,
   extractPathsFromObject,
+  getValueAtPath,
 } from "../objectUtils";
 
 type CompressObjectFixture = {
@@ -268,6 +269,34 @@ describe("compressObject", () => {
       const result = compressObject(input);
       expect(result).toEqual({ outer: { inner: null, empty: "" } });
     });
+  });
+});
+
+describe("getValueAtPath", () => {
+  it("reads keys that dot notation cannot address through bracket segments", () => {
+    const context = {
+      metadata: {
+        "phoenix.online_eval.transcript_policy": { version: 2 },
+        turns: [{ input: "hello" }],
+      },
+    };
+
+    expect(
+      getValueAtPath(
+        context,
+        "metadata['phoenix.online_eval.transcript_policy'].version"
+      )
+    ).toBe(2);
+    expect(getValueAtPath(context, "metadata.turns[0].input")).toBe("hello");
+    // Dot notation cannot reach a key that contains dots.
+    expect(
+      getValueAtPath(
+        context,
+        "metadata.phoenix.online_eval.transcript_policy.version"
+      )
+    ).toBeUndefined();
+    // Syntax only the server resolves stays unresolved here.
+    expect(getValueAtPath(context, "metadata[*]")).toBeUndefined();
   });
 });
 

--- a/js/app/src/utils/jsonUtils.ts
+++ b/js/app/src/utils/jsonUtils.ts
@@ -316,9 +316,14 @@ const BARE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 /**
  * Renders a key as a quoted JSONPath bracket segment, so a key containing dots
  * stays one segment: `phoenix.transcript` becomes `['phoenix.transcript']`.
+ *
+ * Backslashes are escaped before quotes: the resolver on both sides reads a
+ * backslash as an escape character, so a literal one has to be doubled, and
+ * escaping the quotes alone would let a backslash immediately before a quote
+ * swallow it and end the segment somewhere else.
  */
 function toBracketSegment(key: string): string {
-  return `['${key.replace(/'/g, "\\'")}']`;
+  return `['${key.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}']`;
 }
 
 /**

--- a/js/app/src/utils/jsonUtils.ts
+++ b/js/app/src/utils/jsonUtils.ts
@@ -310,6 +310,17 @@ export function filterFlatJSONEntries({
   );
 }
 
+/** Keys that JSONPath dot notation can address directly. */
+const BARE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Renders a key as a quoted JSONPath bracket segment, so a key containing dots
+ * stays one segment: `phoenix.transcript` becomes `['phoenix.transcript']`.
+ */
+function toBracketSegment(key: string): string {
+  return `['${key.replace(/'/g, "\\'")}']`;
+}
+
 /**
  * Flattens an object into a single-level object.
  */
@@ -319,6 +330,7 @@ export function flattenObject({
   separator = ".",
   keepNonTerminalValues = false,
   formatIndices = false,
+  bracketNonIdentifierKeys = false,
 }: {
   obj: object;
   /**
@@ -339,6 +351,14 @@ export function flattenObject({
    * If true, the indices (key names) will be formatted like [0] instead of .0
    */
   formatIndices?: boolean;
+  /**
+   * If true, keys that dot notation cannot address — because they contain dots,
+   * hyphens, or spaces — are emitted as bracket segments instead, so each key
+   * stays addressable as a JSONPath expression.
+   * For example, `{ metadata: { "a.b": 1 } }` flattens to `metadata['a.b']`
+   * rather than the unresolvable `metadata.a.b`.
+   */
+  bracketNonIdentifierKeys?: boolean;
 }) {
   const result: Record<string, string | boolean | number> = {};
 
@@ -347,6 +367,8 @@ export function flattenObject({
     if (formatIndices && Array.isArray(obj)) {
       // For arrays with formatIndices, use bracket notation: parentKey[0] or just [0]
       newKey = parentKey ? `${parentKey}[${key}]` : `[${key}]`;
+    } else if (bracketNonIdentifierKeys && !BARE_IDENTIFIER_PATTERN.test(key)) {
+      newKey = `${parentKey}${toBracketSegment(key)}`;
     } else if (parentKey) {
       newKey = `${parentKey}${separator}${key}`;
     } else {
@@ -365,6 +387,7 @@ export function flattenObject({
           separator,
           keepNonTerminalValues,
           formatIndices,
+          bracketNonIdentifierKeys,
         })
       );
     } else {

--- a/js/app/src/utils/objectUtils.ts
+++ b/js/app/src/utils/objectUtils.ts
@@ -33,25 +33,77 @@ export function compressObject<T extends Record<string, unknown>>(
   return Object.fromEntries(entries) as Partial<T>;
 }
 
+const IDENTIFIER_SEGMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*/;
+const BRACKET_SEGMENT_PATTERN = /^\[(?:'((?:[^'\\]|\\.)*)'|(\d+))\]/;
+
 /**
- * Get a value from an object using a dot-notation path.
+ * Splits a JSONPath expression into the keys it addresses.
  *
- * TODO: Replace this with a JSON path-based utility (e.g., using jsonpath-plus
- * or similar library) to support full JSON path syntax like:
- * - $.input.query
- * - $.metadata.tags[0]
- * - $..nested.field
+ * Covers the subset the server resolves that can also be resolved against an
+ * in-memory context: dot notation (`input.query`), quoted bracket segments for
+ * keys dot notation cannot express (`metadata['a.b']`), and array indices
+ * (`metadata.turns[0]`).
+ *
+ * @returns The keys to walk, or null when the expression uses syntax only the
+ *   server can resolve (wildcards, slices, negative indices, the `$` root
+ *   marker), so callers can tell "cannot check here" from "resolved to
+ *   undefined".
+ */
+export function parsePathSegments(path: string): string[] | null {
+  const segments: string[] = [];
+  let rest = path;
+  let expectSeparator = false;
+
+  while (rest.length > 0) {
+    const bracket = BRACKET_SEGMENT_PATTERN.exec(rest);
+    if (bracket) {
+      const [matched, quotedKey, index] = bracket;
+      segments.push(quotedKey?.replace(/\\(.)/g, "$1") ?? index);
+      rest = rest.slice(matched.length);
+      expectSeparator = true;
+      continue;
+    }
+    if (expectSeparator) {
+      if (!rest.startsWith(".")) {
+        return null;
+      }
+      rest = rest.slice(1);
+    }
+    const identifier = IDENTIFIER_SEGMENT_PATTERN.exec(rest);
+    if (!identifier) {
+      return null;
+    }
+    segments.push(identifier[0]);
+    rest = rest.slice(identifier[0].length);
+    expectSeparator = true;
+  }
+
+  return segments;
+}
+
+/**
+ * Get a value from an object using a JSONPath expression.
+ *
+ * Resolves the same subset {@link parsePathSegments} covers, so a path built
+ * from the mapping source reads the same value here that the server reads at
+ * evaluation time.
  *
  * @param obj - The object to retrieve the value from
- * @param path - Dot-notation path (e.g., "input", "input.query")
- * @returns The value at the path, or undefined if not found
+ * @param path - JSONPath expression (e.g., "input", "input.query",
+ *   "metadata['a.b']")
+ * @returns The value at the path, or undefined if not found or not resolvable
+ *   client-side
  */
 export function getValueAtPath(obj: unknown, path: string): unknown {
   if (!path || !isStringKeyedObject(obj)) {
     return obj;
   }
 
-  const segments = path.split(".");
+  const segments = parsePathSegments(path);
+  if (segments === null) {
+    return undefined;
+  }
+
   let current: unknown = obj;
 
   for (const segment of segments) {

--- a/src/phoenix/db/ddl/postgresql_schema.sql
+++ b/src/phoenix/db/ddl/postgresql_schema.sql
@@ -1415,7 +1415,9 @@ CREATE TABLE public.eval_session_work_units (
             'RUNNING'::character varying,
             'DONE'::character varying,
             'ERROR'::character varying,
-            'EXPIRED'::character varying
+            'EXPIRED'::character varying,
+            'FILTERED_OUT'::character varying,
+            'SAMPLED_OUT'::character varying
         ])::text[]))),
     CONSTRAINT fk_eval_session_work_units_criteria_id_project_evaluato_744c
         FOREIGN KEY (criteria_id)
@@ -1432,7 +1434,7 @@ CREATE TABLE public.eval_session_work_units (
 );
 
 CREATE INDEX ix_eval_session_work_units_claimable ON public.eval_session_work_units
-    USING btree (status, id) WHERE ((status)::text <> ALL ((ARRAY['DONE'::character varying, 'EXPIRED'::character varying])::text[]));
+    USING btree (status, id) WHERE ((status)::text = ANY ((ARRAY['PENDING'::character varying, 'RUNNING'::character varying, 'ERROR'::character varying])::text[]));
 CREATE INDEX ix_eval_session_work_units_criteria_id ON public.eval_session_work_units
     USING btree (criteria_id);
 CREATE INDEX ix_eval_session_work_units_error_attempts ON public.eval_session_work_units
@@ -1444,7 +1446,7 @@ CREATE INDEX ix_eval_session_work_units_terminal ON public.eval_session_work_uni
 CREATE INDEX ix_eval_session_work_units_terminal_watermark ON public.eval_session_work_units
     USING btree (project_session_rowid, evaluator_id, config_fingerprint);
 CREATE UNIQUE INDEX uq_eval_session_work_units_live_key ON public.eval_session_work_units
-    USING btree (project_session_rowid, evaluator_id, config_fingerprint) WHERE (((status)::text = ANY ((ARRAY['PENDING'::character varying, 'RUNNING'::character varying])::text[])) OR (((status)::text = 'ERROR'::text) AND (attempts < 3)));
+    USING btree (project_session_rowid, evaluator_id, config_fingerprint) WHERE (((status)::text = ANY ((ARRAY['PENDING'::character varying, 'RUNNING'::character varying])::text[])) OR (((status)::text = 'ERROR'::text) AND (attempts < 3)) OR ((status)::text = ANY ((ARRAY['FILTERED_OUT'::character varying, 'SAMPLED_OUT'::character varying])::text[])));
 
 
 -- Table: eval_work_units

--- a/src/phoenix/db/ddl/sqlite_schema.sql
+++ b/src/phoenix/db/ddl/sqlite_schema.sql
@@ -1313,7 +1313,15 @@ CREATE TABLE eval_session_work_units (
     transcript_covered_through TIMESTAMP,
     status VARCHAR DEFAULT 'PENDING' NOT NULL
         CONSTRAINT "ck_eval_session_work_units_`valid_eval_work_status`"
-        CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')),
+CHECK (status IN (
+            'PENDING',
+            'RUNNING',
+            'DONE',
+            'ERROR',
+            'EXPIRED',
+            'FILTERED_OUT',
+            'SAMPLED_OUT'
+        )),
     claimed_at TIMESTAMP,
     claimed_by VARCHAR,
     attempts INTEGER DEFAULT '0' NOT NULL,
@@ -1338,7 +1346,7 @@ CREATE TABLE eval_session_work_units (
 
 CREATE INDEX ix_eval_session_work_units_claimable ON eval_session_work_units
     (status, id)
-    WHERE status NOT IN ('DONE', 'EXPIRED');
+    WHERE status IN ('PENDING', 'RUNNING', 'ERROR');
 CREATE INDEX ix_eval_session_work_units_criteria_id ON eval_session_work_units
     (criteria_id);
 CREATE INDEX ix_eval_session_work_units_error_attempts ON eval_session_work_units
@@ -1352,7 +1360,7 @@ CREATE INDEX ix_eval_session_work_units_terminal_watermark ON eval_session_work_
     (project_session_rowid, evaluator_id, config_fingerprint);
 CREATE UNIQUE INDEX uq_eval_session_work_units_live_key ON eval_session_work_units
     (project_session_rowid, evaluator_id, config_fingerprint)
-    WHERE status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3;
+    WHERE status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3 OR status IN ('FILTERED_OUT', 'SAMPLED_OUT');
 
 
 -- Table: eval_work_units

--- a/src/phoenix/db/eval_work.py
+++ b/src/phoenix/db/eval_work.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 # the two sides drifting apart either resurrects dead work or strands retryable work.
 MAX_ATTEMPTS = 3
 
+SESSION_DECLINED_STATUSES = ("FILTERED_OUT", "SAMPLED_OUT")
+
 # Stamped on session work units retired because their session lost content. Like the
 # subsystem's other error markers it is read by operators and matched in tests, so it
 # is spelled once here rather than at the deletion path that writes it.
@@ -28,3 +30,9 @@ def live_eval_work_index_predicate() -> str:
     that rebuilds the index.
     """
     return f"status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < {MAX_ATTEMPTS}"
+
+
+def live_eval_session_work_index_predicate() -> str:
+    """SQL text selecting session work and decisions that hold their dedup key."""
+    declined = ", ".join(f"'{status}'" for status in SESSION_DECLINED_STATUSES)
+    return f"{live_eval_work_index_predicate()} OR status IN ({declined})"

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -14,7 +14,7 @@ from sqlalchemy import JSON
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.compiler import compiles
 
-from phoenix.db.eval_work import live_eval_work_index_predicate
+from phoenix.db.eval_work import live_eval_session_work_index_predicate
 
 _Integer = sa.Integer().with_variant(
     sa.BigInteger(),
@@ -77,7 +77,8 @@ def _create_session_work_units_table() -> None:
             "status",
             sa.String(),
             sa.CheckConstraint(
-                "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')",
+                "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED', "
+                "'FILTERED_OUT', 'SAMPLED_OUT')",
                 name="valid_eval_work_status",
             ),
             nullable=False,
@@ -106,15 +107,15 @@ def _create_session_work_units_table() -> None:
         "eval_session_work_units",
         ["project_session_rowid", "evaluator_id", "config_fingerprint"],
         unique=True,
-        postgresql_where=sa.text(live_eval_work_index_predicate()),
-        sqlite_where=sa.text(live_eval_work_index_predicate()),
+        postgresql_where=sa.text(live_eval_session_work_index_predicate()),
+        sqlite_where=sa.text(live_eval_session_work_index_predicate()),
     )
     op.create_index(
         "ix_eval_session_work_units_claimable",
         "eval_session_work_units",
         ["status", "id"],
-        postgresql_where=sa.text("status NOT IN ('DONE', 'EXPIRED')"),
-        sqlite_where=sa.text("status NOT IN ('DONE', 'EXPIRED')"),
+        postgresql_where=sa.text("status IN ('PENDING', 'RUNNING', 'ERROR')"),
+        sqlite_where=sa.text("status IN ('PENDING', 'RUNNING', 'ERROR')"),
     )
     op.create_index(
         "ix_eval_session_work_units_terminal",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -54,7 +54,7 @@ from typing_extensions import Self, TypeAlias
 
 from phoenix.config import get_env_database_schema
 from phoenix.datetime_utils import normalize_datetime
-from phoenix.db.eval_work import live_eval_work_index_predicate
+from phoenix.db.eval_work import live_eval_session_work_index_predicate
 from phoenix.db.types.annotation_configs import (
     AnnotationConfig as AnnotationConfigModel,
 )
@@ -191,6 +191,15 @@ GenerativeModelSDK: TypeAlias = Literal[
 ]
 ExperimentStatus: TypeAlias = Literal["RUNNING", "COMPLETED", "STOPPED", "ERROR"]
 EvalWorkStatus: TypeAlias = Literal["PENDING", "RUNNING", "DONE", "ERROR", "EXPIRED"]
+EvalSessionWorkStatus: TypeAlias = Literal[
+    "PENDING",
+    "RUNNING",
+    "DONE",
+    "ERROR",
+    "EXPIRED",
+    "FILTERED_OUT",
+    "SAMPLED_OUT",
+]
 EvaluationTarget: TypeAlias = Literal["SPAN", "TRACE", "SESSION"]
 ExperimentLogCategory: TypeAlias = Literal["TASK", "EVAL", "EXPERIMENT"]
 ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
@@ -3770,9 +3779,10 @@ class EvalSessionWorkUnit(HasId):
     config_fingerprint: Mapped[str] = mapped_column(String, nullable=False)
     evaluated_through: Mapped[datetime] = mapped_column(UtcTimeStamp, nullable=False)
     transcript_covered_through: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
-    status: Mapped[EvalWorkStatus] = mapped_column(
+    status: Mapped[EvalSessionWorkStatus] = mapped_column(
         CheckConstraint(
-            "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')",
+            "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED', "
+            "'FILTERED_OUT', 'SAMPLED_OUT')",
             name="valid_eval_work_status",
         ),
         default="PENDING",
@@ -3799,15 +3809,15 @@ class EvalSessionWorkUnit(HasId):
             "evaluator_id",
             "config_fingerprint",
             unique=True,
-            postgresql_where=text(live_eval_work_index_predicate()),
-            sqlite_where=text(live_eval_work_index_predicate()),
+            postgresql_where=text(live_eval_session_work_index_predicate()),
+            sqlite_where=text(live_eval_session_work_index_predicate()),
         ),
         Index(
             "ix_eval_session_work_units_claimable",
             "status",
             "id",
-            postgresql_where=text("status NOT IN ('DONE', 'EXPIRED')"),
-            sqlite_where=text("status NOT IN ('DONE', 'EXPIRED')"),
+            postgresql_where=text("status IN ('PENDING', 'RUNNING', 'ERROR')"),
+            sqlite_where=text("status IN ('PENDING', 'RUNNING', 'ERROR')"),
         ),
         Index(
             "ix_eval_session_work_units_terminal",

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -1215,6 +1215,7 @@ def create_llm_evaluator_from_inline(
     output_configs: Sequence[CategoricalOutputConfig],
     name: str,
     description: Optional[str] = None,
+    max_message_bytes: Optional[int] = None,
 ) -> LLMEvaluator:
     """
     Creates an LLMEvaluator instance from inline definition without database persistence.
@@ -1236,6 +1237,7 @@ def create_llm_evaluator_from_inline(
         llm_client=llm_client,
         output_configs=output_configs,
         prompt_name="preview-prompt",
+        max_message_bytes=max_message_bytes,
     )
 
 

--- a/src/phoenix/server/api/input_types/EvaluatorPreviewInput.py
+++ b/src/phoenix/server/api/input_types/EvaluatorPreviewInput.py
@@ -64,3 +64,14 @@ class EvaluatorPreviewItemInput:
     evaluator: EvaluatorPreviewInput
     context: JSON
     input_mapping: EvaluatorInputMappingInput
+    apply_online_evaluation_limits: bool = strawberry.field(
+        default=False,
+        description=(
+            "Whether to enforce the execution limits an online evaluation runs "
+            "under: the rendered LLM message cap and the sandbox payload cap. "
+            "Set this when the preview stands in for a scheduled run, so a "
+            "preview cannot succeed where the live evaluation would be "
+            "rejected. The limits themselves come from the server's "
+            "configuration, never from this request."
+        ),
+    )

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
+from phoenix.config import get_env_online_eval_max_sandbox_payload_bytes
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
     CategoricalOutputConfig,
@@ -52,6 +53,10 @@ from phoenix.server.monty_runtime import (
     MontyUnavailable,
     MontyWorkerCrashed,
     MontyWorkerTurnTimedOut,
+)
+from phoenix.server.online_eval.session_policy import (
+    ONLINE_SANDBOX_PAYLOAD_LIMIT_REMEDIATION,
+    SessionTranscriptPolicy,
 )
 from phoenix.server.sandbox import (
     MissingSecretError,
@@ -238,6 +243,14 @@ class ChatCompletionMutationMixin:
             evaluator_input = preview_item.evaluator
             context = cast(dict[str, Any], preview_item.context)
             input_mapping = preview_item.input_mapping
+            # Read from the server's configuration, never from the request: a
+            # preview that stands in for a scheduled run has to be rejected by
+            # the same caps, and a client-supplied cap would not be one.
+            max_message_bytes: Optional[int] = None
+            max_payload_bytes: Optional[int] = None
+            if preview_item.apply_online_evaluation_limits:
+                max_message_bytes = SessionTranscriptPolicy.from_env().max_llm_message_bytes
+                max_payload_bytes = get_env_online_eval_max_sandbox_payload_bytes()
 
             if evaluator_id := evaluator_input.built_in_evaluator_id:
                 type_name, db_id = from_global_id(evaluator_id)
@@ -301,6 +314,7 @@ class ChatCompletionMutationMixin:
                     output_configs=categorical_configs,
                     name=inline_llm_evaluator.name,
                     description=inline_llm_evaluator.description,
+                    max_message_bytes=max_message_bytes,
                 )
 
                 try:
@@ -425,6 +439,8 @@ class ChatCompletionMutationMixin:
                         GlobalID("CodeEvaluatorVersion", str(code_evaluator_version.id))
                     ),
                     sandbox_session_manager=None,
+                    max_payload_bytes=max_payload_bytes,
+                    payload_limit_remediation=ONLINE_SANDBOX_PAYLOAD_LIMIT_REMEDIATION,
                 )
                 eval_results = await _evaluate_code_preview(
                     runner,
@@ -481,6 +497,8 @@ class ChatCompletionMutationMixin:
                     language=language,
                     timeout=sandbox_timeout,
                     sandbox_session_manager=None,
+                    max_payload_bytes=max_payload_bytes,
+                    payload_limit_remediation=ONLINE_SANDBOX_PAYLOAD_LIMIT_REMEDIATION,
                 )
                 eval_results = await _evaluate_code_preview(
                     runner,

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -6,6 +6,7 @@ import strawberry
 from fastapi import Request
 from pydantic import ValidationError
 from sqlalchemy import and_, delete, select, true
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -71,6 +72,7 @@ from phoenix.server.online_eval.session_policy import (
 )
 from phoenix.server.sandbox import SANDBOX_ADAPTERS
 from phoenix.server.sandbox.types import SandboxRuntimeContext, SandboxValidationUnavailable
+from phoenix.server.session_filters import compile_session_filter, session_filter_errors
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl.filter import validate_span_filter_condition
 
@@ -317,7 +319,24 @@ async def _ensure_evaluator_prompt_label(
         session.add(association)
 
 
-def _validate_project_evaluator_filter(filter_condition: str) -> None:
+def _validate_project_evaluator_filter(
+    filter_condition: str, evaluation_target: EvaluationTarget
+) -> None:
+    """Validate a filter in the language of the target it selects.
+
+    Spans and traces are filtered with the span filter DSL, sessions with the session
+    filter DSL, so the expression is compiled by the same path its target's scheduler
+    sweep will use.
+    """
+    if evaluation_target is EvaluationTarget.SESSION:
+        if not filter_condition.strip():
+            return
+        with session_filter_errors():
+            session_filter = compile_session_filter(filter_condition)
+            stmt = session_filter(select(models.ProjectSession))
+            stmt.compile(dialect=sqlite.dialect())
+            stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
+        return
     try:
         validate_span_filter_condition(filter_condition)
     except Exception:
@@ -722,7 +741,7 @@ class EvaluatorMutationMixin:
             project_id = from_global_id_with_expected_type(input.project_id, Project.__name__)
         except ValueError:
             raise BadRequest(f"Invalid project id: {input.project_id}")
-        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
             input.evaluation_delay_seconds
@@ -832,7 +851,7 @@ class EvaluatorMutationMixin:
             )
         except ValueError:
             raise BadRequest(f"Invalid project evaluator id: {input.project_evaluator_id}")
-        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
@@ -1001,7 +1020,7 @@ class EvaluatorMutationMixin:
             name = IdentifierModel.model_validate(input.name)
         except ValidationError as error:
             raise BadRequest(str(error))
-        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
             input.evaluation_delay_seconds
@@ -1048,7 +1067,7 @@ class EvaluatorMutationMixin:
             name = IdentifierModel.model_validate(input.name)
         except (ValueError, ValidationError) as error:
             raise BadRequest(str(error))
-        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
             input.evaluation_delay_seconds
@@ -1146,7 +1165,7 @@ class EvaluatorMutationMixin:
             name = IdentifierModel.model_validate(input.name)
         except (ValueError, ValidationError) as error:
             raise BadRequest(str(error))
-        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         if input.evaluator_input_mapping is None:
             raise BadRequest("evaluator_input_mapping cannot be set to null")

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -87,8 +87,8 @@ _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
     "filter first, then deterministic sampling, and schedules admitted work asynchronously. "
     "A filter non-match or sampling miss is permanently declined for that evaluator "
     "configuration; later activity does not reopen the decision. TRACE evaluators are stored "
-    "but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. "
-    "The target can change only until evaluation work exists for the project evaluator."
+    "but not scheduled. Only SESSION scheduling honors the evaluation delay, which a SPAN "
+    "target rejects. The target is fixed at creation."
 )
 
 
@@ -344,19 +344,25 @@ def _validate_project_evaluator_sampling_rate(sampling_rate: float) -> None:
 
 def _materialize_project_evaluator_evaluation_delay(
     evaluation_delay_seconds: Optional[int],
+    evaluation_target: EvaluationTarget,
 ) -> int:
-    if (
-        evaluation_delay_seconds is not None
-        and evaluation_delay_seconds < MINIMUM_EVALUATION_DELAY_SECONDS
-    ):
+    """Resolve the delay to store; only the session sweep waits one out.
+
+    Span work is scheduled off the global ingestion frontier, so a delay supplied for a
+    span evaluator is refused rather than stored as a setting that never applies.
+    """
+    if evaluation_delay_seconds is None:
+        return DEFAULT_SESSION_EVALUATION_DELAY_SECONDS
+    if evaluation_target is EvaluationTarget.SPAN:
+        raise BadRequest(
+            "evaluationDelaySeconds is not accepted for SPAN evaluators: span scheduling "
+            "does not honor an evaluation delay"
+        )
+    if evaluation_delay_seconds < MINIMUM_EVALUATION_DELAY_SECONDS:
         raise BadRequest(
             f"evaluationDelaySeconds must be at least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds"
         )
-    return (
-        DEFAULT_SESSION_EVALUATION_DELAY_SECONDS
-        if evaluation_delay_seconds is None
-        else evaluation_delay_seconds
-    )
+    return evaluation_delay_seconds
 
 
 def _validate_project_evaluator_target_update(
@@ -520,11 +526,12 @@ class CreateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
-            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation. "
-            "Non-SESSION targets preserve this value without using it."
+            "Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Only SESSION scheduling honors a "
+            "delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators "
+            "are stored but not scheduled. Omit or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -547,12 +554,13 @@ class UpdateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
-            f"or use null to store the current default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation. Non-SESSION targets "
-            "preserve this value without using it."
+            "Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Only SESSION scheduling honors a "
+            "delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators "
+            "are stored but not scheduled. Omit to preserve the current setting, or use null "
+            f"to store the current default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
+            "seconds. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         ),
     )
 
@@ -576,11 +584,12 @@ class AddProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
-            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation. "
-            "Non-SESSION targets preserve this value without using it."
+            "Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Only SESSION scheduling honors a "
+            "delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators "
+            "are stored but not scheduled. Omit or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -609,11 +618,12 @@ class CreateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
-            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation. "
-            "Non-SESSION targets preserve this value without using it."
+            "Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Only SESSION scheduling honors a "
+            "delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators "
+            "are stored but not scheduled. Omit or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -643,12 +653,13 @@ class UpdateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
-            f"or use null to store the current default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation. Non-SESSION targets "
-            "preserve this value without using it."
+            "Seconds a SESSION must stay quiet before evaluation is scheduled; the minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Only SESSION scheduling honors a "
+            "delay, so a value supplied for a SPAN target is rejected, and TRACE evaluators "
+            "are stored but not scheduled. Omit to preserve the current setting, or use null "
+            f"to store the current default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
+            "seconds. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         ),
     )
 
@@ -738,7 +749,7 @@ class EvaluatorMutationMixin:
         _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
-            input.evaluation_delay_seconds
+            input.evaluation_delay_seconds, input.evaluation_target
         )
         try:
             name = IdentifierModel.model_validate(input.name)
@@ -850,7 +861,9 @@ class EvaluatorMutationMixin:
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
         if input.evaluation_delay_seconds is not UNSET:
-            _materialize_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+            _materialize_project_evaluator_evaluation_delay(
+                input.evaluation_delay_seconds, input.evaluation_target
+            )
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -974,7 +987,7 @@ class EvaluatorMutationMixin:
                 if input.evaluation_delay_seconds is not UNSET:
                     criteria.evaluation_delay_seconds = (
                         _materialize_project_evaluator_evaluation_delay(
-                            input.evaluation_delay_seconds
+                            input.evaluation_delay_seconds, input.evaluation_target
                         )
                     )
                 if input.enabled is not UNSET:
@@ -1017,7 +1030,7 @@ class EvaluatorMutationMixin:
         _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
-            input.evaluation_delay_seconds
+            input.evaluation_delay_seconds, input.evaluation_target
         )
 
         try:
@@ -1064,7 +1077,7 @@ class EvaluatorMutationMixin:
         _validate_project_evaluator_filter(input.filter_condition, input.evaluation_target)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
-            input.evaluation_delay_seconds
+            input.evaluation_delay_seconds, input.evaluation_target
         )
         _raise_on_uninferable_evaluate_signature(input.source_code, input.language)
         if input.output_configs is not None:
@@ -1166,7 +1179,9 @@ class EvaluatorMutationMixin:
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
         if input.evaluation_delay_seconds is not UNSET:
-            _materialize_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+            _materialize_project_evaluator_evaluation_delay(
+                input.evaluation_delay_seconds, input.evaluation_target
+            )
         if input.source_code is not UNSET and input.source_code is None:
             raise BadRequest("source_code cannot be set to null")
         if input.output_configs is None:
@@ -1315,7 +1330,7 @@ class EvaluatorMutationMixin:
                 if input.evaluation_delay_seconds is not UNSET:
                     criteria.evaluation_delay_seconds = (
                         _materialize_project_evaluator_evaluation_delay(
-                            input.evaluation_delay_seconds
+                            input.evaluation_delay_seconds, input.evaluation_target
                         )
                     )
                 if input.enabled is not UNSET:

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -6,7 +6,6 @@ import strawberry
 from fastapi import Request
 from pydantic import ValidationError
 from sqlalchemy import and_, delete, select, true
-from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -72,7 +71,7 @@ from phoenix.server.online_eval.session_policy import (
 )
 from phoenix.server.sandbox import SANDBOX_ADAPTERS
 from phoenix.server.sandbox.types import SandboxRuntimeContext, SandboxValidationUnavailable
-from phoenix.server.session_filters import compile_session_filter, session_filter_errors
+from phoenix.server.session_filters import validate_session_filter_condition
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl.filter import validate_span_filter_condition
 
@@ -83,13 +82,13 @@ _EVALUATOR_KIND_BY_TYPENAME: dict[str, EvaluatorKind] = {
 }
 
 _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
-    "SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling "
-    "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
-    "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
-    "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
-    "evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation "
-    "delay without using it. The target can change only until evaluation work exists for the "
-    "project evaluator."
+    "SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per "
+    "session at the first quiet period after the evaluation delay: it applies the session "
+    "filter first, then deterministic sampling, and schedules admitted work asynchronously. "
+    "A filter non-match or sampling miss is permanently declined for that evaluator "
+    "configuration; later activity does not reopen the decision. TRACE evaluators are stored "
+    "but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. "
+    "The target can change only until evaluation work exists for the project evaluator."
 )
 
 
@@ -320,7 +319,8 @@ async def _ensure_evaluator_prompt_label(
 
 
 def _validate_project_evaluator_filter(
-    filter_condition: str, evaluation_target: EvaluationTarget
+    filter_condition: str,
+    evaluation_target: EvaluationTarget,
 ) -> None:
     """Validate a filter in the language of the target it selects.
 
@@ -328,17 +328,11 @@ def _validate_project_evaluator_filter(
     filter DSL, so the expression is compiled by the same path its target's scheduler
     sweep will use.
     """
-    if evaluation_target is EvaluationTarget.SESSION:
-        if not filter_condition.strip():
-            return
-        with session_filter_errors():
-            session_filter = compile_session_filter(filter_condition)
-            stmt = session_filter(select(models.ProjectSession))
-            stmt.compile(dialect=sqlite.dialect())
-            stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
-        return
     try:
-        validate_span_filter_condition(filter_condition)
+        if evaluation_target is EvaluationTarget.SESSION:
+            validate_session_filter_condition(filter_condition)
+        else:
+            validate_span_filter_condition(filter_condition)
     except Exception:
         raise BadRequest("Invalid filter condition: unable to compile for supported databases")
 

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -54,13 +54,13 @@ if TYPE_CHECKING:
     from .User import User
 
 _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
-    "SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling "
-    "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
-    "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
-    "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
-    "evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation "
-    "delay without using it. The target can change only until evaluation work exists for the "
-    "project evaluator."
+    "SPAN evaluators run on matching sampled spans. A SESSION evaluator decides once per "
+    "session at the first quiet period after the evaluation delay: it applies the session "
+    "filter first, then deterministic sampling, and schedules admitted work asynchronously. "
+    "A filter non-match or sampling miss is permanently declined for that evaluator "
+    "configuration; later activity does not reopen the decision. TRACE evaluators are stored "
+    "but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. "
+    "The target can change only until evaluation work exists for the project evaluator."
 )
 
 

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1220,9 +1220,8 @@ class ProjectEvaluator(Node):
             f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. New criteria store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds when no value is "
             "provided. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation. Non-SESSION targets preserve this value without using it. A "
-            "later change to SESSION uses the stored value, but the target cannot change after "
-            "evaluation work exists for this project evaluator."
+            "another evaluation. Only SESSION scheduling honors this value: a SPAN evaluator "
+            "cannot set one, and TRACE evaluators are not scheduled."
         )
     )
     async def evaluation_delay_seconds(self, info: Info[Context, None]) -> int:

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -13,7 +13,6 @@ from openinference.semconv.trace import SpanAttributes
 from pandas import DataFrame
 from sqlalchemy import Select, and_, case, desc, distinct, exists, func, or_, select
 from sqlalchemy import cast as sqlalchemy_cast
-from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.expression import tuple_
 from sqlalchemy.sql.functions import percentile_cont
@@ -73,9 +72,8 @@ from phoenix.server.api.types.ValidationResult import ValidationResult
 from phoenix.server.session_filters import (
     SessionFilterConditionError,
     apply_session_filter_to_page,
-    compile_session_filter,
     get_filtered_session_rowids_subquery,
-    session_filter_errors,
+    validate_session_filter_condition,
 )
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl import SpanFilter, SpanFilterError
@@ -1352,11 +1350,7 @@ class Project(Node):
         as valid is one they will accept.
         """
         try:
-            with session_filter_errors():
-                session_filter = compile_session_filter(condition)
-                stmt = session_filter(select(models.ProjectSession))
-                str(stmt.compile(dialect=sqlite.dialect()))
-                str(stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
+            validate_session_filter_condition(condition)
         except SessionFilterConditionError as e:
             return ValidationResult(is_valid=False, error_message=str(e))
         referenced_annotation_names = _referenced_subscript_names(

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.sql.expression import tuple_
 from strawberry import UNSET, Info, lazy
 from strawberry.relay import Connection, Node, NodeID
+from strawberry.scalars import JSON
 
 from phoenix.db import models
 from phoenix.server.api.context import Context
@@ -144,6 +145,44 @@ class ProjectSession(Node):
             attr=models.Span.output_value,
             truncated_value=truncate_value(record.truncated_value),
         )
+
+    @strawberry.field(
+        description=(
+            "The canonical input, output, and metadata context that online "
+            "evaluators bind against when they run on this session. Null when "
+            "the session's transcript exceeds the evaluation byte cap, which is "
+            "the same reason a live evaluation of it would fail."
+        ),
+    )  # type: ignore
+    async def session_evaluation_context(
+        self,
+        info: Info[Context, None],
+    ) -> Optional[JSON]:
+        from phoenix.server.online_eval.executor import (
+            TranscriptTooLargeError,
+            load_session_eval_context,
+        )
+        from phoenix.server.online_eval.session_policy import SessionTranscriptPolicy
+
+        if self.db_record:
+            project_rowid = self.db_record.project_id
+        else:
+            project_rowid = await info.context.data_loaders.project_session_fields.load(
+                (self.id, models.ProjectSession.project_id),
+            )
+        async with info.context.db.read() as session:
+            try:
+                context = await load_session_eval_context(
+                    session,
+                    project_session_rowid=self.id,
+                    project_id=project_rowid,
+                    policy=SessionTranscriptPolicy.from_env(),
+                )
+            except TranscriptTooLargeError:
+                # One unevaluable session must not fail the whole list it is
+                # read in; the null row says why on its own.
+                return None
+        return JSON(context)
 
     @strawberry.field(
         description='The first non-null "user.id" span attribute in the session, '

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -149,9 +149,12 @@ class ProjectSession(Node):
     @strawberry.field(
         description=(
             "The canonical input, output, and metadata context that online "
-            "evaluators bind against when they run on this session. Null when "
-            "the session's transcript exceeds the evaluation byte cap, which is "
-            "the same reason a live evaluation of it would fail."
+            "evaluators bind against when they run on this session. Null "
+            "whenever a live evaluation would refuse this session: its content "
+            "was trimmed after ingestion, it has no eligible root turn to "
+            "transcribe, or no whole turn fits the evaluation byte cap. An "
+            "over-cap transcript that still fits whole turns is truncated and "
+            "returned, exactly as a live evaluation reads it."
         ),
     )  # type: ignore
     async def session_evaluation_context(
@@ -160,16 +163,25 @@ class ProjectSession(Node):
     ) -> Optional[JSON]:
         from phoenix.server.online_eval.executor import (
             TranscriptTooLargeError,
+            has_eligible_root_turns,
             load_session_eval_context,
         )
         from phoenix.server.online_eval.session_policy import SessionTranscriptPolicy
 
         if self.db_record:
             project_rowid = self.db_record.project_id
+            content_complete = self.db_record.content_complete
         else:
             project_rowid = await info.context.data_loaders.project_session_fields.load(
                 (self.id, models.ProjectSession.project_id),
             )
+            content_complete = await info.context.data_loaders.project_session_fields.load(
+                (self.id, models.ProjectSession.content_complete),
+            )
+        # The sweeper only claims content-complete sessions, so a preview of a
+        # trimmed one would bind against a transcript no live evaluation reads.
+        if not content_complete:
+            return None
         async with info.context.db.read() as session:
             try:
                 context = await load_session_eval_context(
@@ -182,6 +194,8 @@ class ProjectSession(Node):
                 # One unevaluable session must not fail the whole list it is
                 # read in; the null row says why on its own.
                 return None
+        if not has_eligible_root_turns(context):
+            return None
         return JSON(context)
 
     @strawberry.field(

--- a/src/phoenix/server/online_eval/derivation.py
+++ b/src/phoenix/server/online_eval/derivation.py
@@ -81,17 +81,14 @@ def annotation_identifier(fingerprint: str) -> str:
     return _IDENTIFIER_PREFIX + fingerprint[:_IDENTIFIER_FINGERPRINT_CHARS]
 
 
-def sample_key(span_id: int) -> float:
-    """Uniform-in-[0,1) sampling key derived from the span id's decimal string.
+def sample_key(artifact_identity: int | str) -> float:
+    """Uniform-in-[0,1) sampling key derived from a stable artifact identity.
 
-    A span is sampled for a criteria iff ``sample_key(span_id) < sampling_rate``. The
+    An artifact is sampled iff ``sample_key(identity) < sampling_rate``. The
     key is deliberately unsalted and shared across all criteria so lower-rate samples
     nest inside higher-rate ones (every 20% sample is a subset of every 60% sample).
-
-    Span-only, and only because sampling is: a SESSION criteria with a sampling rate
-    below 1 is refused as unschedulable rather than sampled.
     """
-    digest = hashlib.sha256(str(span_id).encode("ascii")).digest()
+    digest = hashlib.sha256(str(artifact_identity).encode("utf-8")).digest()
     # Top 53 bits only: dividing the full digest by 2**256 can round up to exactly 1.0,
     # violating the half-open interval; 53-bit numerators are exact in a float.
     return (int.from_bytes(digest[:8], "big") >> 11) / (1 << 53)

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -14,7 +14,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, AsyncIterator, Callable, Literal, Optional, Sequence
+from typing import Any, AsyncIterator, Callable, Literal, Mapping, Optional, Sequence
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -343,6 +343,18 @@ async def load_session_eval_context(
         policy=policy,
         total_eligible_root_count=total_eligible_root_count,
     )
+
+
+def has_eligible_root_turns(context: Mapping[str, Any]) -> bool:
+    """Whether an assembled session context has a turn to evaluate.
+
+    A session whose traces carry no root span assembles to an empty transcript.
+    Live hydration refuses it (``NO_ROOT_TURNS``) rather than evaluating that
+    emptiness, so the preview field reads the same predicate and reports the
+    session as unevaluable instead of offering the empty context.
+    """
+    policy = context["metadata"][_TRANSCRIPT_POLICY_METADATA_KEY]
+    return bool(policy["total_eligible_root_count"])
 
 
 def _transcript_coverage_watermark(hydrated: HydratedWorkUnit) -> Optional[datetime]:
@@ -674,7 +686,7 @@ class OnlineEvalExecutor:
                 HydrationFailureReason.TRANSCRIPT_TOO_LARGE,
                 str(error),
             )
-        if not context["metadata"][_TRANSCRIPT_POLICY_METADATA_KEY]["total_eligible_root_count"]:
+        if not has_eligible_root_turns(context):
             return HydrationFailure(HydrationFailureReason.NO_ROOT_TURNS)
         return context
 

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -251,7 +251,6 @@ def session_eval_context(
         "last_loaded_event_time": last_loaded,
         "first_retained_event_time": first_retained,
         "last_retained_event_time": last_retained,
-        "structured_turns_mapped": False,
     }
     return {
         "input": transcript,
@@ -528,6 +527,9 @@ class OnlineEvalExecutor:
 
         contexts: list[Optional[dict[str, Any]]] = [None for _ in units]
         input_mappings: list[Optional[InputMapping]] = [None for _ in units]
+        # Recorded on the annotation, never in the evaluated context: it is
+        # decided per evaluator, after the context an author previews is built.
+        maps_structured_turns: list[bool] = [False for _ in units]
         for index, (unit, outcome) in enumerate(zip(units, outcomes, strict=True)):
             if outcome is not None:
                 continue
@@ -557,8 +559,7 @@ class OnlineEvalExecutor:
                 outcomes[index] = error
                 continue
             if unit.evaluation_target == "SESSION":
-                policy = hydrated_context["metadata"][_TRANSCRIPT_POLICY_METADATA_KEY]
-                policy["structured_turns_mapped"] = any(
+                maps_structured_turns[index] = any(
                     path_expression.removeprefix("$.").startswith("metadata.turns")
                     for path_expression in (resolved_input_mapping.path_mapping or {}).values()
                 )
@@ -617,11 +618,15 @@ class OnlineEvalExecutor:
                     "input_schema",
                     {},
                 )
-                policy["structured_turns_mapped"] = bool(
-                    policy["structured_turns_mapped"]
-                    or "metadata" in evaluator_input_schema.get("properties", {})
-                )
-                annotation_metadata = {_TRANSCRIPT_POLICY_METADATA_KEY: dict(policy)}
+                annotation_metadata = {
+                    _TRANSCRIPT_POLICY_METADATA_KEY: {
+                        **policy,
+                        "structured_turns_mapped": bool(
+                            maps_structured_turns[index]
+                            or "metadata" in evaluator_input_schema.get("properties", {})
+                        ),
+                    }
+                }
             outcomes[index] = HydratedConfigurationSnapshot(
                 project_id=criteria.project_id,
                 fingerprint=unit.config_fingerprint,

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -263,6 +263,88 @@ def session_eval_context(
     }
 
 
+async def load_session_eval_context(
+    session: AsyncSession,
+    *,
+    project_session_rowid: int,
+    project_id: int,
+    policy: SessionTranscriptPolicy,
+) -> dict[str, Any]:
+    """The session's evaluation context, exactly as an online evaluation reads it.
+
+    The executor and the GraphQL preview field both call this, so what an author
+    previews is the same transcript, turn ordering, turn cap, and truncation the
+    runtime binds against. Raises ``TranscriptTooLargeError`` when no whole turn
+    fits the byte cap.
+    """
+    root_filters = (
+        models.Trace.project_session_rowid == project_session_rowid,
+        models.Trace.project_rowid == project_id,
+        models.Span.parent_id.is_(None),
+    )
+    total_eligible_root_count = (
+        await session.scalar(
+            select(func.count(func.distinct(models.Trace.id)))
+            .select_from(models.Span)
+            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+            .where(*root_filters)
+        )
+        or 0
+    )
+    ranked_roots = (
+        select(
+            models.Span.input_value,
+            models.Span.output_value,
+            models.Span.metadata_,
+            models.Span.start_time.label("event_time"),
+            models.Span.span_id,
+            models.Trace.start_time.label("trace_start_time"),
+            models.Trace.id.label("trace_id"),
+            func.row_number()
+            .over(
+                partition_by=models.Trace.id,
+                order_by=(models.Span.start_time.asc(), models.Span.span_id.asc()),
+            )
+            .label("root_rank"),
+        )
+        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+        .where(*root_filters)
+        .subquery()
+    )
+    root_rows = (
+        await session.execute(
+            select(
+                ranked_roots.c.input_value,
+                ranked_roots.c.output_value,
+                ranked_roots.c.metadata_,
+                ranked_roots.c.event_time,
+                ranked_roots.c.span_id,
+            )
+            .where(ranked_roots.c.root_rank == 1)
+            .order_by(
+                ranked_roots.c.trace_start_time.desc(),
+                ranked_roots.c.trace_id.desc(),
+            )
+            .limit(policy.max_turns)
+        )
+    ).all()
+    turns = [
+        {
+            "input": row.input_value,
+            "output": row.output_value,
+            "metadata": row.metadata_,
+            "event_time": row.event_time.isoformat(),
+            "span_id": row.span_id,
+        }
+        for row in reversed(root_rows)
+    ]
+    return session_eval_context(
+        turns=turns,
+        policy=policy,
+        total_eligible_root_count=total_eligible_root_count,
+    )
+
+
 def _transcript_coverage_watermark(hydrated: HydratedWorkUnit) -> Optional[datetime]:
     """Newest root-span time actually included in the evaluated transcript.
 
@@ -580,80 +662,21 @@ class OnlineEvalExecutor:
             return HydrationFailure(HydrationFailureReason.SESSION_PROJECT_MISMATCH)
         if not project_session.content_complete:
             return HydrationFailure(HydrationFailureReason.SESSION_CONTENT_INCOMPLETE)
-        root_filters = (
-            models.Trace.project_session_rowid == project_session.id,
-            models.Trace.project_rowid == project_id,
-            models.Span.parent_id.is_(None),
-        )
-        total_eligible_root_count = (
-            await session.scalar(
-                select(func.count(func.distinct(models.Trace.id)))
-                .select_from(models.Span)
-                .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-                .where(*root_filters)
-            )
-            or 0
-        )
-        if total_eligible_root_count == 0:
-            return HydrationFailure(HydrationFailureReason.NO_ROOT_TURNS)
-        ranked_roots = (
-            select(
-                models.Span.input_value,
-                models.Span.output_value,
-                models.Span.metadata_,
-                models.Span.start_time.label("event_time"),
-                models.Span.span_id,
-                models.Trace.start_time.label("trace_start_time"),
-                models.Trace.id.label("trace_id"),
-                func.row_number()
-                .over(
-                    partition_by=models.Trace.id,
-                    order_by=(models.Span.start_time.asc(), models.Span.span_id.asc()),
-                )
-                .label("root_rank"),
-            )
-            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-            .where(*root_filters)
-            .subquery()
-        )
-        root_rows = (
-            await session.execute(
-                select(
-                    ranked_roots.c.input_value,
-                    ranked_roots.c.output_value,
-                    ranked_roots.c.metadata_,
-                    ranked_roots.c.event_time,
-                    ranked_roots.c.span_id,
-                )
-                .where(ranked_roots.c.root_rank == 1)
-                .order_by(
-                    ranked_roots.c.trace_start_time.desc(),
-                    ranked_roots.c.trace_id.desc(),
-                )
-                .limit(self._session_transcript_policy.max_turns)
-            )
-        ).all()
-        turns = [
-            {
-                "input": row.input_value,
-                "output": row.output_value,
-                "metadata": row.metadata_,
-                "event_time": row.event_time.isoformat(),
-                "span_id": row.span_id,
-            }
-            for row in reversed(root_rows)
-        ]
         try:
-            return session_eval_context(
-                turns=turns,
+            context = await load_session_eval_context(
+                session,
+                project_session_rowid=project_session.id,
+                project_id=project_id,
                 policy=self._session_transcript_policy,
-                total_eligible_root_count=total_eligible_root_count,
             )
         except TranscriptTooLargeError as error:
             return HydrationFailure(
                 HydrationFailureReason.TRANSCRIPT_TOO_LARGE,
                 str(error),
             )
+        if not context["metadata"][_TRANSCRIPT_POLICY_METADATA_KEY]["total_eligible_root_count"]:
+            return HydrationFailure(HydrationFailureReason.NO_ROOT_TURNS)
+        return context
 
     def hydrate_from_snapshot(
         self,

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -54,6 +54,7 @@ from phoenix.server.online_eval.derivation import (
 )
 from phoenix.server.online_eval.failure_policy import FailureDisposition
 from phoenix.server.online_eval.session_policy import (
+    ONLINE_SANDBOX_PAYLOAD_LIMIT_REMEDIATION,
     SessionTranscriptPolicy,
     session_criteria_is_schedulable,
 )
@@ -860,10 +861,7 @@ class OnlineEvalExecutor:
                 f"online-eval:{evaluator_orm.id}:{self._sandbox_session_manager.replica_id}"
             ),
             max_payload_bytes=max_payload_bytes,
-            payload_limit_remediation=(
-                "Reduce the dominant evaluator source or mapped inputs, or raise the limit with "
-                "PHOENIX_ONLINE_EVAL_MAX_SANDBOX_PAYLOAD_BYTES."
-            ),
+            payload_limit_remediation=ONLINE_SANDBOX_PAYLOAD_LIMIT_REMEDIATION,
         )
         return _HydratedEvaluatorSnapshot(
             annotator_kind="CODE",

--- a/src/phoenix/server/online_eval/session_policy.py
+++ b/src/phoenix/server/online_eval/session_policy.py
@@ -24,6 +24,14 @@ if TYPE_CHECKING:
 DEFAULT_SESSION_EVALUATION_DELAY_SECONDS = 300
 MINIMUM_EVALUATION_DELAY_SECONDS = 10
 
+# What to do about an over-limit sandbox payload. Shared with the preview
+# mutation so a preview run under the online limits reports the rejection in the
+# same words the scheduled evaluation would.
+ONLINE_SANDBOX_PAYLOAD_LIMIT_REMEDIATION = (
+    "Reduce the dominant evaluator source or mapped inputs, or raise the limit with "
+    "PHOENIX_ONLINE_EVAL_MAX_SANDBOX_PAYLOAD_BYTES."
+)
+
 TRANSCRIPT_POLICY_VERSION = "2"
 MAX_SESSION_EVAL_TURNS = 1_000
 

--- a/src/phoenix/server/online_eval/session_policy.py
+++ b/src/phoenix/server/online_eval/session_policy.py
@@ -33,8 +33,6 @@ class SchedulabilityReason(Enum):
 
     DISABLED = "DISABLED"
     TRACE_TARGET_UNSUPPORTED = "TRACE_TARGET_UNSUPPORTED"
-    SESSION_FILTER_UNSUPPORTED = "SESSION_FILTER_UNSUPPORTED"
-    SESSION_SAMPLING_UNSUPPORTED = "SESSION_SAMPLING_UNSUPPORTED"
 
 
 @dataclass(frozen=True)
@@ -58,16 +56,6 @@ SESSION_SCHEDULABILITY_CONDITIONS: tuple[SessionSchedulabilityCondition, ...] = 
         blocks=lambda record: not record.enabled,
         blocks_sql=lambda criteria: not_(criteria.enabled),
     ),
-    SessionSchedulabilityCondition(
-        reason=SchedulabilityReason.SESSION_FILTER_UNSUPPORTED,
-        blocks=lambda record: bool(record.filter_condition),
-        blocks_sql=lambda criteria: criteria.filter_condition != "",
-    ),
-    SessionSchedulabilityCondition(
-        reason=SchedulabilityReason.SESSION_SAMPLING_UNSUPPORTED,
-        blocks=lambda record: record.sampling_rate != 1.0,
-        blocks_sql=lambda criteria: criteria.sampling_rate != 1.0,
-    ),
 )
 
 
@@ -84,7 +72,6 @@ def session_schedulability_reason(
 def session_criteria_is_schedulable(
     criteria: type["models.ProjectEvaluatorCriteria"],
 ) -> ColumnElement[bool]:
-    # Session filters shipped in #14101 (#14041); #14038 owns sampling integration.
     return and_(
         criteria.evaluation_target == "SESSION",
         *(not_(condition.blocks_sql(criteria)) for condition in SESSION_SCHEDULABILITY_CONDITIONS),

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     select,
     text,
     type_coerce,
+    union_all,
     update,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
@@ -40,7 +41,10 @@ from typing_extensions import assert_never
 
 from phoenix.config import get_env_enable_prometheus, get_env_online_eval_max_session_outstanding
 from phoenix.db import models
-from phoenix.db.eval_work import live_eval_work_index_predicate
+from phoenix.db.eval_work import (
+    SESSION_DECLINED_STATUSES,
+    live_eval_session_work_index_predicate,
+)
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.criteria_resolution import resolve_criteria_bulk
@@ -49,6 +53,7 @@ from phoenix.server.online_eval.derivation import (
     MAX_ATTEMPTS,
     STALE_FINGERPRINT_ERROR,
     config_fingerprint,
+    sample_key,
 )
 from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.prometheus import (
@@ -60,6 +65,7 @@ from phoenix.server.prometheus import (
     ONLINE_EVAL_SESSION_SWEEP_FAILURES,
     ONLINE_EVAL_SESSION_SWEEP_SUCCESSES,
 )
+from phoenix.server.session_filters import get_filtered_session_rowids_subquery
 from phoenix.server.types import DaemonTask, DbSessionFactory
 
 logger = logging.getLogger(__name__)
@@ -74,15 +80,7 @@ _MAX_ELIGIBLE_PAIRS_PER_TICK = 1000
 # no retention, so an unbounded aggregate would scan more rows on every tick forever.
 _WATERMARK_LAG_WINDOW_SECONDS = 86_400.0
 
-_LIVE_WORK_INDEX_PREDICATE = text(live_eval_work_index_predicate())
-
-_SESSION_WORK_INSERT_COLUMNS = (
-    "project_session_rowid",
-    "evaluator_id",
-    "criteria_id",
-    "config_fingerprint",
-    "evaluated_through",
-)
+_LIVE_WORK_INDEX_PREDICATE = text(live_eval_session_work_index_predicate())
 
 
 @dataclass(frozen=True)
@@ -93,6 +91,8 @@ class _SessionCriteria:
     fingerprint: str
     delay_seconds: int
     created_at: datetime
+    filter_condition: str
+    sampling_rate: float
 
 
 def _criteria_relation(
@@ -110,6 +110,7 @@ def _criteria_relation(
             f"sc{index}_config_fingerprint": criterion.fingerprint,
             f"sc{index}_delay_seconds": criterion.delay_seconds,
             f"sc{index}_created_at": criterion.created_at,
+            f"sc{index}_sampling_rate": criterion.sampling_rate,
         }
         parameters.update(row_parameters)
         placeholders = [f":{name}" for name in row_parameters]
@@ -124,6 +125,7 @@ def _criteria_relation(
                 f"CAST({placeholders[3]} AS VARCHAR)",
                 f"CAST({placeholders[4]} AS INTEGER)",
                 f"CAST({placeholders[5]} AS {created_at_type})",
+                f"CAST({placeholders[6]} AS FLOAT)",
             ]
         rows.append(f"({', '.join(placeholders)})")
     statement = text(
@@ -133,7 +135,8 @@ def _criteria_relation(
         "sc.column3 AS evaluator_id, "
         "sc.column4 AS config_fingerprint, "
         "sc.column5 AS delay_seconds, "
-        "sc.column6 AS created_at "
+        "sc.column6 AS created_at, "
+        "sc.column7 AS sampling_rate "
         f"FROM (VALUES {', '.join(rows)}) AS sc"
     )
     return (
@@ -145,6 +148,7 @@ def _criteria_relation(
             column("config_fingerprint", String),
             column("delay_seconds", Integer),
             column("created_at", models.UtcTimeStamp()),
+            column("sampling_rate", Float),
         )
         .subquery("sweep_criteria")
     )
@@ -162,6 +166,7 @@ def _live_work_exists(criteria_relation: Subquery) -> ColumnElement[bool]:
             live_work.config_fingerprint == criteria_relation.c.config_fingerprint,
             or_(
                 live_work.status.in_(("PENDING", "RUNNING")),
+                live_work.status.in_(SESSION_DECLINED_STATUSES),
                 and_(
                     live_work.status == "ERROR",
                     live_work.attempts < MAX_ATTEMPTS,
@@ -177,6 +182,8 @@ def _eligible_pairs_statement(
     criteria_relation: Subquery,
     database_now: datetime,
     dialect: SupportedSQLDialect,
+    *,
+    filter_matches: ColumnElement[bool],
 ) -> Select[Any]:
     successful_work = aliased(models.EvalSessionWorkUnit)
     terminal_work = aliased(models.EvalSessionWorkUnit)
@@ -188,6 +195,7 @@ def _eligible_pairs_statement(
             terminal_work.config_fingerprint == criteria_relation.c.config_fingerprint,
             or_(
                 terminal_work.status == "DONE",
+                terminal_work.status.in_(SESSION_DECLINED_STATUSES),
                 and_(
                     terminal_work.status == "EXPIRED",
                     or_(
@@ -231,11 +239,14 @@ def _eligible_pairs_statement(
     return (
         select(
             models.ProjectSession.id.label("project_session_rowid"),
+            models.ProjectSession.session_id,
             criteria_relation.c.criteria_id,
             criteria_relation.c.evaluator_id,
             criteria_relation.c.config_fingerprint,
+            criteria_relation.c.sampling_rate,
             models.ProjectSession.last_span_ingested_at.label("evaluated_through"),
             due_at.label("effective_due_time"),
+            filter_matches.label("filter_matches"),
         )
         .select_from(models.ProjectSession)
         .join(
@@ -257,48 +268,73 @@ def _eligible_pairs_statement(
     )
 
 
-def _session_work_insert_statement(
-    eligible_pairs: Subquery,
+def _eligible_pairs_relation(
+    criteria: Sequence[_SessionCriteria],
+    database_now: datetime,
     dialect: SupportedSQLDialect,
-    *,
-    project_session_rowids: Optional[Sequence[int]] = None,
+) -> Subquery:
+    statements: list[Select[Any]] = []
+    unfiltered = [criterion for criterion in criteria if not criterion.filter_condition]
+    if unfiltered:
+        statements.append(
+            _eligible_pairs_statement(
+                _criteria_relation(unfiltered, dialect),
+                database_now,
+                dialect,
+                filter_matches=literal(True),
+            )
+        )
+    for criterion in criteria:
+        if not criterion.filter_condition:
+            continue
+        filter_matches = models.ProjectSession.id.in_(
+            get_filtered_session_rowids_subquery(
+                criterion.filter_condition,
+                [criterion.project_id],
+            )
+        )
+        statements.append(
+            _eligible_pairs_statement(
+                _criteria_relation([criterion], dialect),
+                database_now,
+                dialect,
+                filter_matches=filter_matches,
+            )
+        )
+    if len(statements) == 1:
+        return statements[0].subquery("eligible_pairs")
+    return union_all(*statements).subquery("eligible_pairs")
+
+
+def _session_work_insert_statement(
+    decisions: Sequence[dict[str, Any]],
+    dialect: SupportedSQLDialect,
 ) -> Insert:
-    """Insert work from a globally ordered page whose PostgreSQL sessions are locked."""
+    """Insert scheduling decisions whose PostgreSQL criteria and sessions are locked."""
     index_elements = (
         models.EvalSessionWorkUnit.project_session_rowid,
         models.EvalSessionWorkUnit.evaluator_id,
         models.EvalSessionWorkUnit.config_fingerprint,
     )
-    candidates = select(
-        eligible_pairs.c.project_session_rowid,
-        eligible_pairs.c.evaluator_id,
-        eligible_pairs.c.criteria_id,
-        eligible_pairs.c.config_fingerprint,
-        eligible_pairs.c.evaluated_through,
-    ).where(literal(True))
-    if project_session_rowids is not None:
-        candidates = candidates.where(
-            eligible_pairs.c.project_session_rowid.in_(project_session_rowids)
-        )
     if dialect is SupportedSQLDialect.POSTGRESQL:
         return (
             insert_postgresql(models.EvalSessionWorkUnit)
-            .from_select(list(_SESSION_WORK_INSERT_COLUMNS), candidates)
+            .values(decisions)
             .on_conflict_do_nothing(
                 index_elements=index_elements,
                 index_where=_LIVE_WORK_INDEX_PREDICATE,
             )
-            .returning(models.EvalSessionWorkUnit.criteria_id)
+            .returning(models.EvalSessionWorkUnit.status)
         )
     if dialect is SupportedSQLDialect.SQLITE:
         return (
             insert_sqlite(models.EvalSessionWorkUnit)
-            .from_select(list(_SESSION_WORK_INSERT_COLUMNS), candidates)
+            .values(decisions)
             .on_conflict_do_nothing(
                 index_elements=index_elements,
                 index_where=_LIVE_WORK_INDEX_PREDICATE,
             )
-            .returning(models.EvalSessionWorkUnit.criteria_id)
+            .returning(models.EvalSessionWorkUnit.status)
         )
     assert_never(dialect)
 
@@ -496,6 +532,8 @@ class SessionEvalSweeper(DaemonTask):
                     fingerprint=config_fingerprint(resolved),
                     delay_seconds=criteria.evaluation_delay_seconds,
                     created_at=criteria.created_at,
+                    filter_condition=criteria.filter_condition,
+                    sampling_rate=criteria.sampling_rate,
                 )
             )
         return criteria_rows
@@ -528,16 +566,19 @@ class SessionEvalSweeper(DaemonTask):
     ) -> tuple[int, Optional[int]]:
         if not criteria:
             return 0, 0 if self._publish_metrics else None
-        criteria_relation = _criteria_relation(criteria, self._db.dialect)
-        relation = _eligible_pairs_statement(
-            criteria_relation,
+        relation = _eligible_pairs_relation(
+            criteria,
             database_now,
             self._db.dialect,
-        ).subquery("eligible_pairs")
+        )
         eligible_pair_count = None
         if self._publish_metrics:
             eligible_pair_count = (
-                await session.scalar(select(func.count()).select_from(relation))
+                await session.scalar(
+                    select(func.count())
+                    .select_from(relation)
+                    .where(relation.c.filter_matches.is_(True))
+                )
             ) or 0
         eligible_page = (
             select(relation)
@@ -549,6 +590,7 @@ class SessionEvalSweeper(DaemonTask):
             .limit(limit)
             .subquery("eligible_pair_page")
         )
+        locked_criteria_ids: Optional[Sequence[int]] = None
         locked_project_session_rowids: Optional[Sequence[int]] = None
         if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
             page_criteria_ids = tuple(
@@ -596,18 +638,45 @@ class SessionEvalSweeper(DaemonTask):
             )
             if not locked_project_session_rowids:
                 return 0, eligible_pair_count
-        inserted_count = len(
-            (
-                await session.scalars(
-                    _session_work_insert_statement(
-                        eligible_page,
-                        self._db.dialect,
-                        project_session_rowids=locked_project_session_rowids,
-                    )
+        selected_page = select(eligible_page)
+        if locked_criteria_ids is not None:
+            selected_page = selected_page.where(
+                eligible_page.c.criteria_id.in_(locked_criteria_ids)
+            )
+        if locked_project_session_rowids is not None:
+            selected_page = selected_page.where(
+                eligible_page.c.project_session_rowid.in_(locked_project_session_rowids)
+            )
+        rows = (await session.execute(selected_page)).all()
+        decisions: list[dict[str, Any]] = []
+        for row in rows:
+            if not row.filter_matches:
+                status: models.EvalSessionWorkStatus = "FILTERED_OUT"
+            elif sample_key(row.session_id) >= row.sampling_rate:
+                status = "SAMPLED_OUT"
+            else:
+                status = "PENDING"
+            decisions.append(
+                {
+                    "project_session_rowid": row.project_session_rowid,
+                    "evaluator_id": row.evaluator_id,
+                    "criteria_id": row.criteria_id,
+                    "config_fingerprint": row.config_fingerprint,
+                    "evaluated_through": row.evaluated_through,
+                    "status": status,
+                }
+            )
+        if not decisions:
+            return 0, eligible_pair_count
+        inserted_statuses = (
+            await session.scalars(
+                _session_work_insert_statement(
+                    decisions,
+                    self._db.dialect,
                 )
-            ).all()
-        )
-        return inserted_count, eligible_pair_count
+            )
+        ).all()
+        return inserted_statuses.count("PENDING"), eligible_pair_count
 
     async def _publish_eligibility_metrics(self, eligible_pair_count: Optional[int]) -> None:
         """Publish the sweep's observation gauges from a session of its own.

--- a/src/phoenix/server/session_filters.py
+++ b/src/phoenix/server/session_filters.py
@@ -3,6 +3,8 @@ from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, Optional, Sequence
 
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.sql.expression import Select
 from sqlalchemy.sql.selectable import ScalarSelect
 
@@ -62,6 +64,15 @@ def compile_session_filter(session_filter_condition: str) -> SessionFilter:
     """Compile a session filter expression, reporting an unusable one as ``BadRequest``."""
     with session_filter_errors():
         return SessionFilter(condition=session_filter_condition)
+
+
+def validate_session_filter_condition(session_filter_condition: str) -> None:
+    """Compile a session filter for every supported database dialect."""
+    with session_filter_errors():
+        session_filter = compile_session_filter(session_filter_condition)
+        stmt = session_filter(select(models.ProjectSession))
+        str(stmt.compile(dialect=sqlite.dialect()))
+        str(stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
 
 
 def get_filtered_session_rowids_subquery(

--- a/tests/unit/server/api/mutations/test_evaluator_preview_mutation.py
+++ b/tests/unit/server/api/mutations/test_evaluator_preview_mutation.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import select
 from strawberry.relay.types import GlobalID
 
+from phoenix.config import ENV_PHOENIX_ONLINE_EVAL_MAX_SANDBOX_PAYLOAD_BYTES
 from phoenix.db import models
 from phoenix.server.monty_runtime import (
     MontyBusy,
@@ -174,6 +175,8 @@ class TestInlineCodeEvaluatorPreviewMutation:
         sandbox_config_id: str | None,
         language: str = "PYTHON",
         source_code: str = "def evaluate(output):\n    return 1.0",
+        context: Any = None,
+        apply_online_evaluation_limits: bool = False,
     ) -> Any:
         return await gql_client.execute(
             TestEvaluatorPreviewMutation._MUTATION,
@@ -200,11 +203,14 @@ class TestInlineCodeEvaluatorPreviewMutation:
                                     ],
                                 }
                             },
-                            "context": {"output": {"answer": "4"}},
+                            "context": (
+                                {"output": {"answer": "4"}} if context is None else context
+                            ),
                             "inputMapping": {
                                 "literalMapping": {},
                                 "pathMapping": {},
                             },
+                            "applyOnlineEvaluationLimits": apply_online_evaluation_limits,
                         }
                     ]
                 }
@@ -345,6 +351,47 @@ class TestInlineCodeEvaluatorPreviewMutation:
         backend.find_or_create_session.assert_not_called()
         backend.execute_in_session.assert_not_called()
         backend.close_session.assert_not_called()
+
+    async def test_applies_the_online_sandbox_payload_limit_on_request(
+        self,
+        gql_client: AsyncGraphQLClient,
+        sandbox_config: models.SandboxConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_MAX_SANDBOX_PAYLOAD_BYTES, "1024")
+        backend = AsyncMock()
+        fenced_stdout = f"{PHOENIX_RESULT_BEGIN}\n1.0\n{PHOENIX_RESULT_END}\n"
+        backend.execute_with_inputs = AsyncMock(
+            return_value=ExecutionResult(stdout=fenced_stdout, stderr="", error=None)
+        )
+        backend.close = AsyncMock(return_value=None)
+        oversized_context = {"output": "o" * 4096}
+
+        with patch(
+            "phoenix.server.api.mutations.chat_mutations.build_sandbox_backend",
+            return_value=backend,
+        ):
+            unlimited = await self._preview_inline_code_evaluator(
+                gql_client,
+                sandbox_config_id=str(GlobalID("SandboxConfig", str(sandbox_config.id))),
+                context=oversized_context,
+            )
+            limited = await self._preview_inline_code_evaluator(
+                gql_client,
+                sandbox_config_id=str(GlobalID("SandboxConfig", str(sandbox_config.id))),
+                context=oversized_context,
+                apply_online_evaluation_limits=True,
+            )
+
+        # Authoring against a dataset stays unlimited; a preview standing in for
+        # a scheduled run is rejected exactly as the live evaluation rejects it.
+        assert unlimited.data and not unlimited.errors
+        assert unlimited.data["evaluatorPreviews"]["results"][0]["error"] is None
+        assert limited.data and not limited.errors
+        error = limited.data["evaluatorPreviews"]["results"][0]["error"]
+        assert error is not None
+        assert "exceeds the allowed 1024 bytes" in error
+        assert ENV_PHOENIX_ONLINE_EVAL_MAX_SANDBOX_PAYLOAD_BYTES in error
 
     async def test_reports_busy_monty_runtime_as_bad_request(
         self,

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -166,7 +166,7 @@ def _code_add_input(
         "samplingRate": 0.25,
         "evaluationTarget": "SESSION",
         "inputMapping": _mapping(context="override"),
-        "filterCondition": "num_traces >= 2",
+        "filterCondition": "num_traces >= 1",
         "enabled": False,
         "evaluationDelaySeconds": 30,
     }
@@ -421,7 +421,7 @@ async def test_add_project_code_evaluator_binds_existing_core(
     assert attached["samplingRate"] == 0.25
     assert attached["evaluationTarget"] == "SESSION"
     assert attached["inputMapping"] == _mapping(context="override")
-    assert attached["filterCondition"] == "num_traces >= 2"
+    assert attached["filterCondition"] == "num_traces >= 1"
     assert attached["enabled"] is False
     assert attached["evaluationDelaySeconds"] == 30
 
@@ -804,27 +804,33 @@ async def test_invalid_filter_rejects_before_project_evaluator_writes(
     assert await _row_counts(db) == before
 
 
-async def test_session_evaluator_filter_is_validated_in_the_session_language(
+async def test_session_filter_validation_uses_session_dsl(
     gql_client: AsyncGraphQLClient,
     db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
 ) -> None:
     project = await _add_project(db)
-    filter_condition = "any(span.latency_ms > 1_000 for span in spans)"
-    create_input = _llm_input(project, name="session-filter-llm", text="Evaluate {{input}}")
-    create_input["evaluationTarget"] = "SESSION"
-    create_input["filterCondition"] = filter_condition
+    valid_input = _code_create_input(
+        project,
+        sandbox_config,
+        filter_condition="any(span.latency_ms > 1_000 for span in spans)",
+    )
+    valid_input["evaluationTarget"] = "SESSION"
 
-    result = await gql_client.execute(_CREATE_LLM, {"input": create_input})
+    valid_result = await gql_client.execute(_CREATE_CODE, {"input": valid_input})
 
-    assert result.data and not result.errors
-    created = result.data["createProjectLlmEvaluator"]["evaluator"]
-    assert created["evaluationTarget"] == "SESSION"
-    async with db() as session:
-        criteria = await session.get(
-            models.ProjectEvaluatorCriteria, int(GlobalID.from_id(created["id"]).node_id)
-        )
-        assert criteria is not None
-        assert criteria.filter_condition == filter_condition
+    assert valid_result.data and not valid_result.errors
+    before = await _row_counts(db)
+    invalid_input = _code_create_input(
+        project,
+        sandbox_config,
+        filter_condition="span_kind == 'LLM'",
+    )
+    invalid_input["evaluationTarget"] = "SESSION"
+    invalid_result = await gql_client.execute(_CREATE_CODE, {"input": invalid_input})
+    assert invalid_result.errors
+    assert "Invalid filter condition:" in str(invalid_result.errors)
+    assert await _row_counts(db) == before
 
 
 async def test_sampling_rate_rejected_at_project_evaluator_input_boundary(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -166,7 +166,7 @@ def _code_add_input(
         "samplingRate": 0.25,
         "evaluationTarget": "SESSION",
         "inputMapping": _mapping(context="override"),
-        "filterCondition": "span_kind == 'LLM'",
+        "filterCondition": "num_traces >= 2",
         "enabled": False,
         "evaluationDelaySeconds": 30,
     }
@@ -421,7 +421,7 @@ async def test_add_project_code_evaluator_binds_existing_core(
     assert attached["samplingRate"] == 0.25
     assert attached["evaluationTarget"] == "SESSION"
     assert attached["inputMapping"] == _mapping(context="override")
-    assert attached["filterCondition"] == "span_kind == 'LLM'"
+    assert attached["filterCondition"] == "num_traces >= 2"
     assert attached["enabled"] is False
     assert attached["evaluationDelaySeconds"] == 30
 
@@ -802,6 +802,29 @@ async def test_invalid_filter_rejects_before_project_evaluator_writes(
     assert result.errors
     assert "Invalid filter condition:" in str(result.errors)
     assert await _row_counts(db) == before
+
+
+async def test_session_evaluator_filter_is_validated_in_the_session_language(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    project = await _add_project(db)
+    filter_condition = "any(span.latency_ms > 1_000 for span in spans)"
+    create_input = _llm_input(project, name="session-filter-llm", text="Evaluate {{input}}")
+    create_input["evaluationTarget"] = "SESSION"
+    create_input["filterCondition"] = filter_condition
+
+    result = await gql_client.execute(_CREATE_LLM, {"input": create_input})
+
+    assert result.data and not result.errors
+    created = result.data["createProjectLlmEvaluator"]["evaluator"]
+    assert created["evaluationTarget"] == "SESSION"
+    async with db() as session:
+        criteria = await session.get(
+            models.ProjectEvaluatorCriteria, int(GlobalID.from_id(created["id"]).node_id)
+        )
+        assert criteria is not None
+        assert criteria.filter_condition == filter_condition
 
 
 async def test_sampling_rate_rejected_at_project_evaluator_input_boundary(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -270,7 +270,6 @@ async def test_project_code_evaluator_crud_and_connection(
                 "inputMapping": _mapping(context="override"),
                 "samplingRate": 0.25,
                 "evaluationTarget": "SPAN",
-                "evaluationDelaySeconds": 30,
                 "filterCondition": "span_kind == 'LLM'",
                 "enabled": False,
             }
@@ -280,7 +279,6 @@ async def test_project_code_evaluator_crud_and_connection(
     updated = update_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert updated["name"] == "updated-code"
     assert updated["evaluationTarget"] == "SPAN"
-    assert updated["evaluationDelaySeconds"] == 30
     assert updated["schedulabilityStatus"] == "NOT_SCHEDULABLE"
     assert updated["schedulabilityReason"] == "DISABLED"
     assert updated["inputMapping"] == _mapping(context="override")
@@ -292,7 +290,6 @@ async def test_project_code_evaluator_crud_and_connection(
         assert criteria is not None
         assert criteria.input_mapping is not None
         assert criteria.input_mapping.literal_mapping == {"context": "override"}
-        assert criteria.evaluation_delay_seconds == 30
         evaluator = await session.get(models.CodeEvaluator, criteria.evaluator_id)
         assert evaluator is not None
         user_role_id = await session.scalar(select(models.UserRole.id).limit(1))
@@ -327,7 +324,6 @@ async def test_project_code_evaluator_crud_and_connection(
     omitted = omitted_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert omitted["inputMapping"] == _mapping(context="override")
     assert omitted["enabled"] is False
-    assert omitted["evaluationDelaySeconds"] == 30
     assert omitted["schedulabilityStatus"] == "NOT_SCHEDULABLE"
     assert omitted["schedulabilityReason"] == "DISABLED"
     async with db() as session:
@@ -335,7 +331,6 @@ async def test_project_code_evaluator_crud_and_connection(
         assert criteria is not None
         assert criteria.input_mapping is not None
         assert criteria.input_mapping.literal_mapping == {"context": "override"}
-        assert criteria.evaluation_delay_seconds == 30
         evaluator = await session.get(models.CodeEvaluator, criteria.evaluator_id)
         assert evaluator is not None
         assert evaluator.description == "updated"
@@ -901,6 +896,7 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
     error_message = "evaluationDelaySeconds must be at least 10 seconds"
 
     create_code_input = _code_create_input(project, sandbox_config)
+    create_code_input["evaluationTarget"] = "SESSION"
     create_code_input["evaluationDelaySeconds"] = 9
     before = await _row_counts(db)
     create_code_result = await gql_client.execute(_CREATE_CODE, {"input": create_code_input})
@@ -959,6 +955,56 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
         assert code_criteria is not None and llm_criteria is not None
         assert code_criteria.evaluation_delay_seconds == 300
         assert llm_criteria.evaluation_delay_seconds == 300
+
+
+async def test_evaluation_delay_rejected_for_span_project_evaluators(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    error_message = (
+        "evaluationDelaySeconds is not accepted for SPAN evaluators: span scheduling "
+        "does not honor an evaluation delay"
+    )
+
+    create_input = _code_create_input(project, sandbox_config)
+    create_input["evaluationDelaySeconds"] = 30
+    before = await _row_counts(db)
+    create_result = await gql_client.execute(_CREATE_CODE, {"input": create_input})
+    assert create_result.errors
+    assert create_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    valid_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(project, sandbox_config)},
+    )
+    assert valid_result.data and not valid_result.errors
+    created = valid_result.data["createProjectCodeEvaluator"]["evaluator"]
+    update_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": created["id"],
+                "name": created["name"],
+                "evaluatorInputMapping": _mapping(output="value"),
+                "samplingRate": 1.0,
+                "evaluationTarget": "SPAN",
+                "evaluationDelaySeconds": 30,
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+    assert update_result.errors
+    assert update_result.errors[0].message == error_message
+
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluation_delay_seconds == 300
 
 
 async def test_evaluation_target_change_rejected_from_creation(

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -326,10 +326,8 @@ async def test_project_evaluator_scheduling_fields(
     assert not response.errors and response.data
     edges = response.data["node"]["evaluators"]["edges"]
     assert [edge["node"]["evaluationDelaySeconds"] for edge in edges] == [45]
-    assert [edge["node"]["schedulabilityStatus"] for edge in edges] == ["NOT_SCHEDULABLE"]
-    assert [edge["node"]["schedulabilityReason"] for edge in edges] == [
-        "SESSION_FILTER_UNSUPPORTED"
-    ]
+    assert [edge["node"]["schedulabilityStatus"] for edge in edges] == ["SCHEDULABLE"]
+    assert [edge["node"]["schedulabilityReason"] for edge in edges] == [None]
 
 
 class TestDatasetEvaluatorDescriptionFallback:

--- a/tests/unit/server/api/types/test_ProjectSession.py
+++ b/tests/unit/server/api/types/test_ProjectSession.py
@@ -314,6 +314,9 @@ class TestProjectSession:
         assert policy["retained_turn_count"] == 2
         assert policy["turn_cap_omitted_count"] == 0
         assert policy["byte_cap_omitted_count"] == 0
+        # Decided per evaluator at hydration time and recorded on the
+        # annotation, so it is not part of the context an author previews.
+        assert "structured_turns_mapped" not in policy
 
     async def test_session_evaluation_context_is_null_when_transcript_exceeds_byte_cap(
         self,

--- a/tests/unit/server/api/types/test_ProjectSession.py
+++ b/tests/unit/server/api/types/test_ProjectSession.py
@@ -335,6 +335,38 @@ class TestProjectSession:
         # preview reports it rather than failing the query it is read in.
         assert await self._node("sessionEvaluationContext", oversized_session, httpx_client) is None
 
+    async def test_session_evaluation_context_is_null_when_content_is_incomplete(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        async with db() as session:
+            project = await _add_project(session)
+            trimmed_session = await _add_project_session(session, project)
+            trace = await _add_trace(session, project, trimmed_session)
+            await _add_span(
+                session,
+                trace,
+                attributes={"input": {"value": "hi"}, "output": {"value": "hello"}},
+            )
+            trimmed_session.content_complete = False
+        # The sweeper never claims a trimmed session, so its remaining turns are
+        # not a context any live evaluation would read.
+        assert await self._node("sessionEvaluationContext", trimmed_session, httpx_client) is None
+
+    async def test_session_evaluation_context_is_null_without_eligible_root_turns(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        async with db() as session:
+            project = await _add_project(session)
+            rootless_session = await _add_project_session(session, project)
+            await _add_trace(session, project, rootless_session)
+        # Live hydration returns NO_ROOT_TURNS here, so the preview reports the
+        # session as unevaluable rather than offering an empty transcript.
+        assert await self._node("sessionEvaluationContext", rootless_session, httpx_client) is None
+
     async def test_project(
         self,
         _data: _Data,

--- a/tests/unit/server/api/types/test_ProjectSession.py
+++ b/tests/unit/server/api/types/test_ProjectSession.py
@@ -5,10 +5,15 @@ import httpx
 import pytest
 from strawberry.relay import GlobalID
 
+from phoenix.config import ENV_PHOENIX_ONLINE_EVAL_MAX_TRANSCRIPT_BYTES
 from phoenix.db import models
 from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.ProjectSession import ProjectSession
 from phoenix.server.api.types.Trace import Trace
+from phoenix.server.online_eval.session_policy import (
+    MAX_SESSION_EVAL_TURNS,
+    TRANSCRIPT_POLICY_VERSION,
+)
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -285,6 +290,50 @@ class TestProjectSession:
         project_sessions = _data.project_sessions
         field = "traceLatencyMsQuantile(probability: 0.5)"
         assert await self._node(field, project_sessions[0], httpx_client) == 10000.0
+
+    async def test_session_evaluation_context(
+        self,
+        _data: _Data,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        project_session = _data.project_sessions[0]
+        context = await self._node("sessionEvaluationContext", project_session, httpx_client)
+        assert context["input"] == (
+            f"User: {_LONG_FIRST_INPUT}\nAssistant: 321\n\n"
+            f"User: 1234\nAssistant: {_LONG_LAST_OUTPUT}"
+        )
+        assert context["output"] == _LONG_LAST_OUTPUT
+        assert [(turn["input"], turn["output"]) for turn in context["metadata"]["turns"]] == [
+            (_LONG_FIRST_INPUT, "321"),
+            ("1234", _LONG_LAST_OUTPUT),
+        ]
+        policy = context["metadata"]["phoenix.online_eval.transcript_policy"]
+        assert policy["version"] == TRANSCRIPT_POLICY_VERSION
+        assert policy["max_turns"] == MAX_SESSION_EVAL_TURNS
+        assert policy["total_eligible_root_count"] == 2
+        assert policy["retained_turn_count"] == 2
+        assert policy["turn_cap_omitted_count"] == 0
+        assert policy["byte_cap_omitted_count"] == 0
+
+    async def test_session_evaluation_context_is_null_when_transcript_exceeds_byte_cap(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_MAX_TRANSCRIPT_BYTES, "256")
+        async with db() as session:
+            project = await _add_project(session)
+            oversized_session = await _add_project_session(session, project)
+            trace = await _add_trace(session, project, oversized_session)
+            await _add_span(
+                session,
+                trace,
+                attributes={"input": {"value": "hi"}, "output": {"value": "o" * 300}},
+            )
+        # A live evaluation of this session fails for the same reason, so the
+        # preview reports it rather than failing the query it is read in.
+        assert await self._node("sessionEvaluationContext", oversized_session, httpx_client) is None
 
     async def test_project(
         self,

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -1477,7 +1477,7 @@ async def test_session_hydration_excludes_transferred_trace_roots(
 
 
 async def test_session_filtered_sampled_criteria_survives_hydration(
-    db: DbSessionFactory,
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     async with db() as session:
         project = await _add_project(session)
@@ -1515,6 +1515,7 @@ async def test_session_filtered_sampled_criteria_survives_hydration(
         evaluator_id,
         criteria_id,
     )
+    _patch_playground_client(monkeypatch, _StubLLMClient())
 
     consumer = OnlineEvalConsumer(
         db,

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -1476,33 +1476,45 @@ async def test_session_hydration_excludes_transferred_trace_roots(
     assert await _session_annotations(db) == []
 
 
-async def test_session_criteria_becoming_unschedulable_expires_before_evaluator_call(
-    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+async def test_session_filtered_sampled_criteria_survives_hydration(
+    db: DbSessionFactory,
 ) -> None:
     async with db() as session:
         project = await _add_project(session)
-        project_session = await _add_project_session(session, project)
+        project_session = await _add_project_session(
+            session, project, session_id="hydrated-session"
+        )
         trace = await _add_trace(session, project, project_session)
-        await _add_span(session, trace)
+        await _add_span(
+            session,
+            trace,
+            span_kind="CHAIN",
+            attributes={
+                "input": {"value": "question"},
+                "output": {"value": "answer"},
+                "metadata": {},
+            },
+        )
     evaluator_id, criteria_id = await _seed_llm_criteria(
         db,
         project.id,
         evaluation_target="SESSION",
     )
-    unit_id, _ = await _materialize_session_unit(
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(
+                filter_condition="session_id == 'hydrated-session'",
+                sampling_rate=0.5,
+            )
+        )
+    await _materialize_session_unit(
         db,
         project_session.id,
         evaluator_id,
         criteria_id,
     )
-    async with db() as session:
-        await session.execute(
-            update(models.ProjectEvaluatorCriteria)
-            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
-            .values(filter_condition="span_kind == 'LLM'")
-        )
-    client = _StubLLMClient()
-    _patch_playground_client(monkeypatch, client)
 
     consumer = OnlineEvalConsumer(
         db,
@@ -1513,14 +1525,7 @@ async def test_session_criteria_becoming_unschedulable_expires_before_evaluator_
         claimed_by=consumer._consumer_id,
         limit=1,
     )
-    assert await consumer._executor.hydrate(unit) == HydrationFailure(
-        HydrationFailureReason.CRITERIA_NOT_SCHEDULABLE
-    )
-    await consumer._process_unit(unit)
-
-    assert (await _get_session_unit(db, unit_id)).status == "EXPIRED"
-    assert client.requests == []
-    assert await _session_annotations(db) == []
+    assert isinstance(await consumer._executor.hydrate(unit), HydratedWorkUnit)
 
 
 async def test_session_code_hydration_supplies_configured_payload_cap(

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -540,6 +540,28 @@ async def test_session_claim_lifecycle_and_lag(db: DbSessionFactory) -> None:
     assert 100.0 <= lag.oldest_actionable_age_seconds < 300.0
 
 
+async def test_session_claim_excludes_declined_decisions(db: DbSessionFactory) -> None:
+    _, unit_ids = await _seed_session_work_units(db, 3)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalSessionWorkUnit)
+            .where(models.EvalSessionWorkUnit.id == unit_ids[0])
+            .values(status="FILTERED_OUT")
+        )
+        await session.execute(
+            update(models.EvalSessionWorkUnit)
+            .where(models.EvalSessionWorkUnit.id == unit_ids[1])
+            .values(status="SAMPLED_OUT")
+        )
+
+    claimed = await DbEvalWorkCoordinator(db, evaluation_target="SESSION").claim(
+        claimed_by="session-consumer",
+        limit=3,
+    )
+
+    assert [unit.work_unit_id for unit in claimed] == [unit_ids[2]]
+
+
 @pytest.mark.parametrize("terminal_kind", ["exhausted_error", "expired"])
 async def test_session_no_result_terminal_history_allows_replacement(
     db: DbSessionFactory,

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -10,7 +10,7 @@ from sqlalchemy import Table, func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from phoenix.db import models
-from phoenix.db.eval_work import live_eval_work_index_predicate
+from phoenix.db.eval_work import live_eval_session_work_index_predicate
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.app import _db
 from phoenix.server.online_eval import session_sweeper
@@ -23,6 +23,7 @@ from phoenix.server.online_eval.derivation import (
     MAX_ATTEMPTS,
     STALE_FINGERPRINT_ERROR,
     ResolvedCriteria,
+    sample_key,
 )
 from phoenix.server.online_eval.session_sweeper import (
     SESSION_SWEEP_LEASE_TTL_SECONDS,
@@ -70,7 +71,7 @@ def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
     migration = import_module(
         "phoenix.db.migrations.versions.a7f1c3e9d2b4_add_online_eval_coordination"
     )
-    predicate = live_eval_work_index_predicate()
+    predicate = live_eval_session_work_index_predicate()
     live_key_table = cast(Table, models.EvalSessionWorkUnit.__table__)
     live_key_index = next(
         index
@@ -79,10 +80,14 @@ def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
     )
 
     assert f"attempts < {MAX_ATTEMPTS}" in predicate
+    assert "FILTERED_OUT" in predicate
+    assert "SAMPLED_OUT" in predicate
     assert str(live_key_index.dialect_options["postgresql"]["where"]) == predicate
     assert str(live_key_index.dialect_options["sqlite"]["where"]) == predicate
     assert str(session_sweeper._LIVE_WORK_INDEX_PREDICATE) == predicate
-    assert migration.live_eval_work_index_predicate is live_eval_work_index_predicate
+    assert (
+        migration.live_eval_session_work_index_predicate is live_eval_session_work_index_predicate
+    )
 
 
 @pytest.mark.parametrize(
@@ -149,6 +154,7 @@ async def _add_session_liveness(
     age_seconds: float,
     project_id: int | None = None,
     content_complete: bool = True,
+    session_id: str | None = None,
 ) -> tuple[int, int, datetime]:
     last_span_ingested_at = _now() - timedelta(seconds=age_seconds)
     async with db() as session:
@@ -158,7 +164,7 @@ async def _add_session_liveness(
             existing_project = await session.get(models.Project, project_id)
             assert existing_project is not None
             project = existing_project
-        project_session = await _add_project_session(session, project)
+        project_session = await _add_project_session(session, project, session_id=session_id)
         trace = await _add_trace(session, project, project_session)
         await _add_span(session, trace)
         await session.execute(
@@ -898,23 +904,168 @@ async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
         )
 
 
-async def test_trace_filtered_and_sampled_criteria_remain_unscheduled(
+async def test_session_filter_decisions_are_persisted_before_sampling(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id, matching_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        session_id="matching-session",
+    )
+    _, declined_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        project_id=project_id,
+        session_id="declined-session",
+    )
+    async with db() as session:
+        project = await session.get(models.Project, project_id)
+        project_session = await session.get(models.ProjectSession, matching_session_id)
+        assert project is not None
+        assert project_session is not None
+        trace = await _add_trace(session, project, project_session)
+        await _add_span(session, trace)
+    await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+        filter_condition="num_traces >= 2",
+        sampling_rate=0.5,
+    )
+    sampled_identities: list[str] = []
+
+    def record_sample(identity: int | str) -> float:
+        sampled_identities.append(str(identity))
+        return 0.0
+
+    monkeypatch.setattr(session_sweeper, "sample_key", record_sample)
+    sweeper = SessionEvalSweeper(db)
+    sweeper._publish_metrics = True
+    async with db() as session:
+        criteria = await sweeper._load_criteria(session)
+        database_now = await sweeper._database_now(session)
+        materialized_count, eligible_pair_count = await sweeper._load_eligible_pairs(
+            session,
+            database_now,
+            criteria,
+            limit=2,
+        )
+
+    async with db() as session:
+        statuses = {
+            row.project_session_rowid: row.status
+            for row in (
+                await session.execute(
+                    select(
+                        models.EvalSessionWorkUnit.project_session_rowid,
+                        models.EvalSessionWorkUnit.status,
+                    )
+                )
+            ).all()
+        }
+    assert materialized_count == 1
+    assert eligible_pair_count == 1
+    assert statuses == {
+        matching_session_id: "PENDING",
+        declined_session_id: "FILTERED_OUT",
+    }
+    assert sampled_identities == ["matching-session"]
+
+
+async def test_session_sampling_decisions_are_deterministic_and_idempotent(
+    db: DbSessionFactory,
+) -> None:
+    sampled_in = next(identity for identity in map(str, range(100)) if sample_key(identity) < 0.5)
+    sampled_out = next(identity for identity in map(str, range(100)) if sample_key(identity) >= 0.5)
+    project_id, sampled_in_rowid, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        session_id=sampled_in,
+    )
+    _, sampled_out_rowid, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        project_id=project_id,
+        session_id=sampled_out,
+    )
+    await _seed_criteria(db, project_id, evaluation_target="SESSION", sampling_rate=0.5)
+
+    await SessionEvalSweeper(db)._tick()
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == sampled_out_rowid)
+            .values(last_span_ingested_at=_now() - timedelta(seconds=400))
+        )
+    await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        rows = (
+            await session.execute(
+                select(
+                    models.EvalSessionWorkUnit.project_session_rowid,
+                    models.EvalSessionWorkUnit.status,
+                )
+            )
+        ).all()
+    assert {row.project_session_rowid: row.status for row in rows} == {
+        sampled_in_rowid: "PENDING",
+        sampled_out_rowid: "SAMPLED_OUT",
+    }
+    assert len(rows) == 2
+
+
+async def test_declined_oldest_page_does_not_starve_later_match(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(session_sweeper, "_MAX_ELIGIBLE_PAIRS_PER_TICK", 1)
+    project_id, declined_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=700,
+        session_id="declined-session",
+    )
+    _, matching_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        project_id=project_id,
+        session_id="matching-session",
+    )
+    await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+        filter_condition="session_id == 'matching-session'",
+    )
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    await sweeper._tick()
+
+    async with db() as session:
+        statuses = {
+            row.project_session_rowid: row.status
+            for row in (
+                await session.execute(
+                    select(
+                        models.EvalSessionWorkUnit.project_session_rowid,
+                        models.EvalSessionWorkUnit.status,
+                    )
+                )
+            ).all()
+        }
+    assert statuses == {
+        declined_session_id: "FILTERED_OUT",
+        matching_session_id: "PENDING",
+    }
+
+
+async def test_trace_criteria_remain_unscheduled(
     db: DbSessionFactory,
 ) -> None:
     project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
     await _seed_criteria(db, project_id, evaluation_target="TRACE")
-    await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-        filter_condition="span_kind == 'LLM'",
-    )
-    await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-        sampling_rate=0.5,
-    )
 
     await SessionEvalSweeper(db)._tick()
     async with db() as session:


### PR DESCRIPTION
Sessions become a first-class target for LLM and code project evaluators, with the same scope-authoring system spans have.

**Creation and editing.** Sessions are a selectable target alongside spans in the create and edit forms. Session evaluators carry `evaluationDelaySeconds`: how long a session must stay quiet before its evaluation runs (minimum 10 seconds, default 300). Editing preserves a stored custom delay. The delay input sits at the end of the scope row at the same input height as its siblings.

**Scope authoring.** Session targets get the full scope panel: a filter bar backed by the session filter DSL, a sampling rate, a preview time window, and a live Matching Sessions section showing the count and newest matching sessions for the current filter and window. Session filter conditions are validated server-side in the session DSL — previously every project-evaluator filter was compiled as span DSL, so session-shaped filters could never be stored; validation now routes by target through one shared helper serving both the mutations and the validation resolver.

**Preview and testing against recorded sessions.** The scope panel's session list is now a run list with the same anatomy as the span one: each matching session row shows the exact evaluation context the server computes for it — the conversation transcript as `input`, the final response as `output`, ordered turns and the applied transcript policy under `metadata` — with binding diagnostics, a full-context tab, and a Run action that executes the evaluator (LLM or code) against that session. The context comes from a new nullable `ProjectSession.sessionEvaluationContext` field backed by the same hydration path the live executor uses, so what previews is byte-for-byte what evaluation receives. A session whose transcript exceeds the evaluation byte cap (no whole turn fits) renders as an explained unavailable row — live evaluation would fail it for the same reason — without affecting its neighbors.

## Test plan
- `pnpm typecheck`, lint, and the evaluator vitest suites pass (146 tests); Relay artifacts regenerate with zero drift.
- Backend suites pass on SQLite and PostgreSQL (211 tests on PG), covering the sweeper's decline decisions, the narrowed claimable index, coordinator/executor/producer behavior, mutation validation, and the migration.
- Browser-verified: 300-session project narrowed 300→67 by a filter, a comprehension filter stored and round-tripped through edit, sampling and delay persisted.
- Live end-to-end pass of a filtered/sampled session evaluator producing annotations through the running sweeper is still pending (owner verification in progress).
