### PR TITLE
fix(ci): bump pypa/gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -161,7 +161,7 @@ jobs:
         with:
           name: phoenix-dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   build-packages:
     name: Build Python packages
@@ -271,7 +271,7 @@ jobs:
         with:
           name: ${{ matrix.package_name }}-dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         if: steps.check.outputs.needed == 'true'
 
   # arize-phoenix-sqlean is a vendored C extension (fork of nalgeon/sqlean.py),
@@ -354,7 +354,7 @@ jobs:
           pattern: arize-phoenix-sqlean-dist-*
           path: dist/
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   trigger-version-updates:
     name: Trigger dependency updates
@@ -564,7 +564,7 @@ jobs:
           PY
       - name: Build distribution
         run: rm -rf dist && uv build
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true
 
@@ -640,7 +640,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         working-directory: ${{ matrix.path }}
         run: uv build
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         if: steps.check.outputs.needed == 'true'
         with:
           skip-existing: true


### PR DESCRIPTION
## Problem

The [Publish Python packages run](https://github.com/Arize-ai/phoenix/actions/runs/31826953152/job/94853400362) failed while publishing `arize-phoenix-client` 3.2.0:

```
Checking dist/arize_phoenix_client-3.2.0-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Root cause: `uv build` (hatchling, unpinned in `build-system.requires`) now emits core packaging **Metadata-Version 2.5** in the client wheel, but the pinned `pypa/gh-action-pypi-publish` v1.13.0 bundles an older Twine that rejects it.

## Fix

Bump `pypa/gh-action-pypi-publish` from v1.13.0 to v1.14.2 at all 5 pin sites in `publish.yaml`. Per the [v1.14.2 release notes](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2), it upgrades the bundled Twine to v7, which accepts metadata v2.5. SHA-pinned to the commit the `v1.14.2` tag points to.

## After merge

The failed run published `arize-phoenix-evals` and `arize-phoenix-otel` successfully but **not** `arize-phoenix-client` 3.2.0 — someone needs to re-dispatch the Publish workflow after this merges to publish the client package.