### PR TITLE
chore(deps): bump uv to 0.12.1 to match Dependabot

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -4,9 +4,21 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-uv_version="0.11.31"
-node_version="22.22.0"
-pnpm_version="11.11.0"
+# Read from [tool.uv] required-version, which uv enforces at startup: a second
+# pin here would abort every uv command in this script the moment it drifts.
+uv_version="$(grep -E '^required-version\s*=' pyproject.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+if [[ -z "$uv_version" ]]; then
+  echo "ERROR: could not read uv required-version from pyproject.toml" >&2
+  exit 1
+fi
+# Read from .nvmrc so the orb runs the same node local dev does. The download
+# URL below needs an exact version, so reject the range forms nvm also accepts.
+node_version="$(tr -d '[:space:]' <.nvmrc)"
+node_version="${node_version#v}"
+if [[ ! "$node_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: .nvmrc must hold an exact node version, got '$node_version'" >&2
+  exit 1
+fi
 node_name="node-v${node_version}-linux-x64"
 node_dir="$HOME/.local/share/$node_name"
 node_current="$HOME/.local/share/phoenix-node"
@@ -45,6 +57,14 @@ if [[ ! -x "$node_dir/bin/node" ]]; then
 fi
 ln -sfn "$node_dir" "$node_current"
 
+# Read from the packageManager field CI installs pnpm from. Derived here rather
+# than at the top of the script because it needs the node installed just above.
+pnpm_version="$(node -p "require('./app/package.json').packageManager.split('@')[1].split('+')[0]")"
+if [[ ! "$pnpm_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: app/package.json packageManager must pin an exact pnpm version" >&2
+  exit 1
+fi
+
 echo "==> Enabling pnpm $pnpm_version"
 corepack enable
 corepack install --global "pnpm@$pnpm_version"
@@ -63,7 +83,7 @@ EOF
 fi
 
 echo "==> Installing Python dependencies"
-uv sync --frozen --python 3.10
+uv sync --frozen  # interpreter comes from .python-version
 uv tool install tox --with tox-uv
 
 echo "==> Installing frontend dependencies"

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
 
       - name: Install PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/cost-sync.yml
+++ b/.github/workflows/cost-sync.yml
@@ -23,7 +23,7 @@ jobs:
       
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Sync model cost manifest with LiteLLM

--- a/.github/workflows/harbor-evals.yml
+++ b/.github/workflows/harbor-evals.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      UV_VERSION: "0.11.31"
+      UV_VERSION: "0.12.1"
       HARBOR_ENV: daytona
       # Two attempts, gated on the mean: a one-off agent slip passes while a
       # consistent regression still fails.

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
           python-version: "3.14"
 
       - name: Run Helm chart tests

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -94,7 +94,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Install dependencies
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
         run: uv sync --extra container

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -110,7 +110,7 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Build distribution
         run: rm -rf dist && uv build
       - name: Verify bundled UI assets in wheel
@@ -219,7 +219,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uv build
         if: steps.check.outputs.needed == 'true'
         working-directory: ${{ matrix.path }}
@@ -544,7 +544,7 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
-          version: "0.11.31"
+          version: "0.12.1"
           enable-cache: false
       - name: Stamp dev version
         env:
@@ -616,7 +616,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.11.31"
+          version: "0.12.1"
           enable-cache: false
       - name: Stamp dev version
         if: steps.check.outputs.needed == 'true'

--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Check Phoenix connectivity

--- a/.github/workflows/pxi-online-evals.yml
+++ b/.github/workflows/pxi-online-evals.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --frozen

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -39,7 +39,7 @@ jobs:
             verify_latest: false
     env:
       PYTHON_VERSION: "3.12"
-      UV_VERSION: "0.11.31"
+      UV_VERSION: "0.12.1"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PHOENIX_HOST: "127.0.0.1"
       PHOENIX_PORT: "6606"

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -124,7 +124,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals:
@@ -148,7 +148,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
@@ -171,7 +171,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   test-json-canonicalization-schema:
@@ -207,7 +207,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Install make (Windows)
         if: runner.os == 'Windows'
         run: choco install make --no-progress -y
@@ -241,7 +241,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Clean Jupyter notebooks
         run: make clean-notebooks
       - run: git diff --exit-code
@@ -267,7 +267,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Build GraphQL schema
         run: make schema-graphql
       - run: git diff --exit-code
@@ -293,7 +293,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Run doctests
         run: make doctest
 
@@ -318,7 +318,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Build OpenAPI schema
         run: make schema-openapi
       - run: git diff --exit-code
@@ -344,7 +344,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Create virtual environment
         # `make schema-ddl` installs its dependencies with `uv pip install`,
         # which requires an existing environment.
@@ -374,7 +374,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Compile Prompts
         run: make codegen-prompts
       - name: Check for changes
@@ -402,7 +402,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Check lockfile is up to date
         run: uv lock --check
 
@@ -426,7 +426,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Run formatter and linter
         run: |
           make format-python
@@ -463,7 +463,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Type check all Python code
@@ -503,7 +503,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql'
         # The floor version from the PGDG repository, not whatever the
@@ -577,7 +577,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 16
@@ -616,7 +616,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Install arize-phoenix and database dependencies
         run: |
           uv pip install --system -qU 'arize-phoenix[pg]'
@@ -689,7 +689,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Run canary tests for ${{ matrix.pkg }}
         run: uvx tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
 

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql' && runner.os == 'Linux'
         # Floor version from PGDG; see the note in python-CI.yml. The macOS
@@ -164,7 +164,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
@@ -193,7 +193,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals-non-linux:
@@ -219,7 +219,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel-non-linux:
@@ -245,7 +245,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   slack-notification:

--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.31"
+          version: "0.12.1"
           enable-cache: false
 
       - name: Update lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pnpm install
 RUN pnpm run build
 
 # The second stage builds the backend.
-FROM ghcr.io/astral-sh/uv:0.11.31-python3.13-trixie-slim AS backend-builder
+FROM ghcr.io/astral-sh/uv:0.12.1-python3.13-trixie-slim AS backend-builder
 WORKDIR /phoenix
 COPY ./src /phoenix/src
 COPY ./pyproject.toml /phoenix/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,7 +435,7 @@ line-ending = "native"
 script_location = "src/phoenix/db/migrations"  # enables `uv run alembic <command>`
 
 [tool.uv]
-required-version = "==0.11.31"  # When updating this version, also update the `backend-builder` image in the Dockerfile
+required-version = "==0.12.1"  # When updating this version, also update the `backend-builder` image in the Dockerfile
 exclude-newer = "3 days"
 # Exempt our own packages from the `exclude-newer` window so freshly published
 # versions are immediately resolvable. arize-phoenix-sqlean is not a workspace

--- a/scripts/docker/devops/Dockerfile
+++ b/scripts/docker/devops/Dockerfile
@@ -23,7 +23,7 @@ FROM python:${PYTHON_VERSION}-slim-bullseye AS backend-builder
 WORKDIR /phoenix
 
 # Install uv - pin version to match pyproject.toml [tool.uv] required-version
-RUN pip install uv==0.11.31
+RUN pip install uv==0.12.1
 
 # Copy dependency files first for better layer caching
 COPY ./pyproject.toml ./uv.lock ./LICENSE ./IP_NOTICE ./README.md ./


### PR DESCRIPTION
## Summary

Bumps the pinned `uv` CLI version from `0.11.31` to `0.12.1` across the repo so it matches the version [Dependabot supports](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile).

- `pyproject.toml` (`[tool.uv] required-version`)
- `Dockerfile` and `scripts/docker/devops/Dockerfile` (`ghcr.io/astral-sh/uv` image tag / `pip install uv==`)
- `.agents/setup` (`uv_version`)
- `.github/workflows/*.yml|*.yaml` (`astral-sh/setup-uv` `version:` inputs and `UV_VERSION` env vars)

`uv.lock` was regenerated via `uv lock`; the resolution was unaffected by the version bump.

This PR was generated automatically by [`.github/workflows/check-dependabot-uv-version.yml`](../.github/workflows/check-dependabot-uv-version.yml).

## Test plan

- [ ] CI passes with the new `uv` version
