### PR TITLE
feat: filter traces by trace annotations

### DIFF
--- a/js/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
+++ b/js/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
@@ -13,6 +13,7 @@ import { useTraceFilters } from "@phoenix/pages/project/TraceFiltersContext";
 
 import { groupAnnotationsByName, hasAnnotationValue } from "./annotationUtils";
 import type { AnnotationOptimizationConfig } from "./optimizationUtils";
+import type { Annotation } from "./types";
 
 const useTraceAnnotationSummaryGroup = (
   trace: TraceAnnotationSummaryGroup$key
@@ -70,6 +71,7 @@ type TraceAnnotationSummaryGroupProps = {
   trace: TraceAnnotationSummaryGroup$key;
   annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
   showFilterActions?: boolean;
+  renderFilterActions?: (annotation: Annotation) => React.ReactNode;
   renderEmptyState?: () => React.ReactNode;
 };
 
@@ -95,6 +97,7 @@ export const TraceAnnotationSummaryGroupTokens = ({
   trace,
   annotationConfigsByName,
   showFilterActions = false,
+  renderFilterActions,
   renderEmptyState,
 }: TraceAnnotationSummaryGroupProps) => {
   const { sortedSummariesByName, annotationsByName } =
@@ -115,9 +118,12 @@ export const TraceAnnotationSummaryGroupTokens = ({
       annotationsByName={annotationsByName}
       annotationConfigsByName={annotationConfigsByName}
       showFilterActions={showFilterActions}
-      renderFilterActions={(annotation) => (
-        <TraceAnnotationTooltipFilterActions annotation={annotation} />
-      )}
+      renderFilterActions={
+        renderFilterActions ??
+        ((annotation) => (
+          <TraceAnnotationTooltipFilterActions annotation={annotation} />
+        ))
+      }
     />
   );
 };

--- a/js/app/src/pages/project/AnnotationTooltipFilterActions.tsx
+++ b/js/app/src/pages/project/AnnotationTooltipFilterActions.tsx
@@ -104,3 +104,24 @@ export function TraceSpanAnnotationTooltipFilterActions(
     />
   );
 }
+
+export function SpanTraceAnnotationTooltipFilterActions(
+  props: Omit<
+    AnnotationTooltipFilterActionsProps,
+    "getFilters" | "onAppendFilterCondition"
+  >
+) {
+  const { appendFilterCondition } = useSpanFilterActions();
+  return (
+    <AnnotationTooltipFilterActions
+      {...props}
+      getFilters={(annotation) =>
+        getAnnotationTooltipFilters({
+          ...annotation,
+          accessor: "trace_annotations",
+        })
+      }
+      onAppendFilterCondition={appendFilterCondition}
+    />
+  );
+}

--- a/js/app/src/pages/project/SpansTable.tsx
+++ b/js/app/src/pages/project/SpansTable.tsx
@@ -70,6 +70,7 @@ import {
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
+import { SpanTraceAnnotationTooltipFilterActions } from "@phoenix/pages/project/AnnotationTooltipFilterActions";
 import { MetadataTableCell } from "@phoenix/pages/project/MetadataTableCell";
 import { useTracePagination } from "@phoenix/pages/trace/TracePaginationContext";
 import { getTraceDetailsPath } from "@phoenix/utils/urlUtils";
@@ -602,6 +603,12 @@ export function SpansTable(props: SpansTableProps) {
             <TraceAnnotationSummaryGroupTokens
               trace={row.original.trace}
               annotationConfigsByName={annotationConfigsByName}
+              showFilterActions
+              renderFilterActions={(annotation) => (
+                <SpanTraceAnnotationTooltipFilterActions
+                  annotation={annotation}
+                />
+              )}
             />
           </OverflowRow>
         );

--- a/js/app/src/pages/project/__tests__/annotationFilterUtils.test.ts
+++ b/js/app/src/pages/project/__tests__/annotationFilterUtils.test.ts
@@ -41,6 +41,49 @@ describe("getAnnotationTooltipFilters", () => {
       },
     ]);
   });
+
+  it("builds trace annotation score filters", () => {
+    expect(
+      getAnnotationTooltipFilters({
+        accessor: "trace_annotations",
+        name: "quality",
+        score: 0.5,
+      })
+    ).toEqual([
+      {
+        filterName: "greater than",
+        filterCondition: "trace_annotations['quality'].score > 0.5",
+      },
+      {
+        filterName: "less than",
+        filterCondition: "trace_annotations['quality'].score < 0.5",
+      },
+      {
+        filterName: "equals",
+        filterCondition: "trace_annotations['quality'].score == 0.5",
+      },
+    ]);
+  });
+
+  it("builds trace annotation label filters", () => {
+    expect(
+      getAnnotationTooltipFilters({
+        accessor: "trace_annotations",
+        name: "quality",
+        label: "pass",
+      })
+    ).toEqual([
+      {
+        filterName: "match",
+        filterCondition: "trace_annotations['quality'].label == \"pass\"",
+      },
+      {
+        filterName: "exclude",
+        filterCondition:
+          "(trace_annotations['quality'].label != \"pass\" or trace_annotations['quality'].label is None)",
+      },
+    ]);
+  });
 });
 
 describe("getTraceSpanAnnotationTooltipFilters", () => {

--- a/js/app/src/pages/project/annotationFilterUtils.ts
+++ b/js/app/src/pages/project/annotationFilterUtils.ts
@@ -1,6 +1,7 @@
 import { getDslStringLiteral } from "@phoenix/utils/filterConditionUtils";
 
 export type AnnotationFilterInput = {
+  accessor?: "annotations" | "trace_annotations";
   name: string;
   label?: string | null;
   score?: number | null;
@@ -14,10 +15,10 @@ export type AnnotationFilterDefinition = {
 export function getAnnotationTooltipFilters(
   annotation: AnnotationFilterInput
 ): AnnotationFilterDefinition[] {
-  const { name, label, score } = annotation;
+  const { accessor = "annotations", name, label, score } = annotation;
   const nameLiteral = getDslStringLiteral({ value: name, quote: "'" });
-  const annotationLabel = `annotations[${nameLiteral}].label`;
-  const annotationScore = `annotations[${nameLiteral}].score`;
+  const annotationLabel = `${accessor}[${nameLiteral}].label`;
+  const annotationScore = `${accessor}[${nameLiteral}].score`;
 
   const filters: AnnotationFilterDefinition[] = [];
   if (typeof score === "number") {


### PR DESCRIPTION
## Summary

- complete the remaining frontend work for #15129 by enabling trace-aware filter actions on trace annotation tokens in the Spans and Traces tables
- reuse the existing annotation filter builders with the `trace_annotations` accessor while leaving existing span and session filters unchanged
- cover score and label conditions, including exclude-or-missing label behavior

The trace annotation DSL support already landed in #14192.

This PR is stacked on #15255 and should be retargeted to `main` after it merges.

## Screenshot

Trace annotation score filter actions:

![Trace annotation filter actions](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15442-trace-annotation-filter-actions.png)

## Test plan

- `make build-frontend`
- `make typecheck-frontend`
- `make lint-frontend`
- `make test-frontend` (2,309 passed, 12 skipped)
- manually verified label filtering from the Spans table and score filtering from the Traces table; both updated the filter DSL and URL, then reduced the table to the matching trace

Resolves #15129