### PR TITLE
test: expose openai resource attributes on the model factory client stub

### DIFF
--- a/tests/unit/server/agents/test_model_factory.py
+++ b/tests/unit/server/agents/test_model_factory.py
@@ -1,5 +1,6 @@
 import base64
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -108,6 +109,11 @@ class TestCustomProviderModels:
             def __init__(self, **kwargs: Any) -> None:
                 self.kwargs = kwargs
                 self.base_url = kwargs.get("base_url", "https://example.test/v1")
+                # pydantic-ai reads the resource attribute matching the model class
+                # while constructing the model, so a stand-in client must expose the
+                # attribute for every ``openai_api_type`` under test.
+                self.chat = SimpleNamespace(completions=object())
+                self.responses = object()
 
         monkeypatch.setattr(openai, "AsyncOpenAI", DummyAsyncOpenAI)
 


### PR DESCRIPTION
Fixes a unit test that fails against current `pydantic-ai`.

## The failure

```
tests/unit/server/agents/test_model_factory.py::TestCustomProviderModels::test_openai_family_custom_providers_disable_sdk_retries
AttributeError: 'DummyAsyncOpenAI' object has no attribute 'responses'
```

pydantic-ai eagerly loads the OpenAI SDK resource module for the model class being constructed:

```python
# pydantic_ai/models/openai.py
def _preload_openai_sdk_resource_modules(model, client) -> None:
    if isinstance(model, OpenAIChatModel):
        _ = client.chat.completions
    else:
        _ = client.responses
```

The test's `DummyAsyncOpenAI` stand-in only carried `kwargs` and `base_url`, so constructing an `OpenAIResponsesModel` raised. The fix gives the stub both resource attributes, covering either `openai_api_type`.

## Why it surfaced now

The unit-test job runs via tox against `requirements/unit-tests.txt`, which floats `pydantic-ai-slim>=2.0.0` — CI installed **2.31.0**. `uv.lock` pins **2.26.0**, so local runs and the type-check job (which uses `uv sync --frozen`) never saw it. Main's Python CI last ran on Aug 7, before 2.31.0 shipped.

This is a pre-existing break on `main`, not caused by any dependency change: verified by running the test at `733061c2b` with pydantic-ai 2.31.0 installed, where it fails identically.

## Test plan

`tests/unit/server/agents/test_model_factory.py` — 8 passed, 3 skipped against **both** pydantic-ai 2.26.0 (locked) and 2.31.0 (CI's). Plus `uv run mypy` clean and `ruff check`/`format` clean.

## Follow-up worth considering

The floating `pydantic-ai-slim>=2.0.0` in `requirements/type-check.txt` means CI silently tests against versions the lockfile never resolved, so upstream releases can turn `main` red with no change on our side. Not addressed here.
