### PR TITLE
fix(filters): resolve session I/O prefix collisions

### DIFF
--- a/src/phoenix/db/session_aggregates.py
+++ b/src/phoenix/db/session_aggregates.py
@@ -180,6 +180,7 @@ def root_span_attribute_case_insensitive_contains_by_session(
 ) -> ColumnElement[bool]:
     """Whether any root span in a session contains ``substring``, ignoring case, at
     ``attribute_path``."""
+    value = _root_span_io_value(attribute_path)
     stmt = (
         select(models.Span.id)
         .join_from(models.Span, models.Trace)
@@ -187,7 +188,7 @@ def root_span_attribute_case_insensitive_contains_by_session(
         .where(models.Span.parent_id.is_(None))
         .where(
             models.CaseInsensitiveContains(
-                models.Span.attributes[list(attribute_path)].as_string(),
+                value,
                 substring,
             )
         )
@@ -288,7 +289,7 @@ def root_span_io_value_by_session(
         raise ValueError(f"Unknown root span IO kind: {kind}")
 
     subquery = _ranked_root_span_values_by_session(
-        models.Span.attributes[attribute_path].as_string().label(VALUE),
+        _root_span_io_value(attribute_path).label(VALUE),
         order_by=order_by,
         keys=keys,
         project_rowids=project_rowids,
@@ -298,6 +299,12 @@ def root_span_io_value_by_session(
     return select(subquery.c[SESSION_ROWID], subquery.c[VALUE]).where(
         subquery.c[_ROOT_SPAN_RANK] == 1
     )
+
+
+def _root_span_io_value(attribute_path: Sequence[str]) -> Any:
+    nested = models.Span.attributes[list(attribute_path)].as_string()
+    flat = models.Span.attributes[[".".join(attribute_path)]].as_string()
+    return func.coalesce(nested, flat)
 
 
 def _ranked_root_span_values_by_session(

--- a/tests/unit/trace/dsl/test_session_filter.py
+++ b/tests/unit/trace/dsl/test_session_filter.py
@@ -651,6 +651,35 @@ async def test_session_filter_any_io_returns_any_turn_matches(db: DbSessionFacto
         assert by_upper_needle == by_input
 
 
+async def test_session_filter_io_resolves_prefix_collisions(db: DbSessionFactory) -> None:
+    start = datetime.now(timezone.utc)
+    async with db() as session:
+        project = await _add_project(session)
+        project_session = await _add_project_session(session, project, start_time=start)
+        trace = await _add_trace(session, project, project_session, start_time=start)
+        await _add_span(
+            session,
+            trace,
+            attributes={
+                "input": "prefix",
+                "input.value": "valid-input",
+                "output": "prefix",
+                "output.value": "valid-output",
+            },
+            start_time=start,
+        )
+
+        for condition in (
+            "'valid-input' in any_input",
+            "first_input == 'valid-input'",
+            "'valid-output' in any_output",
+            "last_output == 'valid-output'",
+        ):
+            assert await _matched_rowids(session, SessionFilter(condition), project) == {
+                project_session.id
+            }
+
+
 async def test_session_filter_first_last_io_returns_window_turn_matches(
     db: DbSessionFactory,
 ) -> None:


### PR DESCRIPTION
resolves #15428

## Summary

- resolve session input/output attributes from both nested and prefix-collision storage shapes
- cover any_input, any_output, first_input, and last_output with a regression test

## Tests

- 3 focused session-filter tests passed on SQLite
- session aggregate builder test passed on SQLite
- Ruff formatting and lint checks passed