### PR TITLE
fix(phoenix-sqlean): bump bundled sqlean to 0.28.4+10a13f9

### DIFF
--- a/packages/phoenix-sqlean/Makefile
+++ b/packages/phoenix-sqlean/Makefile
@@ -14,11 +14,11 @@ SQLEAN_REPO := https://github.com/nalgeon/sqlean.git
 # The release SQLEAN_COMMIT corresponds to, +<short sha> when the commit sits
 # ahead of it. check-sqlean-pin enforces that, and that setup.py's copy agrees
 # -- setup.py's is the one compiled in as what sqlean_version() reports.
-SQLEAN_VERSION := 0.28.3+6b969da
+SQLEAN_VERSION := 0.28.4
 # Pinned by commit, not tag: a tag can be moved to different content, a commit
 # cannot, and git verifies every object it receives. Why a given pin was
 # chosen belongs in the commit that moved it.
-SQLEAN_COMMIT := 6b969da844d9c3c79a0b226b403b3d8227b4ed46
+SQLEAN_COMMIT := 17f8f14bdaaea86012420224e179eabdb53a90b7
 # sqlean's crypto extension includes crypto/xxhash.impl.h but does not ship it.
 # XXHASH_TAG is the tag sqlean's own Makefile fetches; download-sqlean asserts
 # they still agree, so an upstream move stops the build.

--- a/packages/phoenix-sqlean/Makefile
+++ b/packages/phoenix-sqlean/Makefile
@@ -14,11 +14,11 @@ SQLEAN_REPO := https://github.com/nalgeon/sqlean.git
 # The release SQLEAN_COMMIT corresponds to, +<short sha> when the commit sits
 # ahead of it. check-sqlean-pin enforces that, and that setup.py's copy agrees
 # -- setup.py's is the one compiled in as what sqlean_version() reports.
-SQLEAN_VERSION := 0.28.4
+SQLEAN_VERSION := 0.28.4+10a13f9
 # Pinned by commit, not tag: a tag can be moved to different content, a commit
 # cannot, and git verifies every object it receives. Why a given pin was
 # chosen belongs in the commit that moved it.
-SQLEAN_COMMIT := 17f8f14bdaaea86012420224e179eabdb53a90b7
+SQLEAN_COMMIT := 10a13f904a80f43da65d8029ab3bb7db2d5a2304
 # sqlean's crypto extension includes crypto/xxhash.impl.h but does not ship it.
 # XXHASH_TAG is the tag sqlean's own Makefile fetches; download-sqlean asserts
 # they still agree, so an upstream move stops the build.

--- a/packages/phoenix-sqlean/setup.py
+++ b/packages/phoenix-sqlean/setup.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 PACKAGE_NAME = "sqlean"
 VERSION = "0.1.0"  # x-release-please-version
-SQLEAN_VERSION = "0.28.4"
+SQLEAN_VERSION = "0.28.4+10a13f9"
 
 SHORT_DESCRIPTION = "sqlite3 with extensions"
 LONG_DESCRIPTION = Path("README.md").read_text()

--- a/packages/phoenix-sqlean/setup.py
+++ b/packages/phoenix-sqlean/setup.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 PACKAGE_NAME = "sqlean"
 VERSION = "0.1.0"  # x-release-please-version
-SQLEAN_VERSION = "0.28.3+6b969da"
+SQLEAN_VERSION = "0.28.4"
 
 SHORT_DESCRIPTION = "sqlite3 with extensions"
 LONG_DESCRIPTION = Path("README.md").read_text()


### PR DESCRIPTION
Bumps the bundled sqlean to **0.28.4+10a13f9** — upstream `main`, four commits past the `0.28.4` tag.

| Pin | Was | Now |
|---|---|---|
| `SQLEAN_VERSION` | 0.28.3+6b969da | 0.28.4+10a13f9 |
| `SQLEAN_COMMIT` | `6b969da844d9...` | `10a13f904a80f43da65d8029ab3bb7db2d5a2304` |
| xxHash | | unchanged (`v0.8.3`) |

`SQLEAN_VERSION` carries the `+10a13f9` suffix because the pin sits ahead of
the `0.28.4` tag, picking up the post-release fixes on upstream `main`: gcc
warning fixes in `fileio`/`text`, and a shared `time/common.h` header replacing
the duplicated `uint64_to_int64` (covered by the existing `time/*.h` copy).
`setup.py` was moved in lockstep, so `sqlean_version()` reports the same string.

Reviewer checklist:

- [x] **Tag or past it?** Retargeted past the tag to upstream `main`
      (`10a13f9`), with the `+<short sha>` suffix restored to both
      `SQLEAN_VERSION` values.
- [x] `src/sqlean-time-msvc.patch` still applies — verified locally (clean
      apply, no fuzz; upstream only shifted line offsets). CI's Windows legs
      exercise it again.

Generated by `.github/workflows/phoenix-sqlean-upstream.yml`; retargeted to
upstream `main` by hand.

> [!NOTE]
> **Opened as a draft.** Verification happens on this PR:
> `phoenix-sqlean-ci.yml` runs the source-prep tripwires and then
> builds and tests every OS/arch/interpreter pair `publish.yaml`
> ships a wheel for — including the Windows legs, the only place
> `src/sqlean-time-msvc.patch` is ever exercised.
>
> Mark ready once those are green and the checklist above is settled.
>
> Opened by run
> https://github.com/Arize-ai/phoenix/actions/runs/32037935859.
