### PR TITLE
feat(online-evals): use segmented control for evaluator target selector

### DIFF
--- a/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
@@ -1,8 +1,8 @@
 import {
   Flex,
+  SegmentedControl,
+  SegmentedControlItem,
   Text,
-  ToggleButton,
-  ToggleButtonGroup,
 } from "@phoenix/components";
 import {
   isProjectEvaluatorTarget,
@@ -23,23 +23,22 @@ export const ProjectEvaluatorTargetField = ({
       <Text size="XS" weight="heavy" color="text-700">
         Target
       </Text>
-      <ToggleButtonGroup
+      <SegmentedControl
         aria-label="Evaluator target"
-        selectedKeys={[value]}
-        onSelectionChange={(keys) => {
-          const target = keys.keys().next().value;
-          if (typeof target === "string" && isProjectEvaluatorTarget(target)) {
-            onChange(target);
+        selectedKey={value}
+        onSelectionChange={(key) => {
+          if (typeof key === "string" && isProjectEvaluatorTarget(key)) {
+            onChange(key);
           }
         }}
       >
-        <ToggleButton id="span" aria-label="Span" isDisabled={isDisabled}>
+        <SegmentedControlItem id="span" isDisabled={isDisabled}>
           Span
-        </ToggleButton>
-        <ToggleButton id="session" aria-label="Session" isDisabled>
+        </SegmentedControlItem>
+        <SegmentedControlItem id="session" isDisabled>
           Session
-        </ToggleButton>
-      </ToggleButtonGroup>
+        </SegmentedControlItem>
+      </SegmentedControl>
     </Flex>
   );
 };


### PR DESCRIPTION
## Summary

Switches the evaluator target selector (Span / Session) in the project evaluator scope panel from a `ToggleButtonGroup` to the design system's `SegmentedControl`.

- Selection stays controlled via `selectedKey` with the same `isProjectEvaluatorTarget` guard
- Span segment disabled via the `isDisabled` prop; Session segment remains hardcoded-disabled
- Dropped redundant per-button `aria-label`s — segment items render their string children as the accessible label, matching other `SegmentedControl` usages