### PR TITLE
fix: write PXI thumbs feedback once so session view is not duplicated

### DIFF
--- a/js/app/src/components/agent/AssistantMessageActions.tsx
+++ b/js/app/src/components/agent/AssistantMessageActions.tsx
@@ -16,20 +16,20 @@ import { useViewer } from "@phoenix/contexts/ViewerContext";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
 /**
- * Annotation name used for both span- and trace-level user feedback on
- * assistant messages. Matches the annotation config expected by the Phoenix
- * backend and should stay in sync with any server-side consumers.
+ * Annotation name used for PXI thumbs-up/down feedback. Written once, on the
+ * turn's trace, so session view does not show the same rating twice. Matches
+ * the annotation config expected by the Phoenix backend and should stay in
+ * sync with any server-side consumers.
  */
 const FEEDBACK_ANNOTATION_NAME = "user_feedback";
 
 type AssistantFeedback = "positive" | "negative";
 
 /**
- * Shared shape of the annotation payload sent to the Phoenix REST API. Fields
- * use snake_case because that is what the `/v1/*_annotations` endpoints
- * expect on the wire.
+ * Shape of the annotation payload sent to `/v1/trace_annotations`. Fields use
+ * snake_case because that is what the REST endpoint expects on the wire.
  */
-type AnnotationPayloadBase = {
+type TraceAnnotationPayload = {
   annotator_kind: "HUMAN";
   identifier: string;
   metadata: Record<string, string>;
@@ -38,10 +38,8 @@ type AnnotationPayloadBase = {
     label: AssistantFeedback;
     score: number;
   };
+  trace_id: string;
 };
-
-type SpanAnnotationPayload = AnnotationPayloadBase & { span_id: string };
-type TraceAnnotationPayload = AnnotationPayloadBase & { trace_id: string };
 
 /**
  * Concatenates all text parts of an assistant message into a single string.
@@ -84,26 +82,15 @@ async function getResponseErrorMessage(response: Response) {
 }
 
 /**
- * POSTs a single annotation to the given Phoenix endpoint and waits for the
- * write to complete (`sync=true`) so the caller knows it was persisted.
- * Throws with a descriptive message on non-2xx responses.
+ * POSTs a trace-level annotation and waits for the write to complete
+ * (`sync=true`) so the caller knows it was persisted. Throws with a
+ * descriptive message on non-2xx responses.
  */
-async function postAnnotation(
-  args:
-    | { endpoint: "/v1/span_annotations"; payload: SpanAnnotationPayload }
-    | { endpoint: "/v1/trace_annotations"; payload: TraceAnnotationPayload }
-) {
-  const params = { query: { sync: true } } as const;
-  const { response } =
-    args.endpoint === "/v1/span_annotations"
-      ? await authApiFetch.POST("/v1/span_annotations", {
-          params,
-          body: { data: [args.payload] },
-        })
-      : await authApiFetch.POST("/v1/trace_annotations", {
-          params,
-          body: { data: [args.payload] },
-        });
+async function postTraceAnnotation(payload: TraceAnnotationPayload) {
+  const { response } = await authApiFetch.POST("/v1/trace_annotations", {
+    params: { query: { sync: true } },
+    body: { data: [payload] },
+  });
 
   if (!response.ok) {
     throw new Error(await getResponseErrorMessage(response));
@@ -112,10 +99,10 @@ async function postAnnotation(
 
 /**
  * Deletes `user_feedback` annotations with the given identifier from both the
- * span and trace annotation tables. Used to undo a previously submitted
- * thumbs-up/down. The identifier is scoped to a single user+message pair so
- * `delete_all=true` only removes that one annotation.
- * Throws with a descriptive message on non-2xx responses.
+ * span and trace annotation tables. Undo still hits both endpoints so ratings
+ * written before this path was trace-only are cleaned up. The identifier is
+ * scoped to a single user+message pair so `delete_all=true` only removes that
+ * one annotation. Throws with a descriptive message on non-2xx responses.
  */
 async function deleteAnnotations(args: {
   projectName: string;
@@ -153,10 +140,11 @@ async function deleteAnnotations(args: {
 /**
  * Toolbar rendered below an assistant message with quick actions:
  *
- * - Thumbs up / thumbs down: writes a `user_feedback` annotation to both the
- *   root span and the trace. Clicking the active button again deletes the
- *   annotation (undo). Requires the message to carry `traceId`, `rootSpanId`,
- *   and `sessionId` metadata.
+ * - Thumbs up / thumbs down: writes a `user_feedback` annotation on the
+ *   turn's trace (one write, so session view does not duplicate it with a
+ *   matching root-span annotation). Clicking the active button again deletes
+ *   the annotation (undo). Requires the message to carry `traceId`,
+ *   `rootSpanId`, and `sessionId` metadata.
  * - Copy: copies the assistant's text response to the clipboard.
  * - Trace: opens the associated trace in a new tab. Requires `traceId`.
  *
@@ -253,16 +241,7 @@ export function AssistantMessageActions({
     };
 
     try {
-      await Promise.all([
-        postAnnotation({
-          endpoint: "/v1/span_annotations",
-          payload: { ...base, span_id: rootSpanId },
-        }),
-        postAnnotation({
-          endpoint: "/v1/trace_annotations",
-          payload: { ...base, trace_id: traceId },
-        }),
-      ]);
+      await postTraceAnnotation({ ...base, trace_id: traceId });
       setSelectedFeedback(feedback);
     } catch {
       // Swallow errors; UI state simply won't reflect the feedback.

--- a/js/app/src/components/agent/__tests__/AssistantMessageActions.test.tsx
+++ b/js/app/src/components/agent/__tests__/AssistantMessageActions.test.tsx
@@ -1,0 +1,142 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { userEvent } from "storybook/test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+import { authApiFetch } from "@phoenix/api/authApiFetch";
+import { AgentContext } from "@phoenix/contexts/AgentContext";
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+import { createAgentStore } from "@phoenix/store/agentStore";
+
+import { AssistantMessageActions } from "../AssistantMessageActions";
+
+installTestStorage();
+
+vi.mock("@phoenix/api/authApiFetch", () => ({
+  authApiFetch: {
+    POST: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+vi.mock("@phoenix/contexts/ViewerContext", () => ({
+  useViewer: () => ({
+    viewer: { username: "alice", id: "user-1" },
+    refetchViewer: () => undefined,
+  }),
+}));
+
+const apiPost = authApiFetch.POST as unknown as Mock;
+const apiDelete = authApiFetch.DELETE as unknown as Mock;
+
+function okResponse() {
+  return { response: { ok: true } };
+}
+
+const assistantMessage = {
+  id: "assistant-message",
+  role: "assistant",
+  parts: [{ type: "text", text: "Here is the answer." }],
+  metadata: {
+    phoenix: {
+      type: "assistant",
+      sessionId: "session-1",
+      turnTraceContext: {
+        traceId: "trace-1",
+        rootSpanId: "span-1",
+        startedAt: "2026-07-22T12:00:00.000Z",
+      },
+    },
+  },
+} as AgentUIMessage;
+
+describe("AssistantMessageActions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    );
+    apiPost.mockReset();
+    apiDelete.mockReset();
+    apiPost.mockResolvedValue(okResponse());
+    apiDelete.mockResolvedValue(okResponse());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  function renderActions() {
+    const store = createAgentStore({});
+    act(() => {
+      root.render(
+        <ThemeProvider themeMode="dark" disableBodyTheme>
+          <AgentContext.Provider value={store}>
+            <AssistantMessageActions message={assistantMessage} />
+          </AgentContext.Provider>
+        </ThemeProvider>
+      );
+    });
+  }
+
+  it("writes user_feedback only on the turn trace, not the root span", async () => {
+    renderActions();
+    const thumbsUp = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Thumbs up"]'
+    );
+    expect(thumbsUp).not.toBeNull();
+
+    await act(async () => {
+      await userEvent.setup().click(thumbsUp!);
+    });
+
+    await vi.waitFor(() => {
+      expect(apiPost).toHaveBeenCalledTimes(1);
+    });
+    expect(apiPost).toHaveBeenCalledWith(
+      "/v1/trace_annotations",
+      expect.objectContaining({
+        params: { query: { sync: true } },
+        body: {
+          data: [
+            expect.objectContaining({
+              annotator_kind: "HUMAN",
+              identifier: "alice:assistant-message",
+              name: "user_feedback",
+              trace_id: "trace-1",
+              result: { label: "positive", score: 1 },
+            }),
+          ],
+        },
+      })
+    );
+    expect(apiPost.mock.calls.map((call) => call[0])).not.toContain(
+      "/v1/span_annotations"
+    );
+  });
+});


### PR DESCRIPTION
fixes #14189

## Summary
- PXI thumbs up/down wrote the same `user_feedback` annotation twice: once on the turn trace and once on the root span.
- Session view renders both trace tokens and root-span tokens on each turn, so one rating showed up twice.
- This keeps the **trace-level** write. A PXI turn is one trace, and session UI already treats turn-level feedback as a trace annotation (`TraceAnnotationSummaryGroupTokens` and `TraceActionToolbar`).
- Undo still deletes from both the trace and span annotation tables so older dual-written ratings can be cleaned up.

## Test plan
- [x] `cd js/app && pnpm exec vitest run src/components/agent/__tests__/AssistantMessageActions.test.tsx`
- [ ] Thumbs up a PXI message, open the session, confirm a single `user_feedback` token on that turn
- [ ] Click the active thumbs button again and confirm the annotation is removed