### PR TITLE
fix: keep filter error indicator from covering the input

### DIFF
--- a/js/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/js/app/src/components/filter/DSLFilterConditionField.tsx
@@ -418,7 +418,8 @@ export type DSLFilterConditionFieldProps<
  * warnings, and composed error states (e.g. an AI conversion failure) so
  * they read identically. `children` is the tooltip's detail below the
  * title. `severity` defaults to danger; warnings render the same shell in
- * the warning palette.
+ * the warning palette. Omit `badgeMessage` for an icon-only indicator so
+ * the truncated copy cannot cover the editor.
  */
 export function DSLFilterErrorBadge({
   ariaLabel,
@@ -428,7 +429,7 @@ export function DSLFilterErrorBadge({
   children,
 }: {
   ariaLabel: string;
-  badgeMessage: string;
+  badgeMessage?: string;
   title: string;
   severity?: "danger" | "warning";
   children?: ReactNode;
@@ -444,7 +445,9 @@ export function DSLFilterErrorBadge({
           aria-label={ariaLabel}
         >
           <Icon svg={<Icons.AlertCircle />} color={severity} />
-          <span className="error-badge__message">{badgeMessage}</span>
+          {badgeMessage ? (
+            <span className="error-badge__message">{badgeMessage}</span>
+          ) : null}
         </div>
       </Pressable>
       <Tooltip placement="bottom end" css={dslFilterErrorTooltipCSS}>
@@ -470,12 +473,12 @@ export function DSLFilterErrorBadge({
  * `snippets`, `loadCompletions`, and `validateCondition`.
  *
  * The typeahead is the only floating surface the field opens on its own.
- * Validation errors surface passively — an in-field danger badge previewing
- * the (truncated) error once the typed text has settled and been confirmed
- * invalid (intermediate keystrokes are not flagged), whose tooltip shows the
- * full error on hover or focus, plus a red border once the user leaves the
- * field — so an error can never fight the suggestions dropdown for the same
- * space.
+ * Validation errors surface passively - a compact in-field danger icon once
+ * the typed text has settled and been confirmed invalid (intermediate
+ * keystrokes are not flagged), whose tooltip shows the full error on hover
+ * or focus, plus a red border once the user leaves the field - so an error
+ * can never fight the suggestions dropdown for the same space or cover the
+ * end of the expression.
  *
  * The field knows nothing beyond the DSL. Richer behaviors compose in from
  * outside through `extensions` (keymaps), `variant` (prose input in the same
@@ -850,7 +853,6 @@ export function DSLFilterConditionField<
           value={value}
           onChange={onChange}
           height="36px"
-          width="100%"
           theme={codeMirrorTheme}
           placeholder={placeholder}
           extensions={extensions}
@@ -860,13 +862,13 @@ export function DSLFilterConditionField<
             <DSLFilterErrorBadge
               severity={hasError ? "danger" : "warning"}
               ariaLabel={
-                hasError ? "Filter condition error" : "Filter condition warning"
-              }
-              badgeMessage={
                 hasError
-                  ? errorMessage || "Invalid filter condition"
-                  : warnings[0]
+                  ? errorMessage
+                    ? `Filter condition error: ${errorMessage}`
+                    : "Filter condition error"
+                  : "Filter condition warning"
               }
+              badgeMessage={hasError ? undefined : warnings[0]}
               title={
                 hasError
                   ? "Invalid filter condition"

--- a/js/app/src/components/filter/__tests__/DSLFilterConditionFieldValidation.test.tsx
+++ b/js/app/src/components/filter/__tests__/DSLFilterConditionFieldValidation.test.tsx
@@ -65,6 +65,27 @@ describe("DSLFilterConditionField validation outcomes", () => {
     expect(onValidationFailed).toHaveBeenLastCalledWith("transport");
   });
 
+  it("keeps the validation error indicator from covering the input", async () => {
+    const errorMessage = "')' was never closed at character 42";
+
+    await renderField({
+      root,
+      value: "condition-invalid",
+      validateCondition: vi.fn().mockResolvedValue({
+        isValid: false,
+        errorMessage,
+      }),
+      onValidationFailed: vi.fn(),
+      validationRetryKey: 0,
+    });
+
+    const badge = container.querySelector(".error-badge");
+    expect(badge?.querySelector(".error-badge__message")).toBeNull();
+    expect(badge?.getAttribute("aria-label")).toBe(
+      `Filter condition error: ${errorMessage}`
+    );
+  });
+
   it("revalidates unchanged text when the retry key advances", async () => {
     const onValidationFailed = vi.fn();
     const validateCondition = vi

--- a/js/app/src/components/filter/styles.ts
+++ b/js/app/src/components/filter/styles.ts
@@ -20,6 +20,10 @@ export const dslFilterCodeMirrorCSS = css`
      controls out of view — without this the flex item's auto minimum is
      the full content width */
   min-width: 0;
+  /* Grow from remaining flex space. An explicit 100% width paints the
+     scroller under the control cluster, so the error badge covers the
+     end of the expression and steals caret clicks. */
+  width: auto;
   .cm-content {
     padding: var(--global-dimension-size-100) 0;
   }
@@ -211,6 +215,12 @@ export const dslFilterFieldCSS = css`
     border-color: var(--global-color-warning);
   }
   box-sizing: border-box;
+  /* The editor row must fill the field so the CodeMirror flex item can
+     shrink instead of overflowing under the control cluster */
+  > .flex {
+    width: 100%;
+    min-width: 0;
+  }
   .filter-icon {
     margin-left: var(--global-dimension-size-100);
     margin-right: var(--global-dimension-size-50);
@@ -228,6 +238,7 @@ export const dslFilterFieldCSS = css`
   .error-badge {
     display: flex;
     align-items: center;
+    flex-shrink: 0;
     gap: var(--global-dimension-size-50);
     max-width: 200px;
     overflow: hidden;
@@ -264,6 +275,13 @@ export const dslFilterFieldCSS = css`
   .error-badge__message {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  /* Icon-only validation errors: truncated copy used to cover the end of
+     the expression and intercept caret placement. Full detail stays in
+     the tooltip and the visually hidden status. */
+  .error-badge:not(:has(.error-badge__message)) {
+    max-width: none;
+    gap: 0;
   }
   /* The clear affordance only exists once there is something to clear —
      it leaves the layout entirely (no reserved empty slot) and grows in


### PR DESCRIPTION
fixes #15453

## Summary
- On the traces filter input, a validation failure used to render truncated error copy in a badge over the right edge of the field. That hid the end of the expression and intercepted clicks meant for caret placement.
- Validation errors now use a compact in-field icon. The full message stays in the hover/focus tooltip, the button `aria-label`, and the existing visually hidden status.
- The editor flex item no longer uses `width: 100%`, so it cedes space to the control cluster instead of painting under it.

## Screenshots
CONTRIBUTING asks for before/after images on UI changes. I was not able to start the Phoenix app in this environment, so screenshots are not attached. Happy to add them if a maintainer wants a visual check.

**Before:** the in-field error badge (up to 200px of truncated copy) sits on the right of the filter and covers the end of the expression.

**After:** only the danger icon remains in the control cluster; the expression stays fully clickable, and the complete error is in the tooltip.

## Test plan
- [ ] On the traces view, enter an invalid filter (for example an unclosed `)`) and wait for validation to settle.
- [ ] Confirm the right edge of the expression is visible and that clicking there places the caret in the editor, not on an overlay.
- [ ] Hover or keyboard-focus the error icon and confirm the full error appears in the tooltip.
- [ ] Confirm the field still gets a red border after blur, and that screen readers still get the error via the status text / `aria-label`.
- [ ] Warning badges that include a short in-field message, plus AI-query conversion errors that still pass `badgeMessage`, should keep their existing copy.