### PR TITLE
fix: use probe lowering for session filter statistics

### DIFF
--- a/internal_docs/specs/session-filter-dsl.md
+++ b/internal_docs/specs/session-filter-dsl.md
@@ -413,7 +413,8 @@ The shipped dispatch follows from that:
 |---|---|---|
 | Page, no annotation access, ordered by an indexed column | direct + probe | `LIMIT` stops after enough matching rows |
 | Page ordered by an aggregate column | direct + scan, reusing the sort's subquery | the sort must materialize that aggregate for every session before it can order rows, so the early exit is already gone |
-| Count, summary loaders, and any condition reading annotations | rowid subquery + scan | no `LIMIT` to exit on, or deduplication required |
+| Count and summary loaders | rowid subquery + probe | no `LIMIT` to exit on; probe keeps `all(...)` mixed with `any`/`len` correlated, which is what avoids the scan anti-set timeout on large corpora |
+| Page whose condition reads annotations | rowid subquery + scan | deduplication required |
 
 "Direct" means the predicate is applied to the statement being paginated. The alternative —
 wrapping it as `session_id IN (SELECT DISTINCT …)` — puts the per-session work outside that

--- a/scripts/perf/session_filter_perf.py
+++ b/scripts/perf/session_filter_perf.py
@@ -384,7 +384,9 @@ def count(condition: str, project_id: int) -> Select[Any]:
         .where(models.ProjectSession.project_id == project_id)
         .where(
             models.ProjectSession.id.in_(
-                get_filtered_session_rowids_subquery(condition, project_rowids=[project_id])
+                get_filtered_session_rowids_subquery(
+                    condition, project_rowids=[project_id], lowering="probe"
+                )
             )
         )
     )
@@ -398,7 +400,9 @@ def sweep(condition: str, project_id: int, candidates: list[int]) -> Select[Any]
         .where(models.ProjectSession.id.in_(candidates))
         .where(
             models.ProjectSession.id.in_(
-                get_filtered_session_rowids_subquery(condition, project_rowids=[project_id])
+                get_filtered_session_rowids_subquery(
+                    condition, project_rowids=[project_id], lowering="probe"
+                )
             )
         )
     )

--- a/src/phoenix/server/api/dataloaders/annotation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/annotation_summaries.py
@@ -222,6 +222,7 @@ def _get_stmt(
             project_rowids=[project_rowid],
             start_time=start_time,
             end_time=end_time,
+            lowering="probe",
         )
         if session_filter_condition
         else None

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -157,6 +157,7 @@ async def _get_results(
             project_rowids=project_rowids,
             start_time=start_time,
             end_time=end_time,
+            lowering="probe",
         )
         stmt = stmt.where(models.Trace.project_session_rowid.in_(filtered_session_rowids))
     if start_time:

--- a/src/phoenix/server/api/dataloaders/record_counts.py
+++ b/src/phoenix/server/api/dataloaders/record_counts.py
@@ -143,6 +143,7 @@ def _get_stmt(
                 project_rowids=project_rowids,
                 start_time=start_time,
                 end_time=end_time,
+                lowering="probe",
             )
             stmt = stmt.where(models.Trace.project_session_rowid.in_(filtered_session_rowids))
     stmt = stmt.where(pid.in_(project_rowids))

--- a/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
@@ -146,6 +146,7 @@ def _get_stmt(
             project_rowids=project_rowids,
             start_time=start_time,
             end_time=end_time,
+            lowering="probe",
         )
         stmt = stmt.where(models.Trace.project_session_rowid.in_(filtered_session_rowids))
 

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -211,7 +211,8 @@ def _apply_project_session_filters(
     the session had activity inside the window.
 
     Every statistic the sessions aside renders runs through here, so a filtered statistic is
-    scoped to exactly the sessions the filtered table lists.
+    scoped to exactly the sessions the filtered table lists. The rowid subquery uses probe
+    lowering so mixed ``all(...)`` conditions stay correlated.
     """
     table = models.ProjectSession
     stmt = stmt.where(table.project_id == project_rowid)
@@ -228,6 +229,7 @@ def _apply_project_session_filters(
                     project_rowids=[project_rowid],
                     start_time=time_range.start if time_range else None,
                     end_time=time_range.end if time_range else None,
+                    lowering="probe",
                 )
             )
         )

--- a/src/phoenix/server/session_filters.py
+++ b/src/phoenix/server/session_filters.py
@@ -71,7 +71,15 @@ def get_filtered_session_rowids_subquery(
     end_time: Optional[datetime] = None,
     lowering: FilterLowering = "scan",
 ) -> ScalarSelect[int]:
-    """Compile the session filter DSL into a subquery of matching project-session rowids."""
+    """Compile the session filter DSL into a subquery of matching project-session rowids.
+
+    The default scan lowering is reserved for whole-scan analytical callers. Session aside
+    statistics (record counts, annotation summaries, latency quantiles, span cost summaries,
+    and the sessions-aside aggregations) should select probe lowering. Lowering is chosen
+    once per condition, so probe keeps sibling ``any`` and ``len`` expressions correlated
+    alongside ``all(...)``. Scan's uncorrelated ``any`` semi-join is the sibling of the
+    ``all`` anti-set that exceeded statement timeouts on a 3M-span corpus.
+    """
     session_filter = compile_session_filter(session_filter_condition)
     with session_filter_errors():
         return session_filter.as_session_rowids_subquery(

--- a/tests/unit/server/test_session_filters.py
+++ b/tests/unit/server/test_session_filters.py
@@ -1,13 +1,27 @@
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import Mock
+
 import pytest
-from sqlalchemy import select
+from sqlalchemy import Select, select
 
 from phoenix.db import models
+from phoenix.server.api.dataloaders import (
+    annotation_summaries,
+    record_counts,
+    span_cost_summary_by_project,
+)
 from phoenix.server.api.exceptions import BadRequest
+from phoenix.server.api.types.Project import _apply_project_session_filters
 from phoenix.server.session_filters import (
     SessionFilterConditionError,
     apply_session_filter_to_page,
     compile_session_filter,
     get_filtered_session_rowids_subquery,
+)
+
+_MIXED_ANY_AND_ALL = (
+    'any(s.status_code == "ERROR" for s in spans) and all(s.span_kind == "LLM" for s in spans)'
 )
 
 
@@ -40,3 +54,106 @@ def test_unusable_expressions_are_reported_as_client_errors(condition: str) -> N
 
 def test_usable_expressions_compile() -> None:
     assert get_filtered_session_rowids_subquery("num_traces >= 2", project_rowids=[1]) is not None
+
+
+def test_rowid_subquery_forwards_scope_and_lowering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    end_time = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    expected = Mock()
+    session_filter = Mock()
+    session_filter.as_session_rowids_subquery.return_value = expected
+    monkeypatch.setattr(
+        "phoenix.server.session_filters.compile_session_filter",
+        Mock(return_value=session_filter),
+    )
+
+    actual = get_filtered_session_rowids_subquery(
+        "num_traces > 2",
+        project_rowids=(1, 2),
+        start_time=start_time,
+        end_time=end_time,
+        lowering="probe",
+    )
+
+    assert actual is expected
+    session_filter.as_session_rowids_subquery.assert_called_once_with(
+        project_rowids=[1, 2],
+        start_time=start_time,
+        end_time=end_time,
+        lowering="probe",
+    )
+
+
+def _compiled_sql(stmt: Select[Any]) -> str:
+    return str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+
+
+def _assert_probe_shaped_any_and_all(compiled: str) -> None:
+    """Probe renders `any` as EXISTS and `all` as NOT EXISTS, both correlated to the session.
+
+    Scan would render `any` as an uncorrelated `id IN (SELECT session_key …)` semi-join instead.
+    """
+    assert "exists (select 1" in compiled
+    assert "not (exists" in compiled
+    assert "project_sessions.id in (select traces.project_session_rowid" not in compiled
+
+
+def test_probe_lowering_keeps_mixed_any_and_all_correlated() -> None:
+    compiled = _compiled_sql(
+        select(models.ProjectSession.id).where(
+            models.ProjectSession.id.in_(
+                get_filtered_session_rowids_subquery(
+                    _MIXED_ANY_AND_ALL,
+                    project_rowids=[1],
+                    lowering="probe",
+                )
+            )
+        )
+    )
+    _assert_probe_shaped_any_and_all(compiled)
+
+
+def test_scan_lowering_renders_any_as_uncorrelated_semi_join() -> None:
+    compiled = _compiled_sql(
+        select(models.ProjectSession.id).where(
+            models.ProjectSession.id.in_(
+                get_filtered_session_rowids_subquery(
+                    _MIXED_ANY_AND_ALL,
+                    project_rowids=[1],
+                    lowering="scan",
+                )
+            )
+        )
+    )
+    assert "not (exists" in compiled
+    assert "project_sessions.id in (select traces.project_session_rowid" in compiled
+
+
+def test_session_statistics_queries_use_probe_lowering() -> None:
+    """Aside statistics wrap matching rowids in an IN predicate and have no LIMIT to protect,
+    but still select probe so `all(...)` mixed with `any` stays correlated.
+    """
+    statements = [
+        _apply_project_session_filters(
+            select(models.ProjectSession),
+            project_rowid=1,
+            time_range=None,
+            session_filter_condition=_MIXED_ANY_AND_ALL,
+        ),
+        record_counts._get_stmt(
+            ("trace", (None, None), None, _MIXED_ANY_AND_ALL),
+            1,
+        ),
+        span_cost_summary_by_project._get_stmt(
+            ((None, None), None, _MIXED_ANY_AND_ALL),
+            1,
+        ),
+        annotation_summaries._get_stmt(
+            ("trace", 1, (None, None), None, _MIXED_ANY_AND_ALL),
+            "quality",
+        ),
+    ]
+    for stmt in statements:
+        _assert_probe_shaped_any_and_all(_compiled_sql(stmt))


### PR DESCRIPTION
fixes #15427

Session aside statistics (record counts, annotation summaries, latency quantiles, span cost summaries, and the sessions-aside aggregations) called `get_filtered_session_rowids_subquery` without a lowering, so they inherited `scan`.

Under `scan`, an `all(...)` condition historically compiled to an uncorrelated `NOT IN` anti-set over the span table. On a 3M-span Postgres corpus that exceeded a 30s statement timeout, while `probe` completed in about 3s. Lowering is chosen once per condition, so `scan` also keeps sibling `any` and `len` expressions uncorrelated.

This change passes `probe` at those statistics call sites so mixed `all(...)` conditions stay correlated. The helper default remains `scan` for whole-scan analytical callers and for the paginated annotation wrapper, which already selects lowering explicitly.

Tests compile the statistics queries and assert that mixed `any`+`all` filters lower to correlated `EXISTS` / `NOT EXISTS` rather than the scan semi-join.