### PR TITLE
ci(docker): native per-platform runners, WASM fetch retry, and layer cache

### DIFF
--- a/.github/actions/docker-build-image/action.yml
+++ b/.github/actions/docker-build-image/action.yml
@@ -33,6 +33,7 @@ runs:
         VARIANT: ${{ inputs.variant }}
         PLATFORM: ${{ inputs.platform }}
       run: |
+        set -euo pipefail
         case "$VARIANT" in
           root)    base=gcr.io/distroless/python3-debian13 ;;
           nonroot) base=gcr.io/distroless/python3-debian13:nonroot ;;
@@ -57,6 +58,30 @@ runs:
       with:
         images: ${{ inputs.registry }}/${{ inputs.image-name }}
 
+    # The WASM fetch is the only download here with no registry-protocol
+    # retry beneath it, and the release asset drops connections. Building
+    # that stage alone parks its layer in the Actions cache so the real
+    # build restores it instead of refetching. Scoped by platform because
+    # the stage never reads the variant. ~78MB per scope; exporting the
+    # builder stages too would be ~1.3GB per leg and would not fit the
+    # repository's shared 10GB budget.
+    - name: Warm the WASM layer cache
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      with:
+        platforms: ${{ inputs.platform }}
+        context: .
+        file: ./Dockerfile
+        target: wasm-runtime
+        provenance: false
+        sbom: false
+        outputs: type=cacheonly
+        cache-from: type=gha,scope=wasm-${{ steps.resolve.outputs.platform-slug }}
+        # ignore-error: the three variant legs on a platform share a scope and
+        # export concurrently. A rejected export must not fail the step — the
+        # layer is already in the local builder cache, which is what the build
+        # below consumes; the export only serves the next run.
+        cache-to: type=gha,scope=wasm-${{ steps.resolve.outputs.platform-slug }},mode=max,ignore-error=true
+
     - name: Build and push by digest
       id: build
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -71,6 +96,8 @@ runs:
           BASE_IMAGE=${{ steps.resolve.outputs.base-image }}
         outputs: >-
           type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+        # Read-only: restores the layer warmed above, exports nothing.
+        cache-from: type=gha,scope=wasm-${{ steps.resolve.outputs.platform-slug }}
 
     - name: Export digest
       shell: bash

--- a/.github/actions/docker-build-image/action.yml
+++ b/.github/actions/docker-build-image/action.yml
@@ -1,0 +1,89 @@
+name: Build Phoenix image for one platform
+description: >-
+  Build a single-platform Phoenix image, push it to Docker Hub by digest, and
+  upload that digest as an artifact. A downstream job collects the digests for
+  every platform of a variant and assembles them into one manifest list, so
+  each platform builds on a native runner instead of under QEMU emulation.
+
+inputs:
+  variant:
+    description: Image variant — root, nonroot, or debug. Selects the distroless base image.
+    required: true
+  platform:
+    description: Target platform in Docker form, e.g. linux/amd64.
+    required: true
+  registry:
+    description: Docker Hub namespace.
+    required: true
+  image-name:
+    description: Repository name within the namespace.
+    required: true
+  dockerhub-username:
+    required: true
+  dockerhub-password:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve base image and artifact suffix
+      id: resolve
+      shell: bash
+      env:
+        VARIANT: ${{ inputs.variant }}
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        case "$VARIANT" in
+          root)    base=gcr.io/distroless/python3-debian13 ;;
+          nonroot) base=gcr.io/distroless/python3-debian13:nonroot ;;
+          debug)   base=gcr.io/distroless/python3-debian13:debug ;;
+          *) echo "unknown variant: $VARIANT" >&2; exit 1 ;;
+        esac
+        echo "base-image=$base" >> "$GITHUB_OUTPUT"
+        echo "platform-slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-password }}
+
+    - name: Extract image labels
+      id: meta
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image-name }}
+
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      with:
+        platforms: ${{ inputs.platform }}
+        context: .
+        file: ./Dockerfile
+        sbom: true
+        provenance: mode=max
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          BASE_IMAGE=${{ steps.resolve.outputs.base-image }}
+        outputs: >-
+          type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digest
+      shell: bash
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        mkdir -p "${RUNNER_TEMP}/digests"
+        touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: digests-${{ inputs.variant }}-${{ steps.resolve.outputs.platform-slug }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/docker-build-image/action.yml
+++ b/.github/actions/docker-build-image/action.yml
@@ -1,13 +1,16 @@
-name: Build Phoenix image for one platform
+name: Build every Phoenix variant for one platform
 description: >-
-  Build a single-platform Phoenix image, push it to Docker Hub by digest, and
-  upload that digest as an artifact. A downstream job collects the digests for
-  every platform of a variant and assembles them into one manifest list, so
-  each platform builds on a native runner instead of under QEMU emulation.
+  Build each requested variant for a single platform on one runner, push each
+  by digest, and upload the digests as one artifact. The variants differ only
+  in the final FROM, so the frontend, backend and WASM stages are built once
+  and reused from the local builder — running them as separate jobs would
+  repeat that work on a cold builder every time. A downstream job collects the
+  digests for every platform of a variant and assembles them into one manifest
+  list, so each platform builds natively instead of under QEMU.
 
 inputs:
-  variant:
-    description: Image variant — root, nonroot, or debug. Selects the distroless base image.
+  variants:
+    description: Space-separated variants to build — any of root, nonroot, debug.
     required: true
   platform:
     description: Target platform in Docker form, e.g. linux/amd64.
@@ -19,28 +22,30 @@ inputs:
     description: Repository name within the namespace.
     required: true
   dockerhub-username:
+    description: Docker Hub user to push as.
     required: true
   dockerhub-password:
+    description: Docker Hub access token for that user.
     required: true
 
 runs:
   using: composite
   steps:
-    - name: Resolve base image and artifact suffix
+    - name: Resolve platform slug
       id: resolve
       shell: bash
       env:
-        VARIANT: ${{ inputs.variant }}
         PLATFORM: ${{ inputs.platform }}
+        VARIANTS: ${{ inputs.variants }}
       run: |
         set -euo pipefail
-        case "$VARIANT" in
-          root)    base=gcr.io/distroless/python3-debian13 ;;
-          nonroot) base=gcr.io/distroless/python3-debian13:nonroot ;;
-          debug)   base=gcr.io/distroless/python3-debian13:debug ;;
-          *) echo "unknown variant: $VARIANT" >&2; exit 1 ;;
-        esac
-        echo "base-image=$base" >> "$GITHUB_OUTPUT"
+        [ -n "${VARIANTS// /}" ] || { echo "no variants requested" >&2; exit 1; }
+        for variant in $VARIANTS; do
+          case "$variant" in
+            root|nonroot|debug) ;;
+            *) echo "unknown variant: $variant" >&2; exit 1 ;;
+          esac
+        done
         echo "platform-slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
@@ -60,11 +65,15 @@ runs:
 
     # The WASM fetch is the only download here with no registry-protocol
     # retry beneath it, and the release asset drops connections. Building
-    # that stage alone parks its layer in the Actions cache so the real
-    # build restores it instead of refetching. Scoped by platform because
-    # the stage never reads the variant. ~78MB per scope; exporting the
-    # builder stages too would be ~1.3GB per leg and would not fit the
-    # repository's shared 10GB budget.
+    # that stage alone parks its layer in the Actions cache so the builds
+    # below restore it instead of refetching. Scoped by platform because the
+    # stage never reads the variant. ~78MB per scope; exporting the builder
+    # stages too would be ~1.3GB per leg and would not fit the repository's
+    # shared 10GB budget.
+    #
+    # This is the only step that touches the Actions cache. Once it runs, the
+    # layer is in the local builder, which is what the variant builds below
+    # consume — they need no cache-from of their own.
     - name: Warm the WASM layer cache
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
@@ -76,41 +85,88 @@ runs:
         sbom: false
         outputs: type=cacheonly
         cache-from: type=gha,scope=wasm-${{ steps.resolve.outputs.platform-slug }}
-        # ignore-error: the three variant legs on a platform share a scope and
-        # export concurrently. A rejected export must not fail the step — the
-        # layer is already in the local builder cache, which is what the build
-        # below consumes; the export only serves the next run.
+        # ignore-error: a cache export must never fail a publish. The layer is
+        # already local by then; the export only serves the next run.
         cache-to: type=gha,scope=wasm-${{ steps.resolve.outputs.platform-slug }},mode=max,ignore-error=true
 
-    - name: Build and push by digest
+    # Sequential on purpose: the first variant builds the frontend, backend and
+    # WASM stages, and the rest reuse them from the local builder, leaving only
+    # the final FROM and its COPYs. Never exits non-zero — a variant that fails
+    # must not withhold the digests of the ones that succeeded, so failures are
+    # recorded and reported after the upload.
+    - name: Build and push each variant by digest
       id: build
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-      with:
-        platforms: ${{ inputs.platform }}
-        context: .
-        file: ./Dockerfile
-        sbom: true
-        provenance: mode=max
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          BASE_IMAGE=${{ steps.resolve.outputs.base-image }}
-        outputs: >-
-          type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
-        # Read-only: restores the layer warmed above, exports nothing.
-        cache-from: type=gha,scope=wasm-${{ steps.resolve.outputs.platform-slug }}
-
-    - name: Export digest
       shell: bash
       env:
-        DIGEST: ${{ steps.build.outputs.digest }}
+        VARIANTS: ${{ inputs.variants }}
+        PLATFORM: ${{ inputs.platform }}
+        IMAGE: ${{ inputs.registry }}/${{ inputs.image-name }}
+        LABELS: ${{ steps.meta.outputs.labels }}
       run: |
-        mkdir -p "${RUNNER_TEMP}/digests"
-        touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+        set -uo pipefail
 
-    - name: Upload digest
+        label_args=()
+        while IFS= read -r label; do
+          [ -n "$label" ] && label_args+=(--label "$label")
+        done <<< "$LABELS"
+
+        out="${RUNNER_TEMP}/digests"
+        failed=""
+        for variant in $VARIANTS; do
+          case "$variant" in
+            root)    base=gcr.io/distroless/python3-debian13 ;;
+            nonroot) base=gcr.io/distroless/python3-debian13:nonroot ;;
+            debug)   base=gcr.io/distroless/python3-debian13:debug ;;
+          esac
+
+          echo "::group::build ${variant} (${PLATFORM})"
+          meta="${RUNNER_TEMP}/metadata-${variant}.json"
+          if docker buildx build \
+               --platform "$PLATFORM" \
+               --file ./Dockerfile \
+               --build-arg "BASE_IMAGE=${base}" \
+               --provenance mode=max \
+               --sbom true \
+               "${label_args[@]}" \
+               --metadata-file "$meta" \
+               --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+               .
+          then
+            digest=$(jq -r '."containerimage.digest"' "$meta")
+            if [ -z "$digest" ] || [ "$digest" = null ]; then
+              echo "::error::${variant}: build reported success but no digest"
+              failed="${failed} ${variant}"
+            else
+              mkdir -p "${out}/${variant}"
+              touch "${out}/${variant}/${digest#sha256:}"
+              echo "${variant}: ${digest}"
+            fi
+          else
+            echo "::error::${variant}: build failed on ${PLATFORM}"
+            failed="${failed} ${variant}"
+          fi
+          echo "::endgroup::"
+        done
+
+        echo "failed=${failed# }" >> "$GITHUB_OUTPUT"
+
+    - name: Upload digests
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: digests-${{ inputs.variant }}-${{ steps.resolve.outputs.platform-slug }}
+        name: digests-${{ steps.resolve.outputs.platform-slug }}
         path: ${{ runner.temp }}/digests/*
-        if-no-files-found: error
+        # warn, not error: every variant failing is reported by the next step,
+        # which is where that failure belongs.
+        if-no-files-found: warn
         retention-days: 1
+
+    - name: Report failed variants
+      shell: bash
+      env:
+        FAILED: ${{ steps.build.outputs.failed }}
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        set -euo pipefail
+        [ -z "$FAILED" ] && exit 0
+        echo "::error::failed on ${PLATFORM}:${FAILED// /, }"
+        exit 1

--- a/.github/actions/docker-merge-manifest/action.yml
+++ b/.github/actions/docker-merge-manifest/action.yml
@@ -1,0 +1,105 @@
+name: Merge per-platform digests into one manifest list
+description: >-
+  Collect the digests pushed by every platform build of a variant and assemble
+  them into a single multi-platform manifest list under the given tags. Fails
+  if any expected digest is missing, so a half-built manifest is never tagged.
+
+inputs:
+  variant:
+    description: Image variant whose digests to collect — must match the build job.
+    required: true
+  registry:
+    description: Docker Hub namespace.
+    required: true
+  image-name:
+    description: Repository name within the namespace.
+    required: true
+  tags:
+    description: Newline-separated list of fully qualified tags to apply.
+    required: true
+  expected-digests:
+    description: Number of platform digests required before tagging.
+    required: true
+  dockerhub-username:
+    required: true
+  dockerhub-password:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        pattern: digests-${{ inputs.variant }}-*
+        merge-multiple: true
+        path: ${{ runner.temp }}/digests
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-password }}
+
+    - name: Create manifest list and push
+      id: create
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.registry }}/${{ inputs.image-name }}
+        TAGS: ${{ inputs.tags }}
+        EXPECTED_DIGESTS: ${{ inputs.expected-digests }}
+      run: |
+        set -euo pipefail
+        cd "${RUNNER_TEMP}/digests"
+
+        sources=()
+        for digest in *; do
+          [ -e "$digest" ] || continue
+          sources+=("${IMAGE}@sha256:${digest}")
+        done
+        if [ "${#sources[@]}" -ne "$EXPECTED_DIGESTS" ]; then
+          echo "expected $EXPECTED_DIGESTS platform digests, found ${#sources[@]}" >&2
+          exit 1
+        fi
+
+        tag_args=()
+        while IFS= read -r tag; do
+          [ -n "$tag" ] || continue
+          tag_args+=(--tag "$tag")
+          first_tag="${first_tag:-$tag}"
+        done <<< "$TAGS"
+        if [ "${#tag_args[@]}" -eq 0 ]; then
+          echo "no tags supplied" >&2
+          exit 1
+        fi
+
+        docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+        echo "first-tag=${first_tag}" >> "$GITHUB_OUTPUT"
+
+    # The push already happened, so this is a tripwire rather than a gate: it
+    # turns a silently single-architecture tag into a red build.
+    - name: Verify published platforms
+      shell: bash
+      env:
+        FIRST_TAG: ${{ steps.create.outputs.first-tag }}
+        EXPECTED_DIGESTS: ${{ inputs.expected-digests }}
+      run: |
+        set -euo pipefail
+        docker buildx imagetools inspect "$FIRST_TAG"
+
+        # Attestation manifests carry platform unknown/unknown; only real
+        # architectures count. `// []` keeps a plain manifest (no index at
+        # all) on the reported-as-0 path instead of erroring out of jq.
+        raw=$(docker buildx imagetools inspect --raw "$FIRST_TAG")
+        real='[.manifests // [] | .[] | select(.platform.os != null and .platform.os != "unknown")]'
+        platforms=$(jq -r "${real} | map(\"\(.platform.os)/\(.platform.architecture)\") | sort | join(\",\")" <<< "$raw")
+        found=$(jq "${real} | length" <<< "$raw")
+
+        echo "published platforms: ${platforms:-<none>}"
+        if [ "$found" -ne "$EXPECTED_DIGESTS" ]; then
+          echo "expected $EXPECTED_DIGESTS platforms in $FIRST_TAG, found $found" >&2
+          exit 1
+        fi

--- a/.github/actions/docker-merge-manifest/action.yml
+++ b/.github/actions/docker-merge-manifest/action.yml
@@ -28,10 +28,12 @@ inputs:
 runs:
   using: composite
   steps:
+    # One artifact per platform, each holding a directory per variant it built.
+    # Merged, they form <variant>/<digest> across every platform.
     - name: Download digests
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
-        pattern: digests-${{ inputs.variant }}-*
+        pattern: digests-*
         merge-multiple: true
         path: ${{ runner.temp }}/digests
 
@@ -51,14 +53,18 @@ runs:
         IMAGE: ${{ inputs.registry }}/${{ inputs.image-name }}
         TAGS: ${{ inputs.tags }}
         EXPECTED_DIGESTS: ${{ inputs.expected-digests }}
+        VARIANT: ${{ inputs.variant }}
       run: |
         set -euo pipefail
+        # nullglob so a variant that failed on every platform — and therefore
+        # has no directory at all — reports found 0 rather than erroring out.
+        shopt -s nullglob
         cd "${RUNNER_TEMP}/digests"
 
         sources=()
-        for digest in *; do
-          [ -e "$digest" ] || continue
-          sources+=("${IMAGE}@sha256:${digest}")
+        for digest in "${VARIANT}"/*; do
+          [ -f "$digest" ] || continue
+          sources+=("${IMAGE}@sha256:$(basename "$digest")")
         done
         if [ "${#sources[@]}" -ne "$EXPECTED_DIGESTS" ]; then
           echo "expected $EXPECTED_DIGESTS platform digests, found ${#sources[@]}" >&2

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -14,17 +14,19 @@ concurrency:
 
 jobs:
   build:
-    name: Build ${{ matrix.variant }} (${{ matrix.platform }})
+    name: Build ${{ matrix.platform }}
     # linux/arm64 builds on a native ARM runner rather than under QEMU
     # emulation on x86, which is both far slower and a source of flakes.
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
-      # Each leg pushes by digest and nothing is tagged until the merge job, so
-      # a failed leg cannot publish a partial image. Letting the others finish
-      # means a rerun has fewer legs left to redo.
+      # One job per platform, not per variant/platform pair: the variants share
+      # every stage but the final FROM, so building them together reuses the
+      # frontend, backend and WASM stages from the local builder instead of
+      # repeating them on a cold one. Each pushes by digest and nothing is
+      # tagged until the merge job, so a failed build cannot publish a partial
+      # image; letting the other platform finish means a rerun has less to redo.
       fail-fast: false
       matrix:
-        variant: [debug]
         platform: [linux/amd64, linux/arm64]
     env:
       REGISTRY: arizephoenix
@@ -35,10 +37,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build and push by digest
+      - name: Build and push every variant by digest
         uses: ./.github/actions/docker-build-image
         with:
-          variant: ${{ matrix.variant }}
+          variants: debug
           platform: ${{ matrix.platform }}
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -48,6 +48,11 @@ jobs:
   merge:
     name: Publish ${{ matrix.variant }} manifest
     needs: build
+    # A matrix job reports failure if any cell fails, so plain `needs` would let
+    # one variant's failed leg withhold every other variant — including ones
+    # whose digests are already on Docker Hub. Publish per variant instead and
+    # let the digest count refuse the variant that is actually incomplete.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -6,16 +6,26 @@ on:
     branches:
       - version-sandboxes
 
+# One push supersedes the previous one on the same branch: the older run is
+# only racing to publish a tag that the newer run will overwrite.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  push_to_registry:
-    name: Push experimental Docker image to Docker Hub
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.variant }} (${{ matrix.platform }})
+    # linux/arm64 builds on a native ARM runner rather than under QEMU
+    # emulation on x86, which is both far slower and a source of flakes.
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
+      # Each leg pushes by digest and nothing is tagged until the merge job, so
+      # a failed leg cannot publish a partial image. Letting the others finish
+      # means a rerun has fewer legs left to redo.
+      fail-fast: false
       matrix:
         variant: [debug]
-    permissions:
-      packages: write
-      contents: read
+        platform: [linux/amd64, linux/arm64]
     env:
       REGISTRY: arizephoenix
       IMAGE_NAME: phoenix
@@ -25,57 +35,62 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set BASE_IMAGE environment variable
-        id: set-base-image
-        run: |
-          if [ "${{ matrix.variant }}" == "root" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13" >> $GITHUB_ENV
-          elif [ "${{ matrix.variant }}" == "debug" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13:debug" >> $GITHUB_ENV
-          elif [ "${{ matrix.variant }}" == "nonroot" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13:nonroot" >> $GITHUB_ENV
-          else
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13" >> $GITHUB_ENV
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      - name: Build and push by digest
+        uses: ./.github/actions/docker-build-image
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          variant: ${{ matrix.variant }}
+          platform: ${{ matrix.platform }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Extract commit hash
-        id: extract_commit
-        run: echo "COMMIT_HASH=${GITHUB_SHA::7}" >> $GITHUB_ENV
+  merge:
+    name: Publish ${{ matrix.variant }} manifest
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [debug]
+    env:
+      REGISTRY: arizephoenix
+      IMAGE_NAME: phoenix
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Compute tag suffix and commit hash
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          if [ "$VARIANT" = "root" ]; then
+            echo "TAG_SUFFIX=" >> "$GITHUB_ENV"
+          else
+            echo "TAG_SUFFIX=-${VARIANT}" >> "$GITHUB_ENV"
+          fi
+          echo "COMMIT_HASH=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Compute tags
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
           tags: |
-            ${{ matrix.variant == 'root' && 'dangerously-experimental' || '' }}
-            ${{ matrix.variant == 'nonroot' && 'dangerously-experimental' || '' }}
-            ${{ matrix.variant == 'debug' && 'dangerously-experimental' || '' }}
+            type=raw,value=dangerously-experimental${{ env.TAG_SUFFIX }}
+            type=raw,value=dangerously-experimental-commit-${{ env.COMMIT_HASH }},enable=${{ matrix.variant == 'root' }}
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      - name: Merge platform digests and push tags
+        uses: ./.github/actions/docker-merge-manifest
         with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: ./Dockerfile
-          push: true
-          sbom: true
-          provenance: mode=max
-          tags: |
-            ${{ matrix.variant == 'root' && format('{0}/{1}:dangerously-experimental', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:dangerously-experimental-commit-{2}', env.REGISTRY, env.IMAGE_NAME, env.COMMIT_HASH) || '' }}
-            ${{ matrix.variant == 'nonroot' && format('{0}/{1}:dangerously-experimental-nonroot', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'debug' && format('{0}/{1}:dangerously-experimental-debug', env.REGISTRY, env.IMAGE_NAME) || '' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=${{ env.BASE_IMAGE }}
+          variant: ${{ matrix.variant }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          expected-digests: 2
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -69,18 +69,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Compute tag suffix and commit hash
-        env:
-          VARIANT: ${{ matrix.variant }}
-        run: |
-          set -euo pipefail
-          if [ "$VARIANT" = "root" ]; then
-            echo "TAG_SUFFIX=" >> "$GITHUB_ENV"
-          else
-            echo "TAG_SUFFIX=-${VARIANT}" >> "$GITHUB_ENV"
-          fi
-          echo "COMMIT_HASH=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-
+      # This workflow's matrix is debug only, so the suffix is unconditional and
+      # the commit tag the other two workflows carry — gated on the root variant
+      # — could never fire here.
       - name: Compute tags
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -88,8 +79,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false
           tags: |
-            type=raw,value=dangerously-experimental${{ env.TAG_SUFFIX }}
-            type=raw,value=dangerously-experimental-commit-${{ env.COMMIT_HASH }},enable=${{ matrix.variant == 'root' }}
+            type=raw,value=dangerously-experimental-${{ matrix.variant }}
 
       - name: Merge platform digests and push tags
         uses: ./.github/actions/docker-merge-manifest

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -15,17 +15,19 @@ concurrency:
 
 jobs:
   build:
-    name: Build ${{ matrix.variant }} (${{ matrix.platform }})
+    name: Build ${{ matrix.platform }}
     # linux/arm64 builds on a native ARM runner rather than under QEMU
     # emulation on x86, which is both far slower and a source of flakes.
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
-      # Each leg pushes by digest and nothing is tagged until the merge job, so
-      # a failed leg cannot publish a partial image. Letting the others finish
-      # means a rerun has fewer legs left to redo.
+      # One job per platform, not per variant/platform pair: the variants share
+      # every stage but the final FROM, so building them together reuses the
+      # frontend, backend and WASM stages from the local builder instead of
+      # repeating them on a cold one. Each pushes by digest and nothing is
+      # tagged until the merge job, so a failed build cannot publish a partial
+      # image; letting the other platform finish means a rerun has less to redo.
       fail-fast: false
       matrix:
-        variant: [root, nonroot, debug]
         platform: [linux/amd64, linux/arm64]
     env:
       REGISTRY: arizephoenix
@@ -36,10 +38,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build and push by digest
+      - name: Build and push every variant by digest
         uses: ./.github/actions/docker-build-image
         with:
-          variant: ${{ matrix.variant }}
+          variants: root nonroot debug
           platform: ${{ matrix.platform }}
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -49,6 +49,11 @@ jobs:
   merge:
     name: Publish ${{ matrix.variant }} manifest
     needs: build
+    # A matrix job reports failure if any cell fails, so plain `needs` would let
+    # one variant's failed leg withhold every other variant — including ones
+    # whose digests are already on Docker Hub. Publish per variant instead and
+    # let the digest count refuse the variant that is actually incomplete.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-build-nightly.yml
+++ b/.github/workflows/docker-build-nightly.yml
@@ -7,16 +7,26 @@ on:
       - main
       - version-*
 
+# One push supersedes the previous one on the same branch: the older run is
+# only racing to publish a `nightly` tag that the newer run will overwrite.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  push_to_registry:
-    name: Push nightly Docker image to Docker Hub
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.variant }} (${{ matrix.platform }})
+    # linux/arm64 builds on a native ARM runner rather than under QEMU
+    # emulation on x86, which is both far slower and a source of flakes.
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
+      # Each leg pushes by digest and nothing is tagged until the merge job, so
+      # a failed leg cannot publish a partial image. Letting the others finish
+      # means a rerun has fewer legs left to redo.
+      fail-fast: false
       matrix:
         variant: [root, nonroot, debug]
-    permissions:
-      packages: write
-      contents: read
+        platform: [linux/amd64, linux/arm64]
     env:
       REGISTRY: arizephoenix
       IMAGE_NAME: phoenix
@@ -26,65 +36,70 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set BASE_IMAGE environment variable
-        id: set-base-image
-        run: |
-          if [ "${{ matrix.variant }}" == "root" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13" >> $GITHUB_ENV
-          elif [ "${{ matrix.variant }}" == "debug" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13:debug" >> $GITHUB_ENV
-          elif [ "${{ matrix.variant }}" == "nonroot" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13:nonroot" >> $GITHUB_ENV
-          else
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13" >> $GITHUB_ENV
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      - name: Build and push by digest
+        uses: ./.github/actions/docker-build-image
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          variant: ${{ matrix.variant }}
+          platform: ${{ matrix.platform }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Extract commit hash
-        id: extract_commit
-        run: echo "COMMIT_HASH=${GITHUB_SHA::7}" >> $GITHUB_ENV
+  merge:
+    name: Publish ${{ matrix.variant }} manifest
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [root, nonroot, debug]
+    env:
+      REGISTRY: arizephoenix
+      IMAGE_NAME: phoenix
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Compute tag suffix and commit hash
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          if [ "$VARIANT" = "root" ]; then
+            echo "TAG_SUFFIX=" >> "$GITHUB_ENV"
+          else
+            echo "TAG_SUFFIX=-${VARIANT}" >> "$GITHUB_ENV"
+          fi
+          echo "COMMIT_HASH=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Compute tags
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
           tags: |
-            ${{ matrix.variant == 'root' && 'nightly' || '' }}
-            ${{ matrix.variant == 'nonroot' && 'nightly-nonroot' || '' }}
-            ${{ matrix.variant == 'debug' && 'nightly-debug' || '' }}
+            type=raw,value=nightly${{ env.TAG_SUFFIX }}
+            type=raw,value=commit-${{ env.COMMIT_HASH }},enable=${{ matrix.variant == 'root' }}
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      - name: Merge platform digests and push tags
+        uses: ./.github/actions/docker-merge-manifest
         with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: ./Dockerfile
-          push: true
-          sbom: true
-          provenance: mode=max
-          tags: |
-            ${{ matrix.variant == 'root' && format('{0}/{1}:nightly', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:commit-{2}', env.REGISTRY, env.IMAGE_NAME, env.COMMIT_HASH) || '' }}
-            ${{ matrix.variant == 'nonroot' && format('{0}/{1}:nightly-nonroot', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'debug' && format('{0}/{1}:nightly-debug', env.REGISTRY, env.IMAGE_NAME) || '' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=${{ env.BASE_IMAGE }}
+          variant: ${{ matrix.variant }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          expected-digests: 2
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   slack:
     name: Slack notification
-    needs: [push_to_registry]
-    if: always() && needs.push_to_registry.result == 'failure'
+    needs: [build, merge]
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Send message to Slack

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -7,17 +7,39 @@ on:
       - "arize-phoenix-v*"
 
 jobs:
-  push_to_registry:
-    name: Push Docker images to Docker Hub
+  version:
+    name: Extract version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.extract_version.outputs.VERSION }}
+      version: ${{ steps.extract.outputs.version }}
+      major: ${{ steps.extract.outputs.major }}
+      minor: ${{ steps.extract.outputs.minor }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF#refs/tags/arize-phoenix-v}"
+          rest="${version#*.}"
+          {
+            echo "version=${version}"
+            echo "major=${version%%.*}"
+            echo "minor=${rest%%.*}"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.variant }} (${{ matrix.platform }})
+    # linux/arm64 builds on a native ARM runner rather than under QEMU
+    # emulation on x86, which is both far slower and a source of flakes.
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
+      # Each leg pushes by digest and nothing is tagged until the merge job, so
+      # a failed leg cannot publish a partial image. Letting the others finish
+      # means a rerun has fewer legs left to redo.
+      fail-fast: false
       matrix:
         variant: [root, nonroot, debug]
-    permissions:
-      packages: write
-      contents: read
+        platform: [linux/amd64, linux/arm64]
     env:
       REGISTRY: arizephoenix
       IMAGE_NAME: phoenix
@@ -27,78 +49,80 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Extract version from tag
-        id: extract_version
-        run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/arize-phoenix-v}" >> $GITHUB_ENV
-          echo "VERSION=${GITHUB_REF#refs/tags/arize-phoenix-v}" >> $GITHUB_OUTPUT
-          echo "MAJOR_VERSION=$(echo ${GITHUB_REF#refs/tags/arize-phoenix-v} | cut -d. -f1)" >> $GITHUB_ENV
-          echo "MINOR_VERSION=$(echo ${GITHUB_REF#refs/tags/arize-phoenix-v} | cut -d. -f2)" >> $GITHUB_ENV
+      - name: Build and push by digest
+        uses: ./.github/actions/docker-build-image
+        with:
+          variant: ${{ matrix.variant }}
+          platform: ${{ matrix.platform }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Set BASE_IMAGE environment variable
-        id: set-base-image
+  merge:
+    name: Publish ${{ matrix.variant }} manifest
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [root, nonroot, debug]
+    env:
+      REGISTRY: arizephoenix
+      IMAGE_NAME: phoenix
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Applied to every tag below. root publishes unsuffixed names, so a
+      # suffix bug would silently point `latest` at the wrong variant — hence
+      # an explicit value per tag rather than the metadata-action flavor.
+      - name: Compute tag suffix
+        env:
+          VARIANT: ${{ matrix.variant }}
         run: |
-          if [ "${{ matrix.variant }}" == "root" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13" >> $GITHUB_ENV
-          elif [ "${{ matrix.variant }}" == "debug" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13:debug" >> $GITHUB_ENV
-          elif [ "${{ matrix.variant }}" == "nonroot" ]; then
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13:nonroot" >> $GITHUB_ENV
+          set -euo pipefail
+          if [ "$VARIANT" = "root" ]; then
+            echo "TAG_SUFFIX=" >> "$GITHUB_ENV"
           else
-            echo "BASE_IMAGE=gcr.io/distroless/python3-debian13" >> $GITHUB_ENV
+            echo "TAG_SUFFIX=-${VARIANT}" >> "$GITHUB_ENV"
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Compute tags
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # latest=false because every `latest` variant is listed explicitly
+          # below; left on auto it would also add an unsuffixed `latest` to
+          # nonroot and debug.
+          flavor: latest=false
           tags: |
-            version-${{ env.VERSION }}-${{ matrix.variant }}
-            ${{ matrix.variant == 'root' && 'version-${{ env.VERSION }} latest' || '' }}
+            type=raw,value=latest${{ env.TAG_SUFFIX }}
+            type=raw,value=${{ needs.version.outputs.version }}${{ env.TAG_SUFFIX }}
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}${{ env.TAG_SUFFIX }}
+            type=raw,value=${{ needs.version.outputs.major }}${{ env.TAG_SUFFIX }}
+            type=raw,value=version-${{ needs.version.outputs.version }}${{ env.TAG_SUFFIX }}
+            type=raw,value=version-${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}${{ env.TAG_SUFFIX }}
+            type=raw,value=version-${{ needs.version.outputs.major }}${{ env.TAG_SUFFIX }}
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      - name: Merge platform digests and push tags
+        uses: ./.github/actions/docker-merge-manifest
         with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: ./Dockerfile
-          push: true
-          sbom: true
-          provenance: mode=max
-          tags: |
-            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}.{3}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, env.MINOR_VERSION) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, env.VERSION) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:{2}.{3}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, env.MINOR_VERSION) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, env.VERSION) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}.{3}-{4}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, env.MINOR_VERSION, matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.VERSION, matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:latest-{2}', env.REGISTRY, env.IMAGE_NAME, matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:{2}.{3}-{4}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, env.MINOR_VERSION, matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.VERSION, matrix.variant) || '' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=${{ env.BASE_IMAGE }}
+          variant: ${{ matrix.variant }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          expected-digests: 2
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   update-self-deployment:
     name: Update Kustomize Template
     runs-on: ubuntu-latest
-    needs: push_to_registry
+    needs: [version, merge]
     permissions:
       contents: write
       pull-requests: write
@@ -112,11 +136,11 @@ jobs:
           python-version: "3.14"
       - name: Update Kustomize image version
         env:
-          PHOENIX_VERSION: ${{ needs.push_to_registry.outputs.version }}
+          PHOENIX_VERSION: ${{ needs.version.outputs.version }}
         run: python scripts/update_kustomize.py "$PHOENIX_VERSION"
       - name: Update Helm chart version
         env:
-          PHOENIX_VERSION: ${{ needs.push_to_registry.outputs.version }}
+          PHOENIX_VERSION: ${{ needs.version.outputs.version }}
         run: python scripts/update_helm.py "$PHOENIX_VERSION"
       - name: Setup helm-docs
         uses: gabe565/setup-helm-docs-action@d5c35bdc9133cfbea3b671acadf50a29029e87c2 # v1.0.4
@@ -126,19 +150,19 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          commit-message: "chore: update phoenix version to ${{ needs.push_to_registry.outputs.version }} in kustomize and helm"
-          title: "chore: update phoenix version to ${{ needs.push_to_registry.outputs.version }} in kustomize and helm"
+          commit-message: "chore: update phoenix version to ${{ needs.version.outputs.version }} in kustomize and helm"
+          title: "chore: update phoenix version to ${{ needs.version.outputs.version }} in kustomize and helm"
           body: |
-            This PR updates the phoenix version in the kustomize template to version ${{ needs.push_to_registry.outputs.version }}.
+            This PR updates the phoenix version in the kustomize template to version ${{ needs.version.outputs.version }}.
 
             This change was automatically generated by the docker-build-release workflow.
-          branch: update-phoenix-version-${{ needs.push_to_registry.outputs.version }}
+          branch: update-phoenix-version-${{ needs.version.outputs.version }}
           base: main
 
   slack:
     name: Slack notification
-    needs: [push_to_registry, update-self-deployment]
-    if: always() && (needs.push_to_registry.result == 'failure' || needs.update-self-deployment.result == 'failure')
+    needs: [version, build, merge, update-self-deployment]
+    if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Send message to Slack

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -28,17 +28,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: Build ${{ matrix.variant }} (${{ matrix.platform }})
+    name: Build ${{ matrix.platform }}
     # linux/arm64 builds on a native ARM runner rather than under QEMU
     # emulation on x86, which is both far slower and a source of flakes.
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
-      # Each leg pushes by digest and nothing is tagged until the merge job, so
-      # a failed leg cannot publish a partial image. Letting the others finish
-      # means a rerun has fewer legs left to redo.
+      # One job per platform, not per variant/platform pair: the variants share
+      # every stage but the final FROM, so building them together reuses the
+      # frontend, backend and WASM stages from the local builder instead of
+      # repeating them on a cold one. Each pushes by digest and nothing is
+      # tagged until the merge job, so a failed build cannot publish a partial
+      # image; letting the other platform finish means a rerun has less to redo.
       fail-fast: false
       matrix:
-        variant: [root, nonroot, debug]
         platform: [linux/amd64, linux/arm64]
     env:
       REGISTRY: arizephoenix
@@ -49,10 +51,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build and push by digest
+      - name: Build and push every variant by digest
         uses: ./.github/actions/docker-build-image
         with:
-          variant: ${{ matrix.variant }}
+          variants: root nonroot debug
           platform: ${{ matrix.platform }}
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -62,6 +62,12 @@ jobs:
   merge:
     name: Publish ${{ matrix.variant }} manifest
     needs: [version, build]
+    # A matrix job reports failure if any cell fails, so plain `needs` would let
+    # one variant's failed leg withhold every other variant — including ones
+    # whose digests are already on Docker Hub. Publish per variant instead and
+    # let the digest count refuse the variant that is actually incomplete. The
+    # version job is a real prerequisite: without it the tags are empty.
+    if: ${{ !cancelled() && needs.version.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,14 +71,32 @@ RUN uv pip install dist/*.whl --no-deps
 # executes user code in the sandbox. Uses python (already present in
 # the uv builder image) instead of curl/wget so we don't add an apt-get
 # install layer.
+#
+# Retried with backoff: GitHub intermittently closes the connection to this
+# asset without sending a response, on the native amd64 leg as well as the
+# QEMU-emulated arm64 one. socket.setdefaulttimeout stands in for the
+# timeout argument urlretrieve does not take, and mirrors
+# _WASM_DOWNLOAD_TIMEOUT_SECONDS in _download.py. Verification runs inside
+# the loop and is the only proof of a complete transfer — urlretrieve
+# reports success on a clean close when no Content-Length was received — so
+# the loop breaks only on a digest match and no unverified file survives an
+# attempt.
 RUN mkdir -p /wasm \
-  && python -c "import hashlib, sys, urllib.request; \
-url = 'https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6/python-3.12.0.wasm'; \
+  && for delay in 5 10 20 40 stop; do \
+       python -c "import hashlib, os, socket, sys, urllib.request; \
+socket.setdefaulttimeout(30); \
 dest = '/wasm/python-3.12.0.wasm'; \
 expected = 'e5dc5a398b07b54ea8fdb503bf68fb583d533f10ec3f930963e02b9505f7a763'; \
-urllib.request.urlretrieve(url, dest); \
+urllib.request.urlretrieve( \
+'https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6/python-3.12.0.wasm', \
+dest); \
 actual = hashlib.sha256(open(dest, 'rb').read()).hexdigest(); \
-(actual == expected) or sys.exit(f'SHA-256 mismatch for {dest}: expected {expected}, got {actual}')"
+(actual == expected) or (os.remove(dest), \
+sys.exit(f'SHA-256 mismatch for {dest}: expected {expected}, got {actual}'))" && break; \
+       [ "$delay" = stop ] && { echo 'WASM binary fetch failed after 5 attempts' >&2; exit 1; }; \
+       echo "WASM binary fetch failed; retrying in ${delay}s" >&2; \
+       sleep "$delay"; \
+     done
 
 # Bundle the Deno runtime so the local DENO sandbox provider works inside
 # the distroless image. denoland/deno:bin-<version> is a scratch-based

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ ARG BASE_IMAGE=gcr.io/distroless/python3-debian13:nonroot
 # To deploy it on an arm64, like Raspberry Pi or Apple-Silicon, chose this image instead:
 # ARG BASE_IMAGE=gcr.io/distroless/python3-debian13:nonroot-arm64
 
+# Two stages build on this image, so it is pinned once: they must resolve to
+# the same digest or the build pulls twice. Keep the uv version equal to
+# [tool.uv] required-version in pyproject.toml.
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.12.1-python3.13-trixie-slim
+
 # This Dockerfile is a multi-stage build. The first stage builds the frontend.
 FROM node:22-slim AS frontend-builder
 ENV PNPM_HOME="/pnpm"
@@ -42,7 +47,7 @@ RUN pnpm install
 RUN pnpm --filter 'phoenix-ui...' run build
 
 # The second stage builds the backend.
-FROM ghcr.io/astral-sh/uv:0.12.1-python3.13-trixie-slim AS backend-builder
+FROM ${UV_IMAGE} AS backend-builder
 WORKDIR /phoenix
 COPY ./src /phoenix/src
 COPY ./pyproject.toml /phoenix/
@@ -60,6 +65,14 @@ RUN uv sync \
 RUN uv build
 RUN uv pip install dist/*.whl --no-deps
 
+# Bundle the Deno runtime so the local DENO sandbox provider works inside
+# the distroless image. denoland/deno:bin-<version> is a scratch-based
+# image that contains a single statically-linked /deno binary, which is
+# safe to COPY into the distroless final stage without dragging in a
+# shell or libc. Pinning the version (NOT :latest) keeps builds
+# reproducible.
+FROM denoland/deno:bin-2.1.4 AS deno-binary
+
 # Pre-download the CPython WASM binary so the WASM sandbox provider works
 # inside the distroless final image without network egress or a writable
 # home cache. The URL/filename/sha256 here MUST stay in sync with
@@ -68,19 +81,24 @@ RUN uv pip install dist/*.whl --no-deps
 # stage) is the authoritative resolver hook consumed by
 # ensure_wasm_binary(). The sha256 assertion guards against upstream
 # release-asset tampering — TLS alone is not enough for a binary that
-# executes user code in the sandbox. Uses python (already present in
-# the uv builder image) instead of curl/wget so we don't add an apt-get
-# install layer.
+# executes user code in the sandbox.
+#
+# Its own stage, and it must stay that way: nothing here depends on the
+# repo, so the layer is keyed on the URL and digest alone and survives
+# every source change. Folded back into backend-builder it would sit below
+# COPY ./src and re-download on each commit. Built on UV_IMAGE — the image
+# the backend already pulls — for its python, so no apt-get curl layer and
+# no second pull.
 #
 # Retried with backoff: GitHub intermittently closes the connection to this
-# asset without sending a response, on the native amd64 leg as well as the
-# QEMU-emulated arm64 one. socket.setdefaulttimeout stands in for the
-# timeout argument urlretrieve does not take, and mirrors
+# asset without sending a response. socket.setdefaulttimeout stands in for
+# the timeout argument urlretrieve does not take, and mirrors
 # _WASM_DOWNLOAD_TIMEOUT_SECONDS in _download.py. Verification runs inside
 # the loop and is the only proof of a complete transfer — urlretrieve
 # reports success on a clean close when no Content-Length was received — so
 # the loop breaks only on a digest match and no unverified file survives an
 # attempt.
+FROM ${UV_IMAGE} AS wasm-runtime
 RUN mkdir -p /wasm \
   && for delay in 5 10 20 40 stop; do \
        python -c "import hashlib, os, socket, sys, urllib.request; \
@@ -97,14 +115,6 @@ sys.exit(f'SHA-256 mismatch for {dest}: expected {expected}, got {actual}'))" &&
        echo "WASM binary fetch failed; retrying in ${delay}s" >&2; \
        sleep "$delay"; \
      done
-
-# Bundle the Deno runtime so the local DENO sandbox provider works inside
-# the distroless image. denoland/deno:bin-<version> is a scratch-based
-# image that contains a single statically-linked /deno binary, which is
-# safe to COPY into the distroless final stage without dragging in a
-# shell or libc. Pinning the version (NOT :latest) keeps builds
-# reproducible.
-FROM denoland/deno:bin-2.1.4 AS deno-binary
 
 # The production image is distroless, meaning that it is a minimal image that
 # contains only the necessary dependencies to run the application. This is
@@ -128,7 +138,7 @@ COPY --from=backend-builder /phoenix/.venv/ ./.venv
 # resolves to /usr/local/bin/deno because /usr/local/bin is on the
 # distroless image's default PATH (inherited via the base image's ENV).
 COPY --chmod=755 --from=deno-binary /deno /usr/local/bin/deno
-COPY --from=backend-builder /wasm/python-3.12.0.wasm /opt/phoenix/wasm/python-3.12.0.wasm
+COPY --from=wasm-runtime /wasm/python-3.12.0.wasm /opt/phoenix/wasm/python-3.12.0.wasm
 ENV PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
 # Ensure /usr/local/bin is on PATH so shutil.which("deno") in
 # deno_backend.py resolves to the bundled binary above. The base

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,7 +436,7 @@ line-ending = "native"
 script_location = "src/phoenix/db/migrations"  # enables `uv run alembic <command>`
 
 [tool.uv]
-required-version = "==0.12.1"  # When updating this version, also update the `backend-builder` image in the Dockerfile
+required-version = "==0.12.1"  # When updating this version, also update ARG UV_IMAGE in the Dockerfile
 exclude-newer = "3 days"
 # Exempt our own packages from the `exclude-newer` window so freshly published
 # versions are immediately resolvable. arize-phoenix-sqlean is not a workspace


### PR DESCRIPTION
## Why

The v20.1.0 release publish failed on the WASM binary download, and five nightly runs failed the same way the same day. GitHub intermittently closes the connection to the `vmware-labs` release asset without sending a response — on the native amd64 leg as well as the emulated arm64 one.

That failure was being hit far more often than it had to be, because the download ran on every leg of every build.

## What changed

**1. Retry and verify the fetch** (`554594760`)

Five attempts with backoff. Verification runs *inside* the loop and is the only proof of a complete transfer: `urlretrieve` reports success on a clean close when no `Content-Length` was received, so a digest match is the only evidence the file is whole. No unverified file survives an attempt.

**2. Build each platform on a native runner** (`54e948a52`)

`linux/arm64` moves from QEMU emulation on x86 to `ubuntu-24.04-arm`. Each leg pushes by digest and nothing is tagged until a `merge` job assembles the manifest list, so a failed leg can't publish a partial image. Applied to all three Docker workflows (release, nightly, experimental), with `concurrency`/`cancel-in-progress` on the two that trigger on pushes.

The build and merge logic is factored into two composite actions so the three workflows stay in step.

**3. Stop refetching the WASM binary** (`ae3bed3bc`)

The download sat below `COPY ./src`, so every commit invalidated it. Moved to its own `wasm-runtime` stage that reads nothing from the build context — the layer is now keyed on the URL and digest alone. It also builds in parallel with the frontend instead of after `uv pip install`.

Runners are ephemeral, so a cache-stable layer needs somewhere to live between runs. A pre-pass builds that one stage with `type=gha`; the real build then restores it read-only. Scoped by platform rather than variant, so six legs collapse to two scopes of ~78 MB.

## Verification

Run locally, without pushing:

| Check | Result |
|---|---|
| `wasm-runtime` builds standalone | expected sha256 |
| rebuild after `touch src/…` | `CACHED` |
| two-pass cache handoff, local cache wiped | full build restored the layer in 0.6 s, no download |
| `docker build --check` | stage graph OK (only the pre-existing `$PYTHONPATH` warning) |
| tag parity, old vs new workflows | all 7 variant×workflow cases identical; `latest` proven root-only |
| merge shell, 4 cases | half-built manifests rejected before tagging |
| published-platform check, 4 manifests | attestation-only and single-arch both fail |
| resolve step, 6 matrix cells | 2 cache scopes; unknown variant rejected |
| buildx exit codes | 0 on missing `cache-from`; 0 on failed `cache-to` with `ignore-error`, 1 without |
| actionlint | clean |

## Deliberately not done

**Caching the builder stages.** Measured at 1.3 GB per leg — 7.8 GB across six, against a 10 GB budget shared with the uv and pnpm caches. It doesn't fit, and it needs a registry. Build *speed* is a separate problem from the flake; if it's worth a Docker Hub cache repo later, that's its own PR.

**Hosting the WASM blob ourselves.** The durable fix for the flake is to take GitHub's release CDN out of the build path entirely, but it needs a publishing pipeline and a way to keep it in sync with `_download.py`.

## First run

`type=gha` needs GitHub's cache service, so scope names and token wiring can only be confirmed by a real run. The failure mode is benign: a cache miss means the download happens, which is today's behaviour, with the retry loop behind it.
