### PR TITLE
chore(deps): require openai>=3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ dev = [
   "mypy-boto3-bedrock-runtime",
   "nest-asyncio",  # for executor testing
   "numpy",
-  "openai",
+  "openai>=3.1.0,<4",
   "openinference-semantic-conventions>=0.1.26",
   "openinference-instrumentation>=0.1.44",
   "opentelemetry-exporter-otlp",
@@ -216,7 +216,7 @@ container = [
   "google-genai>=1.50.0 ; python_version >= '3.10'",
   "google-genai ; python_version < '3.10'",
   "prometheus-client",
-  "openai>=2.14.0",
+  "openai>=3.1.0,<4",
   "azure-identity>=1.18.0",  # MSAL-backed in-memory token cache for ManagedIdentityCredential
   "aiohttp",  # used by azure-identity via azure.core.pipeline.transport
   # Note: when updating opentelemetry dependencies, all packages must use versions
@@ -443,13 +443,13 @@ exclude-newer = "3 days"
 # member — it is a setup.py C extension — so it resolves from PyPI and needs
 # this to be installable at all on the day it publishes.
 exclude-newer-package = { arize-phoenix-client = "2099-12-31T00:00:00Z", arize-phoenix-evals = "2099-12-31T00:00:00Z", arize-phoenix-otel = "2099-12-31T00:00:00Z", arize-phoenix-sqlean = "2099-12-31T00:00:00Z" }
-# litellm 1.83.x hard-pins `openai==2.24.0` and `python-dotenv==1.0.1`, which
-# conflict with pydantic-ai (needs openai>=2.29.0) and fastmcp (needs
-# python-dotenv>=1.1.0). Override the over-restrictive pins so resolution
-# succeeds; phoenix uses litellm purely as a client library and does not
-# exercise the pinned-version code paths.
+# litellm bounds shared dependencies below what the rest of the tree needs: it
+# caps `openai<3` while phoenix and pydantic-ai require openai 3, and it has
+# capped `python-dotenv` below the `>=1.1.0` fastmcp requires. Overriding is safe
+# because phoenix uses litellm purely as a client library and never reaches the
+# code paths those bounds guard.
 override-dependencies = [
-  "openai>=2.30.0",
+  "openai>=3.1.0,<4",
   "python-dotenv>=1.1.0",
 ]
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,7 +10,7 @@ pytest-randomly
 pytest-rerunfailures
 deepdiff==8.6.2
 anthropic
-openai>=2.14.0
+openai>=3.1.0,<4
 pystache
 PyYAML
 aioboto3

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -102,6 +102,7 @@ from phoenix.server.api.types.GenerativeProvider import (
 from phoenix.utilities.json import jsonify
 
 if TYPE_CHECKING:
+    import httpx2
     from anthropic import AsyncAnthropic
     from anthropic.lib.streaming import AsyncMessageStreamManager
     from anthropic.types import MessageParam, TextBlockParam, ToolUseBlockParam
@@ -2963,19 +2964,27 @@ LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO = SpanAttributes.LLM_TOKEN_COUNT_COMPLE
 
 
 class _HttpxClient(wrapt.ObjectProxy):  # type: ignore
+    """Records the outgoing request URL on the span without altering the request.
+
+    Provider SDKs disagree on their HTTP library: the openai SDK is built on httpx2, the
+    others on httpx. Both are accepted because only ``request.url`` is read.
+    """
+
     def __init__(
         self,
-        wrapped: httpx.AsyncClient,
+        wrapped: httpx.AsyncClient | httpx2.AsyncClient,
         span: OTelSpan,
     ):
         super().__init__(wrapped)
         self._self_span = span
 
-    async def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+    async def send(
+        self, request: httpx.Request | httpx2.Request, **kwargs: Any
+    ) -> httpx.Response | httpx2.Response:
         self._self_span.set_attribute(URL_FULL, str(request.url))
         self._self_span.set_attribute(URL_PATH, request.url.path.removeprefix(self.base_url.path))
         response = await self.__wrapped__.send(request, **kwargs)
-        return cast(httpx.Response, response)
+        return cast("httpx.Response | httpx2.Response", response)
 
 
 CustomProviderId: TypeAlias = int

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Callable, Optional
 
-import httpx
+import httpx2
 import pytest
 from openai import AsyncOpenAI
 from openinference.semconv.trace import (
@@ -2300,11 +2300,11 @@ class TestLLMEvaluator:
         self,
         openai_api_key: str,
     ) -> Callable[
-        [Optional[httpx.AsyncClient]],
+        [Optional[httpx2.AsyncClient]],
         "OpenAIChatCompletionsClient",
     ]:
         def create_client(
-            http_client: Optional[httpx.AsyncClient],
+            http_client: Optional[httpx2.AsyncClient],
         ) -> "OpenAIChatCompletionsClient":
             @asynccontextmanager
             async def create_openai_client() -> Any:
@@ -2329,7 +2329,7 @@ class TestLLMEvaluator:
     def openai_streaming_client(
         self,
         openai_streaming_client_factory: Callable[
-            [Optional[httpx.AsyncClient]],
+            [Optional[httpx2.AsyncClient]],
             "OpenAIChatCompletionsClient",
         ],
     ) -> "OpenAIChatCompletionsClient":
@@ -3266,7 +3266,7 @@ class TestLLMEvaluator:
         tracer: Tracer,
         llm_evaluator_factory: Callable[["OpenAIChatCompletionsClient"], LLMEvaluator],
         openai_streaming_client_factory: Callable[
-            [Optional[httpx.AsyncClient]],
+            [Optional[httpx2.AsyncClient]],
             "OpenAIChatCompletionsClient",
         ],
         output_config: CategoricalOutputConfig,
@@ -3295,14 +3295,14 @@ class TestLLMEvaluator:
                 },
             }
         )
-        transport = httpx.MockTransport(
-            lambda request: httpx.Response(
+        transport = httpx2.MockTransport(
+            lambda request: httpx2.Response(
                 200,
                 content=text_response_body,
                 headers={"content-type": "application/json"},
             )
         )
-        async with httpx.AsyncClient(transport=transport) as http_client:
+        async with httpx2.AsyncClient(transport=transport) as http_client:
             llm_evaluator = llm_evaluator_factory(openai_streaming_client_factory(http_client))
             evaluation_results = await llm_evaluator.evaluate(
                 context={"input": "What is 2 + 2?", "output": "4"},
@@ -3450,7 +3450,7 @@ class TestLLMEvaluator:
         tracer: Tracer,
         llm_evaluator_factory: Callable[["OpenAIChatCompletionsClient"], LLMEvaluator],
         openai_streaming_client_factory: Callable[
-            [Optional[httpx.AsyncClient]],
+            [Optional[httpx2.AsyncClient]],
             "OpenAIChatCompletionsClient",
         ],
         output_config: CategoricalOutputConfig,
@@ -3489,14 +3489,14 @@ class TestLLMEvaluator:
                 },
             }
         )
-        transport = httpx.MockTransport(
-            lambda request: httpx.Response(
+        transport = httpx2.MockTransport(
+            lambda request: httpx2.Response(
                 200,
                 content=tool_call_response_body,
                 headers={"content-type": "application/json"},
             )
         )
-        async with httpx.AsyncClient(transport=transport) as http_client:
+        async with httpx2.AsyncClient(transport=transport) as http_client:
             llm_evaluator = llm_evaluator_factory(openai_streaming_client_factory(http_client))
             evaluation_results = await llm_evaluator.evaluate(
                 context={"input": "What is 2 + 2?", "output": "4"},

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -4,6 +4,7 @@ import json
 from typing import Any, AsyncIterator, Union
 
 import httpx
+import httpx2
 import pytest
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionChunk as OpenAIChatCompletionChunk
@@ -17,6 +18,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCalls, FunctionModel
+from starlette.types import ASGIApp
 from strawberry.relay import GlobalID
 
 import phoenix.server.api.routers.v1.chat_completions as chat_completions_module
@@ -64,11 +66,12 @@ def build_model_spy(monkeypatch: pytest.MonkeyPatch) -> _BuildModelSpy:
 
 
 @pytest.fixture
-def openai_client(httpx_client: httpx.AsyncClient) -> AsyncOpenAI:
+def openai_client(asgi_app: ASGIApp) -> AsyncOpenAI:
     return AsyncOpenAI(
         base_url="http://test/v1",
         api_key="sk-unused",  # the app under test runs with authentication disabled
-        http_client=httpx_client,
+        # the openai SDK is httpx2-based; the shared httpx fixture cannot back its transport
+        http_client=httpx2.AsyncClient(transport=httpx2.ASGITransport(app=asgi_app)),
         max_retries=0,  # surface the first response instead of retrying 5xx
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,7 @@ members = [
     "arize-phoenix-otel",
 ]
 overrides = [
-    { name = "openai", specifier = ">=2.30.0" },
+    { name = "openai", specifier = ">=3.1.0,<4" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]
 
@@ -732,7 +732,7 @@ requires-dist = [
     { name = "modal", marker = "extra == 'container'", specifier = ">=1.2.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.2.0" },
     { name = "numpy" },
-    { name = "openai", marker = "extra == 'container'", specifier = ">=2.14.0" },
+    { name = "openai", marker = "extra == 'container'", specifier = ">=3.1.0,<4" },
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
     { name = "openinference-instrumentation-openai", specifier = ">=0.1.41" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.26" },
@@ -821,7 +821,7 @@ dev = [
     { name = "mypy-protobuf", specifier = ">=5.0.0" },
     { name = "nest-asyncio" },
     { name = "numpy" },
-    { name = "openai" },
+    { name = "openai", specifier = ">=3.1.0,<4" },
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.26" },
     { name = "opentelemetry-exporter-otlp" },
@@ -4922,21 +4922,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.53.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/9b/d45911bf9abfc5a754d800d79fe56e4dcf6e7b679d6ff4b7e9689b56bc02/openai-3.1.0.tar.gz", hash = "sha256:3ae7190da63f718727f9c525740d3f713e85553d2bf1d0cc9247346bd9063a4d", size = 1131016, upload-time = "2026-08-14T23:49:46.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/45/84b9e909968c0f4c3112a828bba9aa8be6a5ee322fcb3d781145ee53d88e/openai-3.1.0-py3-none-any.whl", hash = "sha256:f06d5a5c8d06a0aead3a67d33fe5a3c3c31540a0f7a8017b02ba8cd99bc5c736", size = 1670762, upload-time = "2026-08-14T23:49:43.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Raises the `openai` floor to `>=3.1.0,<4` and adapts the code to openai 3's transport change.

## Why the code changes

openai 3 moved its HTTP transport from `httpx` to `httpx2`. That surfaced 6 type errors, because `AsyncOpenAI._client` and the `http_client` parameter are now `httpx2` types. Runtime was never broken — openai 3 still accepts an `httpx` client by duck typing — but the annotations were wrong.

The fix keeps `httpx2` confined to the openai SDK boundary:

- `_HttpxClient` (playground) now accepts **both** `httpx` and `httpx2` clients. It is not a transitional shim — the same proxy wraps the anthropic client, which is `httpx`-based. Both are safe because the proxy only reads `request.url`.
- The openai test transports in `test_chat_completions.py` and `test_evaluators.py` are rebuilt on `httpx2`.

Everything else stays on `httpx` by necessity: 21 packages in the lock depend on it (`anthropic`, `google-genai`, `mcp`, `fastmcp`, `pydantic-ai`, `litellm`, `respx`), versus 2 on `httpx2` (`openai`, `genai-prices`). `httpx[http2]` is also still required and unrelated — `oauth2.py` passes `http2=True` to authlib's httpx-backed client (#14559).

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | dev group, container extra, litellm override → `openai>=3.1.0,<4` |
| `requirements/ci.txt` | `openai>=3.1.0,<4`, so the tox envs resolve the same |
| `uv.lock` | openai 2.53.0 → 3.1.0 |
| `playground_clients.py` | `_HttpxClient` accepts httpx and httpx2 |
| `test_evaluators.py` / `test_chat_completions.py` | openai transports on httpx2 |

## Reviewer notes

- The `override-dependencies` entry now spans a **major** version: litellm 1.95.0 declares `openai<3.0.0`. The existing rationale holds — phoenix uses litellm purely as a client library — but this is a larger override than the point pin it replaces.
- The sibling `python-dotenv>=1.1.0` override is now **stale** (litellm 1.95.0 allows it). Left for a separate cleanup.
- `openai>=1.62.0` (phoenix-client) and `>=1.66.5` (canary) are untouched. Those declare the minimum SDK the client helpers support, and `ci.txt` supersedes them in the installed env; raising them is a support-policy call.
- `packages/phoenix-evals` is intentionally **not** in this PR.

## Test plan

- `uv run mypy` — clean, 1132 files
- `ruff check` / `ruff format` — clean
- `uv lock --check` — consistent
- Unit suite (`-n auto`) — 8188 passed
- phoenix-evals + phoenix-client canary (`-n auto`) — 772 passed

Pre-existing failures on `main`, not introduced here: `test_sandbox_queries.py::test_sandbox_providers_returns_nested_configs` (verified failing identically on `733061c2b` with openai 2.53.0), plus assorted `pytest-randomly` ordering errors that pass in isolation.