### PR TITLE
fix: handle missing annotation labels with pandas 3

### DIFF
--- a/src/phoenix/server/api/types/AnnotationSummary.py
+++ b/src/phoenix/server/api/types/AnnotationSummary.py
@@ -46,7 +46,8 @@ class AnnotationSummary:
                 fraction=float(row.avg_label_fraction),
             )
             for row in self.df.itertuples()
-            if row.label is not None
+            # Pandas can represent the synthetic coverage row's SQL NULL as NaN.
+            if pd.notna(row.label)
         ]
 
     @strawberry.field

--- a/tests/unit/server/api/types/test_AnnotationSummary.py
+++ b/tests/unit/server/api/types/test_AnnotationSummary.py
@@ -1,0 +1,28 @@
+import math
+from typing import cast
+
+import pandas as pd
+
+from phoenix.server.api.types.AnnotationSummary import AnnotationSummary
+from phoenix.server.api.types.LabelFraction import LabelFraction
+
+
+def test_label_fractions_ignore_nan_label() -> None:
+    summary = AnnotationSummary(
+        name="overall",
+        df=pd.DataFrame(
+            [
+                {"label": "pass", "avg_label_fraction": 1.0},
+                # The metrics query uses this row for coverage rather than a label.
+                {"label": math.nan, "avg_label_fraction": math.nan},
+            ]
+        ),
+    )
+
+    label_fractions = cast(
+        list[LabelFraction],
+        summary.label_fractions(),  # type: ignore[call-arg]
+    )
+    assert [
+        (label_fraction.label, label_fraction.fraction) for label_fraction in label_fractions
+    ] == [("pass", 1.0)]


### PR DESCRIPTION
## Summary

Fix annotation metrics serialization with pandas 3.

The metrics query includes a synthetic coverage row whose label is SQL `NULL`. Pandas 3 represents that missing value as `NaN`, so the existing `row.label is not None` check incorrectly included it in `labelFractions`. Strawberry then failed to serialize `NaN` as a GraphQL `String`.

This changes the check to `pd.notna(row.label)` and adds a focused regression test for the `NaN` case.

## Alternative considered

We considered a broader refactor where `AnnotationSummary` stores the values returned by GraphQL directly and the query joins label fractions onto a real summary row. That removes the synthetic coverage row and the pandas dependency, making the data flow easier to understand.

For this fix, we chose the narrower change because it restores pandas 3 compatibility with substantially less surface area. The broader cleanup can be handled separately without coupling it to the bug fix.

## Testing

- Python formatting
- Python lint
- Python typecheck
- Regression test with the default pandas version
- Regression test with Python 3.12 and pandas 3.0.5
- Manually verified score and label metric views in the UI

Resolves #15470