### PR TITLE
ci: prune superseded Actions caches on main

### DIFF
--- a/.github/workflows/prune-main-caches.yml
+++ b/.github/workflows/prune-main-caches.yml
@@ -1,0 +1,122 @@
+# Companion to clean_up_caches.yml, which deletes a PR's caches when the PR
+# closes and therefore only ever reaches refs/pull/*. Nothing prunes
+# refs/heads/main, where keys carry a commit SHA and run ID, so every push
+# mints a fresh entry that is never superseded — CodeQL overlay databases at
+# ~290MB apiece are the bulk of it. Left alone, main crowds the repository's
+# shared 10GB budget and GitHub evicts by LRU across every workflow.
+name: Prune stale caches on main
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # daily, 09:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report what would be deleted without deleting it.
+        type: boolean
+        default: true
+
+permissions:
+  actions: write # delete Actions caches
+
+# Two runs would list the same entries and race to delete them. The loser
+# gets 404s, which is handled, but queueing keeps the summaries honest.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune superseded caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune superseded cache entries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          KEEP: "2"
+        run: |
+          set -euo pipefail
+
+          # A scheduled run carries no inputs, so DRY_RUN is empty rather than
+          # false. Only a dispatch can ask for a rehearsal.
+          if [ "$EVENT" = "schedule" ]; then dry=false; else dry="${DRY_RUN:-true}"; fi
+          echo "event=$EVENT dry_run=$dry keep=$KEEP"
+
+          gh api "repos/${REPO}/actions/caches?per_page=100" --paginate \
+            --jq '.actions_caches[] | select(.ref == "refs/heads/main")
+                  | [.id, .size_in_bytes, .created_at, .key] | @tsv' > all.tsv
+          echo "main-ref entries: $(wc -l < all.tsv)"
+
+          # Group by the key with its trailing volatile segments removed, keep
+          # the newest $KEEP of each group, and mark the rest superseded. Only
+          # hex blobs and bare integers are stripped, so version-like segments
+          # (2.26.2, 24.04) survive and distinct variants stay in distinct
+          # groups.
+          python3 - <<'PY' > doomed.tsv
+          import collections, os, re
+
+          HEX = re.compile(r"^[0-9a-f]{7,}$", re.I)
+          NUM = re.compile(r"^\d+$")
+          KEEP = int(os.environ["KEEP"])
+
+          def group_of(key):
+              parts = key.split("-")
+              while len(parts) > 1 and (HEX.match(parts[-1]) or NUM.match(parts[-1])):
+                  parts.pop()
+              return "-".join(parts)
+
+          groups = collections.defaultdict(list)
+          with open("all.tsv") as f:
+              for line in f:
+                  cache_id, size, created, key = line.rstrip("\n").split("\t")
+                  groups[group_of(key)].append((created, int(size), cache_id, key))
+
+          rows, reclaim = [], 0
+          summary = ["| group | entries | deleting | reclaimed |", "| --- | --- | --- | --- |"]
+          for group, members in sorted(groups.items(), key=lambda kv: -sum(m[1] for m in kv[1])):
+              if len(members) <= KEEP:
+                  continue
+              members.sort(reverse=True)  # newest created_at first
+              doomed = members[KEEP:]
+              freed = sum(m[1] for m in doomed)
+              reclaim += freed
+              rows.extend(doomed)
+              summary.append(f"| `{group}` | {len(members)} | {len(doomed)} | {freed / 1e6:.0f} MB |")
+
+          for _, size, cache_id, key in rows:
+              print(f"{cache_id}\t{size}\t{key}")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as out:
+              print(f"### {len(rows)} superseded entries, {reclaim / 1e9:.2f} GB\n", file=out)
+              print("\n".join(summary) if rows else "Nothing to prune.", file=out)
+          PY
+
+          count=$(wc -l < doomed.tsv)
+          echo "superseded: $count"
+          if [ "$count" -eq 0 ] || [ "$dry" = true ]; then
+            [ "$dry" = true ] && echo "dry run — nothing deleted"
+            exit 0
+          fi
+
+          ok=0 gone=0
+          while IFS=$'\t' read -r id size key; do
+            if gh api -X DELETE "repos/${REPO}/actions/caches/${id}" --silent 2>/dev/null; then
+              ok=$((ok + 1))
+            else
+              # Expected: the repository sits over budget, so LRU evicts entries
+              # between the listing above and this delete. Already gone is the
+              # outcome we wanted.
+              gone=$((gone + 1))
+              echo "::debug::already evicted: $key"
+            fi
+          done < doomed.tsv
+
+          echo "deleted=$ok already-gone=$gone"
+          # Every single call failing is a broken token or endpoint, not eviction.
+          if [ "$ok" -eq 0 ]; then
+            echo "::error::no cache deletion succeeded across $count attempts"
+            exit 1
+          fi


### PR DESCRIPTION
## Why

The repo is over its Actions cache limit and has been for a while:

```
total cache in use: 10.67 GB across 239 entries     (limit: 10 GB)
```

GitHub responds by evicting least-recently-used entries, across every workflow — so playwright browsers, uv caches and CodeQL databases are all quietly competing and losing.

`clean_up_caches.yml` already prunes caches when a PR closes, and it works — the last five runs all succeeded. But it deletes by `-B refs/pull/<N>/merge`, so it can only ever reach PR branches. That's the smaller half:

```
  8.82 GB   94 entries   refs/heads/main    <- nothing prunes this
  1.82 GB  143 entries   refs/pull/*        <- clean_up_caches.yml handles this
  0.03 GB    2 entries   everything else
```

`main` accumulates because the keys embed a commit SHA and run ID:

```
codeql-overlay-base-database-1-91101d5ed5828f0c-javascript-2.26.2-<sha>-<run-id>-1
```

Every push to `main` mints a fresh ~290 MB database that supersedes the last one but never replaces it. There are 20 of them. And 20 more for the Python analysis.

## What this does

Groups each `refs/heads/main` key by its stable prefix, keeps the two newest, deletes the rest. Deriving the prefix strips only trailing hex blobs and bare integers, so version-like segments (`2.26.2`, `24.04`) survive and distinct variants stay in distinct groups — `setup-uv-…-macos-16-3.10.11-pruned` never merges with `…-ubuntu-24.04-…`.

Scheduled runs delete. Manual dispatch defaults to a dry run that reports to the step summary and touches nothing.

## Measured against the live cache listing

| group | entries | deleting | reclaimed |
| --- | --- | --- | --- |
| `codeql-overlay-base-database-1-…-javascript-2.26.2` | 20 | 18 | 5263 MB |
| `codeql-overlay-base-database-1-…-python-2.26.2` | 20 | 18 | 1944 MB |
| `setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-unknown-pruned` | 12 | 10 | 1 MB |
| `setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.10.20-pruned` | 11 | 9 | 1 MB |
| `setup-uv-2-aarch64-apple-darwin-macos-16-3.10.11-pruned` | 9 | 7 | 2 MB |
| `setup-uv-2-aarch64-apple-darwin-macos-16-unknown-pruned` | 9 | 7 | 1 MB |
| `setup-uv-2-x86_64-pc-windows-msvc-windows-2025-3.10.11-pruned` | 6 | 4 | 1 MB |

**73 entries, 7.21 GB.** `main` drops 8.82 GB → 1.61 GB; the repo drops 10.67 GB → 3.46 GB, back under the limit with room to spare. Singleton entries (playwright, pnpm, bun) are untouched.

## Verification

Neither trigger can fire before merge — `schedule` only runs from the default branch, and `workflow_dispatch` needs the file to already exist there. So the step's script was extracted and run directly:

**Against the live API**, dispatch + `dry_run=true`: reports the 73 entries and the table above, issues zero `DELETE` calls.

**Against a stub**, five cases:

| case | expected | result |
| --- | --- | --- |
| schedule with empty input | deletes anyway | `dry_run=false` |
| entry evicted between list and delete | counted, not fatal | `deleted=1 already-gone=1`, rc 0 |
| every delete fails | red | rc 1, `no cache deletion succeeded` |
| dispatch, no input | dry run | 0 delete calls |
| dispatch, `dry_run=false` | deletes | `deleted=2` |

Retention confirmed: of four entries in a group it targeted only the two oldest.

`actionlint` and `zizmor` clean.

## Notes on the design

- **The dry-run default is resolved in shell, not YAML.** A scheduled run carries no inputs, so `inputs.dry_run` is `''` rather than `false`; the `&&`/`||` expression idiom would work here by accident.
- **A missing entry is success.** The repo is over budget, so LRU is evicting underneath us between the listing and the delete. Already-gone is the outcome we wanted. Only a total failure across every attempt fails the job, which points at a broken token rather than eviction.
- **Scope is `refs/heads/main` only.** `version-*` branches also accumulate, but they hold 0.03 GB — not worth widening the blast radius for.

## After merging

Dispatch it once with `dry_run: true` and read the step summary before the first cron fires at 09:00 UTC.
