### PR TITLE
fix(evals): use a non-blocking cooldown on the async rate limit path

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/rate_limiters.py
+++ b/packages/phoenix-evals/src/phoenix/evals/rate_limiters.py
@@ -94,11 +94,12 @@ class AdaptiveTokenBucket:
             self.rate = min(self.rate, self.maximum_rate)
         self.last_rate_update = time.time()
 
-    def on_rate_limit_error(self, request_start_time: float, verbose: bool = False) -> None:
+    def _reduce_rate_on_error(self, request_start_time: float, verbose: bool = False) -> bool:
+        """Throttle the rate, returning whether the caller should cool down."""
         now = time.time()
         if request_start_time < (self.last_error + self.cooldown):
             # do not reduce the rate for concurrent requests
-            return
+            return False
 
         original_rate = self.rate
 
@@ -115,7 +116,17 @@ class AdaptiveTokenBucket:
         self.last_checked = now
         self.last_rate_update = now
         self.last_error = now
-        time.sleep(self.cooldown)  # block for a bit to let the rate limit reset
+        return True
+
+    def on_rate_limit_error(self, request_start_time: float, verbose: bool = False) -> None:
+        if self._reduce_rate_on_error(request_start_time, verbose=verbose):
+            time.sleep(self.cooldown)  # block for a bit to let the rate limit reset
+
+    async def async_on_rate_limit_error(
+        self, request_start_time: float, verbose: bool = False
+    ) -> None:
+        if self._reduce_rate_on_error(request_start_time, verbose=verbose):
+            await asyncio.sleep(self.cooldown)  # never block the shared event loop
 
     def max_tokens(self) -> float:
         return self.rate * self.enforcement_window
@@ -273,7 +284,9 @@ class RateLimiter:
             except self._rate_limit_error:
                 async with self._rate_limit_handling_lock:
                     self._rate_limit_handling.clear()  # prevent new requests from starting
-                    self._throttler.on_rate_limit_error(request_start_time, verbose=self._verbose)
+                    await self._throttler.async_on_rate_limit_error(
+                        request_start_time, verbose=self._verbose
+                    )
                     try:
                         for _attempt in range(self._max_rate_limit_retries):
                             try:
@@ -281,7 +294,7 @@ class RateLimiter:
                                 await self._throttler.async_wait_until_ready()
                                 return await fn(*args, **kwargs)
                             except self._rate_limit_error:
-                                self._throttler.on_rate_limit_error(
+                                await self._throttler.async_on_rate_limit_error(
                                     request_start_time, verbose=self._verbose
                                 )
                                 continue

--- a/packages/phoenix-evals/tests/phoenix/evals/test_rate_limiters.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_rate_limiters.py
@@ -9,6 +9,8 @@ import pytest
 
 from phoenix.evals.rate_limiters import (
     AdaptiveTokenBucket,
+    RateLimiter,
+    RateLimitError,
     UnavailableTokensError,
 )
 
@@ -362,3 +364,80 @@ def test_token_bucket_decreases_rate_once_per_cooldown_period():
     with warp_time(start + 6):
         bucket.on_rate_limit_error(request_start_time=time.time())
         assert isclose(bucket.rate, 6.25)
+
+
+class _StubRateLimitError(Exception):
+    pass
+
+
+async def test_async_rate_limit_cooldown_does_not_block_the_event_loop():
+    """A blocking sleep here freezes every in-flight request, not just this one."""
+    bucket = AdaptiveTokenBucket(
+        initial_per_second_request_rate=100,
+        maximum_per_second_request_rate=200,
+        enforcement_window_minutes=1,
+        cooldown_seconds=5,
+    )
+
+    with mock.patch("time.sleep") as blocking_sleep:
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock) as non_blocking_sleep:
+            await bucket.async_on_rate_limit_error(request_start_time=time.time())
+
+    blocking_sleep.assert_not_called()
+    non_blocking_sleep.assert_awaited_once_with(bucket.cooldown)
+    assert isclose(bucket.rate, 50), "the rate is still reduced"
+    assert bucket.tokens == 0
+
+
+async def test_async_rate_limit_cooldown_matches_the_sync_state_changes():
+    """Only the kind of sleep should differ between the two paths."""
+    kwargs = dict(
+        initial_per_second_request_rate=100,
+        maximum_per_second_request_rate=200,
+        enforcement_window_minutes=1,
+        rate_reduction_factor=0.25,
+        cooldown_seconds=5,
+    )
+    sync_bucket = AdaptiveTokenBucket(**kwargs)
+    async_bucket = AdaptiveTokenBucket(**kwargs)
+
+    start = time.time()
+    with freeze_time(start):
+        with mock.patch("time.sleep"):
+            sync_bucket.on_rate_limit_error(request_start_time=start)
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+            await async_bucket.async_on_rate_limit_error(request_start_time=start)
+
+    assert isclose(async_bucket.rate, sync_bucket.rate)
+    assert async_bucket.tokens == sync_bucket.tokens
+    assert async_bucket.last_error == sync_bucket.last_error
+
+    # requests that started before the cooldown are ignored, as in the sync path
+    with freeze_time(start + 1):
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock) as skipped_sleep:
+            await async_bucket.async_on_rate_limit_error(request_start_time=start + 1)
+        skipped_sleep.assert_not_awaited()
+    assert isclose(async_bucket.rate, sync_bucket.rate), "still inside the cooldown"
+
+
+async def test_alimit_never_blocks_the_event_loop_on_rate_limit_errors():
+    """End to end through the decorator."""
+    limiter = RateLimiter(
+        rate_limit_error=_StubRateLimitError,
+        max_rate_limit_retries=1,
+        initial_per_second_request_rate=100,
+        maximum_per_second_request_rate=200,
+        enforcement_window_minutes=1,
+        cooldown_seconds=5,
+    )
+
+    @limiter.alimit
+    async def always_rate_limited() -> None:
+        raise _StubRateLimitError
+
+    with mock.patch("time.sleep") as blocking_sleep:
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+            with pytest.raises(RateLimitError):
+                await always_rate_limited()
+
+    blocking_sleep.assert_not_called()


### PR DESCRIPTION
`AdaptiveTokenBucket.on_rate_limit_error` calls the synchronous `time.sleep(self.cooldown)`, and `RateLimiter.alimit` invoked it from inside a coroutine. A single 429 therefore froze the whole event loop for the cooldown, stalling every other in-flight eval request rather than just the throttled one.

Adds `async_on_rate_limit_error`, which awaits `asyncio.sleep`, and awaits it from `alimit`. The synchronous `limit` path keeps the blocking sleep.

The rate reduction itself moves to a shared `_reduce_rate_on_error` helper used by both paths, so they cannot drift apart again -- the server-side twin in `src/phoenix/server/rate_limiters.py` grew an async variant while this copy did not, which is how the blocking call survived here.

resolves #<issue-number>
