### PR TITLE
docs: rewrite Phoenix vs Arize FAQ 

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -478,6 +478,7 @@
                 "group": "Arize AX",
                 "root": "docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize",
                 "pages": [
+                  "docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize",
                   "docs/phoenix/resources/phoenix-to-arize-ax-migration"
                 ]
               },

--- a/docs.json
+++ b/docs.json
@@ -458,7 +458,6 @@
                 "group": "Frequently Asked Questions",
                 "pages": [
                   "docs/phoenix/resources/frequently-asked-questions",
-                  "docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize",
                   "docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint",
                   "docs/phoenix/resources/frequently-asked-questions/can-i-add-other-users-to-my-phoenix-instance",
                   "docs/phoenix/resources/frequently-asked-questions/can-i-use-azure-openai",
@@ -475,7 +474,13 @@
                 ]
               },
               "docs/phoenix/resources/contribute-to-phoenix",
-              "docs/phoenix/resources/phoenix-to-arize-ax-migration",
+              {
+                "group": "Arize AX",
+                "root": "docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize",
+                "pages": [
+                  "docs/phoenix/resources/phoenix-to-arize-ax-migration"
+                ]
+              },
               "docs/phoenix/resources/typescript-api",
               "docs/phoenix/resources/python-api",
               "docs/phoenix/resources/github",

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -461,8 +461,8 @@
 
 - [General FAQs](https://arize.com/docs/phoenix/resources/frequently-asked-questions): Common questions about Phoenix features, pricing, and compatibility
 - [Contribute](https://arize.com/docs/phoenix/resources/contribute-to-phoenix): Open-source contribution guide
-- [Phoenix to Arize AX Migration](https://arize.com/docs/phoenix/resources/phoenix-to-arize-ax-migration): Migration guide from Phoenix to Arize AX
-
+- [Arize Phoenix or Arize AX](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize): Compare open-source Phoenix with the commercial Arize AX platform and decide which fits your team
+- [Migrating to Arize AX](https://arize.com/docs/phoenix/resources/phoenix-to-arize-ax-migration): Move traces, evaluations, annotations, datasets, and experiments from Phoenix to Arize AX
 
 - [Braintrust Open Source Alternative? LLM Evaluation Platform Comparison](https://arize.com/docs/phoenix/resources/frequently-asked-questions/braintrust-open-source-alternative-llm-evaluation-platform-comparison): Compare Phoenix and Braintrust across tracing, evaluation, and licensing
 - [Can I add other users to my Phoenix Instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-add-other-users-to-my-phoenix-instance): Enable authentication and invite teammates to a Phoenix deployment
@@ -477,7 +477,6 @@
 - [Open Source LangSmith Alternative: Arize Phoenix vs. LangSmith](https://arize.com/docs/phoenix/resources/frequently-asked-questions/open-source-langsmith-alternative-arize-phoenix-vs.-langsmith): Compare Phoenix and LangSmith across observability, evaluation, and open-source features
 - [What is my Phoenix Endpoint?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint): Find the collector endpoint and base URL to point your SDK at
 - [What is the difference between GRPC and HTTP?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-grpc-and-http): Choose between the gRPC and HTTP OTLP transports for span export
-- [What is the difference between Phoenix and Arize?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize): Understand how open-source Phoenix relates to the Arize AX platform
 
 ## SDK & API Reference
 

--- a/docs/phoenix/resources/frequently-asked-questions.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Overview"
 </Info>
 
 <CardGroup cols={2}>
-  <Card title="What is the difference between Phoenix and Arize?" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize" icon="circle-question" horizontal description="Product comparison overview"/>
+  <Card title="Arize Phoenix or Arize AX" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize" icon="circle-question" horizontal description="How the two platforms differ and how to choose"/>
   <Card title="What is my Phoenix Endpoint?" href="/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint" icon="circle-question" horizontal description="Endpoint discovery guidance"/>
   <Card title="Can I add other users to my Phoenix Instance?" href="/docs/phoenix/resources/frequently-asked-questions/can-i-add-other-users-to-my-phoenix-instance" icon="circle-question" horizontal description="User management guidance"/>
   <Card title="Can I use Azure OpenAI?" href="/docs/phoenix/resources/frequently-asked-questions/can-i-use-azure-openai" icon="circle-question" horizontal description="Azure OpenAI support"/>

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -5,7 +5,7 @@ description: "Phoenix is a fully open-source platform for agent development and 
 
 Phoenix is an open-source platform for agent development and evaluation, intended to be self-hosted and free to use: you run it on your own infrastructure, locally, or in a container.
 
-Phoenix is sponsored by Arize and maintained by a team of core maintainers, but it is a community project, striving to further the open development of tracing and evaluation for developers and OSS contributors alike. It is a unique project in this space in that it is fully open-source end-to-end — there is no closed core or paywalled tier within Phoenix itself.
+Phoenix is sponsored by Arize and maintained by a team of core maintainers, but it is a community project, striving to further the open development of tracing and evaluation for developers and OSS contributors alike. It is a unique project in this space in that it is fully open-source end-to-end — there is no closed core or paywalled tier within Phoenix itself. No Phoenix feature is gated by the commercial offering: Phoenix is built in the open, and it will never decline to develop a feature because Arize AX offers it.
 
 **[Arize AX](https://arize.com/products/ax/)** is Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. If you are looking for a managed SaaS platform with full support and SLAs, Arize AX is the solution.
 
@@ -20,7 +20,7 @@ The clearest way to decide is by who you want operating the infrastructure:
 
 ## What does Arize AX include that Phoenix does not?
 
-Because Arize manages the infrastructure, Arize AX can offer capabilities that go beyond running the core workflow:
+Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project — such as ADB (the Arize database) and Signal (managed agents) — and offers a suite of comprehensive managed services we hope teams take advantage of as they scale up their agents:
 
 * **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize operates for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
 * **Monitors and custom dashboards.** Production monitoring, alerting, and dashboards tailored for non-developer stakeholders.

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -7,7 +7,7 @@ Phoenix is an open-source platform for agent development and evaluation, intende
 
 Phoenix is sponsored by Arize and maintained by a team of core maintainers, but it is a community project, striving to further the open development of tracing and evaluation for developers and OSS contributors alike. It is a unique project in this space in that it is fully open-source end-to-end — there is no closed core or paywalled tier within Phoenix itself. No Phoenix feature is gated by the commercial offering: Phoenix is built in the open, and it will never decline to develop a feature because Arize AX offers it.
 
-**[Arize AX](https://arize.com/products/ax/)** is Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. If you are looking for a managed SaaS platform with full support and SLAs, Arize AX is the solution.
+**[Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix)** is Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. If you are looking for a managed SaaS platform with full support and SLAs, Arize AX is the solution.
 
 The two products are complementary, not competing. They are built on the same open standards ([OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference)) and share the same core tracing and evaluation workflow, so an application instrumented for one can send the same data to the other without re-instrumenting; you simply point your traces at the other destination.
 
@@ -16,17 +16,17 @@ The two products are complementary, not competing. They are built on the same op
 The clearest way to decide is by who you want operating the infrastructure:
 
 * **Phoenix** is free to use and the right choice when you want to keep both your data _and_ your infrastructure under your own control — for example in an air-gapped network or on a regulated team that must keep trace data inside its own environment. Your team owns the deployment, upgrades, and scaling, with community support behind it.
-* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize operates the platform and backs it with enterprise-grade support and SLAs. [Arize AX can also be self-hosted](https://arize.com/docs/ax) in your own environment, though this requires a commercial license.
+* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize operates the platform and backs it with enterprise-grade support and SLAs. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
 
 ## What does Arize AX include that Phoenix does not?
 
 Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project — such as ADB (the Arize database) and Signal (managed agents) — and offers a suite of comprehensive managed services we hope teams take advantage of as they scale up their agents:
 
-* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize operates for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
+* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize operates for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
 * **Monitors and custom dashboards.** Production monitoring, alerting, and dashboards tailored for non-developer stakeholders.
 * **Enterprise-grade support.** Dedicated support and SLAs rather than community support.
 
-For the full breakdown of Arize AX plans and features, see [arize.com/pricing](https://arize.com/pricing/).
+For the full breakdown of Arize AX plans and features, see [arize.com/pricing](https://arize.com/pricing?utm_source=docs&utm_medium=web&utm_content=phoenix).
 
 ## Can Phoenix run in production?
 

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -19,14 +19,14 @@ description: "How the open-source Phoenix platform and the commercial Arize AX p
 | Scaling        | Your team provisions and scales the deployment                          | Infrastructure auto-scales, managed by Arize                                    |
 | Support        | Community support                                                        | Enterprise-grade support and SLAs                                               |
 
-What they share matters as much as what separates them. Both are built on the same open standards, [OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference), and share the same core tracing and evaluation workflow. An application instrumented for one can send the same data to the other without re-instrumenting; you simply point your traces at the other destination.
+The two platforms share a common DNA and core. Both are built on the same open standards, [OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference), and use the same core tracing and evaluation workflow, which makes them complementary tools for teams and companies of any size. An application instrumented for one can send the same data to the other without re-instrumenting; you simply point your traces at the other destination, or even at both when needed.
 
 ## How do I choose?
 
 Either platform will get you started, and starting with one never closes the door on the other. The choice comes down to what your team values:
 
 * **Choose Phoenix** if you are deeply passionate about open source and want a platform you can read, extend, and contribute back to, with a roadmap you can help shape. Phoenix is also extremely privacy-conscious: it runs in the most regulated, air-gapped environments, keeping both your data _and_ your infrastructure entirely under your own control. In scenarios where a commercial offering is largely off the table, Phoenix is often the preferred choice, and sometimes the only viable one. Your team owns the deployment, upgrades, and scaling, with community support behind it.
-* **Choose Arize AX** if you prefer a SaaS experience: enterprise-ready out of the box, with dedicated support, SLAs, and infrastructure that auto-scales without a single ticket to your platform team. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
+* **Choose Arize AX** if you prefer a SaaS experience: enterprise-ready out of the box, with dedicated support, SLAs, and infrastructure that auto-scales without a single ticket to your platform team. If you are looking to procure an observability and evaluation platform as a B2B purchase, start with Arize AX. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
 
 ## What does Arize AX include that Phoenix does not?
 

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -16,13 +16,13 @@ The two products are complementary, not competing. They are built on the same op
 The clearest way to decide is by who you want operating the infrastructure:
 
 * **Phoenix** is free to use and the right choice when you want to keep both your data _and_ your infrastructure under your own control — for example in an air-gapped network or on a regulated team that must keep trace data inside its own environment. Your team owns the deployment, upgrades, and scaling, with community support behind it.
-* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize operates the platform and backs it with enterprise-grade support and SLAs. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
+* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize AX is fully managed and backed by enterprise-grade support and SLAs. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
 
 ## What does Arize AX include that Phoenix does not?
 
 Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project — such as ADB (the Arize database) and Signal (managed agents) — and offers a suite of comprehensive managed services we hope teams take advantage of as they scale up their agents:
 
-* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize operates for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
+* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize AX manages for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
 * **Monitors and custom dashboards.** Production monitoring, alerting, and dashboards tailored for non-developer stakeholders.
 * **Enterprise-grade support.** Dedicated support and SLAs rather than community support.
 

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -1,40 +1,54 @@
 ---
-title: "What is the difference between Phoenix and Arize?"
-description: "Phoenix is a fully open-source platform for agent development and evaluation, sponsored by Arize, intended to be self-hosted and free to use. Arize AX is Arize's managed AI engineering platform, delivered as a fully supported SaaS."
+title: "Arize Phoenix or Arize AX"
+description: "How the open-source Phoenix platform and the commercial Arize AX platform differ, and how to choose between them."
 ---
 
-Phoenix is an open-source platform for agent development and evaluation, intended to be self-hosted and free to use: you run it on your own infrastructure, locally, or in a container.
+[Arize](https://arize.com/) is the company behind both products. Its mission is to make the world's AI work, and it pursues that mission through two platforms: Arize AX, a commercial offering, and Phoenix, an open-source one. The two are not rivals separated by a paywall. They are complementary observability and evaluation tools, and the choice between them comes down to how a team prefers to operate: on a managed commercial platform, or on open-source software it hosts and scales itself.
 
-Phoenix is sponsored by Arize and maintained by a team of core maintainers, but it is a community project, striving to further the open development of tracing and evaluation for developers and OSS contributors alike. It is a unique project in this space in that it is fully open-source end-to-end — there is no closed core or paywalled tier within Phoenix itself. No Phoenix feature is gated by the commercial offering: Phoenix is built in the open, and it will never decline to develop a feature because Arize AX offers it.
+## The two platforms, side by side
 
-**[Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix)** is Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. If you are looking for a managed SaaS platform with full support and SLAs, Arize AX is the solution.
+**Phoenix** is Arize's open-source platform for agent development and evaluation: self-hosted, free to use, and fully open end-to-end. There is no closed core and no paywalled tier within Phoenix itself: no Phoenix feature is gated by the commercial offering, and Phoenix will never decline to build a feature because Arize AX offers it. It has a dedicated team of core maintainers but lives as a community project, built for developers and teams who want to grow their agent observability on open-source tools.
 
-The two products are complementary, not competing. They are built on the same open standards ([OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference)) and share the same core tracing and evaluation workflow, so an application instrumented for one can send the same data to the other without re-instrumenting; you simply point your traces at the other destination.
+**[Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix)** is Arize's managed, all-in-one AI engineering platform for observing, evaluating, and improving agents in production. It is geared toward teams that require large-scale managed deployments: in its managed form, the infrastructure, the scaling, and the operational burden belong to Arize, not to you.
+
+|                | Phoenix                                                                 | Arize AX                                                                       |
+| -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| What it is     | Open-source agent development and evaluation platform                    | Managed, all-in-one AI engineering platform                                     |
+| How it runs    | Self-hosted: your laptop, your cloud, your air-gapped network            | Fully managed SaaS (self-hosting available under a commercial license)          |
+| Cost           | Free to use                                                              | Commercial, with a free tier (see [pricing](https://arize.com/pricing?utm_source=docs&utm_medium=web&utm_content=phoenix)) |
+| Scaling        | Your team provisions and scales the deployment                          | Infrastructure auto-scales, managed by Arize                                    |
+| Support        | Community support                                                        | Enterprise-grade support and SLAs                                               |
+
+What they share matters as much as what separates them. Both are built on the same open standards, [OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference), and share the same core tracing and evaluation workflow. An application instrumented for one can send the same data to the other without re-instrumenting; you simply point your traces at the other destination.
 
 ## How do I choose?
 
-The clearest way to decide is by who you want operating the infrastructure:
+Either platform will get you started, and starting with one never closes the door on the other. The choice comes down to what your team values:
 
-* **Phoenix** is free to use and the right choice when you want to keep both your data _and_ your infrastructure under your own control — for example in an air-gapped network or on a regulated team that must keep trace data inside its own environment. Your team owns the deployment, upgrades, and scaling, with community support behind it.
-* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize AX is fully managed and backed by enterprise-grade support and SLAs. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
+* **Choose Phoenix** if you are deeply passionate about open source and want a platform you can read, extend, and contribute back to, with a roadmap you can help shape. Phoenix is also extremely privacy-conscious: it runs in the most regulated, air-gapped environments, keeping both your data _and_ your infrastructure entirely under your own control. In scenarios where a commercial offering is largely off the table, Phoenix is often the preferred choice, and sometimes the only viable one. Your team owns the deployment, upgrades, and scaling, with community support behind it.
+* **Choose Arize AX** if you prefer a SaaS experience: enterprise-ready out of the box, with dedicated support, SLAs, and infrastructure that auto-scales without a single ticket to your platform team. [Arize AX can also be self-hosted](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=phoenix) in your own environment, though this requires a commercial license.
 
 ## What does Arize AX include that Phoenix does not?
 
-Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project — such as ADB (the Arize database) and Signal (managed agents) — and offers a suite of comprehensive managed services we hope teams take advantage of as they scale up their agents:
+Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project, such as ADB (the Arize database) and Signal, and offers managed services that become more valuable as teams scale up their agents:
 
-* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize AX manages for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
+* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix), a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues, run on infrastructure Arize AX manages for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
+* **Built for large AI engineering teams.** Dedicated workspaces and organizations keep many teams and projects in order, powerful auditing capabilities track who did what across them, and the evaluation infrastructure is designed to run on massive production workloads.
 * **Monitors and custom dashboards.** Production monitoring, alerting, and dashboards tailored for non-developer stakeholders.
+* **Compliance certifications.** As a managed SaaS, Arize AX carries the certifications enterprises expect, including HIPAA and SOC 2. Phoenix is no less secure; those certifications simply don't apply to it in the same way. Because Phoenix is self-hosted, your data resides entirely on your own premises and never touches Arize's infrastructure, so compliance is governed by your own environment rather than by a vendor's certification.
 * **Enterprise-grade support.** Dedicated support and SLAs rather than community support.
 
 For the full breakdown of Arize AX plans and features, see [arize.com/pricing](https://arize.com/pricing?utm_source=docs&utm_medium=web&utm_content=phoenix).
 
 ## Can Phoenix run in production?
 
-Yes. Phoenix is used in both development and production by teams that are able to manage their own infrastructure. The difference is not whether Phoenix can run in production (it can), but who operates the platform and the level of support and capability behind it.
+Yes. Phoenix runs in production today at companies of every size, from small teams to large enterprises that have scaled to tens of Phoenix instances in production. The real question is not whether Phoenix can handle production workloads (it can), but who operates the platform and what level of support sits behind it.
 
 ## Do I have to pick one?
 
-No. Because both products speak the same open standards, many teams use them together, and adopting one never locks you out of the other:
+No, and the strongest teams often don't. Because both platforms speak the same open standards, adopting one never locks you out of the other, and they work well together:
 
-* **Start with Phoenix, grow into Arize AX.** Teams often begin with Phoenix for development and early production, then move to Arize AX when enterprise constraints — support requirements, SLAs, monitoring for a broader set of stakeholders — come into play. Your instrumentation carries over unchanged.
-* **Use Arize AX, keep Phoenix for the workloads you choose.** Teams on Arize AX still reach for Phoenix where a local, self-contained instance fits best: local experimentation, CI pipelines, or isolated environments.
+* **Start with Phoenix, grow into Arize AX.** Teams often begin with Phoenix for development and early production, then move to Arize AX when enterprise constraints such as support requirements, SLAs, and monitoring for a broader set of stakeholders come into play. Your instrumentation carries over unchanged.
+* **Use Arize AX, keep Phoenix for the workloads you choose.** Teams on Arize AX still reach for Phoenix where a local, self-contained instance fits best: local experimentation, CI pipelines, or isolated and regulated environments.
+
+Wherever you start, both remain within reach: an open platform you can shape, a managed platform that scales for you, and a single set of instrumentation that works with either.

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -16,7 +16,7 @@ The two products are complementary, not competing. They are built on the same op
 The clearest way to decide is by who you want operating the infrastructure:
 
 * **Phoenix** is free to use and the right choice when you want to keep both your data _and_ your infrastructure under your own control — for example in an air-gapped network or on a regulated team that must keep trace data inside its own environment. Your team owns the deployment, upgrades, and scaling, with community support behind it.
-* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize operates the platform and backs it with enterprise-grade support and SLAs.
+* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize operates the platform and backs it with enterprise-grade support and SLAs. [Arize AX can also be self-hosted](https://arize.com/docs/ax) in your own environment, though this requires a commercial license.
 
 ## What does Arize AX include that Phoenix does not?
 

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -1,6 +1,21 @@
 ---
 title: "What is the difference between Phoenix and Arize?"
-description: "Arize is the company that makes Phoenix. Phoenix is an open source LLM observability tool offered by Arize. It can be access in its Cloud form online, or self-hosted and run on your own machine or server."
+description: "Arize is the company that makes Phoenix. Phoenix is Arize's open-source platform for agent development and evaluation. You run it yourself: self-hosted on your own infrastructure, locally, or in a container."
 ---
 
-"Arize" can also refer to Arize's enterprise platform, often called Arize AX, available on arize.com. Arize AX is the enterprise SaaS version of Phoenix that comes with additional features like Copilot, ML and CV support, HIPAA compliance, Security Reviews, a customer success team, and more. See [here for a breakdown](https://arize.com/pricing/) of the two tools.
+Arize is the company that makes Phoenix. Phoenix is Arize's open-source platform for agent development and evaluation. You run it yourself: self-hosted on your own infrastructure, locally, or in a container.
+
+"Arize" can also refer to **[Arize AX](https://arize.com/products/ax/)**, Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. Phoenix and Arize AX are built on the same open standards ([OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference)), so an application instrumented for Phoenix can send the same data to Arize AX without re-instrumenting it; you simply point your traces at the other destination.
+
+The main difference is open source versus commercial product:
+
+* **Phoenix** is open source and self-managed. Your team runs it and owns the deployment, upgrades, scaling, and maintenance, with community support.
+* **Arize AX** is a commercial product built on the same core tracing and evaluation workflow. It adds capabilities and dedicated support that Phoenix does not include, and can be used as a hosted service or [self-hosted](https://arize.com/docs/ax/selfhosting).
+
+## Can Phoenix run in production?
+
+Yes. Phoenix is used in both development and production by teams that are able to manage their own infrastructure. Phoenix is often the right choice for local, self-hosted, or isolated environments, such as an air-gapped network or a regulated team that must keep its trace data within its own infrastructure.
+
+The difference is not whether Phoenix can run in production (it can), but the level of support and capability behind it. With Phoenix, your team owns the deployment and maintenance, backed by community support. Arize AX provides the same core workflow as a supported commercial product, whether you run it hosted or self-hosted.
+
+Beyond support, Arize AX adds capabilities that Phoenix does not include, such as online evals on production traffic and custom alerting with dashboards tailored for non-developer stakeholders. For the full breakdown of Arize AX plans and features, see [arize.com/pricing](https://arize.com/pricing/).

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -30,7 +30,7 @@ Either platform will get you started, and starting with one never closes the doo
 
 ## What does Arize AX include that Phoenix does not?
 
-Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project, such as ADB (the Arize database) and Signal, and offers managed services that become more valuable as teams scale up their agents:
+Arize AX is backed by an industry-leading engineering team that builds infrastructure beyond the scope of an open-source project, such as ADB (the Arize database) and [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix), and offers managed services that become more valuable as teams scale up their agents:
 
 * **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal?utm_source=docs&utm_medium=web&utm_content=phoenix), a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues, run on infrastructure Arize AX manages for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
 * **Built for large AI engineering teams.** Dedicated workspaces and organizations keep many teams and projects in order, powerful auditing capabilities track who did what across them, and the evaluation infrastructure is designed to run on massive production workloads.
@@ -49,6 +49,6 @@ Yes. Phoenix runs in production today at companies of every size, from small tea
 No, and the strongest teams often don't. Because both platforms speak the same open standards, adopting one never locks you out of the other, and they work well together:
 
 * **Start with Phoenix, grow into Arize AX.** Teams often begin with Phoenix for development and early production, then move to Arize AX when enterprise constraints such as support requirements, SLAs, and monitoring for a broader set of stakeholders come into play. Your instrumentation carries over unchanged.
-* **Use Arize AX, keep Phoenix for the workloads you choose.** Teams on Arize AX still reach for Phoenix where a local, self-contained instance fits best: local experimentation, CI pipelines, or isolated and regulated environments.
+* **Use Arize AX, keep Phoenix for the workloads you choose.** Teams on Arize AX still reach for Phoenix where a local, self-contained instance fits best: local experimentation, CI pipelines, skunkworks projects, internal agent observability, isolated and regulated environments, and more.
 
-Wherever you start, both remain within reach: an open platform you can shape, a managed platform that scales for you, and a single set of instrumentation that works with either.
+Whichever you pick first, the other is always there when you need it: an open platform you can shape, a managed platform that scales for you, and one set of instrumentation that works with both.

--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -1,21 +1,40 @@
 ---
 title: "What is the difference between Phoenix and Arize?"
-description: "Arize is the company that makes Phoenix. Phoenix is Arize's open-source platform for agent development and evaluation. You run it yourself: self-hosted on your own infrastructure, locally, or in a container."
+description: "Phoenix is a fully open-source platform for agent development and evaluation, sponsored by Arize, intended to be self-hosted and free to use. Arize AX is Arize's managed AI engineering platform, delivered as a fully supported SaaS."
 ---
 
-Arize is the company that makes Phoenix. Phoenix is Arize's open-source platform for agent development and evaluation. You run it yourself: self-hosted on your own infrastructure, locally, or in a container.
+Phoenix is an open-source platform for agent development and evaluation, intended to be self-hosted and free to use: you run it on your own infrastructure, locally, or in a container.
 
-"Arize" can also refer to **[Arize AX](https://arize.com/products/ax/)**, Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. Phoenix and Arize AX are built on the same open standards ([OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference)), so an application instrumented for Phoenix can send the same data to Arize AX without re-instrumenting it; you simply point your traces at the other destination.
+Phoenix is sponsored by Arize and maintained by a team of core maintainers, but it is a community project, striving to further the open development of tracing and evaluation for developers and OSS contributors alike. It is a unique project in this space in that it is fully open-source end-to-end — there is no closed core or paywalled tier within Phoenix itself.
 
-The main difference is open source versus commercial product:
+**[Arize AX](https://arize.com/products/ax/)** is Arize's commercial AI engineering platform for observing, evaluating, and improving agents in production. If you are looking for a managed SaaS platform with full support and SLAs, Arize AX is the solution.
 
-* **Phoenix** is open source and self-managed. Your team runs it and owns the deployment, upgrades, scaling, and maintenance, with community support.
-* **Arize AX** is a commercial product built on the same core tracing and evaluation workflow. It adds capabilities and dedicated support that Phoenix does not include, and can be used as a hosted service or [self-hosted](https://arize.com/docs/ax/selfhosting).
+The two products are complementary, not competing. They are built on the same open standards ([OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference)) and share the same core tracing and evaluation workflow, so an application instrumented for one can send the same data to the other without re-instrumenting; you simply point your traces at the other destination.
+
+## How do I choose?
+
+The clearest way to decide is by who you want operating the infrastructure:
+
+* **Phoenix** is free to use and the right choice when you want to keep both your data _and_ your infrastructure under your own control — for example in an air-gapped network or on a regulated team that must keep trace data inside its own environment. Your team owns the deployment, upgrades, and scaling, with community support behind it.
+* **Arize AX** is the right choice when you want a managed platform that is enterprise-ready out of the box, with no additional burden on your infrastructure team. Arize operates the platform and backs it with enterprise-grade support and SLAs.
+
+## What does Arize AX include that Phoenix does not?
+
+Because Arize manages the infrastructure, Arize AX can offer capabilities that go beyond running the core workflow:
+
+* **Managed compute for heavy workloads.** Large evaluation jobs and features like [Signal](https://arize.com/docs/ax/observe/signal) — a built-in worker that scans your traces on a schedule and groups recurring failure patterns into issues — run on infrastructure Arize operates for you. With Phoenix, the same workflows are possible through the Phoenix APIs, but the compute behind them is provisioned and operated by your own infrastructure team.
+* **Monitors and custom dashboards.** Production monitoring, alerting, and dashboards tailored for non-developer stakeholders.
+* **Enterprise-grade support.** Dedicated support and SLAs rather than community support.
+
+For the full breakdown of Arize AX plans and features, see [arize.com/pricing](https://arize.com/pricing/).
 
 ## Can Phoenix run in production?
 
-Yes. Phoenix is used in both development and production by teams that are able to manage their own infrastructure. Phoenix is often the right choice for local, self-hosted, or isolated environments, such as an air-gapped network or a regulated team that must keep its trace data within its own infrastructure.
+Yes. Phoenix is used in both development and production by teams that are able to manage their own infrastructure. The difference is not whether Phoenix can run in production (it can), but who operates the platform and the level of support and capability behind it.
 
-The difference is not whether Phoenix can run in production (it can), but the level of support and capability behind it. With Phoenix, your team owns the deployment and maintenance, backed by community support. Arize AX provides the same core workflow as a supported commercial product, whether you run it hosted or self-hosted.
+## Do I have to pick one?
 
-Beyond support, Arize AX adds capabilities that Phoenix does not include, such as online evals on production traffic and custom alerting with dashboards tailored for non-developer stakeholders. For the full breakdown of Arize AX plans and features, see [arize.com/pricing](https://arize.com/pricing/).
+No. Because both products speak the same open standards, many teams use them together, and adopting one never locks you out of the other:
+
+* **Start with Phoenix, grow into Arize AX.** Teams often begin with Phoenix for development and early production, then move to Arize AX when enterprise constraints — support requirements, SLAs, monitoring for a broader set of stakeholders — come into play. Your instrumentation carries over unchanged.
+* **Use Arize AX, keep Phoenix for the workloads you choose.** Teams on Arize AX still reach for Phoenix where a local, self-contained instance fits best: local experimentation, CI pipelines, or isolated environments.

--- a/docs/phoenix/resources/phoenix-to-arize-ax-migration.mdx
+++ b/docs/phoenix/resources/phoenix-to-arize-ax-migration.mdx
@@ -35,7 +35,7 @@ If you are looking to migrate to Arize AX but want to preserve your data, this t
     PHOENIX_ENDPOINT="http://localhost:6006"
     PHOENIX_API_KEY=your-phoenix-api-key 
 
-    # Arize
+    # Arize AX
     ARIZE_API_KEY=your-arize-api-key
     ARIZE_SPACE_ID=your-arize-space-id
 
@@ -44,7 +44,7 @@ If you are looking to migrate to Arize AX but want to preserve your data, this t
     ```
 
     <Info>
-    You can find your Arize API key and Space ID in your Arize AX account settings.
+    You can find your Arize AX API key and Space ID in your Arize AX account settings.
 
     </Info>
   </Step>
@@ -61,7 +61,7 @@ If you are looking to migrate to Arize AX but want to preserve your data, this t
 
 * **Wait for traces to be indexed**: After importing traces, you must wait a few minutes for them to be loaded and indexed in Arize AX before sending annotation data. The import process will prompt you to verify traces are available before proceeding with annotations.
 
-* **31-day window**: Only annotations for traces from the past 31 days can be logged to Arize. If your traces are older than 31 days, their annotations will be skipped with a warning message.
+* **31-day window**: Only annotations for traces from the past 31 days can be logged to Arize AX. If your traces are older than 31 days, their annotations will be skipped with a warning message.
 
 ## Usage
 
@@ -76,7 +76,7 @@ python export_all_projects.py --de      # datasets and experiments
 python export_all_projects.py --traces   # traces with evaluations and annotations
 ```
 
-### Import to Arize
+### Import to Arize AX
 
 ```bash
 # Import everything
@@ -115,11 +115,11 @@ results/  # Overview of import and export jobs
 
 ### Import issues with traces
 
-The formatting of some span attributes may not be compatible between Arize and Phoenix. We tried to cover as many cases as possible, but there may be some missing ones. If you encounter errors:
+The formatting of some span attributes may not be compatible between Arize AX and Phoenix. We tried to cover as many cases as possible, but there may be some missing ones. If you encounter errors:
 
 1. Check the `results/` folder to see what errors have occured
 2. Fix them in the project's `traces.json` file
-3. Re-import the data to Arize
+3. Re-import the data to Arize AX
 
 ### Import issues with annotations
 

--- a/docs/phoenix/resources/phoenix-to-arize-ax-migration.mdx
+++ b/docs/phoenix/resources/phoenix-to-arize-ax-migration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Phoenix to Arize AX Migration"
+title: "Migrating to Arize AX"
 description: Seamlessly migrate your data from Phoenix to Arize AX
 ---
 


### PR DESCRIPTION
Update the FAQ to match current Phoenix (open-source platform for agent development and evaluation) and Arize AX (commercial AI engineering platform) positioning. Clarify that both share OpenInference/OTel standards, both can run in production, and both can be self-hosted; the real difference is open source vs commercial product plus the support and production capabilities (online evals, custom alerting) behind AX. Remove the stale Phoenix Cloud reference and pricing-page-as-comparison framing.

