### PR TITLE
chore(deps): upgrade sqlglot to 30.17.0 and drop obsolete workarounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "openinference-semantic-conventions>=0.1.26",
   "openinference-instrumentation>=0.1.44",
   "openinference-instrumentation-openai>=0.1.41",
-  "sqlglot==30.15.0",
+  "sqlglot==30.17.0",
   "sqlalchemy[asyncio]>=2.0.46, <3",
   "alembic>=1.3.0, <2",
   "aiosqlite>=0.22.1",

--- a/src/phoenix/server/mcp/sql/allowlist.py
+++ b/src/phoenix/server/mcp/sql/allowlist.py
@@ -479,10 +479,9 @@ ALLOWED_ANON_FUNCTIONS_BY_DIALECT: dict[SupportedSQLDialectName, frozenset[str]]
             "jsonb_path_query_array",
             "jsonb_path_exists",
             "jsonb_path_match",
-            # Dynamic-key extraction. Not a workaround: callers write these, and
-            # PostgreSQL defines them. The rewrite that emits them for
-            # ``jsonb -> expr`` is the workaround (sqlglot<=30.15.0, remove when
-            # pin > 30.16.0; tobymao/sqlglot#8063). The names stay after that.
+            # Path extraction by name. Callers write these, and PostgreSQL
+            # defines them for jsonb; the rewrite of a portable
+            # ``json_extract`` call also emits them.
             "jsonb_extract_path",
             "jsonb_extract_path_text",
             # Key enumeration, which is how an undeclared key space is explored.

--- a/src/phoenix/server/mcp/sql/catalog.py
+++ b/src/phoenix/server/mcp/sql/catalog.py
@@ -114,39 +114,9 @@ class EngineInfo:
     extensions: tuple[str, ...] = ()
 
 
-# WORKAROUND sqlglot<=30.15.0 -- remove when pin > 30.16.0
-# Upstream: tobymao/sqlglot#8063 (closes #8035)
-# https://github.com/tobymao/sqlglot/issues/8035
-#
-# Remove when SQLGlot binds a cast to the operand of a JSON operator
-# rather than to the whole extraction. 30.16.0 does.
-#
-# `pg_get_indexdef` renders the operand of `#>>` as `'{a,b}'::text[]`, spelling
-# out a cast PostgreSQL applies implicitly. Publishing it verbatim would be
-# right -- admission allows an array of an allowed element type -- except that
-# SQLGlot's PostgreSQL parser binds `::` to the whole extraction rather than to
-# the literal, so `a #>> b::text[]` becomes `CAST(a #>> b AS TEXT[])`. That is a
-# different statement, and it fails: "malformed array literal".
-#
-# The defect is in the parse, so nothing downstream can recover the meaning, and
-# a caller who reproduces the published spelling -- which the surrounding text
-# tells them to do -- gets an error. Dropping the redundant cast yields a
-# spelling that survives the round trip and reaches the same index: verified
-# with EXPLAIN that the form with both casts, with only the outer one, and with
-# neither all produce `Index Scan using ix_spans_session_id`.
-# Anchored to a JSON operator, because that is the only place the cast is both
-# redundant and mis-parsed. A bare `(?<=')::text\[\]` also stripped casts that
-# resolve a polymorphic argument -- `array_length('{a,b}'::text[], 1)` becomes
-# `array_length('{a,b}', 1)`, which PostgreSQL refuses with "could not determine
-# polymorphic type" -- so the workaround reintroduced the defect it exists to
-# fix, moved from `#>>` to any operator-written index over an array literal.
-_IMPLICIT_ARRAY_CAST = re.compile(r"((?:#>>|#>|->>|->)\s*'[^']*')::text\[\]", re.IGNORECASE)
-
-
 def _body(definition: str) -> str:
     """The parenthesised body of an index definition, as a caller can write it."""
-    body = _DDL_PREAMBLE.sub("", definition.replace("\n", " ")).strip()
-    return _IMPLICIT_ARRAY_CAST.sub(r"\1", body)
+    return _DDL_PREAMBLE.sub("", definition.replace("\n", " ")).strip()
 
 
 def _classify(*, is_expression: bool, is_partial: bool, column_count: int) -> Optional[IndexKind]:

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -157,8 +157,7 @@ def _finish_parse(root: Optional[exp.Expr], *, dialect: SupportedSQLDialectName)
                 "Simplify the statement, or split it into CTEs."
             ),
         )
-    repaired = _repair_jsonb_extract_array_bracket(root)
-    repaired = _repair_lambda_json_accessor(repaired, dialect=dialect)
+    repaired = _repair_lambda_json_accessor(root, dialect=dialect)
     repaired = _promote_lateral_table_references(repaired, dialect=dialect)
     repaired = _repair_row_constructor(repaired, dialect=dialect)
     repaired = _repair_jsonb_typeof_text_extract(repaired, dialect=dialect)
@@ -249,41 +248,6 @@ def _recover_grouping_limit_parse(
         root.set("limit", exp.Limit(expression=exp.Literal.number(limit)))
     if offset is not None:
         root.set("offset", exp.Offset(expression=exp.Literal.number(offset)))
-    return root
-
-
-def _is_bare_array_name(expression: Optional[exp.Expression]) -> bool:
-    """Whether this is the unquoted identifier SQLGlot leaves when it misparses ARRAY[...]."""
-    if not isinstance(expression, exp.Column) or expression.table:
-        return False
-    identifier = expression.this
-    if isinstance(identifier, exp.Identifier) and identifier.args.get("quoted"):
-        return False
-    return (expression.name or "").casefold() == "array"
-
-
-def _repair_jsonb_extract_array_bracket(root: exp.Expression) -> exp.Expression:
-    """Rebuild ``doc #> ARRAY['a','b']`` from SQLGlot's Bracket misparse.
-
-    SQLGlot parses that spelling as subscripting ``JSONB_EXTRACT(doc, ARRAY)``
-    with the array elements as keys, so admission saw a Bracket (not in the
-    grammar) while ``doc #> '{a,b}'`` and ``doc #- ARRAY['a','b']`` both
-    admitted. Postgres treats the two path spellings as equivalent.
-    """
-    for bracket in list(root.find_all(exp.Bracket)):
-        extract = bracket.this
-        if not isinstance(extract, (exp.JSONBExtract, exp.JSONBExtractScalar)):
-            continue
-        if not _is_bare_array_name(extract.expression):
-            continue
-        elements = bracket.expressions
-        if not elements:
-            continue
-        rebuilt = type(extract)(
-            this=extract.this.copy(),
-            expression=exp.Array(expressions=[item.copy() for item in elements]),
-        )
-        bracket.replace(rebuilt)
     return root
 
 
@@ -1478,46 +1442,7 @@ def _check_node_classes(root: exp.Expression) -> Optional[AdmissionResult]:
                     f"CAST to {refused} is not supported; cast to one of the column "
                     "types describeSqlSchema reports.",
                 )
-            if _is_ambiguous_path_cast(node):
-                return AdmissionResult(
-                    AdmissionOutcome.UNSUPPORTED_SYNTAX,
-                    "A cast written directly after `#>` or `#>>` is ambiguous: it could "
-                    "cast the path or the extracted value. Parenthesise the one you mean "
-                    "-- `a #>> (b::text[])` casts the path, `(a #>> b)::text[]` casts the "
-                    "result. A path literal needs no cast at all.",
-                )
     return None
-
-
-# WORKAROUND sqlglot<=30.15.0 -- remove when pin > 30.16.0
-# Upstream: tobymao/sqlglot#8063 (closes #8035)
-# https://github.com/tobymao/sqlglot/issues/8035
-#
-# `#>` and `#>>` take a `text[]` path, so a cast on their right operand is
-# meaningful; `pg_get_indexdef` emits exactly that form for an expression index
-# over a JSON path.
-#
-# Through 30.15.0 SQLGlot binds such a cast to the whole extraction, so
-# `a #>> b::text[]` parses as `CAST(a #>> b AS TEXT[])`. A deliberate
-# `CAST(a #>> b AS text[])` produces the identical tree and means something
-# else: it parses the extracted string as an array literal, so
-# `('{"tags":"{a,b}"}'::jsonb #>> '{tags}')::text[]` yields a two-element array.
-#
-# Nothing in the tree separates the two, so neither reading can be chosen on the
-# caller's behalf, and the shape is refused with both unambiguous spellings
-# named. A parenthesised operand is unambiguous and never reaches this test: it
-# arrives under a `Paren` node.
-#
-# 30.16.0 binds the cast to the path. The two readings become distinct trees,
-# and this refusal is then only hitting the deliberate CAST-of-extraction form.
-_JSON_PATH_EXTRACTIONS = (exp.JSONBExtract, exp.JSONBExtractScalar)
-
-
-def _is_ambiguous_path_cast(node: exp.Cast) -> bool:
-    """True for a cast to an array type applied directly to a `#>`/`#>>` extraction."""
-    if not isinstance(node.this, _JSON_PATH_EXTRACTIONS):
-        return False
-    return isinstance(node.to, exp.DataType) and bool(node.to.this == exp.DataType.Type.ARRAY)
 
 
 def _cast_type_name(target: exp.Expression) -> str:

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -572,9 +572,13 @@ def _canonicalize_postgres_json_extract_function(
         inner = _strip_parens(node.expression)
         if not isinstance(inner, exp.JSONPath):
             operand = node.expression
-            # exp.Paren is itself a Unary, and an already-parenthesised operand
-            # renders unambiguously.
-            if isinstance(operand, (exp.Binary, exp.Unary)) and not isinstance(operand, exp.Paren):
+            # Binary and Unary cover the infix and prefix operators; Predicate
+            # adds the comparison forms that are neither, such as BETWEEN and
+            # IN. exp.Paren is itself a Unary, and an already-parenthesised
+            # operand renders unambiguously.
+            if isinstance(operand, (exp.Binary, exp.Unary, exp.Predicate)) and not isinstance(
+                operand, exp.Paren
+            ):
                 node.set("expression", exp.Paren(this=operand))
                 parenthesised = True
             continue

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -178,7 +178,7 @@ def rewrite(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
     root = _rewrite_sqlite_casts(root, ctx)
     root = _rewrite_sqlite_median(root, ctx)
     root = _canonicalize_json_extract(root, ctx)
-    root = _canonicalize_postgres_dynamic_json_extract(root, ctx)
+    root = _canonicalize_postgres_json_extract_function(root, ctx)
     root = _qualify_schema(root, ctx)
     root = _parenthesize_setop_operands(root, ctx)
     root = _inject_limit(root, ctx)
@@ -485,13 +485,12 @@ def _canonicalize_json_extract(root: exp.Expression, ctx: RewriteContext) -> exp
         return root
     changed = False
     for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
-        # `->` and `json_extract` parse to the same class, and rewriting both
-        # meant a caller who chose `->` deliberately got the other accessor's
-        # semantics -- a different value and a different type on every JSON
-        # scalar. The parser records which was written: the operator sets
-        # `only_json_types`, the function leaves it absent. Canonicalising is
-        # what stops the generator turning the function back into `->`, so it is
-        # still applied where the marker is missing.
+        # `->` returns JSON text; `json_extract` and `->>` return the SQL value.
+        # Rewriting the operator would therefore change both the value and the
+        # type of every JSON scalar, so only the function form is canonicalised
+        # -- which is also what stops the generator emitting it back as `->`.
+        # `only_json_types` marks the operator spelling. It decides rather than
+        # the node class, which is not stable across parser versions.
         if isinstance(node, exp.JSONExtract) and node.args.get("only_json_types") is not None:
             continue
         keys = _json_path_keys(node.expression)
@@ -540,82 +539,36 @@ def _canonicalize_json_extract(root: exp.Expression, ctx: RewriteContext) -> exp
     return root
 
 
-def _canonicalize_postgres_dynamic_json_extract(
+def _canonicalize_postgres_json_extract_function(
     root: exp.Expression, ctx: RewriteContext
 ) -> exp.Expression:
-    """Stop SQLGlot rendering ``jsonb -> expr`` as ``json_extract_path``.
+    """Emit PostgreSQL JSON reads written as a function against the jsonb forms.
 
-    WORKAROUND sqlglot<=30.15.0 -- remove when pin > 30.16.0.
-    Upstream: tobymao/sqlglot#8063 (closes #8035).
+    SQLGlot renders ``json_extract(attributes, '$.llm')`` -- the portable
+    spelling, and the one this surface canonicalises to on SQLite -- as
+    ``json_extract_path``, which PostgreSQL defines over ``json`` and not
+    ``jsonb``, so it refuses the stored column. ``jsonb_extract_path`` and
+    ``jsonb_extract_path_text`` are the jsonb equivalents; both are in the anon
+    allowlist, since callers may also write them directly.
 
-    PostgreSQL's ``json_extract_path`` takes ``json``, not ``jsonb``. A caller
-    who writes ``attributes -> k.key`` -- a dynamic key from ``jsonb_each`` --
-    is parsed as ``JSONExtract`` whose expression is a column, and the generator
-    emits ``JSON_EXTRACT_PATH(attributes, k.key)``, which the engine refuses.
-    Literal keys (``attributes -> 'llm'``) already render as ``->`` and are
-    left alone.
-
-    The replacement is ``jsonb_extract_path`` / ``jsonb_extract_path_text``,
-    which are the functions PostgreSQL defines for jsonb. Callers may also
-    write those names directly; they are in the anon allowlist for that reason.
-
-    30.16.0 renders a single non-literal segment as ``->`` / ``->>`` instead of
-    ``json_extract_path``. The allowlisted function names stay: they are real
-    PostgreSQL, not part of the workaround.
+    Two conditions bound the rewrite. The operand must be a ``JSONPath``, since
+    only a static path supplies the key arguments; any other operand renders as
+    ``->`` whichever spelling produced it -- ``a -> k.key`` and
+    ``json_extract(a, k.key)`` parse to the same tree -- and needs nothing here.
+    ``only_json_types`` then separates the two spellings that do carry a path,
+    marking the operator, which already renders correctly.
     """
     if ctx.dialect != "postgresql":
         return root
     changed = False
     for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
         inner = _strip_parens(node.expression)
-        if inner is None:
+        if not isinstance(inner, exp.JSONPath):
             continue
-        if isinstance(inner, exp.JSONPath):
-            # Operator form (`->` / `->>`) already renders correctly. The
-            # function form `json_extract` is emitted as json_extract_path,
-            # which takes json not jsonb and fails on the stored column.
-            if node.args.get("only_json_types") is not None:
-                continue
-            path_args = _json_path_extract_args(inner)
-            if path_args is None:
-                continue
-            name = (
-                "jsonb_extract_path_text"
-                if isinstance(node, exp.JSONExtractScalar)
-                else "jsonb_extract_path"
-            )
-            node.replace(
-                exp.Anonymous(
-                    this=name,
-                    expressions=[node.this, *path_args],
-                )
-            )
-            changed = True
+        if node.args.get("only_json_types") is not None:
             continue
-        # Array subscripts (`-> 1`, `-> (0)`) are integers. jsonb_extract_path
-        # only accepts text keys, so rewriting them changes a working operator
-        # into a missing function. A parenthesised integer still has to become
-        # a JSONPath subscript: SQLGlot renders `-> (1)` as json_extract_path.
-        if isinstance(inner, exp.Literal) and inner.is_number:
-            if inner is not node.expression:
-                try:
-                    index = int(inner.this)
-                except (TypeError, ValueError):
-                    continue
-                # `only_json_types` is how the generator distinguishes `-> 1`
-                # from json_extract_path. Copying the path without it still
-                # emits the function, and `'1'` is an object key, not index 1.
-                node.set(
-                    "expression",
-                    exp.JSONPath(
-                        expressions=[
-                            exp.JSONPathRoot(),
-                            exp.JSONPathSubscript(this=index),
-                        ]
-                    ),
-                )
-                node.set("only_json_types", True)
-                changed = True
+        path_args = _json_path_extract_args(inner)
+        if path_args is None:
             continue
         name = (
             "jsonb_extract_path_text"
@@ -625,7 +578,7 @@ def _canonicalize_postgres_dynamic_json_extract(
         node.replace(
             exp.Anonymous(
                 this=name,
-                expressions=[node.this, inner],
+                expressions=[node.this, *path_args],
             )
         )
         changed = True

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -551,19 +551,32 @@ def _canonicalize_postgres_json_extract_function(
     ``jsonb_extract_path_text`` are the jsonb equivalents; both are in the anon
     allowlist, since callers may also write them directly.
 
-    Two conditions bound the rewrite. The operand must be a ``JSONPath``, since
-    only a static path supplies the key arguments; any other operand renders as
-    ``->`` whichever spelling produced it -- ``a -> k.key`` and
-    ``json_extract(a, k.key)`` parse to the same tree -- and needs nothing here.
-    ``only_json_types`` then separates the two spellings that do carry a path,
-    marking the operator, which already renders correctly.
+    Only a ``JSONPath`` operand can supply the key arguments, so that is the
+    condition for the rewrite; ``only_json_types`` then separates the two
+    spellings that carry a path, marking the operator, which already renders
+    correctly.
+
+    Any other operand renders inline as ``a -> operand``, and an operand that is
+    itself an operator regroups when it does: ``json_extract(a, 'x' || 'y')``
+    emits ``a -> 'x' || 'y'``, which PostgreSQL reads as ``(a -> 'x') || 'y'``
+    because ``->`` and ``||`` share a precedence class and associate left. That
+    is a different statement, so such an operand is parenthesised. It can only
+    arise from the function spelling: written as an operator, the same text
+    groups that way in the parser too, and the extraction is not the top node.
     """
     if ctx.dialect != "postgresql":
         return root
     changed = False
+    parenthesised = False
     for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
         inner = _strip_parens(node.expression)
         if not isinstance(inner, exp.JSONPath):
+            operand = node.expression
+            # exp.Paren is itself a Unary, and an already-parenthesised operand
+            # renders unambiguously.
+            if isinstance(operand, (exp.Binary, exp.Unary)) and not isinstance(operand, exp.Paren):
+                node.set("expression", exp.Paren(this=operand))
+                parenthesised = True
             continue
         if node.args.get("only_json_types") is not None:
             continue
@@ -582,6 +595,8 @@ def _canonicalize_postgres_json_extract_function(
             )
         )
         changed = True
+    if parenthesised:
+        ctx.applied.append("json_operand_parens")
     if changed:
         ctx.applied.append("jsonb_extract_path")
     return root

--- a/src/phoenix/server/mcp/sql/tools.py
+++ b/src/phoenix/server/mcp/sql/tools.py
@@ -103,21 +103,12 @@ def _preamble(dialect: str, engine: Optional[EngineInfo]) -> str:
         "indexed. Predicates on them evaluate their expression and cannot use a direct index. "
         "Where listed, graphql_node_id is the ID shown in the Phoenix UI and REST API."
     )
-    # WORKAROUND sqlglot<=30.15.0 -- shorten when pin > 30.16.0
-    # Upstream: tobymao/sqlglot#8063 (closes #8035)
-    # https://github.com/tobymao/sqlglot/issues/8035
-    #
-    # Stated once here rather than paid for as a refusal per caller. Through
-    # 30.15.0 a suffix on the right operand of a JSON operator binds to the
-    # whole extraction instead of to the operand, so `a #>> b::text[]`,
-    # `a -> b[1]` and `a -> b.c -> d` all group differently from the way
-    # PostgreSQL reads them. Brackets settle every one of them, and cost the
-    # caller nothing when the operand is a bare literal, which is nearly always.
-    # After 30.16.0 the parser matches PostgreSQL; parenthesising a dotted or
-    # subscripted operand remains good advice, but the cast-path warning can go.
+    # Stated once here rather than paid for as a refusal per caller. Operands
+    # group as PostgreSQL groups them, so brackets change no meaning; they cost
+    # nothing and keep a subscripted or dotted operand readable.
     lines.append(
-        "-- JSON operators: parenthesise a cast, subscript, dotted name or arithmetic "
-        "operand; plain literals need no brackets."
+        "-- JSON operators: a subscript, dotted name or arithmetic operand reads more "
+        "clearly parenthesised; plain literals need no brackets."
     )
     # Stated here for the same reason as the JSON rules: the alternative is a
     # refusal, and a refusal costs a round trip to learn a rule that fits on one
@@ -127,12 +118,6 @@ def _preamble(dialect: str, engine: Optional[EngineInfo]) -> str:
         "-- Timestamps: time-of-day literals require a UTC offset, e.g. "
         "`start_time >= '2026-07-01T14:30:00Z'`; bare dates are read as UTC."
     )
-    if dialect == "postgresql":
-        # WORKAROUND sqlglot<=30.15.0 -- remove when pin > 30.16.0 (#8063 / #8035).
-        lines.append(
-            "-- PostgreSQL `#>`/`#>>`: parenthesise a cast path, e.g. `attributes #>> "
-            "('{a,b}'::text[])`; cast an extracted value as `(attributes #>> '{a,b}')::text[]`."
-        )
     return "\n".join(lines)
 
 

--- a/tests/unit/server/mcp/sql/admission_corpus.py
+++ b/tests/unit/server/mcp/sql/admission_corpus.py
@@ -385,14 +385,14 @@ CASES: tuple[AdmissionCase, ...] = (
     ),
     AdmissionCase(
         sql="SELECT count(*) FROM spans WHERE (attributes #>> '{session,id}'::text[]) IS NOT NULL",
-        expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
-        note="a cast written bare after #>> parses as a cast of the whole extraction, which is also what a deliberate CAST(a #>> b AS text[]) produces; the two readings are indistinguishable after parsing so neither is chosen for the caller",
+        expect=AdmissionOutcome.ADMIT,
+        note="a cast written bare after #>> binds to the path, the way PostgreSQL reads it, and is the form pg_get_indexdef publishes",
         dialect="postgresql",
     ),
     AdmissionCase(
         sql="SELECT CAST(attributes #>> '{session,id}' AS text[]) AS v FROM spans",
-        expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
-        note="the deliberate spelling of the same ambiguous tree, refused for the same reason; (attributes #>> '{session,id}')::text[] says it unambiguously and is admitted",
+        expect=AdmissionOutcome.ADMIT,
+        note="casting the extraction parses the extracted string as an array literal, a distinct operation and a distinct tree from casting the path",
         dialect="postgresql",
     ),
     AdmissionCase(
@@ -666,7 +666,7 @@ CASES: tuple[AdmissionCase, ...] = (
     AdmissionCase(
         sql="SELECT attributes #> ARRAY['session', 'id'] FROM spans",
         expect=AdmissionOutcome.ADMIT,
-        note="#> ARRAY['a','b'] is equivalent to #> '{a,b}' and must not be refused as Bracket",
+        note="#> ARRAY['a','b'] is the array-constructor spelling of the #> '{a,b}' path and reaches the same value, so it is admitted on the same terms",
         dialect="postgresql",
     ),
     AdmissionCase(

--- a/tests/unit/server/mcp/sql/test_ddl.py
+++ b/tests/unit/server/mcp/sql/test_ddl.py
@@ -519,16 +519,10 @@ def test_published_index_spellings_survive_the_parser() -> None:
     cannot itself carry is worse than none: it sends the caller to a
     documentation string that fails when used.
 
-    SQLGlot's PostgreSQL parser binds `::` to the whole extraction rather than
-    to the literal, so `a #>> b::text[]` -- the form `pg_get_indexdef` emits --
-    parses as `CAST(a #>> b AS TEXT[])` and errors on execution. Dropping that
-    redundant cast is a workaround, not a policy: admission allows array casts,
-    and the restriction it once fell foul of exists to block catalog types like
-    regclass, not arrays.
-
-    WORKAROUND sqlglot<=30.15.0 -- the catalog strip in `_IMPLICIT_ARRAY_CAST`
-    can go when pin > 30.16.0 (tobymao/sqlglot#8063, closes #8035). Keep the
-    round-trip assertion: published spellings must still parse.
+    `pg_get_indexdef` renders the operand of `#>>` as `'{a,b}'::text[]`, and
+    that cast is published verbatim. It must parse to what it says -- a cast of
+    the path -- because a cast bound to the whole extraction is a different
+    statement and errors on execution.
     """
 
     from phoenix.server.mcp.sql.catalog import _body
@@ -537,40 +531,29 @@ def test_published_index_spellings_survive_the_parser() -> None:
         "CREATE INDEX ix ON spans USING btree "
         "((((attributes #>> '{session,id}'::text[]))::character varying))"
     )
-    assert "::text[]" not in published
+    assert "::text[]" in published
 
-    # The published text must parse to the same thing it parses to a second
-    # time -- which the cast-bearing form does too, since the tree is wrong
-    # from the start -- so assert the operand instead: no array cast survives
-    # to be mis-bound.
     parsed = sqlglot.parse_one(
         f"SELECT count(*) FROM spans WHERE {published} IS NOT NULL", dialect="postgres"
     )
-    assert not [c for c in parsed.find_all(exp.DataType) if c.this == exp.DataType.Type.ARRAY]
+    extraction = next(parsed.find_all(exp.JSONBExtractScalar))
+    assert isinstance(extraction.expression, exp.Cast)
+    # No cast wraps the extraction, which would be the other reading.
+    assert not [c for c in parsed.find_all(exp.Cast) if isinstance(c.this, exp.JSONBExtractScalar)]
 
 
-def test_the_array_cast_workaround_only_touches_json_operands() -> None:
-    """Stripping a cast that resolves a polymorphic argument breaks the index.
+def test_the_index_body_is_published_without_editing_its_casts() -> None:
+    """A cast in an index definition is load-bearing and must reach the caller.
 
-    WORKAROUND sqlglot<=30.15.0 -- keep this guard after the catalog strip
-    is removed (pin > 30.16.0, #8063 / #8035): a future broader strip must
-    still not eat a load-bearing polymorphic cast.
-
-    The workaround exists because SQLGlot mis-parses `a #>> b::text[]`. A
-    blanket `(?<=')::text[]` also caught casts doing real work:
-    `array_length('{a,b}'::text[], 1)` became `array_length('{a,b}', 1)`, which
-    PostgreSQL refuses with "could not determine polymorphic type". That is the
-    same defect the workaround exists to fix -- the surface publishing a
-    spelling it cannot run -- moved from `#>>` to any operator-written index
-    over an array literal, which is exactly the population live reflection
-    serves.
+    An index body is published for a caller to reproduce exactly, so editing one
+    yields a spelling that does not run. `array_length('{a,b}'::text[], 1)`
+    resolves a polymorphic argument; stripped to `array_length('{a,b}', 1)`,
+    PostgreSQL refuses it with "could not determine polymorphic type".
     """
     from phoenix.server.mcp.sql.catalog import _body
 
-    stripped = _body("CREATE INDEX i ON spans (((attributes #>> '{a,b}'::text[])))")
-    assert "::text[]" not in stripped
-
     for kept in (
+        "CREATE INDEX i ON spans (((attributes #>> '{a,b}'::text[])))",
         "CREATE INDEX i ON spans ((array_length('{a,b}'::text[], 1)))",
         "CREATE INDEX i ON spans (tags) WHERE tags = '{a}'::text[]",
     ):

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -960,6 +960,45 @@ POSTGRES_JSON_SURFACE = [
         "SELECT jsonb_extract_path_text(attributes, 'session') AS v FROM spans",
         id="extract_path_text",
     ),
+    # The portable function spelling, which PostgreSQL does not define. It is
+    # rewritten to jsonb_extract_path because the generator would otherwise emit
+    # json_extract_path, which takes json and refuses the stored jsonb column.
+    pytest.param(
+        "SELECT json_extract('{\"a\":1}'::jsonb, '$.a') AS v FROM spans", id="json_extract_function"
+    ),
+    # The array-constructor spelling of a `#>` path, which reaches the same
+    # value as `#> '{a,b}'`.
+    pytest.param(
+        "SELECT '{\"a\":{\"b\":1}}'::jsonb #> ARRAY['a','b'] AS v FROM spans", id="array_path"
+    ),
+    pytest.param(
+        "SELECT '{\"a\":{\"b\":1}}'::jsonb #>> ARRAY['a','b'] AS v FROM spans",
+        id="array_path_scalar",
+    ),
+    # Operand shapes that reach the engine as written rather than through a
+    # rewrite. Each depends on the parser grouping the operand as PostgreSQL
+    # does, so each has to be executed rather than only rendered.
+    pytest.param(
+        "SELECT '{\"a\":1}'::jsonb -> k.key AS v FROM spans "
+        "CROSS JOIN LATERAL jsonb_each('{\"a\":1}'::jsonb) AS k",
+        id="dynamic_key",
+    ),
+    pytest.param(
+        "SELECT '{\"a\":1}'::jsonb ->> k.key AS v FROM spans "
+        "CROSS JOIN LATERAL jsonb_each('{\"a\":1}'::jsonb) AS k",
+        id="dynamic_key_scalar",
+    ),
+    pytest.param("SELECT '{\"a\":1}'::jsonb -> ('a') AS v FROM spans", id="parenthesised_key"),
+    pytest.param("SELECT '[1,2]'::jsonb -> (0) AS v FROM spans", id="parenthesised_subscript"),
+    pytest.param("SELECT '[1,2]'::jsonb -> 0 AS v FROM spans", id="bare_subscript"),
+    pytest.param(
+        "SELECT '{\"a\":{\"b\":1}}'::jsonb #>> '{a,b}'::text[] AS v FROM spans",
+        id="bare_cast_binds_to_path",
+    ),
+    pytest.param(
+        "SELECT CAST('{\"t\":\"{x,y}\"}'::jsonb #>> '{t}' AS text[]) AS v FROM spans",
+        id="cast_of_extraction",
+    ),
 ]
 
 

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -966,6 +966,18 @@ POSTGRES_JSON_SURFACE = [
     pytest.param(
         "SELECT json_extract('{\"a\":1}'::jsonb, '$.a') AS v FROM spans", id="json_extract_function"
     ),
+    # A computed key through the function spelling. `->` and `||` share a
+    # precedence class, so the operand has to reach the engine parenthesised or
+    # it is read as `(doc -> 'a') || 'b'`.
+    pytest.param(
+        "SELECT json_extract('{\"ab\":1}'::jsonb, 'a' || 'b') AS v FROM spans",
+        id="computed_key_concat",
+    ),
+    pytest.param(
+        'SELECT json_extract(\'{"k":"a","a":1}\'::jsonb, \'{"k":"a"}\'::jsonb ->> \'k\') AS v '
+        "FROM spans",
+        id="computed_key_nested_accessor",
+    ),
     # The array-constructor spelling of a `#>` path, which reaches the same
     # value as `#> '{a,b}'`.
     pytest.param(

--- a/tests/unit/server/mcp/sql/test_node_coverage.py
+++ b/tests/unit/server/mcp/sql/test_node_coverage.py
@@ -132,10 +132,6 @@ GOVERNED_BY_CHECK: dict[str, str] = {
     # SQLite has no interval type. Additive `start_time + INTERVAL '1 day'` is
     # rewritten to datetime(); a leftover Interval is refused. PostgreSQL runs it.
     "Interval": "parse._rewrite_sqlite_interval_arithmetic",
-    # SQLGlot misparses `jsonb #> ARRAY['a','b']` as Bracket around
-    # JSONBExtract(doc, Column(ARRAY)). parse_sql rebuilds the Array path;
-    # any other Bracket still fails the structural allowlist.
-    "Bracket": "parse._repair_jsonb_extract_array_bracket",
     # `col -> 'k'` inside a call parses as Lambda. parse_sql rebuilds JSON
     # accessors; a remaining Lambda is refused by `_REFUSED_NODE_CLASSES`.
     "Lambda": "parse._repair_lambda_json_accessor",

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -474,10 +474,9 @@ class TestCastTargetsAreRestrictedToDataTypes:
     published an index spelling under a heading telling the caller to reproduce
     it exactly, and admission then refused it.
 
-    The `#>>` case is written here with the cast parenthesised, which is the
-    spelling this surface asks for. The unparenthesised form is refused for
-    being ambiguous rather than for its cast target, and is pinned in
-    `TestPathCastAmbiguityIsRefused`.
+    The `#>>` case is written here with the cast parenthesised. The
+    unparenthesised form is admitted too, as a cast of the path rather than of
+    the extraction, and is pinned in `TestPathCastBindsToTheOperandItFollows`.
     """
 
     @pytest.mark.parametrize(

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -505,45 +505,33 @@ class TestCastTargetsAreRestrictedToDataTypes:
         assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
 
 
-class TestPathCastAmbiguityIsRefused:
-    """A cast straight after `#>`/`#>>` has two readings and the parse keeps neither.
+class TestPathCastBindsToTheOperandItFollows:
+    """A cast after `#>`/`#>>` casts the path; a cast around one casts the result.
 
-    SQLGlot binds the cast to the whole extraction, so `a #>> b::text[]` becomes
-    `CAST(a #>> b AS TEXT[])`. A caller who writes `CAST(a #>> b AS text[])`
-    deliberately gets that identical tree, and means something else by it: the
-    extracted string parsed as an array literal, which is a real operation.
+    `#>` and `#>>` take a `text[]` path, so `a #>> b::text[]` casts `b` -- which
+    is how PostgreSQL reads it and the form `pg_get_indexdef` emits for an
+    expression index over a JSON path. `CAST(a #>> b AS text[])` is a different
+    operation: it parses the extracted string as an array literal, so
+    `('{"tags":"{a,b}"}'::jsonb #>> '{tags}')::text[]` yields two elements.
 
-    Since the two are indistinguishable after parsing, choosing either one for
-    the caller answers a question somebody did not ask. Refusing costs a round
-    trip and names two spellings that cannot be misread.
-
-    WORKAROUND sqlglot<=30.15.0 -- delete or invert when pin > 30.16.0.
-    Upstream: tobymao/sqlglot#8063 (closes #8035). After that bump, `a #>>
-    b::text[]` binds the cast to the path and should admit; the deliberate
-    `CAST(a #>> b AS text[])` remains a real operation.
+    The two are distinct trees, so each is admitted as the operation it names.
     """
-
-    @pytest.mark.parametrize(
-        "sql",
-        [
-            "SELECT attributes #>> '{a,b}'::text[] AS v FROM spans",
-            "SELECT attributes #> '{a,b}'::text[] AS v FROM spans",
-            "SELECT count(*) FROM spans WHERE (attributes #>> '{s,id}'::text[]) IS NOT NULL",
-            # The same tree, reached by writing the cast out. Refused for the same
-            # reason: nothing here distinguishes it from the line above.
-            "SELECT CAST(attributes #>> '{a,b}' AS text[]) AS v FROM spans",
-        ],
-    )
-    def test_bare_cast_after_a_path_operator_is_refused(self, sql: str) -> None:
-        with pytest.raises(AnalyticsSqlError) as caught:
-            admit_sql(sql, allowlist=load_allowlist("sqlite"), dialect="postgresql")
-        assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
 
     @pytest.mark.parametrize(
         ("sql", "expected"),
         [
-            # Cast the path. Verified against PostgreSQL 17: returns the extracted
-            # value, and reaches an expression index built on the same path.
+            # Cast the path, written bare. Verified against PostgreSQL 17:
+            # returns the extracted value, and reaches an expression index built
+            # on the same path.
+            (
+                "SELECT attributes #>> '{a,b}'::text[] AS v FROM spans",
+                "SELECT attributes #>> CAST('{a,b}' AS TEXT[]) AS v FROM spans",
+            ),
+            (
+                "SELECT attributes #> '{a,b}'::text[] AS v FROM spans",
+                "SELECT attributes #> CAST('{a,b}' AS TEXT[]) AS v FROM spans",
+            ),
+            # The same, parenthesised. Both spellings survive as themselves.
             (
                 "SELECT attributes #>> ('{a,b}'::text[]) AS v FROM spans",
                 "SELECT attributes #>> (CAST('{a,b}' AS TEXT[])) AS v FROM spans",
@@ -554,6 +542,10 @@ class TestPathCastAmbiguityIsRefused:
                 "SELECT (attributes #>> '{a,b}')::text[] AS v FROM spans",
                 "SELECT CAST((attributes #>> '{a,b}') AS TEXT[]) AS v FROM spans",
             ),
+            (
+                "SELECT CAST(attributes #>> '{a,b}' AS text[]) AS v FROM spans",
+                "SELECT CAST(attributes #>> '{a,b}' AS TEXT[]) AS v FROM spans",
+            ),
             # No cast at all, which is what the path literal needs and what
             # describeSqlSchema publishes.
             (
@@ -562,9 +554,22 @@ class TestPathCastAmbiguityIsRefused:
             ),
         ],
     )
-    def test_both_unambiguous_spellings_are_admitted(self, sql: str, expected: str) -> None:
+    def test_every_spelling_is_admitted_as_written(self, sql: str, expected: str) -> None:
         _, rendered = admit_sql(sql, allowlist=load_allowlist("sqlite"), dialect="postgresql")
         assert rendered == expected
+
+    def test_the_two_readings_are_distinct_trees(self) -> None:
+        """The guard on the test above: identical trees would satisfy it by accident."""
+        path_cast = parse_sql(
+            "SELECT attributes #>> '{a,b}'::text[] AS v FROM spans", dialect="postgresql"
+        )
+        result_cast = parse_sql(
+            "SELECT CAST(attributes #>> '{a,b}' AS text[]) AS v FROM spans", dialect="postgresql"
+        )
+        assert path_cast != result_cast
+        # The cast hangs off the path in one and wraps the extraction in the other.
+        assert isinstance(next(path_cast.find_all(exp.JSONBExtractScalar)).expression, exp.Cast)
+        assert isinstance(next(result_cast.find_all(exp.Cast)).this, exp.JSONBExtractScalar)
 
     @pytest.mark.parametrize(
         "sql",
@@ -576,18 +581,8 @@ class TestPathCastAmbiguityIsRefused:
             "SELECT count(*) FROM spans WHERE id = ANY('{1,2}'::int[])",
         ],
     )
-    def test_the_refusal_does_not_reach_ordinary_casts(self, sql: str) -> None:
+    def test_ordinary_casts_are_unaffected(self, sql: str) -> None:
         admit_sql(sql, allowlist=load_allowlist("sqlite"), dialect="postgresql")
-
-    def test_the_message_names_both_spellings(self) -> None:
-        result = try_parse_and_admit(
-            "SELECT attributes #>> '{a,b}'::text[] AS v FROM spans", dialect="postgresql"
-        )
-        assert result.outcome is AdmissionOutcome.UNSUPPORTED_SYNTAX
-        # A refusal a caller cannot act on costs them a round trip and teaches
-        # nothing, so both working spellings have to appear in the text.
-        assert "#>> (b::text[])" in result.detail
-        assert "(a #>> b)::text[]" in result.detail
 
 
 class TestScopeInvariantIsPerScope:

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -771,14 +771,12 @@ def test_schema_qualification_still_qualifies_tables_and_joins() -> None:
     assert "public.spans" in out and "public.traces" in out
 
 
-def test_postgres_dynamic_json_key_renders_as_jsonb_extract_path() -> None:
+def test_postgres_dynamic_json_key_keeps_the_arrow_operator() -> None:
     """`attributes -> k.key` must not reach PostgreSQL as `json_extract_path`.
 
-    That function takes `json`, not `jsonb`. The rewrite emits the jsonb
-    spelling so a dynamic key from jsonb_each actually runs.
-
-    WORKAROUND sqlglot<=30.15.0 -- delete this assertion when pin > 30.16.0:
-    #8063 already keeps `->`. Invert to assert the operator survives.
+    That function takes `json`, not `jsonb`, and would refuse the stored column.
+    The operator renders as itself, which is both what the caller wrote and what
+    an expression index over the same accessor matches.
     """
     allowlist = load_allowlist("postgresql")
     sql = (
@@ -788,12 +786,12 @@ def test_postgres_dynamic_json_key_renders_as_jsonb_extract_path() -> None:
     root = admit(parse_sql(sql, dialect="postgresql"), allowlist=allowlist, dialect="postgresql")
     ctx = RewriteContext(allowlist=allowlist, dialect="postgresql", row_limit=500)
     out = render(rewrite(root, ctx), dialect="postgresql")
-    assert "JSONB_EXTRACT_PATH" in out.upper()
-    assert "JSON_EXTRACT_PATH(" not in out.upper().replace("JSONB_EXTRACT_PATH(", "")
-    assert "jsonb_extract_path" in ctx.applied
+    assert "-> k.key" in out
+    assert "EXTRACT_PATH" not in out.upper()
+    assert "jsonb_extract_path" not in ctx.applied
 
 
-def test_postgres_dynamic_json_key_scalar_renders_as_jsonb_extract_path_text() -> None:
+def test_postgres_dynamic_json_key_scalar_keeps_the_arrow_operator() -> None:
     allowlist = load_allowlist("postgresql")
     sql = (
         "SELECT s.attributes ->> k.key AS v FROM spans s "
@@ -802,8 +800,9 @@ def test_postgres_dynamic_json_key_scalar_renders_as_jsonb_extract_path_text() -
     root = admit(parse_sql(sql, dialect="postgresql"), allowlist=allowlist, dialect="postgresql")
     ctx = RewriteContext(allowlist=allowlist, dialect="postgresql", row_limit=500)
     out = render(rewrite(root, ctx), dialect="postgresql")
-    assert "JSONB_EXTRACT_PATH_TEXT" in out.upper()
-    assert "JSON_EXTRACT_PATH_TEXT" not in out.upper().replace("JSONB_EXTRACT_PATH_TEXT", "")
+    assert "->> k.key" in out
+    assert "EXTRACT_PATH" not in out.upper()
+    assert "jsonb_extract_path" not in ctx.applied
 
 
 def test_postgres_literal_json_key_keeps_the_arrow_operator() -> None:
@@ -904,7 +903,9 @@ def test_json_path_with_an_embedded_quote_is_left_alone() -> None:
     from phoenix.server.mcp.sql.rewrite import _quoted_json_path
 
     path = parse_sql("SELECT json_extract(attributes, '$.a') FROM spans", dialect="sqlite")
-    node = next(iter(path.find_all(__import__("sqlglot").exp.JSONExtract)))
+    # Both classes: which one `json_extract` parses to is a parser detail, and
+    # the canonicaliser walks both for that reason.
+    node = next(iter(path.find_all(exp.JSONExtract, exp.JSONExtractScalar)))
     assert _quoted_json_path(node.expression) == '$."a"'
 
 

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -805,6 +805,52 @@ def test_postgres_dynamic_json_key_scalar_keeps_the_arrow_operator() -> None:
     assert "jsonb_extract_path" not in ctx.applied
 
 
+@pytest.mark.parametrize(
+    ("sql", "expected_operand"),
+    [
+        # `->` and `||` share a precedence class and associate left, so an
+        # unparenthesised `a -> 'x' || 'y'` is `(a -> 'x') || 'y'`.
+        ("SELECT json_extract(attributes, 'a' || 'b') AS v FROM spans", "('a' || 'b')"),
+        # Nested accessors are in that class as well.
+        (
+            "SELECT json_extract(attributes, attributes ->> 'k') AS v FROM spans",
+            "(attributes ->> 'k')",
+        ),
+    ],
+)
+def test_postgres_operator_json_key_is_parenthesised(sql: str, expected_operand: str) -> None:
+    """A computed key must reach PostgreSQL grouped as the caller wrote it.
+
+    Only the function spelling produces this tree: written as an operator, the
+    same text groups in the parser the way PostgreSQL groups it, leaving the
+    extraction below the outer operator rather than at the top.
+    """
+    allowlist = load_allowlist("postgresql")
+    root = admit(parse_sql(sql, dialect="postgresql"), allowlist=allowlist, dialect="postgresql")
+    ctx = RewriteContext(allowlist=allowlist, dialect="postgresql", row_limit=500)
+    out = render(rewrite(root, ctx), dialect="postgresql")
+    assert expected_operand in out
+    assert "json_operand_parens" in ctx.applied
+    # The emitted SQL must parse back to an extraction, not to the outer operator.
+    reparsed = sqlglot.parse_one(out, read="postgres")
+    assert isinstance(reparsed, exp.Select)
+    assert isinstance(reparsed.expressions[0].this, (exp.JSONExtract, exp.JSONExtractScalar))
+
+
+def test_postgres_atomic_json_key_is_not_parenthesised() -> None:
+    """Guards the test above: parenthesising everything would also satisfy it."""
+    allowlist = load_allowlist("postgresql")
+    sql = (
+        "SELECT s.attributes -> k.key AS v FROM spans s "
+        "CROSS JOIN LATERAL jsonb_each(s.attributes) AS k"
+    )
+    root = admit(parse_sql(sql, dialect="postgresql"), allowlist=allowlist, dialect="postgresql")
+    ctx = RewriteContext(allowlist=allowlist, dialect="postgresql", row_limit=500)
+    out = render(rewrite(root, ctx), dialect="postgresql")
+    assert "-> k.key" in out
+    assert "json_operand_parens" not in ctx.applied
+
+
 def test_postgres_literal_json_key_keeps_the_arrow_operator() -> None:
     allowlist = load_allowlist("postgresql")
     root = admit(

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -816,6 +816,16 @@ def test_postgres_dynamic_json_key_scalar_keeps_the_arrow_operator() -> None:
             "SELECT json_extract(attributes, attributes ->> 'k') AS v FROM spans",
             "(attributes ->> 'k')",
         ),
+        # Comparison forms that are neither infix nor prefix operators, and so
+        # are reached by exp.Predicate rather than by Binary or Unary.
+        (
+            "SELECT json_extract(attributes, name BETWEEN 'a' AND 'b') AS v FROM spans",
+            "(name BETWEEN 'a' AND 'b')",
+        ),
+        (
+            "SELECT json_extract(attributes, name IN ('a', 'b')) AS v FROM spans",
+            "(name IN ('a', 'b'))",
+        ),
     ],
 )
 def test_postgres_operator_json_key_is_parenthesised(sql: str, expected_operand: str) -> None:

--- a/tests/unit/server/test_mcp_sql_tools.py
+++ b/tests/unit/server/test_mcp_sql_tools.py
@@ -55,7 +55,7 @@ async def test_schema_carries_the_invariants_the_envelope_does_not(
     assert "percentile(x, p)" in text or "percentile_cont(p)" in text
     assert 'detail="detailed"' in text
     assert "cannot use a direct index" in text
-    assert "JSON operators: parenthesise a cast" in text
+    assert "JSON operators: a subscript, dotted name or arithmetic operand" in text
 
 
 def test_postgres_preamble_advertises_its_percentile_spelling() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -763,7 +763,7 @@ requires-dist = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46,<3" },
-    { name = "sqlglot", specifier = "==30.15.0" },
+    { name = "sqlglot", specifier = "==30.17.0" },
     { name = "starlette", specifier = ">=0.37.0" },
     { name = "strawberry-graphql", specifier = "==0.320.4" },
     { name = "strawberry-graphql", extras = ["opentelemetry"], marker = "extra == 'container'", specifier = "==0.320.4" },
@@ -7899,11 +7899,11 @@ asyncio = [
 
 [[package]]
 name = "sqlglot"
-version = "30.15.0"
+version = "30.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/fb/c43bfdc662bd6fcdf93158f9239b975ac01b775cfcb56015913fee9b95e2/sqlglot-30.15.0.tar.gz", hash = "sha256:fe5412f4da61075f532d3de2482144bf7139028980a37bbd79fb016c49dc2dbe", size = 5973319, upload-time = "2026-08-04T17:37:12.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/d4/da49abcc81beebbb25f29ddf87f2980c63c949569d7f2da40c06d95fa415/sqlglot-30.17.0.tar.gz", hash = "sha256:2d6b8def93304fa300f4d20f48e3909e7f436fda56ca1fafd8975f6c561ef62c", size = 5999019, upload-time = "2026-08-12T19:36:50.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/f1e99aca0c23e2406dc8727555476647d58c2d6315d7d8101dffbb2cbc0f/sqlglot-30.15.0-py3-none-any.whl", hash = "sha256:594da0bc9d020edfb9982fd56b61dc93483cb24edca5ed1b3bb17937ba9b59bc", size = 731813, upload-time = "2026-08-04T17:37:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bc/2a07cef49046e6cf5d1a8b1de553aaef8491b4170dbfe254c8687c764408/sqlglot-30.17.0-py3-none-any.whl", hash = "sha256:84435ac283a60173da31b5fd7d11a725037a1c3fd6ed1e21fb065de74ddb579f", size = 741795, upload-time = "2026-08-12T19:36:48.699Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades `sqlglot` 30.15.0 → 30.17.0 and removes the compensations that release makes unnecessary.

## Why

Two upstream parser/generator defects had workarounds in `src/phoenix/server/mcp/sql/`. 30.17.0 fixes both:

- A cast now binds to the **operand** of a JSON operator rather than to the whole extraction ([tobymao/sqlglot#8063](https://github.com/tobymao/sqlglot/pull/8063), closes [#8035](https://github.com/tobymao/sqlglot/issues/8035)). `a #>> b::text[]` casts the path, as PostgreSQL reads it.
- A non-literal operand renders as `->` rather than `json_extract_path`.

Five source sites carried `WORKAROUND sqlglot<=30.15.0 -- remove when pin > 30.16.0` markers. All are gone.

## What changed

| Area | Change |
|---|---|
| `catalog.py` | Publish `pg_get_indexdef` output verbatim; the array-cast strip is gone |
| `parse.py` | Admit `a #>> b::text[]` and `CAST(a #>> b AS text[])` — now distinct trees naming distinct operations |
| `parse.py` | Drop the `#> ARRAY[...]` `Bracket` repair |
| `rewrite.py` | Reduce the postgres JSON pass to its still-load-bearing branches |
| `tools.py` | Drop cast-path guidance the parser makes unnecessary |

### Two findings worth a reviewer's attention

**One workaround survived, reduced.** `_canonicalize_postgres_dynamic_json_extract` was tagged wholesale as a workaround, but its JSONPath branch is load-bearing for an unrelated reason: `json_extract(attributes, '$.llm')` still renders as `JSON_EXTRACT_PATH`, which PostgreSQL defines over `json`, not `jsonb`, so it refuses the stored column. That is dialect portability, not #8063. The branch is kept; the function is renamed `_canonicalize_postgres_json_extract_function` and its docstring rewritten to say what it actually does.

**An untagged workaround was also dead.** `_repair_jsonb_extract_array_bracket` compensated for `doc #> ARRAY['a','b']` misparsing as a `Bracket`. It carried no `WORKAROUND` marker, and in 30.17.0 that shape parses natively — the repair silently no-opped. It fails invisibly in both directions (the native parse yields the tree the repair used to build), so no test would have caught it. Its removal was checked against 306 generated spellings — quoting, casing, qualification, nesting, chaining — with zero occurrences of the guarded pattern and zero admission regressions.

### A regression this branch found and fixed (8cea9ff1e)

Deleting the pass's generic branch over-reached, and adversarial review caught it before merge.

`->` and `||` share a precedence class in PostgreSQL and associate left. So `json_extract(attributes, 'a' || 'b')` — admitted as an extraction of key `ab` — emitted `attributes -> 'a' || 'b'`, which PostgreSQL executes as `(attributes -> 'a') || 'b'`. A **different statement**: it errors on a jsonb column, or silently concatenates. Nested accessors (`json_extract(attributes, attributes ->> 'k')`) regroup the same way.

The fix parenthesises an operand that is itself an operator. Atomic operands are untouched, so a dynamic key keeps its arrow and any index match. Only the function spelling can reach this — written as an operator, the same text groups in the parser the way PostgreSQL groups it, leaving the extraction below the outer operator.

## Testing

Each shape whose rewrite was removed is now covered by a **liveness case that executes against the engine**, not merely renders — dynamic key from `jsonb_each`, parenthesised key and subscript, bare cast path, cast-of-extraction, the array-constructor path, computed keys, and the function form that still needs its rewrite. Admission-only coverage is precisely what let both defects above hide.

- PostgreSQL 17: **2001 passed**
- SQLite: **1892 passed**
- `make lint-python`, `make typecheck-python`: clean

Scope note: counts are for `tests/unit/server/mcp/` plus `test_mcp_sql_tools.py`. `sqlglot` is imported nowhere in `src/` or `packages/` outside `src/phoenix/server/mcp/sql/`.
