### PR TITLE
fix(js): count eligible runs in acceptance criteria denominator

### DIFF
--- a/js/.changeset/acceptance-denominator-eligible-runs.md
+++ b/js/.changeset/acceptance-denominator-eligible-runs.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Acceptance criteria now count every eligible (non-skipped) run in their denominator: runs that finish without logging a criterion's annotation count as not passing for `passRate` and as a score of `0` for `average`, instead of being silently dropped. This keeps a suite whose annotation is missing on most runs from passing at `minPassRate: 1` (or a near-perfect `average`).

--- a/js/packages/phoenix-client/src/testing/acceptance.ts
+++ b/js/packages/phoenix-client/src/testing/acceptance.ts
@@ -69,7 +69,10 @@ function evaluateAcceptanceCriterion({
   criterion: AcceptanceCriterion;
   results: readonly TestResult[];
 }): AcceptanceResult {
-  const annotations = collectAnnotations({ criterion, results });
+  const { annotations, eligibleCount } = collectAnnotations({
+    criterion,
+    results,
+  });
 
   if (criterion.metric === "average") {
     // Only numeric / boolean scores can be averaged.
@@ -86,11 +89,11 @@ function evaluateAcceptanceCriterion({
       };
     }
     const direction = criterion.direction ?? "maximize";
-    const value = calculateAverage(scores);
+    const value = calculateAverage(scores, eligibleCount);
     return {
       ...criterion,
       value,
-      sampleCount: scores.length,
+      sampleCount: eligibleCount,
       passed: meetsBar(value, criterion.threshold, direction),
     };
   }
@@ -98,7 +101,7 @@ function evaluateAcceptanceCriterion({
   // passRate: each run passes when `passFn` returns true for its annotation;
   // the suite passes when the fraction of passing runs is at least
   // `minPassRate`. The reported value is that fraction.
-  if (annotations.length === 0) {
+  if (eligibleCount === 0 || annotations.length === 0) {
     return {
       ...criterion,
       value: null,
@@ -110,11 +113,11 @@ function evaluateAcceptanceCriterion({
   const passed = annotations.filter((annotation) =>
     criterion.passFn(annotation)
   ).length;
-  const value = passed / annotations.length;
+  const value = passed / eligibleCount;
   return {
     ...criterion,
     value,
-    sampleCount: annotations.length,
+    sampleCount: eligibleCount,
     passed: value >= criterion.minPassRate,
   };
 }
@@ -129,9 +132,11 @@ function meetsBar(
 }
 
 /**
- * The last annotation matching `annotationName` from each non-skipped run that
- * logged it. One entry per run; runs that never logged the annotation are
- * omitted.
+ * Collect the last annotation matching `annotationName` from each eligible
+ * (non-skipped) run, alongside the count of eligible runs. Runs that never
+ * logged the annotation are not dropped: they count as non-passing for
+ * `passRate` and as a zero score for `average`, so callers divide by
+ * `eligibleCount`, not by `annotations.length`.
  */
 function collectAnnotations({
   criterion,
@@ -139,16 +144,24 @@ function collectAnnotations({
 }: {
   criterion: AcceptanceCriterion;
   results: readonly TestResult[];
-}): Annotation[] {
-  return results
-    .filter((result) => result.status !== "skipped")
-    .map((result) =>
-      findLastAnnotation({
-        annotations: result.annotations,
-        annotationName: criterion.annotationName,
-      })
-    )
-    .filter((annotation): annotation is Annotation => annotation !== undefined);
+}): {
+  annotations: Annotation[];
+  eligibleCount: number;
+} {
+  const eligible = results.filter((result) => result.status !== "skipped");
+  return {
+    eligibleCount: eligible.length,
+    annotations: eligible
+      .map((result) =>
+        findLastAnnotation({
+          annotations: result.annotations,
+          annotationName: criterion.annotationName,
+        })
+      )
+      .filter(
+        (annotation): annotation is Annotation => annotation !== undefined
+      ),
+  };
 }
 
 function findLastAnnotation({
@@ -178,11 +191,14 @@ function isValidScore(score: Annotation["score"]): score is number | boolean {
   );
 }
 
-function calculateAverage(scores: readonly (number | boolean)[]): number {
+function calculateAverage(
+  scores: readonly (number | boolean)[],
+  eligibleCount: number
+): number {
   const total = scores
     .map(scoreToNumber)
     .reduce((sum, score) => sum + score, 0);
-  return total / scores.length;
+  return total / eligibleCount;
 }
 
 function scoreToNumber(score: number | boolean): number {

--- a/js/packages/phoenix-client/src/testing/types.ts
+++ b/js/packages/phoenix-client/src/testing/types.ts
@@ -195,6 +195,10 @@ export interface PassRateAcceptanceCriterion extends AcceptanceCriterionBase {
  * - Boolean scores count as `1` (`true`) / `0` (`false`).
  * - If a run logs the same annotation more than once, the last one counts.
  * - Skipped tests are excluded; dry-run tests are included (they still run).
+ * - A run that finishes without logging the criterion's annotation counts as
+ *   not passing for `passRate` and as a score of `0` for `average` (it is not
+ *   dropped from the denominator); the criterion's `sampleCount` is the number
+ *   of eligible (non-skipped) runs.
  * - A criterion whose annotation was never logged on any run fails (rather
  *   than passing vacuously) — see {@link AcceptanceResultFields.failureReason}.
  */
@@ -211,7 +215,7 @@ export interface AcceptanceResultFields {
    * reports `1`).
    */
   value: number | null;
-  /** Number of runs included in the aggregate. */
+  /** Number of eligible runs the aggregate was computed over. */
   sampleCount: number;
   /** Whether the aggregate cleared the criterion. */
   passed: boolean;

--- a/js/packages/phoenix-client/test/testing/acceptance.test.ts
+++ b/js/packages/phoenix-client/test/testing/acceptance.test.ts
@@ -206,6 +206,205 @@ describe("acceptance criteria", () => {
       "Acceptance criteria failed:\n  FAIL valid_sql passRate 0.000 (need pass rate >= 1.000; 1 sample)"
     );
   });
+
+  it("counts runs with no annotation in the passRate denominator", () => {
+    const results = [
+      ...Array.from({ length: 70 }, () =>
+        createRun([{ name: "correctness", score: 1 }])
+      ),
+      ...Array.from({ length: 30 }, () => createRun([], "failed")),
+    ];
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        {
+          annotationName: "correctness",
+          metric: "passRate",
+          passFn: (annotation) => annotation.score === 1,
+          minPassRate: 1,
+        },
+      ],
+      results,
+    });
+
+    // 70/100 runs pass; the 30 runs that logged no annotation count as
+    // non-passing instead of being dropped from the denominator.
+    expect(result).toMatchObject({
+      value: expect.closeTo(0.7, 3),
+      sampleCount: 100,
+      passed: false,
+    });
+  });
+
+  it("counts failed runs with a zero score in the passRate denominator", () => {
+    const results = [
+      ...Array.from({ length: 70 }, () =>
+        createRun([{ name: "correctness", score: 1 }])
+      ),
+      ...Array.from({ length: 30 }, () =>
+        createRun([{ name: "correctness", score: 0 }], "failed")
+      ),
+    ];
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        {
+          annotationName: "correctness",
+          metric: "passRate",
+          passFn: (annotation) => annotation.score === 1,
+          minPassRate: 1,
+        },
+      ],
+      results,
+    });
+
+    expect(result).toMatchObject({
+      value: expect.closeTo(0.7, 3),
+      sampleCount: 100,
+      passed: false,
+    });
+  });
+
+  it("fails passRate when nearly every run logged no annotation", () => {
+    const results = [
+      ...Array.from({ length: 99 }, () => createRun([], "failed")),
+      createRun([{ name: "correctness", score: 1 }]),
+    ];
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        {
+          annotationName: "correctness",
+          metric: "passRate",
+          passFn: (annotation) => annotation.score === 1,
+          minPassRate: 1,
+        },
+      ],
+      results,
+    });
+
+    // 1/100 passes; the 99 unannotated runs must not vanish from the sample.
+    expect(result).toMatchObject({
+      value: expect.closeTo(0.01, 3),
+      sampleCount: 100,
+      passed: false,
+    });
+  });
+
+  it("fails passRate when no run logged the annotation", () => {
+    const results = Array.from({ length: 100 }, () => createRun([], "failed"));
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        {
+          annotationName: "correctness",
+          metric: "passRate",
+          passFn: (annotation) => annotation.score === 1,
+          minPassRate: 1,
+        },
+      ],
+      results,
+    });
+
+    expect(result).toMatchObject({
+      value: null,
+      sampleCount: 0,
+      passed: false,
+      failureReason: "no matching annotations found",
+    });
+  });
+
+  it("counts runs with no annotation as zero in the average", () => {
+    const results = [
+      ...Array.from({ length: 70 }, () =>
+        createRun([{ name: "quality", score: 1 }])
+      ),
+      ...Array.from({ length: 30 }, () => createRun([], "failed")),
+    ];
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        { annotationName: "quality", metric: "average", threshold: 0.95 },
+      ],
+      results,
+    });
+
+    // (70×1 + 30×0) / 100 = 0.7, which misses the 0.95 bar.
+    expect(result).toMatchObject({
+      value: expect.closeTo(0.7, 3),
+      sampleCount: 100,
+      passed: false,
+    });
+  });
+
+  it("fails average when no run logged a valid score", () => {
+    const results = Array.from({ length: 100 }, () => createRun([], "failed"));
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        { annotationName: "quality", metric: "average", threshold: 0.5 },
+      ],
+      results,
+    });
+
+    expect(result).toMatchObject({
+      value: null,
+      sampleCount: 0,
+      passed: false,
+      failureReason: "no numeric or boolean scores found",
+    });
+  });
+
+  it("excludes skipped runs from the denominator", () => {
+    const results = [
+      ...Array.from({ length: 70 }, () =>
+        createRun([{ name: "correctness", score: 1 }])
+      ),
+      ...Array.from({ length: 30 }, () => createRun([], "skipped")),
+    ];
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        {
+          annotationName: "correctness",
+          metric: "passRate",
+          passFn: (annotation) => annotation.score === 1,
+          minPassRate: 1,
+        },
+      ],
+      results,
+    });
+
+    expect(result).toMatchObject({
+      value: 1,
+      sampleCount: 70,
+      passed: true,
+    });
+  });
+
+  it("passes when every run annotates and clears the bar", () => {
+    const results = Array.from({ length: 100 }, () =>
+      createRun([{ name: "correctness", score: 1 }])
+    );
+
+    const [result] = evaluateAcceptanceCriteria({
+      criteria: [
+        {
+          annotationName: "correctness",
+          metric: "passRate",
+          passFn: (annotation) => annotation.score === 1,
+          minPassRate: 1,
+        },
+      ],
+      results,
+    });
+
+    expect(result).toMatchObject({
+      value: 1,
+      sampleCount: 100,
+      passed: true,
+    });
+  });
 });
 
 function createResult(annotations: Annotation[]): TestResult {
@@ -213,6 +412,19 @@ function createResult(annotations: Annotation[]): TestResult {
     suiteName: "acceptance suite",
     testName: "case",
     status: "passed",
+    annotations,
+    durationMs: 1,
+  };
+}
+
+function createRun(
+  annotations: Annotation[],
+  status: TestResult["status"] = "passed"
+): TestResult {
+  return {
+    suiteName: "acceptance suite",
+    testName: "case",
+    status,
     annotations,
     durationMs: 1,
   };


### PR DESCRIPTION
resolves #15425

## Summary

Acceptance criteria now compute the `passRate` and `average` denominators over
every eligible (non-skipped) run instead of only the runs that logged the
criterion's annotation. A run that finishes without logging it counts as
non-passing for `passRate` and as a score of `0` for `average`, so a suite can
no longer pass `minPassRate: 1` (or a near-perfect `average`) while a large
share of its runs errored before annotating.

## Root cause

`collectAnnotations` silently dropped non-skipped runs that never logged the
criterion's annotation, and both metrics derived their denominator from the
truncated list (`annotations.length` / `scores.length`) instead of the
eligible-run count. The gate was non-monotonic: at `minPassRate: 1`, 99 runs
that errored without annotating plus one passing run PASSed, while 100 errored
runs FAILed; and 70 passing + 30 failing-but-silent runs PASSed, while the same
split with the failing runs logging `score: 0` FAILed. Failing runs are the
least likely to produce an annotation, so the reported rate improved as quality
degraded. The documented contract in `types.ts` ("minimum fraction of runs ...
`1` requires all of them"; skipped is the only named exclusion) describes a
denominator of non-skipped runs.

## Change

- `passRate`: `value = passed / eligibleCount`; runs without the annotation
  count as non-passing.
- `average`: `value = total / eligibleCount`; runs without the annotation
  contribute a score of `0` (missing is treated as the best possible value when
  `direction: "minimize"`, the one trade-off of a plain mean).
- `sampleCount` now reports the eligible-run count for both metrics, so
  reporters show the true population.
- The fail-not-vacuous guards (no matching annotations / no valid scores ->
  fail) and fully-annotated suites behave exactly as before.

## Testing

Eight new cases in `test/testing/acceptance.test.ts`, each asserting `value`,
`sampleCount`, and `passed`: the issue's 70/30 repro for both metrics, the
annotate-`0` control pair, the non-monotonic 99-silent + 1-passing case, the
all-silent guards for both metrics, skipped-run exclusion, and an
all-annotating positive control. The denominator cases fail on the pre-fix
code and pass with this change. Typecheck, lint, and format checks are clean.

Added a `patch` changeset for `@arizeai/phoenix-client`.