### PR TITLE
fix(mcp/sql): keep DISTINCT ON key lists out of the row-constructor repair

### DIFF
--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -782,13 +782,19 @@ def _repair_row_constructor(
     # `(1,)` is a one-field row. A one-element Tuple renders as `(1)`, a
     # scalar. ROW(1) is the spelling PostgreSQL still treats as a record.
     # VALUES (1) is a one-column row, not a record constructor — leave it.
+    # The excluded parents spell a parenthesised list that is grammar rather
+    # than a constructor: a grouping key, or the `DISTINCT ON (expr)` key list,
+    # where `ROW` is a syntax error.
     for tuple_node in list(root.find_all(exp.Tuple)):
         items = list(tuple_node.expressions)
         if len(items) != 1:
             continue
         if tuple_node.find_ancestor(exp.Values) is not None:
             continue
-        if isinstance(tuple_node.parent, (exp.GroupingSets, exp.Cube, exp.Rollup, exp.Group)):
+        if isinstance(
+            tuple_node.parent,
+            (exp.GroupingSets, exp.Cube, exp.Rollup, exp.Group, exp.Distinct),
+        ):
             continue
         tuple_node.replace(exp.Anonymous(this="row", expressions=[items[0].copy()]))
     return root

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -1001,3 +1001,29 @@ async def test_portable_function_classes_are_executable_on_sqlite(
     db, db_path = analytics_sqlite_db
     result = await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
     assert result.envelope.row_count > 0
+
+
+DISTINCT_ON_SHAPES = [
+    pytest.param("SELECT DISTINCT ON (name) id FROM spans ORDER BY name, id", id="single-key"),
+    pytest.param("SELECT DISTINCT ON ((name)) id FROM spans ORDER BY name, id", id="parenthesised"),
+    pytest.param(
+        "SELECT DISTINCT ON (name, id) id FROM spans ORDER BY name, id", id="multi-key"
+    ),
+]
+
+
+@pytest.mark.postgres_only
+@pytest.mark.parametrize("sql", DISTINCT_ON_SHAPES)
+async def test_distinct_on_executes(analytics_postgres_db: DbSessionFactory, sql: str) -> None:
+    """`DISTINCT ON (expr)` is a key list, not a row constructor.
+
+    A one-element parenthesised list is a record constructor almost everywhere
+    it appears, and is rewritten to `ROW(expr)` so PostgreSQL reads it as one.
+    In `DISTINCT ON` the same text is grammar, and `ROW` there is a syntax
+    error, so admission accepted a statement the engine then rejected.
+
+    Executed rather than rendered: the corpus pinned admission for this shape
+    and could not see that the emitted SQL does not parse.
+    """
+    result = await execute_analytics_sql(analytics_postgres_db, ExecuteParams(sql=sql))
+    assert result.envelope.row_count > 0


### PR DESCRIPTION
`SELECT DISTINCT ON (name) id FROM spans ORDER BY name, id` is admitted, then emitted as `SELECT DISTINCT ON ROW(name) id ...`, which PostgreSQL rejects:

```
ERROR:  syntax error at or near "ROW"
```

The caller's SQL is valid PostgreSQL and returns the right rows. Ours does not parse.

## Cause

`_repair_row_constructor` rewrites a one-element `Tuple` to `ROW(expr)`, because `(1)` renders as a scalar where PostgreSQL needs a record constructor. `DISTINCT ON (name)` parses as `Distinct(on=Tuple[name])` — the same node, but there the parentheses are grammar, not a constructor, and `ROW` is a syntax error.

`exp.Distinct` joins `GroupingSets`/`Cube`/`Rollup`/`Group`, which are excluded for exactly this reason.

Scope: single-key only, including `DISTINCT ON ((name))`. Multi-key is unaffected — the repair only fires on a one-element list. `ROW(1)` and `(1, 2)` still round-trip as record constructors.

## Why no test caught it

The admission corpus pins this statement as ADMIT, and nothing in the repo *executes* a `DISTINCT ON` statement — so the emitted SQL was never handed to PostgreSQL. This adds three liveness cases (single-key, parenthesised, multi-key) that execute against a real engine and require rows.

Verified those tests fail without the fix, with the exact production error:

```
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near "ROW"
```

## Provenance

Pre-existing, not a regression. `_repair_row_constructor` is byte-identical on `main` and the parse shape is the same under sqlglot 30.15.0 and 30.17.0 — reproduced on `main` at the pinned 30.15.0.

Found by a tree-fidelity sweep (admit → rewrite → render → re-parse → compare) written while reviewing #15469; that sweep is not included here.

## Testing

- PostgreSQL 17: **1991 passed**
- SQLite: **1891 passed**
- `make lint-python`, `make typecheck-python`: clean

Independent of #15469 — branched from `main` and mergeable in either order.
