### PR TITLE
feat(ui): narrow time range by clicking chart bins

### DIFF
--- a/js/app/src/components/chart/TimeRangeChartBrush.tsx
+++ b/js/app/src/components/chart/TimeRangeChartBrush.tsx
@@ -3,7 +3,14 @@ import type { MouseEvent, ReactNode } from "react";
 import { useRef, useState } from "react";
 import type { MouseHandlerDataParam } from "recharts";
 
+import { useUTCOffsetMinutes } from "@phoenix/hooks/useUTCOffsetMinutes";
 import { clampNumber } from "@phoenix/utils/numberUtils";
+
+import { getTimeBinRange } from "./timeBins";
+
+// Click slop in container pixels. Use pixels rather than snapped timestamps so
+// a real drag that starts and ends in one bin remains a drag.
+const CLICK_MAX_DRAG_PX = 4;
 
 const timeRangeChartBrushCSS = css`
   /* Dragging out a selection must not select axis text or the chart svg */
@@ -15,9 +22,21 @@ const timeRangeChartBrushCSS = css`
     cursor: crosshair !important;
   }
 
+  &[data-bin-click="true"] {
+    .recharts-wrapper,
+    .recharts-surface {
+      cursor: pointer !important;
+    }
+  }
+
   &[data-selecting="true"] {
     .recharts-tooltip-cursor {
       display: none;
+    }
+
+    .recharts-wrapper,
+    .recharts-surface {
+      cursor: crosshair !important;
     }
   }
 `;
@@ -40,6 +59,11 @@ type TimeRangeChartBrushRenderProps = {
 type TimeRangeChartBrushProps = {
   children: (props: TimeRangeChartBrushRenderProps) => ReactNode;
   onTimeRangeSelected?: (timeRange: TimeRange) => void;
+  /**
+   * Must match the `timeBinConfig.scale` used to query the chart. When
+   * provided, clicking narrows the selected time range to the clicked bin.
+   */
+  scale?: TimeBinScale;
 };
 
 type BrushSelection = {
@@ -126,9 +150,9 @@ function getPlotArea(container: HTMLDivElement): BrushPlotArea {
 }
 
 /**
- * Convert an in-progress brush selection into a normalized TimeRange with
- * start <= end. Returns null for zero-width selections (e.g. a click without
- * a drag) so callers can ignore non-gestures.
+ * Convert a dragged brush selection into a normalized TimeRange with start <=
+ * end. Returns null when both snapped timestamps are equal. Depending on the
+ * pointer distance, callers may handle that gesture as a bin click instead.
  */
 function getOrderedSelectionRange(selection: BrushSelection): TimeRange | null {
   const start = Math.min(selection.start, selection.end);
@@ -143,11 +167,43 @@ function getOrderedSelectionRange(selection: BrushSelection): TimeRange | null {
 }
 
 /**
- * Wraps a recharts time-series chart with a click-and-drag brush that emits a
- * `TimeRange` for the selected window. The chart is rendered via a render prop
- * so the brush stays agnostic to the chart's data shape and axis configuration;
- * spread the supplied `chartProps` onto the chart element to wire up the mouse
- * handlers.
+ * Resolve a completed pointer gesture to either the clicked bin or the dragged
+ * time range.
+ *
+ * @param params - completed gesture parameters
+ * @param params.selection - snapped timestamps and clamped pointer positions
+ * @param params.scale - chart query scale, if bin clicking is enabled
+ * @param params.utcOffsetMinutes - fixed UTC offset used for chart binning
+ * @param params.clickMaxDragPx - maximum pointer movement treated as a click
+ */
+export function getBrushGestureTimeRange({
+  selection,
+  scale,
+  utcOffsetMinutes,
+  clickMaxDragPx = CLICK_MAX_DRAG_PX,
+}: {
+  selection: BrushSelection;
+  scale?: TimeBinScale;
+  utcOffsetMinutes: number;
+  clickMaxDragPx?: number;
+}): TimeRange | null {
+  const pointerDistance = Math.abs(selection.endX - selection.startX);
+  if (scale != null && pointerDistance <= clickMaxDragPx) {
+    return getTimeBinRange({
+      binStartMs: selection.end,
+      scale,
+      utcOffsetMinutes,
+    });
+  }
+  return getOrderedSelectionRange(selection);
+}
+
+/**
+ * Wraps a recharts time-series chart with two narrowing gestures: clicking a
+ * bin when `scale` is provided, or dragging a brush across a window. The chart
+ * is rendered via a render prop so the brush stays agnostic to the chart's data
+ * shape and axis configuration; spread the supplied `chartProps` onto the chart
+ * element to wire up the mouse handlers.
  *
  * When `onTimeRangeSelected` is omitted the brush is a transparent passthrough
  * with no overlay, mouse handlers, or extra DOM, so it is safe to use even for
@@ -156,7 +212,9 @@ function getOrderedSelectionRange(selection: BrushSelection): TimeRange | null {
 export function TimeRangeChartBrush({
   children,
   onTimeRangeSelected,
+  scale,
 }: TimeRangeChartBrushProps) {
+  const utcOffsetMinutes = useUTCOffsetMinutes();
   const [selection, setSelection] = useState<BrushSelection | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const selectionRef = useRef<BrushSelection | null>(null);
@@ -247,8 +305,12 @@ export function TimeRangeChartBrush({
               end: timestamp,
               endX: cursorX ?? currentSelection.endX,
             };
-      const timeRange = getOrderedSelectionRange(nextSelection);
       setBrushSelection(null);
+      const timeRange = getBrushGestureTimeRange({
+        selection: nextSelection,
+        scale,
+        utcOffsetMinutes,
+      });
       if (timeRange) {
         onTimeRangeSelected(timeRange);
       }
@@ -268,6 +330,7 @@ export function TimeRangeChartBrush({
   return (
     <div
       css={timeRangeChartBrushCSS}
+      data-bin-click={scale != null ? "true" : undefined}
       data-selecting={selection != null ? "true" : undefined}
       ref={containerRef}
       style={{ position: "relative", width: "100%", height: "100%" }}
@@ -292,7 +355,7 @@ export function TimeRangeChartBrush({
           position: "relative",
           width: "100%",
           height: "100%",
-          cursor: "crosshair",
+          cursor: selection != null || scale == null ? "crosshair" : "pointer",
           zIndex: 1,
         }}
       >

--- a/js/app/src/components/chart/__tests__/TimeRangeChartBrush.test.ts
+++ b/js/app/src/components/chart/__tests__/TimeRangeChartBrush.test.ts
@@ -1,0 +1,101 @@
+import { ONE_DAY_MS } from "@phoenix/constants/timeConstants";
+
+import { getBrushGestureTimeRange } from "../TimeRangeChartBrush";
+
+const plotArea = { left: 0, top: 0, width: 100, height: 100 };
+const binStartMs = Date.UTC(2026, 5, 9);
+
+describe("getBrushGestureTimeRange", () => {
+  it("selects the bin for a stationary click", () => {
+    expect(
+      getBrushGestureTimeRange({
+        selection: {
+          start: binStartMs,
+          end: binStartMs,
+          startX: 20,
+          endX: 20,
+          plotArea,
+        },
+        scale: "DAY",
+        utcOffsetMinutes: 0,
+        clickMaxDragPx: 4,
+      })
+    ).toEqual({
+      start: new Date(binStartMs),
+      end: new Date(binStartMs + ONE_DAY_MS),
+    });
+  });
+
+  it("uses the mouseup bin for a small cross-boundary drag", () => {
+    expect(
+      getBrushGestureTimeRange({
+        selection: {
+          start: binStartMs,
+          end: binStartMs + ONE_DAY_MS,
+          startX: 20,
+          endX: 22,
+          plotArea,
+        },
+        scale: "DAY",
+        utcOffsetMinutes: 0,
+        clickMaxDragPx: 4,
+      })
+    ).toEqual({
+      start: new Date(binStartMs + ONE_DAY_MS),
+      end: new Date(binStartMs + 2 * ONE_DAY_MS),
+    });
+  });
+
+  it("ignores a real drag whose timestamps snap to the same bin", () => {
+    expect(
+      getBrushGestureTimeRange({
+        selection: {
+          start: binStartMs,
+          end: binStartMs,
+          startX: 20,
+          endX: 60,
+          plotArea,
+        },
+        scale: "DAY",
+        utcOffsetMinutes: 0,
+        clickMaxDragPx: 4,
+      })
+    ).toBeNull();
+  });
+
+  it("returns the ordered range for a multi-bin drag", () => {
+    expect(
+      getBrushGestureTimeRange({
+        selection: {
+          start: binStartMs + 2 * ONE_DAY_MS,
+          end: binStartMs,
+          startX: 80,
+          endX: 20,
+          plotArea,
+        },
+        scale: "DAY",
+        utcOffsetMinutes: 0,
+        clickMaxDragPx: 4,
+      })
+    ).toEqual({
+      start: new Date(binStartMs),
+      end: new Date(binStartMs + 2 * ONE_DAY_MS),
+    });
+  });
+
+  it("keeps a stationary click disabled when no scale is provided", () => {
+    expect(
+      getBrushGestureTimeRange({
+        selection: {
+          start: binStartMs,
+          end: binStartMs,
+          startX: 20,
+          endX: 20,
+          plotArea,
+        },
+        utcOffsetMinutes: 0,
+        clickMaxDragPx: 4,
+      })
+    ).toBeNull();
+  });
+});

--- a/js/app/src/components/chart/__tests__/timeBins.test.ts
+++ b/js/app/src/components/chart/__tests__/timeBins.test.ts
@@ -1,0 +1,131 @@
+import {
+  ONE_DAY_MS,
+  ONE_HOUR_MS,
+  ONE_MINUTE_MS,
+  ONE_WEEK_MS,
+} from "@phoenix/constants/timeConstants";
+
+import { getTimeBinRange } from "../timeBins";
+
+describe("getTimeBinRange", () => {
+  it.each([
+    { scale: "MINUTE" as const, durationMs: ONE_MINUTE_MS },
+    { scale: "HOUR" as const, durationMs: ONE_HOUR_MS },
+    { scale: "DAY" as const, durationMs: ONE_DAY_MS },
+    { scale: "WEEK" as const, durationMs: ONE_WEEK_MS },
+  ])("returns the fixed width of a $scale bin", ({ scale, durationMs }) => {
+    const binStartMs = Date.UTC(2026, 5, 9, 10);
+    const range = getTimeBinRange({
+      binStartMs,
+      scale,
+      utcOffsetMinutes: 0,
+    });
+
+    expect(range.start.getTime()).toBe(binStartMs);
+    expect(range.end.getTime()).toBe(binStartMs + durationMs);
+  });
+
+  it.each([
+    { scale: "DAY" as const, durationMs: ONE_DAY_MS, utcOffsetMinutes: 330 },
+    { scale: "DAY" as const, durationMs: ONE_DAY_MS, utcOffsetMinutes: -300 },
+    {
+      scale: "WEEK" as const,
+      durationMs: ONE_WEEK_MS,
+      utcOffsetMinutes: 330,
+    },
+    {
+      scale: "WEEK" as const,
+      durationMs: ONE_WEEK_MS,
+      utcOffsetMinutes: -300,
+    },
+  ])(
+    "keeps $scale fixed-width at offset $utcOffsetMinutes",
+    ({ scale, durationMs, utcOffsetMinutes }) => {
+      const binStartMs =
+        Date.UTC(2026, 5, 8) - utcOffsetMinutes * ONE_MINUTE_MS;
+      const range = getTimeBinRange({
+        binStartMs,
+        scale,
+        utcOffsetMinutes,
+      });
+
+      expect(range.end.getTime()).toBe(binStartMs + durationMs);
+    }
+  );
+
+  it.each([
+    {
+      name: "January",
+      start: [2026, 0],
+      end: [2026, 1],
+      utcOffsetMinutes: 0,
+    },
+    {
+      name: "April",
+      start: [2026, 3],
+      end: [2026, 4],
+      utcOffsetMinutes: 0,
+    },
+    {
+      name: "leap-year February",
+      start: [2024, 1],
+      end: [2024, 2],
+      utcOffsetMinutes: 0,
+    },
+    {
+      name: "non-leap-year February",
+      start: [2025, 1],
+      end: [2025, 2],
+      utcOffsetMinutes: 0,
+    },
+    {
+      name: "January at UTC+05:30",
+      start: [2026, 0],
+      end: [2026, 1],
+      utcOffsetMinutes: 330,
+    },
+    {
+      name: "April at UTC-05:00",
+      start: [2026, 3],
+      end: [2026, 4],
+      utcOffsetMinutes: -300,
+    },
+  ])(
+    "returns the next month boundary for $name",
+    ({ start, end, utcOffsetMinutes }) => {
+      const utcOffsetMs = utcOffsetMinutes * ONE_MINUTE_MS;
+      const binStartMs = Date.UTC(start[0]!, start[1]!) - utcOffsetMs;
+      const nextBinStartMs = Date.UTC(end[0]!, end[1]!) - utcOffsetMs;
+      const range = getTimeBinRange({
+        binStartMs,
+        scale: "MONTH",
+        utcOffsetMinutes,
+      });
+
+      expect(range.start.getTime()).toBe(binStartMs);
+      expect(range.end.getTime()).toBe(nextBinStartMs);
+    }
+  );
+
+  it.each([
+    { year: 2024, utcOffsetMinutes: 0 },
+    { year: 2025, utcOffsetMinutes: 0 },
+    { year: 2024, utcOffsetMinutes: 330 },
+    { year: 2025, utcOffsetMinutes: -300 },
+  ])(
+    "returns the next year boundary for $year at offset $utcOffsetMinutes",
+    ({ year, utcOffsetMinutes }) => {
+      const utcOffsetMs = utcOffsetMinutes * ONE_MINUTE_MS;
+      const binStartMs = Date.UTC(year, 0) - utcOffsetMs;
+      const nextBinStartMs = Date.UTC(year + 1, 0) - utcOffsetMs;
+      const range = getTimeBinRange({
+        binStartMs,
+        scale: "YEAR",
+        utcOffsetMinutes,
+      });
+
+      expect(range.start.getTime()).toBe(binStartMs);
+      expect(range.end.getTime()).toBe(nextBinStartMs);
+    }
+  );
+});

--- a/js/app/src/components/chart/timeBins.ts
+++ b/js/app/src/components/chart/timeBins.ts
@@ -1,0 +1,58 @@
+import {
+  ONE_DAY_MS,
+  ONE_HOUR_MS,
+  ONE_MINUTE_MS,
+  ONE_WEEK_MS,
+} from "@phoenix/constants/timeConstants";
+import { assertUnreachable } from "@phoenix/typeUtils";
+
+/**
+ * Get the half-open time range represented by a chart bin.
+ *
+ * Minute through week bins need no offset adjustment: the server applies a
+ * fixed minute shift rather than a timezone database, so their UTC durations
+ * remain fixed. Month and year bins use calendar arithmetic in the same
+ * offset-shifted frame as the server.
+ *
+ * @param params - time bin parameters
+ * @param params.binStartMs - bin start in epoch milliseconds
+ * @param params.scale - scale used to query the chart data
+ * @param params.utcOffsetMinutes - fixed UTC offset used to query the chart
+ */
+export function getTimeBinRange({
+  binStartMs,
+  scale,
+  utcOffsetMinutes,
+}: {
+  binStartMs: number;
+  scale: TimeBinScale;
+  utcOffsetMinutes: number;
+}): TimeRange {
+  const start = new Date(binStartMs);
+  switch (scale) {
+    case "MINUTE":
+      return { start, end: new Date(binStartMs + ONE_MINUTE_MS) };
+    case "HOUR":
+      return { start, end: new Date(binStartMs + ONE_HOUR_MS) };
+    case "DAY":
+      return { start, end: new Date(binStartMs + ONE_DAY_MS) };
+    case "WEEK":
+      return { start, end: new Date(binStartMs + ONE_WEEK_MS) };
+    case "MONTH":
+    case "YEAR": {
+      const utcOffsetMs = utcOffsetMinutes * ONE_MINUTE_MS;
+      const shiftedEnd = new Date(binStartMs + utcOffsetMs);
+      if (scale === "MONTH") {
+        shiftedEnd.setUTCMonth(shiftedEnd.getUTCMonth() + 1);
+      } else {
+        shiftedEnd.setUTCFullYear(shiftedEnd.getUTCFullYear() + 1);
+      }
+      return {
+        start,
+        end: new Date(shiftedEnd.getTime() - utcOffsetMs),
+      };
+    }
+    default:
+      return assertUnreachable(scale);
+  }
+}

--- a/js/app/src/components/datetime/TimeRangeContext.tsx
+++ b/js/app/src/components/datetime/TimeRangeContext.tsx
@@ -34,12 +34,21 @@ export type TimeRangeContextType = {
    * steering interactions (preset picks, pan/zoom) do not block the input
    * event.
    */
-  setTimeRange: (timeRange: OpenTimeRangeWithKey) => void;
+  setTimeRange: (
+    timeRange: OpenTimeRangeWithKey,
+    options?: SetTimeRangeOptions
+  ) => void;
   /**
-   * Apply a closed time range as a custom selection. Wraps the state write in
-   * a transition so brush-driven updates do not block the input event.
+   * Apply a chart-selected closed time range as a custom selection. The URL
+   * write remains transition-wrapped and pushes a history entry so browser
+   * Back restores the prior range.
    */
   setCustomTimeRange: (timeRange: TimeRange) => void;
+};
+
+export type SetTimeRangeOptions = {
+  /** Choose whether the URL write replaces or pushes browser history. */
+  history?: "replace" | "push";
 };
 
 /** ISO 8601 bounds for the active time range. */
@@ -153,10 +162,14 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
    *
    * The URL write is declarative: a last-N key is written as just the key
    * (clearing any bounds) and a custom range as just its bounds. The write
-   * replaces history (no new entry per change) and any last-N key is persisted
-   * as the user's preference.
+   * replaces history by default and any last-N key is persisted as the user's
+   * preference. Callers can explicitly push discrete changes that should be
+   * undoable with browser Back.
    */
-  const setTimeRange = (timeRange: OpenTimeRangeWithKey) => {
+  const setTimeRange = (
+    timeRange: OpenTimeRangeWithKey,
+    options?: SetTimeRangeOptions
+  ) => {
     startTransition(() => {
       setSearchParams(
         (currentSearchParams) =>
@@ -164,7 +177,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
             searchParams: currentSearchParams,
             timeRange,
           }),
-        { replace: true }
+        { replace: options?.history !== "push" }
       );
       // Persist the preset and re-anchor "now" so the live window refreshes.
       if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
@@ -175,11 +188,14 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   };
 
   const setCustomTimeRange = (timeRange: TimeRange) => {
-    setTimeRange({
-      timeRangeKey: "custom",
-      start: timeRange.start,
-      end: timeRange.end,
-    });
+    setTimeRange(
+      {
+        timeRangeKey: "custom",
+        start: timeRange.start,
+        end: timeRange.end,
+      },
+      { history: "push" }
+    );
   };
 
   // Seed a fresh URL from the stored preference on first load. Once the URL

--- a/js/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
+++ b/js/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
@@ -24,21 +24,27 @@ function TimeRangeReader({
   onRender,
   onRenderISOStrings,
   onSetTimeRange,
+  onSetCustomTimeRange,
   onLocation,
   onNavigate,
 }: {
   onRender: (timeRange: OpenTimeRangeWithKey) => void;
   onRenderISOStrings?: (timeRangeISOStrings: TimeRangeISOStrings) => void;
   onSetTimeRange?: (setTimeRange: TimeRangeContextType["setTimeRange"]) => void;
+  onSetCustomTimeRange?: (
+    setCustomTimeRange: TimeRangeContextType["setCustomTimeRange"]
+  ) => void;
   onLocation?: (search: string) => void;
   onNavigate?: (navigate: NavigateFunction) => void;
 }) {
-  const { timeRange, timeRangeISOStrings, setTimeRange } = useTimeRange();
+  const { timeRange, timeRangeISOStrings, setTimeRange, setCustomTimeRange } =
+    useTimeRange();
   const location = useLocation();
   const navigate = useNavigate();
   onRender(timeRange);
   onRenderISOStrings?.(timeRangeISOStrings);
   onSetTimeRange?.(setTimeRange);
+  onSetCustomTimeRange?.(setCustomTimeRange);
   onLocation?.(location.search);
   onNavigate?.(navigate);
   return null;
@@ -51,6 +57,7 @@ function renderTimeRangeProvider({
   onRender,
   onRenderISOStrings,
   onSetTimeRange,
+  onSetCustomTimeRange,
   onLocation,
   onNavigate,
 }: {
@@ -60,6 +67,9 @@ function renderTimeRangeProvider({
   onRender: (timeRange: OpenTimeRangeWithKey) => void;
   onRenderISOStrings?: (timeRangeISOStrings: TimeRangeISOStrings) => void;
   onSetTimeRange?: (setTimeRange: TimeRangeContextType["setTimeRange"]) => void;
+  onSetCustomTimeRange?: (
+    setCustomTimeRange: TimeRangeContextType["setCustomTimeRange"]
+  ) => void;
   onLocation?: (search: string) => void;
   onNavigate?: (navigate: NavigateFunction) => void;
 }) {
@@ -73,6 +83,7 @@ function renderTimeRangeProvider({
                 onRender={onRender}
                 onRenderISOStrings={onRenderISOStrings}
                 onSetTimeRange={onSetTimeRange}
+                onSetCustomTimeRange={onSetCustomTimeRange}
                 onLocation={onLocation}
                 onNavigate={onNavigate}
               />
@@ -351,5 +362,95 @@ describe("TimeRangeProvider", () => {
     expect(latestSearchParams.get("timeRangeEnd")).toBe(
       "2026-06-09T11:00:00.000Z"
     );
+  });
+
+  it("pushes chart-selected custom ranges so Back restores the prior range", () => {
+    const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
+    const renderedLocations: string[] = [];
+    let setCustomTimeRange: TimeRangeContextType["setCustomTimeRange"] | null =
+      null;
+    let navigate: NavigateFunction | null = null;
+    const start = new Date("2026-06-09T09:00:00.000Z");
+    const end = new Date("2026-06-09T10:00:00.000Z");
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry: "/projects/project-1/traces?timeRangeKey=15m",
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
+      onSetCustomTimeRange: (nextSetCustomTimeRange) => {
+        setCustomTimeRange = nextSetCustomTimeRange;
+      },
+      onLocation: (search) => {
+        renderedLocations.push(search);
+      },
+      onNavigate: (nextNavigate) => {
+        navigate = nextNavigate;
+      },
+    });
+
+    act(() => {
+      setCustomTimeRange?.({ start, end });
+    });
+
+    expect(renderedTimeRanges.at(-1)).toMatchObject({
+      timeRangeKey: "custom",
+      start,
+      end,
+    });
+
+    act(() => {
+      navigate?.(-1);
+    });
+
+    expect(renderedTimeRanges.at(-1)?.timeRangeKey).toBe("15m");
+    expect(renderedTimeRanges.at(-1)?.start?.toISOString()).toBe(
+      "2026-06-09T09:45:00.000Z"
+    );
+    expect(renderedTimeRanges.at(-1)?.end).toBeNull();
+    expect(renderedLocations.at(-1)).toBe("?timeRangeKey=15m");
+  });
+
+  it("replaces history for ordinary setTimeRange writes", () => {
+    const renderedTimeRanges: OpenTimeRangeWithKey[] = [];
+    const renderedLocations: string[] = [];
+    let setTimeRange: TimeRangeContextType["setTimeRange"] | null = null;
+    let navigate: NavigateFunction | null = null;
+    const start = new Date("2026-06-09T09:00:00.000Z");
+    const end = new Date("2026-06-09T10:00:00.000Z");
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry: "/projects/project-1/traces?timeRangeKey=15m",
+      onRender: (timeRange) => {
+        renderedTimeRanges.push(timeRange);
+      },
+      onSetTimeRange: (nextSetTimeRange) => {
+        setTimeRange = nextSetTimeRange;
+      },
+      onLocation: (search) => {
+        renderedLocations.push(search);
+      },
+      onNavigate: (nextNavigate) => {
+        navigate = nextNavigate;
+      },
+    });
+
+    act(() => {
+      setTimeRange?.({ timeRangeKey: "custom", start, end });
+    });
+
+    const customLocation = renderedLocations.at(-1);
+    act(() => {
+      navigate?.(-1);
+    });
+
+    expect(renderedTimeRanges.at(-1)).toMatchObject({
+      timeRangeKey: "custom",
+      start,
+      end,
+    });
+    expect(renderedLocations.at(-1)).toBe(customLocation);
   });
 });

--- a/js/app/src/pages/project/TableMetricsCharts.tsx
+++ b/js/app/src/pages/project/TableMetricsCharts.tsx
@@ -45,8 +45,9 @@ const chartsResizeHandleCSS = css`
  * A strip of user-selected metric charts shown above a project table (spans,
  * traces, or sessions) for troubleshooting. Any chart in the chart catalog
  * can be added. Charts support legend-based series filtering, and most
- * support drag-to-select time range zooming. The selection is persisted per
- * project and per table view.
+ * support click-to-narrow and drag-to-select time range zooming, with browser
+ * Back restoring the prior range. The chart selection is persisted per project
+ * and per table view.
  */
 const TableMetricsCharts = memo(function TableMetricsCharts({
   view,

--- a/js/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
+++ b/js/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
@@ -151,7 +151,10 @@ export function AnnotationScoreTimeSeriesChart({
     useInteractiveLegend();
 
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}

--- a/js/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/js/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -123,6 +123,7 @@ function ProjectAnnotationMetricsPanel({
   timeTickFormatter,
   fullTimeFormatter,
   onTimeRangeSelected,
+  scale,
   fillHeight = false,
 }: {
   series: AnnotationMetricsSeries;
@@ -131,6 +132,7 @@ function ProjectAnnotationMetricsPanel({
   timeTickFormatter: (date: Date) => string;
   fullTimeFormatter: (date: Date) => string;
   onTimeRangeSelected?: (timeRange: TimeRange) => void;
+  scale: TimeBinScale;
   fillHeight?: boolean;
 }) {
   const [view, setView] = useState(() =>
@@ -152,7 +154,10 @@ function ProjectAnnotationMetricsPanel({
         ) : undefined
       }
     >
-      <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+      <TimeRangeChartBrush
+        onTimeRangeSelected={onTimeRangeSelected}
+        scale={scale}
+      >
         {({ chartProps }) => (
           <AnnotationMetricsChart
             series={series}
@@ -281,6 +286,7 @@ function ProjectAnnotationMetricPanelContent({
       {...props}
       series={series}
       annotationConfig={annotationConfigsByName.get(series.name)}
+      scale={scale}
       timeTickFormatter={timeTickFormatter}
       fullTimeFormatter={fullTimeFormatter}
       fillHeight={fillHeight}

--- a/js/app/src/pages/project/metrics/SpanCountTimeSeries.tsx
+++ b/js/app/src/pages/project/metrics/SpanCountTimeSeries.tsx
@@ -114,7 +114,10 @@ export function SpanCountTimeSeries({
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}

--- a/js/app/src/pages/project/metrics/SpanErrorsTimeSeries.tsx
+++ b/js/app/src/pages/project/metrics/SpanErrorsTimeSeries.tsx
@@ -85,7 +85,10 @@ export function SpanErrorsTimeSeries({
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasErrors}

--- a/js/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
+++ b/js/app/src/pages/project/metrics/TraceCountTimeSeries.tsx
@@ -95,7 +95,10 @@ export function TraceCountTimeSeries({
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}

--- a/js/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
+++ b/js/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
@@ -142,7 +142,10 @@ export function TraceLatencyPercentilesTimeSeries({
     useInteractiveLegend();
 
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}

--- a/js/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
+++ b/js/app/src/pages/project/metrics/TraceTokenCostTimeSeries.tsx
@@ -131,7 +131,10 @@ export function TraceTokenCostTimeSeries({
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}

--- a/js/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
+++ b/js/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
@@ -229,7 +229,10 @@ export function TraceTokenCountTimeSeries({
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}
@@ -334,7 +337,10 @@ function TraceTokenDetailsTimeSeries({
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
   return (
-    <TimeRangeChartBrush onTimeRangeSelected={onTimeRangeSelected}>
+    <TimeRangeChartBrush
+      onTimeRangeSelected={onTimeRangeSelected}
+      scale={scale}
+    >
       {({ chartProps }) => (
         <ChartEmptyStateOverlay
           isEmpty={!hasData}


### PR DESCRIPTION
## Summary

- make time-series chart bins clickable to narrow the shared time range
- preserve drag-to-select behavior with pointer-movement click slop
- push committed chart selections into browser history so Back and Forward undo and redo them
- support fixed-width and offset-aware calendar bins

## Demo

https://github.com/user-attachments/assets/dde54344-de2c-4a4e-8874-ccfde7e5be21




## Testing

- `make build-frontend`
- `make typecheck-frontend`
- `make lint-frontend`
- `make test-frontend` (2,359 passed, 12 skipped)
- browser-tested bar, line, annotation, drag, Back/Forward, and cancellation/no-op interactions with representative seeded data

Resolves #15095
