### PR TITLE
fix(api): reject Relay node ids too large for any row id

### DIFF
--- a/src/phoenix/server/api/types/node.py
+++ b/src/phoenix/server/api/types/node.py
@@ -10,6 +10,19 @@ _COMPOSITE_GLOBAL_ID_PATTERN = re.compile(r"[^:]+:[^:]+(:[^:]+)+")
 if TYPE_CHECKING:
     from phoenix.db.models import SandboxBackendType
 
+#: Widest row id any supported dialect's integer primary key holds (sqlite's 64-bit
+#: rowid; postgres `SERIAL` is narrower still). A larger value identifies no row and
+#: raises when bound rather than missing, so it is rejected here.
+_ROWID_RANGE = range(-(2**63), 2**63)
+
+
+def _to_rowid(node_id: str) -> int:
+    """Parse a Relay node id as a row id, rejecting values no row can have."""
+    rowid = int(node_id)
+    if rowid not in _ROWID_RANGE:
+        raise ValueError(f"The node id is out of range: {node_id}")
+    return rowid
+
 
 def is_composite_global_id(node_id: str) -> bool:
     try:
@@ -26,7 +39,7 @@ def from_global_id(global_id: GlobalID) -> tuple[str, int]:
     :param global_id: The global id to decode.
     :return: A tuple of type and id.
     """
-    return global_id.type_name, int(global_id.node_id)
+    return global_id.type_name, _to_rowid(global_id.node_id)
 
 
 def from_global_id_with_expected_type(global_id: GlobalID, expected_type_name: str) -> int:
@@ -41,7 +54,7 @@ def from_global_id_with_expected_type(global_id: GlobalID, expected_type_name: s
             f"but instead corresponds to a node of type: {type_name}"
         )
     try:
-        return int(global_id.node_id)
+        return _to_rowid(global_id.node_id)
     except ValueError as exc:
         raise ValueError(
             f"The node id must correspond to a node of type {expected_type_name}, "

--- a/tests/unit/server/api/routers/v1/test_projects.py
+++ b/tests/unit/server/api/routers/v1/test_projects.py
@@ -1022,3 +1022,23 @@ class TestProjects:
         for i, p in enumerate(projects):
             print(f"Created test project {i + 1}: id={p.id}, name='{p.name}'")
         return projects
+
+
+class TestOversizedProjectGlobalID:
+    """An id too large for any row must miss, not raise when bound."""
+
+    @pytest.mark.parametrize("node_id", [10**20, 2**63])
+    async def test_get_project_returns_404(
+        self, httpx_client: httpx.AsyncClient, node_id: int
+    ) -> None:
+        gid = str(GlobalID("Project", str(node_id)))
+        response = await httpx_client.get(f"v1/projects/{quote(gid, safe='')}")
+        assert response.status_code == 404, response.text
+
+    @pytest.mark.parametrize("node_id", [10**20, 2**63])
+    async def test_list_project_traces_returns_404(
+        self, httpx_client: httpx.AsyncClient, node_id: int
+    ) -> None:
+        gid = str(GlobalID("Project", str(node_id)))
+        response = await httpx_client.get(f"v1/projects/{quote(gid, safe='')}/traces")
+        assert response.status_code == 404, response.text

--- a/tests/unit/server/api/types/test_node.py
+++ b/tests/unit/server/api/types/test_node.py
@@ -40,3 +40,29 @@ def test_is_composite_global_id_returns_false_for_simple_global_id() -> None:
 def test_is_composite_global_id_returns_true_for_composite_global_id() -> None:
     node_id = str(GlobalID(type_name="ExperimentRepeatedRunGroup", node_id="1:2"))
     assert is_composite_global_id(node_id) is True
+
+
+@pytest.mark.parametrize("node_id", [2**63, -(2**63) - 1, 10**20])
+def test_from_global_id_with_expected_type_raises_value_error_for_out_of_range_id(
+    node_id: int,
+) -> None:
+    """Such an id fits no integer primary key, and would raise when bound."""
+    global_id = GlobalID(type_name="Dimension", node_id=str(node_id))
+    with pytest.raises(ValueError):
+        from_global_id_with_expected_type(global_id=global_id, expected_type_name="Dimension")
+
+
+@pytest.mark.parametrize("node_id", [2**63 - 1, -(2**63), 2**31])
+def test_from_global_id_with_expected_type_accepts_ids_a_row_could_have(node_id: int) -> None:
+    """Sqlite row ids are 64-bit, so the bound cannot be narrower than that."""
+    global_id = GlobalID(type_name="Dimension", node_id=str(node_id))
+    assert (
+        from_global_id_with_expected_type(global_id=global_id, expected_type_name="Dimension")
+        == node_id
+    )
+
+
+@pytest.mark.parametrize("node_id", [2**63, 10**20])
+def test_from_global_id_raises_value_error_for_out_of_range_id(node_id: int) -> None:
+    with pytest.raises(ValueError):
+        from_global_id(GlobalID(type_name="Dimension", node_id=str(node_id)))


### PR DESCRIPTION
A Relay global ID carries an arbitrary integer node id, and `from_global_id_with_expected_type` passed it through unbounded. An id too large for the row's primary key then raised where it was bound rather than simply missing: sqlite `OverflowError: Python int too large to convert to SQLite INTEGER`, postgres `asyncpg DataError: value out of int32 range`. Both escaped as a 500 where the endpoint's contract is 404.

`GET /v1/projects/{GlobalID("Project", "100000000000000000000")}` reproduces it on both dialects, and the pattern reaches ~131 call sites across 17 v1 router modules — `get_project_by_identifier` alone has 25 callers — so the check belongs at the one place they all parse through.

The bound is 64-bit, the widest row id any supported dialect can hold: sqlite's `INTEGER PRIMARY KEY` is the 64-bit rowid, and postgres `SERIAL` is narrower still. A narrower bound would reject ids sqlite can legitimately assign. Out-of-range ids now raise `ValueError`, which every call site already maps to its 404 or 422 path.

Known gap, deliberately not closed here: on postgres a crafted id between 2^31 and 2^63 still reaches the bind and 500s, because the correct bound is per dialect and this helper is shared with GraphQL, where no session is in scope. Closing it means plumbing the dialect to the call sites, which is a much larger change than this one.
