### PR TITLE
fix(chat-completions): preserve prompt cache usage

### DIFF
--- a/js/app/src/api/__generated__/v1.ts
+++ b/js/app/src/api/__generated__/v1.ts
@@ -2283,6 +2283,12 @@ export interface components {
             completion_tokens: number;
             /** Total Tokens */
             total_tokens: number;
+            prompt_tokens_details?: components["schemas"]["ChatCompletionUsagePromptTokensDetails"] | null;
+        };
+        /** ChatCompletionUsagePromptTokensDetails */
+        ChatCompletionUsagePromptTokensDetails: {
+            /** Cached Tokens */
+            cached_tokens: number;
         };
         /**
          * ChatContext

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2283,6 +2283,12 @@ export interface components {
             completion_tokens: number;
             /** Total Tokens */
             total_tokens: number;
+            prompt_tokens_details?: components["schemas"]["ChatCompletionUsagePromptTokensDetails"] | null;
+        };
+        /** ChatCompletionUsagePromptTokensDetails */
+        ChatCompletionUsagePromptTokensDetails: {
+            /** Cached Tokens */
+            cached_tokens: number;
         };
         /**
          * ChatContext

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -2283,6 +2283,12 @@ export interface components {
             completion_tokens: number;
             /** Total Tokens */
             total_tokens: number;
+            prompt_tokens_details?: components["schemas"]["ChatCompletionUsagePromptTokensDetails"] | null;
+        };
+        /** ChatCompletionUsagePromptTokensDetails */
+        ChatCompletionUsagePromptTokensDetails: {
+            /** Cached Tokens */
+            cached_tokens: number;
         };
         /**
          * ChatContext

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -110,10 +110,8 @@ class ChatCompletionTextPart(TypedDict):
     text: str
 
 
-class ChatCompletionUsage(TypedDict):
-    prompt_tokens: int
-    completion_tokens: int
-    total_tokens: int
+class ChatCompletionUsagePromptTokensDetails(TypedDict):
+    cached_tokens: int
 
 
 class CodeEvaluatorContext(TypedDict):
@@ -1357,6 +1355,13 @@ class ChatCompletionChoice(TypedDict):
 class ChatCompletionRequestMessage(TypedDict):
     role: Literal["system", "developer", "user", "assistant"]
     content: Union[str, Sequence[ChatCompletionTextPart]]
+
+
+class ChatCompletionUsage(TypedDict):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    prompt_tokens_details: NotRequired[ChatCompletionUsagePromptTokensDetails]
 
 
 class ContinuousAnnotationConfigData(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -10599,6 +10599,16 @@
           "total_tokens": {
             "type": "integer",
             "title": "Total Tokens"
+          },
+          "prompt_tokens_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionUsagePromptTokensDetails"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -10608,6 +10618,19 @@
           "total_tokens"
         ],
         "title": "ChatCompletionUsage"
+      },
+      "ChatCompletionUsagePromptTokensDetails": {
+        "properties": {
+          "cached_tokens": {
+            "type": "integer",
+            "title": "Cached Tokens"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cached_tokens"
+        ],
+        "title": "ChatCompletionUsagePromptTokensDetails"
       },
       "ChatContext": {
         "oneOf": [

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -200,10 +200,15 @@ class ChatCompletionChoice(V1RoutesBaseModel):
     finish_reason: str
 
 
+class ChatCompletionUsagePromptTokensDetails(V1RoutesBaseModel):
+    cached_tokens: int
+
+
 class ChatCompletionUsage(V1RoutesBaseModel):
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    prompt_tokens_details: Optional[ChatCompletionUsagePromptTokensDetails] = None
 
 
 class ChatCompletion(V1RoutesBaseModel):
@@ -351,11 +356,16 @@ def _to_openai_finish_reason(finish_reason: Optional[FinishReason]) -> str:
 
 
 def _to_openai_usage(usage: RequestUsage) -> ChatCompletionUsage:
-    return ChatCompletionUsage(
-        prompt_tokens=usage.input_tokens,
-        completion_tokens=usage.output_tokens,
-        total_tokens=usage.input_tokens + usage.output_tokens,
-    )
+    kwargs: dict[str, Any] = {
+        "prompt_tokens": usage.input_tokens,
+        "completion_tokens": usage.output_tokens,
+        "total_tokens": usage.input_tokens + usage.output_tokens,
+    }
+    if usage.cache_read_tokens:
+        kwargs["prompt_tokens_details"] = ChatCompletionUsagePromptTokensDetails(
+            cached_tokens=usage.cache_read_tokens
+        )
+    return ChatCompletionUsage(**kwargs)
 
 
 def _response_text(response: PydanticAIModelResponse) -> str:
@@ -436,7 +446,7 @@ async def create_chat_completion(
         ],
         usage=_to_openai_usage(response.usage),
     )
-    return Response(completion.model_dump_json(), media_type="application/json")
+    return Response(completion.model_dump_json(exclude_none=True), media_type="application/json")
 
 
 _HTTP_STATUS_CODE_LIMIT = 600

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -18,6 +18,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCalls, FunctionModel
+from pydantic_ai.usage import RequestUsage
 from starlette.types import ASGIApp
 from strawberry.relay import GlobalID
 
@@ -102,6 +103,18 @@ def _validated_chunks(sse_text: str) -> list[dict[str, Any]]:
 
 
 class TestCreateChatCompletion:
+    def test_openai_usage_preserves_prompt_cache_hits(self) -> None:
+        usage = chat_completions_module._to_openai_usage(
+            RequestUsage(input_tokens=100, output_tokens=20, cache_read_tokens=60)
+        )
+
+        assert usage.model_dump(exclude_none=True) == {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+            "prompt_tokens_details": {"cached_tokens": 60},
+        }
+
     async def test_returns_openai_response_shape(
         self,
         openai_client: AsyncOpenAI,


### PR DESCRIPTION
Fixes #15444

## What changed

- Adds `usage.prompt_tokens_details.cached_tokens` to the OpenAI-compatible chat completions response model.
- Populates it from Pydantic AI `RequestUsage.cache_read_tokens` when cache reads are present.
- Keeps the field omitted when no cache-read usage is reported.

## Why

The route already returns an OpenAI-shaped `usage` object, but cache-read tokens were dropped while mapping `RequestUsage` into that response. Downstream OpenAI-compatible clients and telemetry need that detail to distinguish cached prompt reads from ordinary prompt input.

## Validation

- `.venv/bin/python -m pytest tests/unit/server/api/routers/v1/test_chat_completions.py -q` -> 20 passed, 19 skipped
- `.venv/bin/ruff check src/phoenix/server/api/routers/v1/chat_completions.py tests/unit/server/api/routers/v1/test_chat_completions.py` -> passed
- `.venv/bin/ruff format --check src/phoenix/server/api/routers/v1/chat_completions.py tests/unit/server/api/routers/v1/test_chat_completions.py` -> passed