### PR TITLE
chore(lint): silence noisy warn-level rules pending cleanup

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,12 +10,29 @@
     "typescript/no-require-imports": "error",
     "typescript/no-import-type-side-effects": "error",
     "typescript/prefer-ts-expect-error": "error",
-    // TODO: Re-promote no-unsafe-type-assertion to "error" once existing
-    // violations are fixed. It became far stricter when tsgolint (type-aware
-    // linting) was adopted and pre-existing code has not been cleaned up yet.
     "typescript/consistent-return": "error",
     "typescript/consistent-type-imports": "error",
-    "typescript/no-unsafe-type-assertion": "warn",
+    // TODO: Re-enable the type-aware rules below (one at a time, as "error")
+    // once existing violations are fixed. They arrived default-on at "warn"
+    // when tsgolint (type-aware linting) was adopted, and pre-existing code
+    // has not been cleaned up: together they produced ~1,100 warnings that
+    // drowned out actionable lint output. Counts at time of disabling:
+    "typescript/no-unsafe-type-assertion": "off", // 810
+    "typescript/no-floating-promises": "off", // 105
+    "typescript/no-redundant-type-constituents": "off", // 70
+    "typescript/no-base-to-string": "off", // 56
+    "typescript/restrict-template-expressions": "off", // 47
+    "typescript/unbound-method": "off", // 22
+    "typescript/require-array-sort-compare": "off", // 4
+    "typescript/await-thenable": "off", // 4
+    "typescript/no-misused-spread": "off", // 2
+    "typescript/no-useless-default-assignment": "off", // 2
+    // Intentional patterns that the default-warn core rules flag: control
+    // characters in terminal/filter regexes (phoenix-cli TUI, the app's
+    // filter-condition utils) and demo constructs in tests/stories.
+    "eslint/no-control-regex": "off",
+    "eslint/no-unsafe-optional-chaining": "off",
+    "eslint/no-constant-binary-expression": "off",
     // "eslint/no-shadow": "warn",
     "eqeqeq": ["error", "smart"],
     "eslint/prefer-const": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,12 +27,6 @@
     "typescript/await-thenable": "off", // 4
     "typescript/no-misused-spread": "off", // 2
     "typescript/no-useless-default-assignment": "off", // 2
-    // Intentional patterns that the default-warn core rules flag: control
-    // characters in terminal/filter regexes (phoenix-cli TUI, the app's
-    // filter-condition utils) and demo constructs in tests/stories.
-    "eslint/no-control-regex": "off",
-    "eslint/no-unsafe-optional-chaining": "off",
-    "eslint/no-constant-binary-expression": "off",
     // "eslint/no-shadow": "warn",
     "eqeqeq": ["error", "smart"],
     "eslint/prefer-const": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,8 +12,8 @@
     "typescript/prefer-ts-expect-error": "error",
     "typescript/consistent-return": "error",
     "typescript/consistent-type-imports": "error",
-    // TODO: Re-enable the type-aware rules below (one at a time, as "error")
-    // once existing violations are fixed. They arrived default-on at "warn"
+    // TODO(#15439): Re-enable the type-aware rules below (one at a time, as
+    // "error") once existing violations are fixed. They arrived default-on at "warn"
     // when tsgolint (type-aware linting) was adopted, and pre-existing code
     // has not been cleaned up: together they produced ~1,100 warnings that
     // drowned out actionable lint output. Counts at time of disabling:

--- a/js/app/.oxlintrc.json
+++ b/js/app/.oxlintrc.json
@@ -58,7 +58,15 @@
   "overrides": [
     {
       "files": ["stories/**/*.stories.tsx"],
-      "plugins": ["react", "typescript", "jsx-a11y"]
+      "plugins": ["react", "typescript", "jsx-a11y"],
+      "rules": {
+        // Stories are isolated component demos: autofocus and label-less
+        // controls are deliberate showcase constructs there, not shipped UI.
+        // Keep the rest of jsx-a11y active so stories stay honest examples.
+        "jsx-a11y/no-autofocus": "off",
+        "jsx-a11y/control-has-associated-label": "off",
+        "jsx-a11y/prefer-tag-over-role": "off"
+      }
     }
   ],
 

--- a/js/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
+++ b/js/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
@@ -86,10 +86,10 @@ describe("applyClientToolTimingMetadata", () => {
     expect(messages[0]?.parts[0]).toMatchObject({
       callProviderMetadata: CLIENT_EXECUTION_METADATA,
     });
-    expect(
-      (messages[0]?.parts[0] as { callProviderMetadata: object })
-        .callProviderMetadata
-    ).toEqual(CLIENT_EXECUTION_METADATA);
+    const firstPart = messages[0]?.parts[0] as
+      | { callProviderMetadata: object }
+      | undefined;
+    expect(firstPart?.callProviderMetadata).toEqual(CLIENT_EXECUTION_METADATA);
   });
 
   it("returns the same array when the call has no recorded timings", () => {

--- a/js/app/src/utils/filterConditionUtils.ts
+++ b/js/app/src/utils/filterConditionUtils.ts
@@ -24,6 +24,7 @@ const DSL_STRING_ESCAPES: Record<string, string> = {
 };
 
 /** C0 controls plus DEL — none of which may appear raw inside a DSL string literal. */
+// oxlint-disable-next-line no-control-regex -- deliberately matches control characters to escape them
 const DSL_CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/gu;
 
 /**

--- a/js/app/stories/ExperimentItem.stories.tsx
+++ b/js/app/stories/ExperimentItem.stories.tsx
@@ -253,7 +253,8 @@ const Template: Story = (args) => {
   const includeRepetitions = args.experiment.repetitions > 1;
 
   const hasAnnotations =
-    args.experimentRepetition.experimentRun?.annotations.edges.length ?? 0 > 0;
+    (args.experimentRepetition.experimentRun?.annotations.edges.length ?? 0) >
+    0;
   const annotationSummaries = hasAnnotations ? mockAnnotationSummaries : [];
 
   return (

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -129,7 +129,9 @@ const FORWARD_DELETE_INPUTS = new Set([
   `${ESCAPE_INPUT}[3^`,
 ]);
 const KITTY_BACKSPACE_INPUT_PATTERN =
+  // oxlint-disable-next-line no-control-regex -- matches Kitty keyboard-protocol escape sequences
   /^\x1B\[(?:8|127)(?:;\d+(?::[12])?(?:;[\d:]+)?)?u$/;
+// oxlint-disable-next-line no-control-regex -- matches Kitty keyboard-protocol escape sequences
 const KITTY_FORWARD_DELETE_INPUT_PATTERN = /^\x1B\[3;\d+:[12]~$/;
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";


### PR DESCRIPTION
Stacked on #15436 → #15394

## Summary

`pnpm lint` emitted **~1,130 warnings** across the js workspace. None of them fail CI (all warn severity), so in practice they were pure noise burying actionable diagnostics — including the new `import/no-cycle` errors from #15436. This PR turns the offending rules off via config rather than fixing the violations, which are too numerous to address right now. Lint output is now **completely clean** (zero warnings, workspace-wide).

## What was turned off, and where

### Root `.oxlintrc.json` — ten type-aware typescript rules

These arrived default-on at `warn` when tsgolint (type-aware linting) was adopted; pre-existing code was never cleaned up. Violation counts are recorded next to each rule for the eventual re-enable:

| Rule | Count |
| --- | ---: |
| `no-unsafe-type-assertion` (was already demoted to warn with a TODO) | 810 |
| `no-floating-promises` | 105 |
| `no-redundant-type-constituents` | 70 |
| `no-base-to-string` | 56 |
| `restrict-template-expressions` | 47 |
| `unbound-method` | 22 |
| `require-array-sort-compare` / `await-thenable` | 4 each |
| `no-misused-spread` / `no-useless-default-assignment` | 2 each |

Re-enablement is tracked in **#15439** (one rule per PR, at `error` severity, smallest-first), which the config TODO references; the `no-unsafe-type-assertion` burn-down specifically continues in #14724. The config records per-rule violation counts for that audit.

### Core rules kept active — hits fixed or suppressed (second commit)

`no-control-regex`, `no-unsafe-optional-chaining`, and `no-constant-binary-expression` catch real bugs and had only 5 hits total, so they stay at their default warn severity:

- **Real bug fixed** (caught by `no-constant-binary-expression`): `ExperimentItem.stories.tsx` had `length ?? 0 > 0`, which parses as `length ?? (0 > 0)` — `hasAnnotations` was `number | false` instead of a boolean comparison. Now `(length ?? 0) > 0`
- **Fixed**: `createAgentSessionChat.test.ts` restructured so the optional-chain result isn't dereferenced unsafely
- **Suppressed inline** (3 sites): control-character regexes that are intentional — Kitty keyboard-protocol escapes in the phoenix-cli TUI (2) and DSL string-literal escaping in the app's filter utils (1), each with an `oxlint-disable-next-line` + reason

### App stories override — three jsx-a11y rules

`no-autofocus`, `control-has-associated-label`, `prefer-tag-over-role` — all 5 hits are deliberate showcase constructs in stories (isolated component demos, not shipped UI). The rest of jsx-a11y stays active for stories, and the TODO to enable jsx-a11y globally is untouched.

## Verification

- [x] `pnpm run lint` (workspace root, delegates to app): exit 0, **zero diagnostics**
- [x] `oxlint` direct in `js/app` and on `packages examples benchmarks scripts`: silent, exit 0
- [x] `pnpm run fmt:check` clean (config files are jsonc-formatted)
- [x] No rule that previously reported at `error` severity was changed
- [x] Affected tests pass (`createAgentSessionChat.test.ts` 5/5, phoenix-cli suite); app + cli typecheck clean


