### PR TITLE
fix: keep table load-more at the footer in Safari

### DIFF
--- a/js/app/src/components/table/LoadMoreRow.tsx
+++ b/js/app/src/components/table/LoadMoreRow.tsx
@@ -3,14 +3,11 @@ import { css } from "@emotion/react";
 import type { LoadMoreButtonProps } from "@phoenix/components/core/LoadMoreButton";
 import { LoadMoreButton } from "@phoenix/components/core/LoadMoreButton";
 
-const rowCSS = css`
-  position: relative;
-`;
 const tdCSS = css`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+  text-align: center;
+`;
+
+const buttonWrapCSS = css`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -25,9 +22,14 @@ export function LoadMoreRow({
   isLoadingNext,
 }: LoadMoreButtonProps) {
   return (
-    <tr css={rowCSS}>
+    <tr>
       <td colSpan={100} css={tdCSS}>
-        <LoadMoreButton onLoadMore={onLoadMore} isLoadingNext={isLoadingNext} />
+        <div css={buttonWrapCSS}>
+          <LoadMoreButton
+            onLoadMore={onLoadMore}
+            isLoadingNext={isLoadingNext}
+          />
+        </div>
       </td>
     </tr>
   );


### PR DESCRIPTION
fixes #15451

## Summary
- Safari does not treat `position: relative` on a `<tr>` as a containing block. The load-more `<td>` used `position: absolute; top: 0; left: 0`, so its containing block became the viewport and the button rendered at the page top.
- `LoadMoreRow` now keeps the cell in table flow (`text-align: center` plus an in-flow flex wrapper), the same pattern as `TableEmptyWrap`. This is the shared footer used by spans, experiments, and users tables.

## Screenshots
Before (Safari, from #15451): the Load More control is pinned to the top of the page.

<img width="1125" height="806" alt="Load More control at the page top in Safari" src="https://github.com/user-attachments/assets/e947163d-806f-4344-9643-99a926995b31" />

After: I could not run Safari locally. Chrome and Firefox already placed this control at the table footer; the change is in-flow table-cell layout so Safari resolves the same containing block.

## Test plan
- [ ] In Safari, open a paginated table that shows Load More (project spans, experiments, or settings users) and confirm the control sits at the table footer, not the page top
- [ ] Confirm the same layout in Chrome and Firefox
- [ ] Click Load More and confirm the next page still loads