### PR TITLE
feat(evals): expose evaluator gallery metadata

### DIFF
--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -702,7 +702,6 @@ type ClassificationEvaluatorConfig {
   scope: EvaluatorScope
   recommended: Boolean!
   category: EvaluatorCategory
-  kind: EvaluatorKind!
   details: String
   inputs: [EvaluatorInput!]
 }
@@ -1897,7 +1896,6 @@ enum EvaluatorFilterColumn {
 type EvaluatorInput {
   name: String!
   description: String!
-  format: String
 }
 
 type EvaluatorInputMapping {

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -698,6 +698,14 @@ type ClassificationEvaluatorConfig {
   optimizationDirection: OptimizationDirection!
   messages: [PromptMessage!]!
   choices: JSON!
+  labels: [String!]!
+  scope: EvaluatorScope
+  recommended: Boolean!
+  category: EvaluatorCategory
+  kind: EvaluatorKind!
+  details: String
+  inputs: [EvaluatorInput!]
+  docsLink: String
 }
 
 input ClearProjectInput {
@@ -1841,6 +1849,14 @@ interface Evaluator implements Node {
   datasetEvaluators: [DatasetEvaluator!]!
 }
 
+enum EvaluatorCategory {
+  GROUNDING_AND_RETRIEVAL
+  AGENTS
+  RESPONSE_QUALITY
+  SAFETY_AND_SECURITY
+  USER_EXPERIENCE
+}
+
 enum EvaluatorColumn {
   name
   kind
@@ -1874,6 +1890,12 @@ input EvaluatorFilter {
 
 enum EvaluatorFilterColumn {
   name
+}
+
+type EvaluatorInput {
+  name: String!
+  description: String!
+  format: String
 }
 
 type EvaluatorInputMapping {
@@ -1917,6 +1939,12 @@ input EvaluatorPreviewsInput {
 
 type EvaluatorPreviewsPayload {
   results: [EvaluationResult!]!
+}
+
+enum EvaluatorScope {
+  SPAN
+  TRACE
+  SESSION
 }
 
 """The sort key and direction for evaluator connections"""
@@ -4133,6 +4161,7 @@ type Query {
   evaluators(first: Int = 50, last: Int, after: String, before: String, sort: EvaluatorSort, filter: EvaluatorFilter): EvaluatorConnection!
   annotationConfigs(first: Int = 50, last: Int = null, after: String = null, before: String = null): AnnotationConfigConnection!
   classificationEvaluatorConfigs(labels: [String!]): [ClassificationEvaluatorConfig!]!
+  evaluatorGalleryConfigs: [ClassificationEvaluatorConfig!]!
   defaultProjectTraceRetentionPolicy: ProjectTraceRetentionPolicy!
   projectTraceRetentionPolicies(first: Int = 100, last: Int, after: String, before: String): ProjectTraceRetentionPolicyConnection!
 

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -705,7 +705,6 @@ type ClassificationEvaluatorConfig {
   kind: EvaluatorKind!
   details: String
   inputs: [EvaluatorInput!]
-  docsLink: String
 }
 
 input ClearProjectInput {

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -1849,6 +1849,9 @@ interface Evaluator implements Node {
   datasetEvaluators: [DatasetEvaluator!]!
 }
 
+"""
+Stable category identifiers whose display labels are supplied by clients.
+"""
 enum EvaluatorCategory {
   GROUNDING_AND_RETRIEVAL
   AGENTS

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/__init__.py
@@ -15,7 +15,14 @@ from ._faithfulness_classification_evaluator_config import (
 from ._hallucination_classification_evaluator_config import (
     HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG,
 )
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorKind,
+    EvaluatorScope,
+    PromptMessage,
+)
 from ._refusal_classification_evaluator_config import REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG
 from ._retrieval_relevance_classification_evaluator_config import (
     RETRIEVAL_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG,
@@ -36,6 +43,10 @@ from ._user_friction_classification_evaluator_config import (
 
 __all__ = [
     "ClassificationEvaluatorConfig",
+    "EvaluatorCategory",
+    "EvaluatorInput",
+    "EvaluatorKind",
+    "EvaluatorScope",
     "PromptMessage",
     "CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG",
     "CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG",

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/__init__.py
@@ -19,7 +19,6 @@ from ._models import (
     ClassificationEvaluatorConfig,
     EvaluatorCategory,
     EvaluatorInput,
-    EvaluatorKind,
     EvaluatorScope,
     PromptMessage,
 )
@@ -45,7 +44,6 @@ __all__ = [
     "ClassificationEvaluatorConfig",
     "EvaluatorCategory",
     "EvaluatorInput",
-    "EvaluatorKind",
     "EvaluatorScope",
     "PromptMessage",
     "CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG",

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -16,4 +16,11 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"concise": 1.0, "verbose": 0.0},
     substitutions={"output": "output_messages_to_conversation"},
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -18,7 +18,7 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Assesses whether an LLM's response uses the minimum number of words necessary to fully answer the question. It detects unnecessary pleasantries, hedging language, meta-commentary, redundant restatements, and unsolicited explanations.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="conciseness",
@@ -16,13 +22,13 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"concise": 1.0, "verbose": 0.0},
     substitutions={"output": "output_messages_to_conversation"},
     labels=[],
-    scope="span",
-    category="response_quality",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.RESPONSE_QUALITY,
     details="Assesses whether an LLM's response uses the minimum number of words necessary to fully answer the question. It detects unnecessary pleasantries, hedging language, meta-commentary, redundant restatements, and unsolicited explanations.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -20,7 +20,9 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     category="response_quality",
     details="Assesses whether an LLM's response uses the minimum number of words necessary to fully answer the question. It detects unnecessary pleasantries, hedging language, meta-commentary, redundant restatements, and unsolicited explanations.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -16,4 +16,11 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="correctness",
@@ -16,13 +22,13 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="response_quality",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.RESPONSE_QUALITY,
     details="A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -18,9 +18,11 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="Assesses whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
+    details="A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -18,7 +18,7 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Assesses whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -23,6 +23,7 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=["promoted_dataset_evaluator"],
     scope=EvaluatorScope.SPAN,
+    recommended=True,
     category=EvaluatorCategory.RESPONSE_QUALITY,
     details="A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -18,7 +18,7 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether a retrieved document contains information relevant to answering a specific question. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
     inputs={
         "document_text": {"description": "TODO: Describe the document_text field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -16,4 +16,11 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     choices={"relevant": 1.0, "unrelated": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "document_text": {"description": "TODO: Describe the document_text field."},
+        "input": {"description": "TODO: Describe the input field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="document_relevance",
@@ -16,11 +22,13 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     choices={"relevant": 1.0, "unrelated": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="grounding_and_retrieval",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether a retrieved document contains information relevant to answering the input query. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
     inputs={
-        "document_text": {"description": "The content of the retrieved document or context."},
-        "input": {"description": "The input query or conversational context."},
+        "document_text": EvaluatorInput(
+            description="The content of the retrieved document or context."
+        ),
+        "input": EvaluatorInput(description="The input query or conversational context."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -17,10 +17,10 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
-    details="Determines whether a retrieved document contains information relevant to answering a specific question. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
+    category="grounding_and_retrieval",
+    details="Determines whether a retrieved document contains information relevant to answering the input query. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
     inputs={
-        "document_text": {"description": "TODO: Describe the document_text field."},
-        "input": {"description": "TODO: Describe the input field."},
+        "document_text": {"description": "The content of the retrieved document or context."},
+        "input": {"description": "The input query or conversational context."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -16,4 +16,12 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"faithful": 1.0, "unfaithful": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "context": {"description": "TODO: Describe the context field."},
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="faithfulness",
@@ -16,12 +22,12 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"faithful": 1.0, "unfaithful": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="grounding_and_retrieval",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether an LLM's response is grounded in and faithful to the provided context. It detects information that is unsupported by or contradicts the reference context and is intended for grounded responses such as RAG outputs.",
     inputs={
-        "context": {"description": "The content of the retrieved documents or context."},
-        "input": {"description": "The input query or conversational context."},
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "context": EvaluatorInput(description="The content of the retrieved documents or context."),
+        "input": EvaluatorInput(description="The input query or conversational context."),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -17,11 +17,11 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
+    category="grounding_and_retrieval",
     details="Determines whether an LLM's response is grounded in and faithful to the provided context. It detects information that is unsupported by or contradicts the reference context and is intended for grounded responses such as RAG outputs.",
     inputs={
-        "context": {"description": "TODO: Describe the context field."},
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "context": {"description": "The content of the retrieved documents or context."},
+        "input": {"description": "The input query or conversational context."},
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -18,7 +18,7 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an LLM's response is grounded in and faithful to the provided context. It detects information that is unsupported by or contradicts the reference context and is intended for grounded responses such as RAG outputs.",
     inputs={
         "context": {"description": "TODO: Describe the context field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -23,6 +23,7 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
     scope=EvaluatorScope.SPAN,
+    recommended=True,
     category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -17,10 +17,14 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
     scope="span",
-    category="response_quality",
+    category="grounding_and_retrieval",
     details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The entire conversational context, including all messages, tool calls, and tool results."
+        },
+        "output": {
+            "description": "The LLM's output response (messages and tool calls) to be evaluated."
+        },
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -18,7 +18,7 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -16,4 +16,11 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"hallucinated": 1.0, "grounded": 0.0},
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="hallucination",
@@ -16,15 +22,15 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"hallucinated": 1.0, "grounded": 0.0},
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="grounding_and_retrieval",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={
-        "input": {
-            "description": "The entire conversational context, including all messages, tool calls, and tool results."
-        },
-        "output": {
-            "description": "The LLM's output response (messages and tool calls) to be evaluated."
-        },
+        "input": EvaluatorInput(
+            description="The entire conversational context, including all messages, tool calls, and tool results."
+        ),
+        "output": EvaluatorInput(
+            description="The LLM's output response (messages and tool calls) to be evaluated."
+        ),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
@@ -1,11 +1,12 @@
 # This file is generated. Do not edit by hand.
 
+import re
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
-import pystache
 from pydantic import BaseModel, field_validator, model_validator
-from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
+
+from phoenix.evals.llm.prompts import FormatterFactory
 
 
 class PromptMessage(BaseModel):
@@ -74,9 +75,9 @@ class ClassificationEvaluatorConfig(BaseModel):
         if self.inputs is None:
             return self
 
-        source_variables = set(self.substitutions or {})
+        source_variables = set()
         for message in self.messages:
-            source_variables.update(_get_direct_mustache_variables(message.content))
+            source_variables.update(_get_template_variables(message.content))
 
         declared_inputs = set(self.inputs)
         missing_inputs = source_variables - declared_inputs
@@ -91,14 +92,10 @@ class ClassificationEvaluatorConfig(BaseModel):
         return self
 
 
-def _get_direct_mustache_variables(template: str) -> set[str]:
-    parsed = pystache.parse(template, raise_on_mismatch=True)
-    parse_tree: list[Any] = parsed._parse_tree
-    variables: set[str] = set()
-    for node in parse_tree:
-        if not isinstance(node, (_EscapeNode, _LiteralNode)):
-            continue
-        key = getattr(node, "key", None)
-        if isinstance(key, str) and key != "." and "." not in key:
-            variables.add(key)
-    return variables
+def _get_template_variables(template: str) -> set[str]:
+    formatter = FormatterFactory.auto_detect_and_create(template)
+    return {
+        re.split(r"[.\[]", variable, maxsplit=1)[0]
+        for variable in formatter.extract_variables(template)
+        if variable != "."
+    }

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
@@ -59,7 +59,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     kind: EvaluatorKind = EvaluatorKind.LLM
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
-    docs_link: Optional[str] = None
 
     @field_validator("inputs")
     @classmethod

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
@@ -1,13 +1,47 @@
 # This file is generated. Do not edit by hand.
 
-from typing import Literal, Optional
+from enum import Enum
+from typing import Any, Literal, Optional
 
-from pydantic import BaseModel
+import pystache
+from pydantic import BaseModel, field_validator, model_validator
+from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 class PromptMessage(BaseModel):
     role: Literal["user"]
     content: str
+
+
+class EvaluatorScope(str, Enum):
+    SPAN = "span"
+    TRACE = "trace"
+    SESSION = "session"
+
+
+class EvaluatorCategory(str, Enum):
+    GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
+    AGENTS = "agents"
+    RESPONSE_QUALITY = "response_quality"
+    SAFETY_AND_SECURITY = "safety_and_security"
+    USER_EXPERIENCE = "user_experience"
+
+
+class EvaluatorKind(str, Enum):
+    LLM = "LLM"
+    CODE = "CODE"
+
+
+class EvaluatorInput(BaseModel):
+    description: str
+    format: Optional[str] = None
+
+    @field_validator("description")
+    @classmethod
+    def description_must_not_be_empty(cls, description: str) -> str:
+        if not description.strip():
+            raise ValueError("input description must not be empty")
+        return description
 
 
 class ClassificationEvaluatorConfig(BaseModel):
@@ -18,3 +52,53 @@ class ClassificationEvaluatorConfig(BaseModel):
     choices: dict[str, float]
     substitutions: Optional[dict[str, str]] = None  # placeholder -> substitution_name
     labels: list[str] = []
+    scope: Optional[EvaluatorScope] = None
+    recommended: bool = False
+    category: Optional[EvaluatorCategory] = None
+    kind: EvaluatorKind = EvaluatorKind.LLM
+    details: Optional[str] = None
+    inputs: Optional[dict[str, EvaluatorInput]] = None
+    docs_link: Optional[str] = None
+
+    @field_validator("inputs")
+    @classmethod
+    def input_names_must_not_be_empty(
+        cls, inputs: Optional[dict[str, EvaluatorInput]]
+    ) -> Optional[dict[str, EvaluatorInput]]:
+        if inputs is not None and any(not input_name.strip() for input_name in inputs):
+            raise ValueError("input name must not be empty")
+        return inputs
+
+    @model_validator(mode="after")
+    def validate_source_inputs(self) -> "ClassificationEvaluatorConfig":
+        if self.inputs is None:
+            return self
+
+        source_variables = set(self.substitutions or {})
+        for message in self.messages:
+            source_variables.update(_get_direct_mustache_variables(message.content))
+
+        declared_inputs = set(self.inputs)
+        missing_inputs = source_variables - declared_inputs
+        unused_inputs = declared_inputs - source_variables
+        if missing_inputs or unused_inputs:
+            errors = []
+            if missing_inputs:
+                errors.append(f"missing inputs: {sorted(missing_inputs)}")
+            if unused_inputs:
+                errors.append(f"unused inputs: {sorted(unused_inputs)}")
+            raise ValueError("; ".join(errors))
+        return self
+
+
+def _get_direct_mustache_variables(template: str) -> set[str]:
+    parsed = pystache.parse(template, raise_on_mismatch=True)
+    parse_tree: list[Any] = parsed._parse_tree
+    variables: set[str] = set()
+    for node in parse_tree:
+        if not isinstance(node, (_EscapeNode, _LiteralNode)):
+            continue
+        key = getattr(node, "key", None)
+        if isinstance(key, str) and key != "." and "." not in key:
+            variables.add(key)
+    return variables

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_models.py
@@ -28,14 +28,8 @@ class EvaluatorCategory(str, Enum):
     USER_EXPERIENCE = "user_experience"
 
 
-class EvaluatorKind(str, Enum):
-    LLM = "LLM"
-    CODE = "CODE"
-
-
 class EvaluatorInput(BaseModel):
     description: str
-    format: Optional[str] = None
 
     @field_validator("description")
     @classmethod
@@ -56,7 +50,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     scope: Optional[EvaluatorScope] = None
     recommended: bool = False
     category: Optional[EvaluatorCategory] = None
-    kind: EvaluatorKind = EvaluatorKind.LLM
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
 

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -16,4 +16,11 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"refused": 1.0, "answered": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -17,10 +17,12 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
-    details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers.",
+    category="user_experience",
+    details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="refusal",
@@ -16,13 +22,13 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"refused": 1.0, "answered": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="user_experience",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.USER_EXPERIENCE,
     details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -18,7 +18,7 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_retrieval_relevance_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_retrieval_relevance_classification_evaluator_config.py
@@ -1,7 +1,10 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    PromptMessage,
+)
 
 RETRIEVAL_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="retrieval_relevance",

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -20,11 +20,17 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     },
     labels=["promoted_dataset_evaluator"],
     scope="span",
-    category="response_quality",
-    details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected.",
+    category="agents",
+    details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected. It works even if no tools were called.",
     inputs={
-        "available_tools": {"description": "TODO: Describe the available_tools field."},
-        "input": {"description": "TODO: Describe the input field."},
-        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+        "available_tools": {
+            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
+        },
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "tool_selection": {
+            "description": "The LLM's output response (including messages and tool calls) to be evaluated."
+        },
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="tool_invocation",
@@ -19,18 +25,18 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="agents",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.AGENTS,
     details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected. It works even if no tools were called.",
     inputs={
-        "available_tools": {
-            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
-        },
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "tool_selection": {
-            "description": "The LLM's output response (including messages and tool calls) to be evaluated."
-        },
+        "available_tools": EvaluatorInput(
+            description="The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
+        ),
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "tool_selection": EvaluatorInput(
+            description="The LLM's output response (including messages and tool calls) to be evaluated."
+        ),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -21,7 +21,7 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected.",
     inputs={
         "available_tools": {"description": "TODO: Describe the available_tools field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -19,4 +19,12 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "available_tools": {"description": "TODO: Describe the available_tools field."},
+        "input": {"description": "TODO: Describe the input field."},
+        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -16,4 +16,13 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+        "tool_call": {"description": "TODO: Describe the tool_call field."},
+        "tool_result": {"description": "TODO: Describe the tool_result field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="tool_response_handling",
@@ -16,19 +22,21 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=[],
-    scope="trace",
-    category="agents",
+    scope=EvaluatorScope.TRACE,
+    category=EvaluatorCategory.AGENTS,
     details="Determines whether an AI agent correctly processed a tool's result to produce an appropriate output. It focuses on what happens after a tool call by checking that the agent used the result accurately, handled errors, and disclosed information safely.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
-        },
-        "tool_call": {
-            "description": "Details of the tool or tools that were called, including name and parameters."
-        },
-        "tool_result": {"description": "The complete tool results, including any errors."},
-        "output": {
-            "description": "The LLM's output messages after the tool call (including messages and tool calls)."
-        },
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        ),
+        "tool_call": EvaluatorInput(
+            description="Details of the tool or tools that were called, including name and parameters."
+        ),
+        "tool_result": EvaluatorInput(
+            description="The complete tool results, including any errors."
+        ),
+        "output": EvaluatorInput(
+            description="The LLM's output messages after the tool call (including messages and tool calls)."
+        ),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -16,13 +16,19 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="response_quality",
+    scope="trace",
+    category="agents",
     details="Determines whether an AI agent correctly processed a tool's result to produce an appropriate output. It focuses on what happens after a tool call by checking that the agent used the result accurately, handled errors, and disclosed information safely.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
-        "tool_call": {"description": "TODO: Describe the tool_call field."},
-        "tool_result": {"description": "TODO: Describe the tool_result field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        },
+        "tool_call": {
+            "description": "Details of the tool or tools that were called, including name and parameters."
+        },
+        "tool_result": {"description": "The complete tool results, including any errors."},
+        "output": {
+            "description": "The LLM's output messages after the tool call (including messages and tool calls)."
+        },
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -18,7 +18,7 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an AI agent correctly processed a tool's result to produce an appropriate output. It focuses on what happens after a tool call by checking that the agent used the result accurately, handled errors, and disclosed information safely.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -20,11 +20,15 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     },
     labels=["promoted_dataset_evaluator"],
     scope="span",
-    category="response_quality",
+    category="agents",
     details="Determines whether an LLM selected the most appropriate tool or tools for a given task. It focuses on what tool was chosen rather than whether the invocation arguments were correct.",
     inputs={
-        "available_tools": {"description": "TODO: Describe the available_tools field."},
-        "input": {"description": "TODO: Describe the input field."},
-        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+        "available_tools": {
+            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
+        },
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        },
+        "tool_selection": {"description": "The tool or tools called by the LLM."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="tool_selection",
@@ -19,16 +25,16 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="agents",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.AGENTS,
     details="Determines whether an LLM selected the most appropriate tool or tools for a given task. It focuses on what tool was chosen rather than whether the invocation arguments were correct.",
     inputs={
-        "available_tools": {
-            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
-        },
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
-        },
-        "tool_selection": {"description": "The tool or tools called by the LLM."},
+        "available_tools": EvaluatorInput(
+            description="The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
+        ),
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        ),
+        "tool_selection": EvaluatorInput(description="The tool or tools called by the LLM."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -19,4 +19,12 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "available_tools": {"description": "TODO: Describe the available_tools field."},
+        "input": {"description": "TODO: Describe the input field."},
+        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -21,7 +21,7 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an LLM selected the most appropriate tool or tools for a given task. It focuses on what tool was chosen rather than whether the invocation arguments were correct.",
     inputs={
         "available_tools": {"description": "TODO: Describe the available_tools field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="toxicity",
@@ -16,12 +22,12 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"toxic": 1.0, "non-toxic": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="safety_and_security",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.SAFETY_AND_SECURITY,
     details="Classifies a single piece of text as toxic or non-toxic. Text is toxic when it makes hateful or discriminatory statements about a person or group, demeans or insults someone, uses abusive language directed at a person, or threatens or incites harm.",
     inputs={
-        "text": {
-            "description": "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
-        }
+        "text": EvaluatorInput(
+            description="The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
+        )
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -17,7 +17,11 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
+    category="safety_and_security",
     details="Classifies a single piece of text as toxic or non-toxic. Text is toxic when it makes hateful or discriminatory statements about a person or group, demeans or insults someone, uses abusive language directed at a person, or threatens or incites harm.",
-    inputs={"text": {"description": "TODO: Describe the text field."}},
+    inputs={
+        "text": {
+            "description": "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
+        }
+    },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -16,4 +16,8 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"toxic": 1.0, "non-toxic": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={"text": {"description": "TODO: Describe the text field."}},
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -18,6 +18,6 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Classifies a single piece of text as toxic or non-toxic. Text is toxic when it makes hateful or discriminatory statements about a person or group, demeans or insults someone, uses abusive language directed at a person, or threatens or incites harm.",
     inputs={"text": {"description": "TODO: Describe the text field."}},
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="user_friction",
@@ -16,13 +22,13 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"friction": 1.0, "no_friction": 0.0},
     substitutions=None,
     labels=[],
-    scope="trace",
-    category="user_experience",
+    scope=EvaluatorScope.TRACE,
+    category=EvaluatorCategory.USER_EXPERIENCE,
     details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={
-        "conversation": {
-            "description": "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
-        },
-        "user_message": {"description": "The latest user message to be evaluated."},
+        "conversation": EvaluatorInput(
+            description="The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
+        ),
+        "user_message": EvaluatorInput(description="The latest user message to be evaluated."),
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -23,6 +23,7 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope=EvaluatorScope.TRACE,
+    recommended=True,
     category=EvaluatorCategory.USER_EXPERIENCE,
     details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -18,7 +18,7 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={
         "conversation": {"description": "TODO: Describe the conversation field."},
         "user_message": {"description": "TODO: Describe the user_message field."},

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -16,11 +16,13 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"friction": 1.0, "no_friction": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="response_quality",
+    scope="trace",
+    category="user_experience",
     details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={
-        "conversation": {"description": "TODO: Describe the conversation field."},
-        "user_message": {"description": "TODO: Describe the user_message field."},
+        "conversation": {
+            "description": "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
+        },
+        "user_message": {"description": "The latest user message to be evaluated."},
     },
 )

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -16,4 +16,11 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"friction": 1.0, "no_friction": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "conversation": {"description": "TODO: Describe the conversation field."},
+        "user_message": {"description": "TODO: Describe the user_message field."},
+    },
 )

--- a/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -50,3 +50,15 @@ choices:
   verbose: 0.0
 substitutions:
   output: output_messages_to_conversation
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  input:
+    description: "TODO: Describe the input field."
+  output:
+    description: "TODO: Describe the output field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,6 +1,18 @@
 name: conciseness
 description: Evaluate whether model outputs are concise and free of unnecessary content.
+scope: span
+category: response_quality
 labels: []
+recommended: false
+details: >-
+  Assesses whether an LLM's response uses the minimum number of words necessary
+  to fully answer the question. It detects unnecessary pleasantries, hedging
+  language, meta-commentary, redundant restatements, and unsolicited explanations.
+inputs:
+  input:
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+  output:
+    description: "The LLM's output response to be evaluated."
 optimization_direction: maximize
 messages:
   - role: user
@@ -45,20 +57,8 @@ messages:
       Evaluate only the conciseness of the response. Do not assess correctness, helpfulness, or quality of information. Focus solely on whether the response uses more words than necessary to answer the question.
 
       Is the output concise or verbose?
+substitutions:
+  output: output_messages_to_conversation
 choices:
   concise: 1.0
   verbose: 0.0
-substitutions:
-  output: output_messages_to_conversation
-scope: span
-recommended: false
-category: response_quality
-details: >-
-  Assesses whether an LLM's response uses the minimum number of words necessary
-  to fully answer the question. It detects unnecessary pleasantries, hedging
-  language, meta-commentary, redundant restatements, and unsolicited explanations.
-inputs:
-  input:
-    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-  output:
-    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -50,7 +50,6 @@ choices:
   verbose: 0.0
 substitutions:
   output: output_messages_to_conversation
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
 category: response_quality
@@ -61,7 +60,6 @@ details: >-
   language, meta-commentary, redundant restatements, and unsolicited explanations.
 inputs:
   input:
-    description: "TODO: Describe the input field."
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
   output:
-    description: "TODO: Describe the output field."
-docs_link: null
+    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -53,7 +53,6 @@ substitutions:
 scope: span
 recommended: false
 category: response_quality
-kind: LLM
 details: >-
   Assesses whether an LLM's response uses the minimum number of words necessary
   to fully answer the question. It detects unnecessary pleasantries, hedging

--- a/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -55,7 +55,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Assesses whether an LLM's response uses the minimum number of words necessary
+  to fully answer the question. It detects unnecessary pleasantries, hedging
+  language, meta-commentary, redundant restatements, and unsolicited explanations.
 inputs:
   input:
     description: "TODO: Describe the input field."

--- a/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -48,3 +48,15 @@ messages:
 choices:
   correct: 1.0
   incorrect: 0.0
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  input:
+    description: "TODO: Describe the input field."
+  output:
+    description: "TODO: Describe the output field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -48,18 +48,16 @@ messages:
 choices:
   correct: 1.0
   incorrect: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
 category: response_quality
 kind: LLM
 details: >-
-  Assesses whether an LLM's response is factually accurate, complete, and
+  A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and
   logically consistent. It evaluates answer quality without requiring external
   context or reference responses.
 inputs:
   input:
-    description: "TODO: Describe the input field."
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
   output:
-    description: "TODO: Describe the output field."
-docs_link: null
+    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -53,7 +53,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Assesses whether an LLM's response is factually accurate, complete, and
+  logically consistent. It evaluates answer quality without requiring external
+  context or reference responses.
 inputs:
   input:
     description: "TODO: Describe the input field."

--- a/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -51,7 +51,6 @@ choices:
 scope: span
 recommended: false
 category: response_quality
-kind: LLM
 details: >-
   A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and
   logically consistent. It evaluates answer quality without requiring external

--- a/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,7 +1,19 @@
 name: correctness
 description: Assess general correctness and completeness of model outputs.
+scope: span
+category: response_quality
 labels:
   - promoted_dataset_evaluator
+recommended: true
+details: >-
+  A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and
+  logically consistent. It evaluates answer quality without requiring external
+  context or reference responses.
+inputs:
+  input:
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+  output:
+    description: "The LLM's output response to be evaluated."
 optimization_direction: maximize
 messages:
   - role: user
@@ -48,15 +60,3 @@ messages:
 choices:
   correct: 1.0
   incorrect: 0.0
-scope: span
-recommended: false
-category: response_quality
-details: >-
-  A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and
-  logically consistent. It evaluates answer quality without requiring external
-  context or reference responses.
-inputs:
-  input:
-    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-  output:
-    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -34,7 +34,6 @@ choices:
 scope: span
 recommended: false
 category: grounding_and_retrieval
-kind: LLM
 details: >-
   Determines whether a retrieved document contains information relevant to
   answering the input query. This is essential for evaluating RAG systems,

--- a/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -31,3 +31,15 @@ messages:
 choices:
   relevant: 1.0
   unrelated: 0.0
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  document_text:
+    description: "TODO: Describe the document_text field."
+  input:
+    description: "TODO: Describe the input field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,6 +1,18 @@
 name: document_relevance
 description: For determining if a document is relevant to a given question.
+scope: span
+category: grounding_and_retrieval
 labels: []
+recommended: false
+details: >-
+  Determines whether a retrieved document contains information relevant to
+  answering the input query. This is essential for evaluating RAG systems,
+  where document quality directly impacts response quality.
+inputs:
+  document_text:
+    description: "The content of the retrieved document or context."
+  input:
+    description: "The input query or conversational context."
 optimization_direction: maximize
 messages:
   - role: user
@@ -31,15 +43,3 @@ messages:
 choices:
   relevant: 1.0
   unrelated: 0.0
-scope: span
-recommended: false
-category: grounding_and_retrieval
-details: >-
-  Determines whether a retrieved document contains information relevant to
-  answering the input query. This is essential for evaluating RAG systems,
-  where document quality directly impacts response quality.
-inputs:
-  document_text:
-    description: "The content of the retrieved document or context."
-  input:
-    description: "The input query or conversational context."

--- a/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -36,7 +36,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Determines whether a retrieved document contains information relevant to
+  answering a specific question. This is essential for evaluating RAG systems,
+  where document quality directly impacts response quality.
 inputs:
   document_text:
     description: "TODO: Describe the document_text field."

--- a/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -31,18 +31,16 @@ messages:
 choices:
   relevant: 1.0
   unrelated: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: grounding_and_retrieval
 kind: LLM
 details: >-
   Determines whether a retrieved document contains information relevant to
-  answering a specific question. This is essential for evaluating RAG systems,
+  answering the input query. This is essential for evaluating RAG systems,
   where document quality directly impacts response quality.
 inputs:
   document_text:
-    description: "TODO: Describe the document_text field."
+    description: "The content of the retrieved document or context."
   input:
-    description: "TODO: Describe the input field."
-docs_link: null
+    description: "The input query or conversational context."

--- a/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -40,7 +40,6 @@ choices:
 scope: span
 recommended: false
 category: grounding_and_retrieval
-kind: LLM
 details: >-
   Determines whether an LLM's response is grounded in and faithful to the
   provided context. It detects information that is unsupported by or contradicts

--- a/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -37,4 +37,17 @@ messages:
 choices:
   faithful: 1.0
   unfaithful: 0.0
-
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  context:
+    description: "TODO: Describe the context field."
+  input:
+    description: "TODO: Describe the input field."
+  output:
+    description: "TODO: Describe the output field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,6 +1,20 @@
 name: faithfulness
 description: For determining if a response is faithful to the context.
+scope: span
+category: grounding_and_retrieval
 labels: []
+recommended: false
+details: >-
+  Determines whether an LLM's response is grounded in and faithful to the
+  provided context. It detects information that is unsupported by or contradicts
+  the reference context and is intended for grounded responses such as RAG outputs.
+inputs:
+  context:
+    description: "The content of the retrieved documents or context."
+  input:
+    description: "The input query or conversational context."
+  output:
+    description: "The LLM's output response to be evaluated."
 optimization_direction: maximize
 messages:
   - role: user
@@ -37,17 +51,3 @@ messages:
 choices:
   faithful: 1.0
   unfaithful: 0.0
-scope: span
-recommended: false
-category: grounding_and_retrieval
-details: >-
-  Determines whether an LLM's response is grounded in and faithful to the
-  provided context. It detects information that is unsupported by or contradicts
-  the reference context and is intended for grounded responses such as RAG outputs.
-inputs:
-  context:
-    description: "The content of the retrieved documents or context."
-  input:
-    description: "The input query or conversational context."
-  output:
-    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -42,7 +42,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Determines whether an LLM's response is grounded in and faithful to the
+  provided context. It detects information that is unsupported by or contradicts
+  the reference context and is intended for grounded responses such as RAG outputs.
 inputs:
   context:
     description: "TODO: Describe the context field."

--- a/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -37,10 +37,9 @@ messages:
 choices:
   faithful: 1.0
   unfaithful: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: grounding_and_retrieval
 kind: LLM
 details: >-
   Determines whether an LLM's response is grounded in and faithful to the
@@ -48,9 +47,8 @@ details: >-
   the reference context and is intended for grounded responses such as RAG outputs.
 inputs:
   context:
-    description: "TODO: Describe the context field."
+    description: "The content of the retrieved documents or context."
   input:
-    description: "TODO: Describe the input field."
+    description: "The input query or conversational context."
   output:
-    description: "TODO: Describe the output field."
-docs_link: null
+    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -71,10 +71,9 @@ choices:
   grounded: 0.0
 substitutions:
   output: output_with_tool_calls
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: grounding_and_retrieval
 kind: LLM
 details: >-
   Determines whether an assistant's response contains claims unsupported by or
@@ -83,7 +82,6 @@ details: >-
   conversation, including earlier turns, tool calls, tool results, and retrieved context.
 inputs:
   input:
-    description: "TODO: Describe the input field."
+    description: "The entire conversational context, including all messages, tool calls, and tool results."
   output:
-    description: "TODO: Describe the output field."
-docs_link: null
+    description: "The LLM's output response (messages and tool calls) to be evaluated."

--- a/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -71,3 +71,15 @@ choices:
   grounded: 0.0
 substitutions:
   output: output_with_tool_calls
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  input:
+    description: "TODO: Describe the input field."
+  output:
+    description: "TODO: Describe the output field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,7 +1,20 @@
 name: hallucination
 description: Detect whether an assistant's response contains hallucinations — claims not supported by the input it came from (prior turns, tool calls and results, and any content read, retrieved, or provided).
+scope: span
+category: grounding_and_retrieval
 labels:
   - promoted_dataset_evaluator
+recommended: true
+details: >-
+  Determines whether an assistant's response contains claims unsupported by or
+  contradictory to the conversation it had access to. Unlike Faithfulness, which
+  grounds a response in one retrieved context block, Hallucination uses the broader
+  conversation, including earlier turns, tool calls, tool results, and retrieved context.
+inputs:
+  input:
+    description: "The entire conversational context, including all messages, tool calls, and tool results."
+  output:
+    description: "The LLM's output response (messages and tool calls) to be evaluated."
 optimization_direction: minimize
 messages:
   - role: user
@@ -66,21 +79,8 @@ messages:
       Work through the claims in the output one at a time, checking each against the input, before you decide.
 
       Is the output above grounded or hallucinated?
+substitutions:
+  output: output_with_tool_calls
 choices:
   hallucinated: 1.0
   grounded: 0.0
-substitutions:
-  output: output_with_tool_calls
-scope: span
-recommended: false
-category: grounding_and_retrieval
-details: >-
-  Determines whether an assistant's response contains claims unsupported by or
-  contradictory to the conversation it had access to. Unlike Faithfulness, which
-  grounds a response in one retrieved context block, Hallucination uses the broader
-  conversation, including earlier turns, tool calls, tool results, and retrieved context.
-inputs:
-  input:
-    description: "The entire conversational context, including all messages, tool calls, and tool results."
-  output:
-    description: "The LLM's output response (messages and tool calls) to be evaluated."

--- a/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -74,7 +74,6 @@ substitutions:
 scope: span
 recommended: false
 category: grounding_and_retrieval
-kind: LLM
 details: >-
   Determines whether an assistant's response contains claims unsupported by or
   contradictory to the conversation it had access to. Unlike Faithfulness, which

--- a/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -76,7 +76,11 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Determines whether an assistant's response contains claims unsupported by or
+  contradictory to the conversation it had access to. Unlike Faithfulness, which
+  grounds a response in one retrieved context block, Hallucination uses the broader
+  conversation, including earlier turns, tool calls, tool results, and retrieved context.
 inputs:
   input:
     description: "TODO: Describe the input field."

--- a/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -49,18 +49,16 @@ messages:
 choices:
   refused: 1.0
   answered: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: user_experience
 kind: LLM
 details: >-
   Detects when an LLM refuses, declines, or avoids answering a user query. It
   captures explicit refusals, scope disclaimers, lack-of-information responses,
-  safety refusals, redirections, and apologetic non-answers.
+  safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.
 inputs:
   input:
-    description: "TODO: Describe the input field."
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
   output:
-    description: "TODO: Describe the output field."
-docs_link: null
+    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -49,3 +49,15 @@ messages:
 choices:
   refused: 1.0
   answered: 0.0
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  input:
+    description: "TODO: Describe the input field."
+  output:
+    description: "TODO: Describe the output field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -54,7 +54,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Detects when an LLM refuses, declines, or avoids answering a user query. It
+  captures explicit refusals, scope disclaimers, lack-of-information responses,
+  safety refusals, redirections, and apologetic non-answers.
 inputs:
   input:
     description: "TODO: Describe the input field."

--- a/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -52,7 +52,6 @@ choices:
 scope: span
 recommended: false
 category: user_experience
-kind: LLM
 details: >-
   Detects when an LLM refuses, declines, or avoids answering a user query. It
   captures explicit refusals, scope disclaimers, lack-of-information responses,

--- a/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,6 +1,18 @@
 name: refusal
 description: Detect when an LLM refuses or declines to answer a query.
+scope: span
+category: user_experience
 labels: []
+recommended: false
+details: >-
+  Detects when an LLM refuses, declines, or avoids answering a user query. It
+  captures explicit refusals, scope disclaimers, lack-of-information responses,
+  safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.
+inputs:
+  input:
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+  output:
+    description: "The LLM's output response to be evaluated."
 optimization_direction: neutral
 messages:
   - role: user
@@ -49,15 +61,3 @@ messages:
 choices:
   refused: 1.0
   answered: 0.0
-scope: span
-recommended: false
-category: user_experience
-details: >-
-  Detects when an LLM refuses, declines, or avoids answering a user query. It
-  captures explicit refusals, scope disclaimers, lack-of-information responses,
-  safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.
-inputs:
-  input:
-    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-  output:
-    description: "The LLM's output response to be evaluated."

--- a/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -74,20 +74,18 @@ choices:
 substitutions:
   available_tools: available_tools_list
   tool_selection: output_with_tool_calls
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: agents
 kind: LLM
 details: >-
   Determines whether an LLM invoked a tool correctly with proper arguments,
   formatting, and safe content. It focuses on how the tool was called rather
-  than whether the right tool was selected.
+  than whether the right tool was selected. It works even if no tools were called.
 inputs:
   available_tools:
-    description: "TODO: Describe the available_tools field."
+    description: "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
   input:
-    description: "TODO: Describe the input field."
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
   tool_selection:
-    description: "TODO: Describe the tool_selection field."
-docs_link: null
+    description: "The LLM's output response (including messages and tool calls) to be evaluated."

--- a/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,7 +1,21 @@
 name: tool_invocation
 description: For determining if a tool was invoked correctly with proper arguments, formatting, and safe content.
+scope: span
+category: agents
 labels:
   - promoted_dataset_evaluator
+recommended: false
+details: >-
+  Determines whether an LLM invoked a tool correctly with proper arguments,
+  formatting, and safe content. It focuses on how the tool was called rather
+  than whether the right tool was selected. It works even if no tools were called.
+inputs:
+  available_tools:
+    description: "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
+  input:
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+  tool_selection:
+    description: "The LLM's output response (including messages and tool calls) to be evaluated."
 optimization_direction: maximize
 messages:
   - role: user
@@ -68,23 +82,9 @@ messages:
       </data>
 
       Given the above data, is the tool invocation correct or incorrect?
-choices:
-  correct: 1.0
-  incorrect: 0.0
 substitutions:
   available_tools: available_tools_list
   tool_selection: output_with_tool_calls
-scope: span
-recommended: false
-category: agents
-details: >-
-  Determines whether an LLM invoked a tool correctly with proper arguments,
-  formatting, and safe content. It focuses on how the tool was called rather
-  than whether the right tool was selected. It works even if no tools were called.
-inputs:
-  available_tools:
-    description: "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
-  input:
-    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-  tool_selection:
-    description: "The LLM's output response (including messages and tool calls) to be evaluated."
+choices:
+  correct: 1.0
+  incorrect: 0.0

--- a/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -74,3 +74,17 @@ choices:
 substitutions:
   available_tools: available_tools_list
   tool_selection: output_with_tool_calls
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  available_tools:
+    description: "TODO: Describe the available_tools field."
+  input:
+    description: "TODO: Describe the input field."
+  tool_selection:
+    description: "TODO: Describe the tool_selection field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -79,7 +79,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Determines whether an LLM invoked a tool correctly with proper arguments,
+  formatting, and safe content. It focuses on how the tool was called rather
+  than whether the right tool was selected.
 inputs:
   available_tools:
     description: "TODO: Describe the available_tools field."

--- a/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -77,7 +77,6 @@ substitutions:
 scope: span
 recommended: false
 category: agents
-kind: LLM
 details: >-
   Determines whether an LLM invoked a tool correctly with proper arguments,
   formatting, and safe content. It focuses on how the tool was called rather

--- a/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -79,7 +79,6 @@ choices:
 scope: trace # todo confirm if this is the right scope
 recommended: false
 category: agents
-kind: LLM
 details: >-
   Determines whether an AI agent correctly processed a tool's result to produce
   an appropriate output. It focuses on what happens after a tool call by checking

--- a/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -81,7 +81,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Determines whether an AI agent correctly processed a tool's result to produce
+  an appropriate output. It focuses on what happens after a tool call by checking
+  that the agent used the result accurately, handled errors, and disclosed information safely.
 inputs:
   input:
     description: "TODO: Describe the input field."

--- a/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -76,3 +76,19 @@ messages:
 choices:
   correct: 1.0
   incorrect: 0.0
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  input:
+    description: "TODO: Describe the input field."
+  output:
+    description: "TODO: Describe the output field."
+  tool_call:
+    description: "TODO: Describe the tool_call field."
+  tool_result:
+    description: "TODO: Describe the tool_result field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,6 +1,22 @@
 name: tool_response_handling
 description: For determining if an AI agent properly handled a tool's response, including error handling, data extraction, transformation, and safe information disclosure. Requires conversation context, the tool call(s), the tool result(s), and the agent's output.
+scope: trace # todo confirm if this is the right scope
+category: agents
 labels: []
+recommended: false
+details: >-
+  Determines whether an AI agent correctly processed a tool's result to produce
+  an appropriate output. It focuses on what happens after a tool call by checking
+  that the agent used the result accurately, handled errors, and disclosed information safely.
+inputs:
+  input:
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+  tool_call:
+    description: "Details of the tool or tools that were called, including name and parameters."
+  tool_result:
+    description: "The complete tool results, including any errors."
+  output:
+    description: "The LLM's output messages after the tool call (including messages and tool calls)."
 optimization_direction: maximize
 messages:
   - role: user
@@ -76,19 +92,3 @@ messages:
 choices:
   correct: 1.0
   incorrect: 0.0
-scope: trace # todo confirm if this is the right scope
-recommended: false
-category: agents
-details: >-
-  Determines whether an AI agent correctly processed a tool's result to produce
-  an appropriate output. It focuses on what happens after a tool call by checking
-  that the agent used the result accurately, handled errors, and disclosed information safely.
-inputs:
-  input:
-    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
-  tool_call:
-    description: "Details of the tool or tools that were called, including name and parameters."
-  tool_result:
-    description: "The complete tool results, including any errors."
-  output:
-    description: "The LLM's output messages after the tool call (including messages and tool calls)."

--- a/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -76,10 +76,9 @@ messages:
 choices:
   correct: 1.0
   incorrect: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
-scope: span
+scope: trace # todo confirm if this is the right scope
 recommended: false
-category: response_quality
+category: agents
 kind: LLM
 details: >-
   Determines whether an AI agent correctly processed a tool's result to produce
@@ -87,11 +86,10 @@ details: >-
   that the agent used the result accurately, handled errors, and disclosed information safely.
 inputs:
   input:
-    description: "TODO: Describe the input field."
-  output:
-    description: "TODO: Describe the output field."
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
   tool_call:
-    description: "TODO: Describe the tool_call field."
+    description: "Details of the tool or tools that were called, including name and parameters."
   tool_result:
-    description: "TODO: Describe the tool_result field."
-docs_link: null
+    description: "The complete tool results, including any errors."
+  output:
+    description: "The LLM's output messages after the tool call (including messages and tool calls)."

--- a/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -62,7 +62,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Determines whether an LLM selected the most appropriate tool or tools for a
+  given task. It focuses on what tool was chosen rather than whether the invocation
+  arguments were correct.
 inputs:
   available_tools:
     description: "TODO: Describe the available_tools field."

--- a/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -57,10 +57,9 @@ choices:
 substitutions:
   available_tools: available_tools_list
   tool_selection: output_with_tool_calls
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: agents
 kind: LLM
 details: >-
   Determines whether an LLM selected the most appropriate tool or tools for a
@@ -68,9 +67,8 @@ details: >-
   arguments were correct.
 inputs:
   available_tools:
-    description: "TODO: Describe the available_tools field."
+    description: "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
   input:
-    description: "TODO: Describe the input field."
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
   tool_selection:
-    description: "TODO: Describe the tool_selection field."
-docs_link: null
+    description: "The tool or tools called by the LLM."

--- a/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -57,3 +57,17 @@ choices:
 substitutions:
   available_tools: available_tools_list
   tool_selection: output_with_tool_calls
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  available_tools:
+    description: "TODO: Describe the available_tools field."
+  input:
+    description: "TODO: Describe the input field."
+  tool_selection:
+    description: "TODO: Describe the tool_selection field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,7 +1,21 @@
 name: tool_selection
 description: For determining if the correct tool was selected for a given context.
+scope: span
+category: agents
 labels:
   - promoted_dataset_evaluator
+recommended: false
+details: >-
+  Determines whether an LLM selected the most appropriate tool or tools for a
+  given task. It focuses on what tool was chosen rather than whether the invocation
+  arguments were correct.
+inputs:
+  available_tools:
+    description: "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
+  input:
+    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+  tool_selection:
+    description: "The tool or tools called by the LLM."
 optimization_direction: maximize
 messages:
   - role: user
@@ -51,23 +65,9 @@ messages:
       </data>
 
       Given the above data, is the tool selection correct or incorrect?
-choices:
-  correct: 1.0
-  incorrect: 0.0
 substitutions:
   available_tools: available_tools_list
   tool_selection: output_with_tool_calls
-scope: span
-recommended: false
-category: agents
-details: >-
-  Determines whether an LLM selected the most appropriate tool or tools for a
-  given task. It focuses on what tool was chosen rather than whether the invocation
-  arguments were correct.
-inputs:
-  available_tools:
-    description: "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
-  input:
-    description: "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
-  tool_selection:
-    description: "The tool or tools called by the LLM."
+choices:
+  correct: 1.0
+  incorrect: 0.0

--- a/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -60,7 +60,6 @@ substitutions:
 scope: span
 recommended: false
 category: agents
-kind: LLM
 details: >-
   Determines whether an LLM selected the most appropriate tool or tools for a
   given task. It focuses on what tool was chosen rather than whether the invocation

--- a/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -40,10 +40,9 @@ messages:
 choices:
   toxic: 1.0
   non-toxic: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
 scope: span
 recommended: false
-category: response_quality
+category: safety_and_security
 kind: LLM
 details: >-
   Classifies a single piece of text as toxic or non-toxic. Text is toxic when it
@@ -51,5 +50,4 @@ details: >-
   insults someone, uses abusive language directed at a person, or threatens or incites harm.
 inputs:
   text:
-    description: "TODO: Describe the text field."
-docs_link: null
+    description: "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."

--- a/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -45,7 +45,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Classifies a single piece of text as toxic or non-toxic. Text is toxic when it
+  makes hateful or discriminatory statements about a person or group, demeans or
+  insults someone, uses abusive language directed at a person, or threatens or incites harm.
 inputs:
   text:
     description: "TODO: Describe the text field."

--- a/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,6 +1,16 @@
 name: toxicity
 description: Detect whether text is toxic — hateful, demeaning, abusive, or threatening.
+scope: span
+category: safety_and_security
 labels: []
+recommended: false
+details: >-
+  Classifies a single piece of text as toxic or non-toxic. Text is toxic when it
+  makes hateful or discriminatory statements about a person or group, demeans or
+  insults someone, uses abusive language directed at a person, or threatens or incites harm.
+inputs:
+  text:
+    description: "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
 optimization_direction: minimize
 messages:
   - role: user
@@ -40,13 +50,3 @@ messages:
 choices:
   toxic: 1.0
   non-toxic: 0.0
-scope: span
-recommended: false
-category: safety_and_security
-details: >-
-  Classifies a single piece of text as toxic or non-toxic. Text is toxic when it
-  makes hateful or discriminatory statements about a person or group, demeans or
-  insults someone, uses abusive language directed at a person, or threatens or incites harm.
-inputs:
-  text:
-    description: "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."

--- a/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -43,7 +43,6 @@ choices:
 scope: span
 recommended: false
 category: safety_and_security
-kind: LLM
 details: >-
   Classifies a single piece of text as toxic or non-toxic. Text is toxic when it
   makes hateful or discriminatory statements about a person or group, demeans or

--- a/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -40,3 +40,13 @@ messages:
 choices:
   toxic: 1.0
   non-toxic: 0.0
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  text:
+    description: "TODO: Describe the text field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -53,7 +53,6 @@ choices:
 scope: trace
 recommended: false
 category: user_experience
-kind: LLM
 details: >-
   Classifies whether the latest user message expresses friction with an assistant's
   preceding behavior. It detects corrections, retries after an unsuccessful response,

--- a/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,5 +1,17 @@
 name: user_friction
 description: Assess whether a user message expresses friction with an assistant's preceding behavior.
+scope: trace
+category: user_experience
+recommended: true
+details: >-
+  Classifies whether the latest user message expresses friction with an assistant's
+  preceding behavior. It detects corrections, retries after an unsuccessful response,
+  frustration, and challenges to unrequested or unexplained actions.
+inputs:
+  conversation:
+    description: "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
+  user_message:
+    description: "The latest user message to be evaluated."
 optimization_direction: minimize
 messages:
   - role: user
@@ -50,15 +62,3 @@ messages:
 choices:
   friction: 1.0
   no_friction: 0.0
-scope: trace
-recommended: false
-category: user_experience
-details: >-
-  Classifies whether the latest user message expresses friction with an assistant's
-  preceding behavior. It detects corrections, retries after an unsuccessful response,
-  frustration, and challenges to unrequested or unexplained actions.
-inputs:
-  conversation:
-    description: "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
-  user_message:
-    description: "The latest user message to be evaluated."

--- a/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -50,10 +50,9 @@ messages:
 choices:
   friction: 1.0
   no_friction: 0.0
-# TODO: Replace these gallery metadata placeholders with final values.
-scope: span
+scope: trace
 recommended: false
-category: response_quality
+category: user_experience
 kind: LLM
 details: >-
   Classifies whether the latest user message expresses friction with an assistant's
@@ -61,7 +60,6 @@ details: >-
   frustration, and challenges to unrequested or unexplained actions.
 inputs:
   conversation:
-    description: "TODO: Describe the conversation field."
+    description: "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
   user_message:
-    description: "TODO: Describe the user_message field."
-docs_link: null
+    description: "The latest user message to be evaluated."

--- a/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -50,3 +50,15 @@ messages:
 choices:
   friction: 1.0
   no_friction: 0.0
+# TODO: Replace these gallery metadata placeholders with final values.
+scope: span
+recommended: false
+category: response_quality
+kind: LLM
+details: "TODO: Add detailed guidance for this evaluator."
+inputs:
+  conversation:
+    description: "TODO: Describe the conversation field."
+  user_message:
+    description: "TODO: Describe the user_message field."
+docs_link: null

--- a/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -55,7 +55,10 @@ scope: span
 recommended: false
 category: response_quality
 kind: LLM
-details: "TODO: Add detailed guidance for this evaluator."
+details: >-
+  Classifies whether the latest user message expresses friction with an assistant's
+  preceding behavior. It detects corrections, retries after an unsuccessful response,
+  frustration, and challenges to unrequested or unexplained actions.
 inputs:
   conversation:
     description: "TODO: Describe the conversation field."

--- a/scripts/prompts/compile_python_prompts.py
+++ b/scripts/prompts/compile_python_prompts.py
@@ -35,14 +35,8 @@ class EvaluatorCategory(str, Enum):
     USER_EXPERIENCE = "user_experience"
 
 
-class EvaluatorKind(str, Enum):
-    LLM = "LLM"
-    CODE = "CODE"
-
-
 class EvaluatorInput(BaseModel):
     description: str
-    format: Optional[str] = None
 
     @field_validator("description")
     @classmethod
@@ -64,7 +58,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     scope: Optional[EvaluatorScope] = None
     recommended: bool = False
     category: Optional[EvaluatorCategory] = None
-    kind: EvaluatorKind = EvaluatorKind.LLM
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
 
@@ -126,8 +119,6 @@ from pydantic import field_validator, model_validator
 
 {{ evaluator_category_source }}
 
-{{ evaluator_kind_source }}
-
 {{ evaluator_input_source }}
 
 {{ classification_evaluator_config_source }}
@@ -155,7 +146,6 @@ from ._models import (
     ClassificationEvaluatorConfig,
     EvaluatorCategory,
     EvaluatorInput,
-    EvaluatorKind,
     EvaluatorScope,
     PromptMessage,
 )
@@ -167,7 +157,6 @@ __all__ = [
     "ClassificationEvaluatorConfig",
     "EvaluatorCategory",
     "EvaluatorInput",
-    "EvaluatorKind",
     "EvaluatorScope",
     "PromptMessage",
     {{ prompt_names|map('tojson')|join(', ') }}
@@ -183,7 +172,6 @@ def get_models_file_contents() -> str:
     prompt_message_source = inspect.getsource(PromptMessage).strip()
     evaluator_scope_source = inspect.getsource(EvaluatorScope).strip()
     evaluator_category_source = inspect.getsource(EvaluatorCategory).strip()
-    evaluator_kind_source = inspect.getsource(EvaluatorKind).strip()
     evaluator_input_source = inspect.getsource(EvaluatorInput).strip()
     classification_evaluator_config_source = inspect.getsource(
         ClassificationEvaluatorConfig
@@ -193,7 +181,6 @@ def get_models_file_contents() -> str:
         prompt_message_source=prompt_message_source,
         evaluator_scope_source=evaluator_scope_source,
         evaluator_category_source=evaluator_category_source,
-        evaluator_kind_source=evaluator_kind_source,
         evaluator_input_source=evaluator_input_source,
         classification_evaluator_config_source=classification_evaluator_config_source,
         get_template_variables_source=get_template_variables_source,
@@ -225,20 +212,14 @@ def get_prompt_file_contents(config: ClassificationEvaluatorConfig, name: str) -
     if config.category is not None:
         model_imports.add("EvaluatorCategory")
         arguments.append(f"category=EvaluatorCategory.{config.category.name}")
-    if config.kind != EvaluatorKind.LLM:
-        model_imports.add("EvaluatorKind")
-        arguments.append(f"kind=EvaluatorKind.{config.kind.name}")
     if config.details is not None:
         arguments.append(f"details={config.details!r}")
     if config.inputs is not None:
         model_imports.add("EvaluatorInput")
         input_definitions = []
         for input_name, evaluator_input in config.inputs.items():
-            input_arguments = [f"description={evaluator_input.description!r}"]
-            if evaluator_input.format is not None:
-                input_arguments.append(f"format={evaluator_input.format!r}")
             input_definitions.append(
-                f"{input_name!r}: EvaluatorInput({', '.join(input_arguments)})"
+                f"{input_name!r}: EvaluatorInput(description={evaluator_input.description!r})"
             )
         arguments.append(f"inputs={{{', '.join(input_definitions)}}}")
     config_definition = f"ClassificationEvaluatorConfig({', '.join(arguments)})"
@@ -281,7 +262,7 @@ if __name__ == "__main__":
     models_path.write_text(models_content, encoding="utf-8")
 
     # Compile all YAML prompts to Python
-    yaml_files = list(prompts_dir.glob("*.yaml"))
+    yaml_files = list(prompts_dir.glob("*_CLASSIFICATION_EVALUATOR_CONFIG.yaml"))
     prompt_names = []
 
     for yaml_file in sorted(yaml_files):

--- a/scripts/prompts/compile_python_prompts.py
+++ b/scripts/prompts/compile_python_prompts.py
@@ -67,7 +67,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     kind: EvaluatorKind = EvaluatorKind.LLM
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
-    docs_link: Optional[str] = None
 
     @field_validator("inputs")
     @classmethod
@@ -222,7 +221,6 @@ def get_prompt_file_contents(config: ClassificationEvaluatorConfig, name: str) -
             "kind",
             "details",
             "inputs",
-            "docs_link",
         },
         exclude_defaults=True,
         exclude_none=True,

--- a/scripts/prompts/compile_python_prompts.py
+++ b/scripts/prompts/compile_python_prompts.py
@@ -4,15 +4,15 @@ Compiles YAML prompts into Python code.
 
 import argparse
 import inspect
+import re
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
-import pystache
 import yaml
 from jinja2 import Template
+from phoenix.evals.llm.prompts import FormatterFactory
 from pydantic import BaseModel, field_validator, model_validator
-from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 # Based message class copied into the compiled module.
@@ -83,9 +83,9 @@ class ClassificationEvaluatorConfig(BaseModel):
         if self.inputs is None:
             return self
 
-        source_variables = set(self.substitutions or {})
+        source_variables = set()
         for message in self.messages:
-            source_variables.update(_get_direct_mustache_variables(message.content))
+            source_variables.update(_get_template_variables(message.content))
 
         declared_inputs = set(self.inputs)
         missing_inputs = source_variables - declared_inputs
@@ -100,29 +100,25 @@ class ClassificationEvaluatorConfig(BaseModel):
         return self
 
 
-def _get_direct_mustache_variables(template: str) -> set[str]:
-    parsed = pystache.parse(template, raise_on_mismatch=True)
-    parse_tree: list[Any] = parsed._parse_tree
-    variables: set[str] = set()
-    for node in parse_tree:
-        if not isinstance(node, (_EscapeNode, _LiteralNode)):
-            continue
-        key = getattr(node, "key", None)
-        if isinstance(key, str) and key != "." and "." not in key:
-            variables.add(key)
-    return variables
+def _get_template_variables(template: str) -> set[str]:
+    formatter = FormatterFactory.auto_detect_and_create(template)
+    return {
+        re.split(r"[.\[]", variable, maxsplit=1)[0]
+        for variable in formatter.extract_variables(template)
+        if variable != "."
+    }
 
 
 MODELS_TEMPLATE = """\
 # This file is generated. Do not edit by hand.
 
 from enum import Enum
-from typing import Any, Literal, Optional
+import re
+from typing import Literal, Optional
 
-import pystache
+from phoenix.evals.llm.prompts import FormatterFactory
 from pydantic import BaseModel
 from pydantic import field_validator, model_validator
-from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 {{ prompt_message_source }}
@@ -137,7 +133,7 @@ from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-unt
 
 {{ classification_evaluator_config_source }}
 
-{{ get_direct_mustache_variables_source }}
+{{ get_template_variables_source }}
 """
 
 CLASSIFICATION_EVALUATOR_CONFIG_TEMPLATE = """\
@@ -189,7 +185,7 @@ def get_models_file_contents() -> str:
     classification_evaluator_config_source = inspect.getsource(
         ClassificationEvaluatorConfig
     ).strip()
-    get_direct_mustache_variables_source = inspect.getsource(_get_direct_mustache_variables).strip()
+    get_template_variables_source = inspect.getsource(_get_template_variables).strip()
     content = template.render(
         prompt_message_source=prompt_message_source,
         evaluator_scope_source=evaluator_scope_source,
@@ -197,7 +193,7 @@ def get_models_file_contents() -> str:
         evaluator_kind_source=evaluator_kind_source,
         evaluator_input_source=evaluator_input_source,
         classification_evaluator_config_source=classification_evaluator_config_source,
-        get_direct_mustache_variables_source=get_direct_mustache_variables_source,
+        get_template_variables_source=get_template_variables_source,
     )
     return content
 

--- a/scripts/prompts/compile_python_prompts.py
+++ b/scripts/prompts/compile_python_prompts.py
@@ -139,7 +139,11 @@ CLASSIFICATION_EVALUATOR_CONFIG_TEMPLATE = """\
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+{% for model_import in model_imports -%}
+    {{ model_import }},
+{% endfor -%}
+)
 
 {{ classification_evaluator_config_name }} = {{ classification_evaluator_config_definition }}
 """
@@ -212,22 +216,34 @@ def get_prompt_file_contents(config: ClassificationEvaluatorConfig, name: str) -
         "labels",
     )
     arguments = [f"{field_name}={getattr(config, field_name)!r}" for field_name in base_field_names]
-    metadata = config.model_dump(
-        mode="json",
-        include={
-            "scope",
-            "recommended",
-            "category",
-            "kind",
-            "details",
-            "inputs",
-        },
-        exclude_defaults=True,
-        exclude_none=True,
-    )
-    arguments.extend(f"{field_name}={value!r}" for field_name, value in metadata.items())
+    model_imports = {"ClassificationEvaluatorConfig", "PromptMessage"}
+    if config.scope is not None:
+        model_imports.add("EvaluatorScope")
+        arguments.append(f"scope=EvaluatorScope.{config.scope.name}")
+    if config.recommended:
+        arguments.append("recommended=True")
+    if config.category is not None:
+        model_imports.add("EvaluatorCategory")
+        arguments.append(f"category=EvaluatorCategory.{config.category.name}")
+    if config.kind != EvaluatorKind.LLM:
+        model_imports.add("EvaluatorKind")
+        arguments.append(f"kind=EvaluatorKind.{config.kind.name}")
+    if config.details is not None:
+        arguments.append(f"details={config.details!r}")
+    if config.inputs is not None:
+        model_imports.add("EvaluatorInput")
+        input_definitions = []
+        for input_name, evaluator_input in config.inputs.items():
+            input_arguments = [f"description={evaluator_input.description!r}"]
+            if evaluator_input.format is not None:
+                input_arguments.append(f"format={evaluator_input.format!r}")
+            input_definitions.append(
+                f"{input_name!r}: EvaluatorInput({', '.join(input_arguments)})"
+            )
+        arguments.append(f"inputs={{{', '.join(input_definitions)}}}")
     config_definition = f"ClassificationEvaluatorConfig({', '.join(arguments)})"
     content = template.render(
+        model_imports=sorted(model_imports),
         classification_evaluator_config_name=name,
         classification_evaluator_config_definition=config_definition,
     )

--- a/scripts/prompts/compile_python_prompts.py
+++ b/scripts/prompts/compile_python_prompts.py
@@ -4,18 +4,52 @@ Compiles YAML prompts into Python code.
 
 import argparse
 import inspect
+from enum import Enum
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
+import pystache
 import yaml
 from jinja2 import Template
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 # Based message class copied into the compiled module.
 class PromptMessage(BaseModel):
     role: Literal["user"]
     content: str
+
+
+class EvaluatorScope(str, Enum):
+    SPAN = "span"
+    TRACE = "trace"
+    SESSION = "session"
+
+
+class EvaluatorCategory(str, Enum):
+    GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
+    AGENTS = "agents"
+    RESPONSE_QUALITY = "response_quality"
+    SAFETY_AND_SECURITY = "safety_and_security"
+    USER_EXPERIENCE = "user_experience"
+
+
+class EvaluatorKind(str, Enum):
+    LLM = "LLM"
+    CODE = "CODE"
+
+
+class EvaluatorInput(BaseModel):
+    description: str
+    format: Optional[str] = None
+
+    @field_validator("description")
+    @classmethod
+    def description_must_not_be_empty(cls, description: str) -> str:
+        if not description.strip():
+            raise ValueError("input description must not be empty")
+        return description
 
 
 # Base classification evaluator config class copied into the compiled module.
@@ -27,19 +61,83 @@ class ClassificationEvaluatorConfig(BaseModel):
     choices: dict[str, float]
     substitutions: Optional[dict[str, str]] = None  # placeholder -> substitution_name
     labels: list[str] = []
+    scope: Optional[EvaluatorScope] = None
+    recommended: bool = False
+    category: Optional[EvaluatorCategory] = None
+    kind: EvaluatorKind = EvaluatorKind.LLM
+    details: Optional[str] = None
+    inputs: Optional[dict[str, EvaluatorInput]] = None
+    docs_link: Optional[str] = None
+
+    @field_validator("inputs")
+    @classmethod
+    def input_names_must_not_be_empty(
+        cls, inputs: Optional[dict[str, EvaluatorInput]]
+    ) -> Optional[dict[str, EvaluatorInput]]:
+        if inputs is not None and any(not input_name.strip() for input_name in inputs):
+            raise ValueError("input name must not be empty")
+        return inputs
+
+    @model_validator(mode="after")
+    def validate_source_inputs(self) -> "ClassificationEvaluatorConfig":
+        if self.inputs is None:
+            return self
+
+        source_variables = set(self.substitutions or {})
+        for message in self.messages:
+            source_variables.update(_get_direct_mustache_variables(message.content))
+
+        declared_inputs = set(self.inputs)
+        missing_inputs = source_variables - declared_inputs
+        unused_inputs = declared_inputs - source_variables
+        if missing_inputs or unused_inputs:
+            errors = []
+            if missing_inputs:
+                errors.append(f"missing inputs: {sorted(missing_inputs)}")
+            if unused_inputs:
+                errors.append(f"unused inputs: {sorted(unused_inputs)}")
+            raise ValueError("; ".join(errors))
+        return self
+
+
+def _get_direct_mustache_variables(template: str) -> set[str]:
+    parsed = pystache.parse(template, raise_on_mismatch=True)
+    parse_tree: list[Any] = parsed._parse_tree
+    variables: set[str] = set()
+    for node in parse_tree:
+        if not isinstance(node, (_EscapeNode, _LiteralNode)):
+            continue
+        key = getattr(node, "key", None)
+        if isinstance(key, str) and key != "." and "." not in key:
+            variables.add(key)
+    return variables
 
 
 MODELS_TEMPLATE = """\
 # This file is generated. Do not edit by hand.
 
-from typing import Literal, Optional
+from enum import Enum
+from typing import Any, Literal, Optional
 
+import pystache
 from pydantic import BaseModel
+from pydantic import field_validator, model_validator
+from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 {{ prompt_message_source }}
 
+{{ evaluator_scope_source }}
+
+{{ evaluator_category_source }}
+
+{{ evaluator_kind_source }}
+
+{{ evaluator_input_source }}
+
 {{ classification_evaluator_config_source }}
+
+{{ get_direct_mustache_variables_source }}
 """
 
 CLASSIFICATION_EVALUATOR_CONFIG_TEMPLATE = """\
@@ -54,13 +152,24 @@ from ._models import ClassificationEvaluatorConfig, PromptMessage
 INIT_TEMPLATE = """\
 # This file is generated. Do not edit by hand.
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorKind,
+    EvaluatorScope,
+    PromptMessage,
+)
 {% for name in prompt_names -%}
 from ._{{ name.lower() }} import {{ name }}
 {% endfor %}
 
 __all__ = [
     "ClassificationEvaluatorConfig",
+    "EvaluatorCategory",
+    "EvaluatorInput",
+    "EvaluatorKind",
+    "EvaluatorScope",
     "PromptMessage",
     {{ prompt_names|map('tojson')|join(', ') }}
 ]
@@ -73,12 +182,22 @@ def get_models_file_contents() -> str:
     """
     template = Template(MODELS_TEMPLATE)
     prompt_message_source = inspect.getsource(PromptMessage).strip()
+    evaluator_scope_source = inspect.getsource(EvaluatorScope).strip()
+    evaluator_category_source = inspect.getsource(EvaluatorCategory).strip()
+    evaluator_kind_source = inspect.getsource(EvaluatorKind).strip()
+    evaluator_input_source = inspect.getsource(EvaluatorInput).strip()
     classification_evaluator_config_source = inspect.getsource(
         ClassificationEvaluatorConfig
     ).strip()
+    get_direct_mustache_variables_source = inspect.getsource(_get_direct_mustache_variables).strip()
     content = template.render(
         prompt_message_source=prompt_message_source,
+        evaluator_scope_source=evaluator_scope_source,
+        evaluator_category_source=evaluator_category_source,
+        evaluator_kind_source=evaluator_kind_source,
+        evaluator_input_source=evaluator_input_source,
         classification_evaluator_config_source=classification_evaluator_config_source,
+        get_direct_mustache_variables_source=get_direct_mustache_variables_source,
     )
     return content
 
@@ -88,9 +207,35 @@ def get_prompt_file_contents(config: ClassificationEvaluatorConfig, name: str) -
     Gets the Python code contents for a ClassificationEvaluatorConfig.
     """
     template = Template(CLASSIFICATION_EVALUATOR_CONFIG_TEMPLATE)
+    base_field_names = (
+        "name",
+        "description",
+        "optimization_direction",
+        "messages",
+        "choices",
+        "substitutions",
+        "labels",
+    )
+    arguments = [f"{field_name}={getattr(config, field_name)!r}" for field_name in base_field_names]
+    metadata = config.model_dump(
+        mode="json",
+        include={
+            "scope",
+            "recommended",
+            "category",
+            "kind",
+            "details",
+            "inputs",
+            "docs_link",
+        },
+        exclude_defaults=True,
+        exclude_none=True,
+    )
+    arguments.extend(f"{field_name}={value!r}" for field_name, value in metadata.items())
+    config_definition = f"ClassificationEvaluatorConfig({', '.join(arguments)})"
     content = template.render(
         classification_evaluator_config_name=name,
-        classification_evaluator_config_definition=repr(config),
+        classification_evaluator_config_definition=config_definition,
     )
     return content
 

--- a/scripts/prompts/compile_typescript_prompts.py
+++ b/scripts/prompts/compile_typescript_prompts.py
@@ -5,15 +5,13 @@ Compiles YAML prompts into TypeScript code.
 import argparse
 import json
 import re
-from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
-import pystache
 import yaml
 from jinja2 import Template
+from phoenix.evals.llm.prompts import FormatterFactory
 from pydantic import BaseModel, field_validator, model_validator
-from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 class PromptMessage(BaseModel):
@@ -21,23 +19,15 @@ class PromptMessage(BaseModel):
     content: str
 
 
-class EvaluatorScope(str, Enum):
-    SPAN = "span"
-    TRACE = "trace"
-    SESSION = "session"
-
-
-class EvaluatorCategory(str, Enum):
-    GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
-    AGENTS = "agents"
-    RESPONSE_QUALITY = "response_quality"
-    SAFETY_AND_SECURITY = "safety_and_security"
-    USER_EXPERIENCE = "user_experience"
-
-
-class EvaluatorKind(str, Enum):
-    LLM = "LLM"
-    CODE = "CODE"
+EvaluatorScope = Literal["span", "trace", "session"]
+EvaluatorCategory = Literal[
+    "grounding_and_retrieval",
+    "agents",
+    "response_quality",
+    "safety_and_security",
+    "user_experience",
+]
+EvaluatorKind = Literal["LLM", "CODE"]
 
 
 class EvaluatorInput(BaseModel):
@@ -63,7 +53,7 @@ class ClassificationEvaluatorConfig(BaseModel):
     scope: Optional[EvaluatorScope] = None
     recommended: bool = False
     category: Optional[EvaluatorCategory] = None
-    kind: EvaluatorKind = EvaluatorKind.LLM
+    kind: EvaluatorKind = "LLM"
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
     docs_link: Optional[str] = None
@@ -82,9 +72,9 @@ class ClassificationEvaluatorConfig(BaseModel):
         if self.inputs is None:
             return self
 
-        source_variables = set(self.substitutions or {})
+        source_variables = set()
         for message in self.messages:
-            source_variables.update(_get_direct_mustache_variables(message.content))
+            source_variables.update(_get_template_variables(message.content))
 
         declared_inputs = set(self.inputs)
         missing_inputs = source_variables - declared_inputs
@@ -99,17 +89,13 @@ class ClassificationEvaluatorConfig(BaseModel):
         return self
 
 
-def _get_direct_mustache_variables(template: str) -> set[str]:
-    parsed = pystache.parse(template, raise_on_mismatch=True)
-    parse_tree: list[Any] = parsed._parse_tree
-    variables: set[str] = set()
-    for node in parse_tree:
-        if not isinstance(node, (_EscapeNode, _LiteralNode)):
-            continue
-        key = getattr(node, "key", None)
-        if isinstance(key, str) and key != "." and "." not in key:
-            variables.add(key)
-    return variables
+def _get_template_variables(template: str) -> set[str]:
+    formatter = FormatterFactory.auto_detect_and_create(template)
+    return {
+        re.split(r"[.\[]", variable, maxsplit=1)[0]
+        for variable in formatter.extract_variables(template)
+        if variable != "."
+    }
 
 
 CLASSIFICATION_EVALUATOR_CONFIG_FILE_TEMPLATE = """\

--- a/scripts/prompts/compile_typescript_prompts.py
+++ b/scripts/prompts/compile_typescript_prompts.py
@@ -56,7 +56,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     kind: EvaluatorKind = "LLM"
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
-    docs_link: Optional[str] = None
 
     @field_validator("inputs")
     @classmethod

--- a/scripts/prompts/compile_typescript_prompts.py
+++ b/scripts/prompts/compile_typescript_prompts.py
@@ -27,12 +27,10 @@ EvaluatorCategory = Literal[
     "safety_and_security",
     "user_experience",
 ]
-EvaluatorKind = Literal["LLM", "CODE"]
 
 
 class EvaluatorInput(BaseModel):
     description: str
-    format: Optional[str] = None
 
     @field_validator("description")
     @classmethod
@@ -53,7 +51,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     scope: Optional[EvaluatorScope] = None
     recommended: bool = False
     category: Optional[EvaluatorCategory] = None
-    kind: EvaluatorKind = "LLM"
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
 
@@ -199,7 +196,7 @@ if __name__ == "__main__":
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Compile all YAML prompts to TypeScript
-    yaml_files = list(prompts_dir.glob("*.yaml"))
+    yaml_files = list(prompts_dir.glob("*_CLASSIFICATION_EVALUATOR_CONFIG.yaml"))
     config_names = []
 
     for yaml_file in sorted(yaml_files):

--- a/scripts/prompts/compile_typescript_prompts.py
+++ b/scripts/prompts/compile_typescript_prompts.py
@@ -5,17 +5,51 @@ Compiles YAML prompts into TypeScript code.
 import argparse
 import json
 import re
+from enum import Enum
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, Optional
 
+import pystache
 import yaml
 from jinja2 import Template
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 class PromptMessage(BaseModel):
     role: Literal["user"]
     content: str
+
+
+class EvaluatorScope(str, Enum):
+    SPAN = "span"
+    TRACE = "trace"
+    SESSION = "session"
+
+
+class EvaluatorCategory(str, Enum):
+    GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
+    AGENTS = "agents"
+    RESPONSE_QUALITY = "response_quality"
+    SAFETY_AND_SECURITY = "safety_and_security"
+    USER_EXPERIENCE = "user_experience"
+
+
+class EvaluatorKind(str, Enum):
+    LLM = "LLM"
+    CODE = "CODE"
+
+
+class EvaluatorInput(BaseModel):
+    description: str
+    format: Optional[str] = None
+
+    @field_validator("description")
+    @classmethod
+    def description_must_not_be_empty(cls, description: str) -> str:
+        if not description.strip():
+            raise ValueError("input description must not be empty")
+        return description
 
 
 class ClassificationEvaluatorConfig(BaseModel):
@@ -24,6 +58,58 @@ class ClassificationEvaluatorConfig(BaseModel):
     optimization_direction: Literal["minimize", "maximize", "neutral"]
     messages: list[PromptMessage]
     choices: dict[str, float]
+    substitutions: Optional[dict[str, str]] = None
+    labels: list[str] = []
+    scope: Optional[EvaluatorScope] = None
+    recommended: bool = False
+    category: Optional[EvaluatorCategory] = None
+    kind: EvaluatorKind = EvaluatorKind.LLM
+    details: Optional[str] = None
+    inputs: Optional[dict[str, EvaluatorInput]] = None
+    docs_link: Optional[str] = None
+
+    @field_validator("inputs")
+    @classmethod
+    def input_names_must_not_be_empty(
+        cls, inputs: Optional[dict[str, EvaluatorInput]]
+    ) -> Optional[dict[str, EvaluatorInput]]:
+        if inputs is not None and any(not input_name.strip() for input_name in inputs):
+            raise ValueError("input name must not be empty")
+        return inputs
+
+    @model_validator(mode="after")
+    def validate_source_inputs(self) -> "ClassificationEvaluatorConfig":
+        if self.inputs is None:
+            return self
+
+        source_variables = set(self.substitutions or {})
+        for message in self.messages:
+            source_variables.update(_get_direct_mustache_variables(message.content))
+
+        declared_inputs = set(self.inputs)
+        missing_inputs = source_variables - declared_inputs
+        unused_inputs = declared_inputs - source_variables
+        if missing_inputs or unused_inputs:
+            errors = []
+            if missing_inputs:
+                errors.append(f"missing inputs: {sorted(missing_inputs)}")
+            if unused_inputs:
+                errors.append(f"unused inputs: {sorted(unused_inputs)}")
+            raise ValueError("; ".join(errors))
+        return self
+
+
+def _get_direct_mustache_variables(template: str) -> set[str]:
+    parsed = pystache.parse(template, raise_on_mismatch=True)
+    parse_tree: list[Any] = parsed._parse_tree
+    variables: set[str] = set()
+    for node in parse_tree:
+        if not isinstance(node, (_EscapeNode, _LiteralNode)):
+            continue
+        key = getattr(node, "key", None)
+        if isinstance(key, str) and key != "." and "." not in key:
+            variables.add(key)
+    return variables
 
 
 CLASSIFICATION_EVALUATOR_CONFIG_FILE_TEMPLATE = """\

--- a/src/phoenix/__generated__/classification_evaluator_configs/__init__.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/__init__.py
@@ -15,7 +15,14 @@ from ._faithfulness_classification_evaluator_config import (
 from ._hallucination_classification_evaluator_config import (
     HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG,
 )
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorKind,
+    EvaluatorScope,
+    PromptMessage,
+)
 from ._refusal_classification_evaluator_config import REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG
 from ._retrieval_relevance_classification_evaluator_config import (
     RETRIEVAL_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG,
@@ -36,6 +43,10 @@ from ._user_friction_classification_evaluator_config import (
 
 __all__ = [
     "ClassificationEvaluatorConfig",
+    "EvaluatorCategory",
+    "EvaluatorInput",
+    "EvaluatorKind",
+    "EvaluatorScope",
     "PromptMessage",
     "CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG",
     "CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG",

--- a/src/phoenix/__generated__/classification_evaluator_configs/__init__.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/__init__.py
@@ -19,7 +19,6 @@ from ._models import (
     ClassificationEvaluatorConfig,
     EvaluatorCategory,
     EvaluatorInput,
-    EvaluatorKind,
     EvaluatorScope,
     PromptMessage,
 )
@@ -45,7 +44,6 @@ __all__ = [
     "ClassificationEvaluatorConfig",
     "EvaluatorCategory",
     "EvaluatorInput",
-    "EvaluatorKind",
     "EvaluatorScope",
     "PromptMessage",
     "CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG",

--- a/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -16,4 +16,11 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"concise": 1.0, "verbose": 0.0},
     substitutions={"output": "output_messages_to_conversation"},
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -18,7 +18,7 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Assesses whether an LLM's response uses the minimum number of words necessary to fully answer the question. It detects unnecessary pleasantries, hedging language, meta-commentary, redundant restatements, and unsolicited explanations.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="conciseness",
@@ -16,13 +22,13 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"concise": 1.0, "verbose": 0.0},
     substitutions={"output": "output_messages_to_conversation"},
     labels=[],
-    scope="span",
-    category="response_quality",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.RESPONSE_QUALITY,
     details="Assesses whether an LLM's response uses the minimum number of words necessary to fully answer the question. It detects unnecessary pleasantries, hedging language, meta-commentary, redundant restatements, and unsolicited explanations.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_conciseness_classification_evaluator_config.py
@@ -20,7 +20,9 @@ CONCISENESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     category="response_quality",
     details="Assesses whether an LLM's response uses the minimum number of words necessary to fully answer the question. It detects unnecessary pleasantries, hedging language, meta-commentary, redundant restatements, and unsolicited explanations.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -16,4 +16,11 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="correctness",
@@ -16,13 +22,13 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="response_quality",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.RESPONSE_QUALITY,
     details="A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -18,9 +18,11 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="Assesses whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
+    details="A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -18,7 +18,7 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Assesses whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_correctness_classification_evaluator_config.py
@@ -23,6 +23,7 @@ CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=["promoted_dataset_evaluator"],
     scope=EvaluatorScope.SPAN,
+    recommended=True,
     category=EvaluatorCategory.RESPONSE_QUALITY,
     details="A broad, general purpose metric to determine whether an LLM's response is factually accurate, complete, and logically consistent. It evaluates answer quality without requiring external context or reference responses.",
     inputs={

--- a/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -18,7 +18,7 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether a retrieved document contains information relevant to answering a specific question. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
     inputs={
         "document_text": {"description": "TODO: Describe the document_text field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -16,4 +16,11 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     choices={"relevant": 1.0, "unrelated": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "document_text": {"description": "TODO: Describe the document_text field."},
+        "input": {"description": "TODO: Describe the input field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="document_relevance",
@@ -16,11 +22,13 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     choices={"relevant": 1.0, "unrelated": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="grounding_and_retrieval",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether a retrieved document contains information relevant to answering the input query. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
     inputs={
-        "document_text": {"description": "The content of the retrieved document or context."},
-        "input": {"description": "The input query or conversational context."},
+        "document_text": EvaluatorInput(
+            description="The content of the retrieved document or context."
+        ),
+        "input": EvaluatorInput(description="The input query or conversational context."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -17,10 +17,10 @@ DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConf
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
-    details="Determines whether a retrieved document contains information relevant to answering a specific question. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
+    category="grounding_and_retrieval",
+    details="Determines whether a retrieved document contains information relevant to answering the input query. This is essential for evaluating RAG systems, where document quality directly impacts response quality.",
     inputs={
-        "document_text": {"description": "TODO: Describe the document_text field."},
-        "input": {"description": "TODO: Describe the input field."},
+        "document_text": {"description": "The content of the retrieved document or context."},
+        "input": {"description": "The input query or conversational context."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -16,4 +16,12 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"faithful": 1.0, "unfaithful": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "context": {"description": "TODO: Describe the context field."},
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="faithfulness",
@@ -16,12 +22,12 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"faithful": 1.0, "unfaithful": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="grounding_and_retrieval",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether an LLM's response is grounded in and faithful to the provided context. It detects information that is unsupported by or contradicts the reference context and is intended for grounded responses such as RAG outputs.",
     inputs={
-        "context": {"description": "The content of the retrieved documents or context."},
-        "input": {"description": "The input query or conversational context."},
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "context": EvaluatorInput(description="The content of the retrieved documents or context."),
+        "input": EvaluatorInput(description="The input query or conversational context."),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -17,11 +17,11 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
+    category="grounding_and_retrieval",
     details="Determines whether an LLM's response is grounded in and faithful to the provided context. It detects information that is unsupported by or contradicts the reference context and is intended for grounded responses such as RAG outputs.",
     inputs={
-        "context": {"description": "TODO: Describe the context field."},
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "context": {"description": "The content of the retrieved documents or context."},
+        "input": {"description": "The input query or conversational context."},
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_faithfulness_classification_evaluator_config.py
@@ -18,7 +18,7 @@ FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an LLM's response is grounded in and faithful to the provided context. It detects information that is unsupported by or contradicts the reference context and is intended for grounded responses such as RAG outputs.",
     inputs={
         "context": {"description": "TODO: Describe the context field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -23,6 +23,7 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
     scope=EvaluatorScope.SPAN,
+    recommended=True,
     category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={

--- a/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -17,10 +17,14 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
     scope="span",
-    category="response_quality",
+    category="grounding_and_retrieval",
     details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The entire conversational context, including all messages, tool calls, and tool results."
+        },
+        "output": {
+            "description": "The LLM's output response (messages and tool calls) to be evaluated."
+        },
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -18,7 +18,7 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -16,4 +16,11 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"hallucinated": 1.0, "grounded": 0.0},
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_hallucination_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="hallucination",
@@ -16,15 +22,15 @@ HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"hallucinated": 1.0, "grounded": 0.0},
     substitutions={"output": "output_with_tool_calls"},
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="grounding_and_retrieval",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.GROUNDING_AND_RETRIEVAL,
     details="Determines whether an assistant's response contains claims unsupported by or contradictory to the conversation it had access to. Unlike Faithfulness, which grounds a response in one retrieved context block, Hallucination uses the broader conversation, including earlier turns, tool calls, tool results, and retrieved context.",
     inputs={
-        "input": {
-            "description": "The entire conversational context, including all messages, tool calls, and tool results."
-        },
-        "output": {
-            "description": "The LLM's output response (messages and tool calls) to be evaluated."
-        },
+        "input": EvaluatorInput(
+            description="The entire conversational context, including all messages, tool calls, and tool results."
+        ),
+        "output": EvaluatorInput(
+            description="The LLM's output response (messages and tool calls) to be evaluated."
+        ),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_models.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_models.py
@@ -1,11 +1,12 @@
 # This file is generated. Do not edit by hand.
 
+import re
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
-import pystache
 from pydantic import BaseModel, field_validator, model_validator
-from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
+
+from phoenix.evals.llm.prompts import FormatterFactory
 
 
 class PromptMessage(BaseModel):
@@ -74,9 +75,9 @@ class ClassificationEvaluatorConfig(BaseModel):
         if self.inputs is None:
             return self
 
-        source_variables = set(self.substitutions or {})
+        source_variables = set()
         for message in self.messages:
-            source_variables.update(_get_direct_mustache_variables(message.content))
+            source_variables.update(_get_template_variables(message.content))
 
         declared_inputs = set(self.inputs)
         missing_inputs = source_variables - declared_inputs
@@ -91,14 +92,10 @@ class ClassificationEvaluatorConfig(BaseModel):
         return self
 
 
-def _get_direct_mustache_variables(template: str) -> set[str]:
-    parsed = pystache.parse(template, raise_on_mismatch=True)
-    parse_tree: list[Any] = parsed._parse_tree
-    variables: set[str] = set()
-    for node in parse_tree:
-        if not isinstance(node, (_EscapeNode, _LiteralNode)):
-            continue
-        key = getattr(node, "key", None)
-        if isinstance(key, str) and key != "." and "." not in key:
-            variables.add(key)
-    return variables
+def _get_template_variables(template: str) -> set[str]:
+    formatter = FormatterFactory.auto_detect_and_create(template)
+    return {
+        re.split(r"[.\[]", variable, maxsplit=1)[0]
+        for variable in formatter.extract_variables(template)
+        if variable != "."
+    }

--- a/src/phoenix/__generated__/classification_evaluator_configs/_models.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_models.py
@@ -59,7 +59,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     kind: EvaluatorKind = EvaluatorKind.LLM
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
-    docs_link: Optional[str] = None
 
     @field_validator("inputs")
     @classmethod

--- a/src/phoenix/__generated__/classification_evaluator_configs/_models.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_models.py
@@ -1,13 +1,47 @@
 # This file is generated. Do not edit by hand.
 
-from typing import Literal, Optional
+from enum import Enum
+from typing import Any, Literal, Optional
 
-from pydantic import BaseModel
+import pystache
+from pydantic import BaseModel, field_validator, model_validator
+from pystache.parser import _EscapeNode, _LiteralNode  # type: ignore[import-untyped]
 
 
 class PromptMessage(BaseModel):
     role: Literal["user"]
     content: str
+
+
+class EvaluatorScope(str, Enum):
+    SPAN = "span"
+    TRACE = "trace"
+    SESSION = "session"
+
+
+class EvaluatorCategory(str, Enum):
+    GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
+    AGENTS = "agents"
+    RESPONSE_QUALITY = "response_quality"
+    SAFETY_AND_SECURITY = "safety_and_security"
+    USER_EXPERIENCE = "user_experience"
+
+
+class EvaluatorKind(str, Enum):
+    LLM = "LLM"
+    CODE = "CODE"
+
+
+class EvaluatorInput(BaseModel):
+    description: str
+    format: Optional[str] = None
+
+    @field_validator("description")
+    @classmethod
+    def description_must_not_be_empty(cls, description: str) -> str:
+        if not description.strip():
+            raise ValueError("input description must not be empty")
+        return description
 
 
 class ClassificationEvaluatorConfig(BaseModel):
@@ -18,3 +52,53 @@ class ClassificationEvaluatorConfig(BaseModel):
     choices: dict[str, float]
     substitutions: Optional[dict[str, str]] = None  # placeholder -> substitution_name
     labels: list[str] = []
+    scope: Optional[EvaluatorScope] = None
+    recommended: bool = False
+    category: Optional[EvaluatorCategory] = None
+    kind: EvaluatorKind = EvaluatorKind.LLM
+    details: Optional[str] = None
+    inputs: Optional[dict[str, EvaluatorInput]] = None
+    docs_link: Optional[str] = None
+
+    @field_validator("inputs")
+    @classmethod
+    def input_names_must_not_be_empty(
+        cls, inputs: Optional[dict[str, EvaluatorInput]]
+    ) -> Optional[dict[str, EvaluatorInput]]:
+        if inputs is not None and any(not input_name.strip() for input_name in inputs):
+            raise ValueError("input name must not be empty")
+        return inputs
+
+    @model_validator(mode="after")
+    def validate_source_inputs(self) -> "ClassificationEvaluatorConfig":
+        if self.inputs is None:
+            return self
+
+        source_variables = set(self.substitutions or {})
+        for message in self.messages:
+            source_variables.update(_get_direct_mustache_variables(message.content))
+
+        declared_inputs = set(self.inputs)
+        missing_inputs = source_variables - declared_inputs
+        unused_inputs = declared_inputs - source_variables
+        if missing_inputs or unused_inputs:
+            errors = []
+            if missing_inputs:
+                errors.append(f"missing inputs: {sorted(missing_inputs)}")
+            if unused_inputs:
+                errors.append(f"unused inputs: {sorted(unused_inputs)}")
+            raise ValueError("; ".join(errors))
+        return self
+
+
+def _get_direct_mustache_variables(template: str) -> set[str]:
+    parsed = pystache.parse(template, raise_on_mismatch=True)
+    parse_tree: list[Any] = parsed._parse_tree
+    variables: set[str] = set()
+    for node in parse_tree:
+        if not isinstance(node, (_EscapeNode, _LiteralNode)):
+            continue
+        key = getattr(node, "key", None)
+        if isinstance(key, str) and key != "." and "." not in key:
+            variables.add(key)
+    return variables

--- a/src/phoenix/__generated__/classification_evaluator_configs/_models.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_models.py
@@ -28,14 +28,8 @@ class EvaluatorCategory(str, Enum):
     USER_EXPERIENCE = "user_experience"
 
 
-class EvaluatorKind(str, Enum):
-    LLM = "LLM"
-    CODE = "CODE"
-
-
 class EvaluatorInput(BaseModel):
     description: str
-    format: Optional[str] = None
 
     @field_validator("description")
     @classmethod
@@ -56,7 +50,6 @@ class ClassificationEvaluatorConfig(BaseModel):
     scope: Optional[EvaluatorScope] = None
     recommended: bool = False
     category: Optional[EvaluatorCategory] = None
-    kind: EvaluatorKind = EvaluatorKind.LLM
     details: Optional[str] = None
     inputs: Optional[dict[str, EvaluatorInput]] = None
 

--- a/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -16,4 +16,11 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"refused": 1.0, "answered": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -17,10 +17,12 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
-    details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers.",
+    category="user_experience",
+    details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "output": {"description": "The LLM's output response to be evaluated."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="refusal",
@@ -16,13 +22,13 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"refused": 1.0, "answered": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="user_experience",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.USER_EXPERIENCE,
     details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers. It does not judge whether the refusal was the appropriate response.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "output": {"description": "The LLM's output response to be evaluated."},
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "output": EvaluatorInput(description="The LLM's output response to be evaluated."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_refusal_classification_evaluator_config.py
@@ -18,7 +18,7 @@ REFUSAL_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Detects when an LLM refuses, declines, or avoids answering a user query. It captures explicit refusals, scope disclaimers, lack-of-information responses, safety refusals, redirections, and apologetic non-answers.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_retrieval_relevance_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_retrieval_relevance_classification_evaluator_config.py
@@ -1,7 +1,10 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    PromptMessage,
+)
 
 RETRIEVAL_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="retrieval_relevance",

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -20,11 +20,17 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     },
     labels=["promoted_dataset_evaluator"],
     scope="span",
-    category="response_quality",
-    details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected.",
+    category="agents",
+    details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected. It works even if no tools were called.",
     inputs={
-        "available_tools": {"description": "TODO: Describe the available_tools field."},
-        "input": {"description": "TODO: Describe the input field."},
-        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+        "available_tools": {
+            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
+        },
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        },
+        "tool_selection": {
+            "description": "The LLM's output response (including messages and tool calls) to be evaluated."
+        },
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="tool_invocation",
@@ -19,18 +25,18 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="agents",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.AGENTS,
     details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected. It works even if no tools were called.",
     inputs={
-        "available_tools": {
-            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
-        },
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation."
-        },
-        "tool_selection": {
-            "description": "The LLM's output response (including messages and tool calls) to be evaluated."
-        },
+        "available_tools": EvaluatorInput(
+            description="The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas."
+        ),
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation."
+        ),
+        "tool_selection": EvaluatorInput(
+            description="The LLM's output response (including messages and tool calls) to be evaluated."
+        ),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -21,7 +21,7 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an LLM invoked a tool correctly with proper arguments, formatting, and safe content. It focuses on how the tool was called rather than whether the right tool was selected.",
     inputs={
         "available_tools": {"description": "TODO: Describe the available_tools field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_invocation_classification_evaluator_config.py
@@ -19,4 +19,12 @@ TOOL_INVOCATION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "available_tools": {"description": "TODO: Describe the available_tools field."},
+        "input": {"description": "TODO: Describe the input field."},
+        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -16,4 +16,13 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "input": {"description": "TODO: Describe the input field."},
+        "output": {"description": "TODO: Describe the output field."},
+        "tool_call": {"description": "TODO: Describe the tool_call field."},
+        "tool_result": {"description": "TODO: Describe the tool_result field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="tool_response_handling",
@@ -16,19 +22,21 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=[],
-    scope="trace",
-    category="agents",
+    scope=EvaluatorScope.TRACE,
+    category=EvaluatorCategory.AGENTS,
     details="Determines whether an AI agent correctly processed a tool's result to produce an appropriate output. It focuses on what happens after a tool call by checking that the agent used the result accurately, handled errors, and disclosed information safely.",
     inputs={
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
-        },
-        "tool_call": {
-            "description": "Details of the tool or tools that were called, including name and parameters."
-        },
-        "tool_result": {"description": "The complete tool results, including any errors."},
-        "output": {
-            "description": "The LLM's output messages after the tool call (including messages and tool calls)."
-        },
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        ),
+        "tool_call": EvaluatorInput(
+            description="Details of the tool or tools that were called, including name and parameters."
+        ),
+        "tool_result": EvaluatorInput(
+            description="The complete tool results, including any errors."
+        ),
+        "output": EvaluatorInput(
+            description="The LLM's output messages after the tool call (including messages and tool calls)."
+        ),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -16,13 +16,19 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     choices={"correct": 1.0, "incorrect": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="response_quality",
+    scope="trace",
+    category="agents",
     details="Determines whether an AI agent correctly processed a tool's result to produce an appropriate output. It focuses on what happens after a tool call by checking that the agent used the result accurately, handled errors, and disclosed information safely.",
     inputs={
-        "input": {"description": "TODO: Describe the input field."},
-        "output": {"description": "TODO: Describe the output field."},
-        "tool_call": {"description": "TODO: Describe the tool_call field."},
-        "tool_result": {"description": "TODO: Describe the tool_result field."},
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        },
+        "tool_call": {
+            "description": "Details of the tool or tools that were called, including name and parameters."
+        },
+        "tool_result": {"description": "The complete tool results, including any errors."},
+        "output": {
+            "description": "The LLM's output messages after the tool call (including messages and tool calls)."
+        },
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_response_handling_classification_evaluator_config.py
@@ -18,7 +18,7 @@ TOOL_RESPONSE_HANDLING_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluator
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an AI agent correctly processed a tool's result to produce an appropriate output. It focuses on what happens after a tool call by checking that the agent used the result accurately, handled errors, and disclosed information safely.",
     inputs={
         "input": {"description": "TODO: Describe the input field."},
         "output": {"description": "TODO: Describe the output field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -20,11 +20,15 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     },
     labels=["promoted_dataset_evaluator"],
     scope="span",
-    category="response_quality",
+    category="agents",
     details="Determines whether an LLM selected the most appropriate tool or tools for a given task. It focuses on what tool was chosen rather than whether the invocation arguments were correct.",
     inputs={
-        "available_tools": {"description": "TODO: Describe the available_tools field."},
-        "input": {"description": "TODO: Describe the input field."},
-        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+        "available_tools": {
+            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
+        },
+        "input": {
+            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        },
+        "tool_selection": {"description": "The tool or tools called by the LLM."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="tool_selection",
@@ -19,16 +25,16 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
-    scope="span",
-    category="agents",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.AGENTS,
     details="Determines whether an LLM selected the most appropriate tool or tools for a given task. It focuses on what tool was chosen rather than whether the invocation arguments were correct.",
     inputs={
-        "available_tools": {
-            "description": "The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
-        },
-        "input": {
-            "description": "The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
-        },
-        "tool_selection": {"description": "The tool or tools called by the LLM."},
+        "available_tools": EvaluatorInput(
+            description="The list of available tools, including names and descriptions. A simple human-readable list is better than including the full tool schemas as JSON."
+        ),
+        "input": EvaluatorInput(
+            description="The conversational context, whether that is a single input query or a full turn-by-turn conversation. Intermediate tool calls/results are not required."
+        ),
+        "tool_selection": EvaluatorInput(description="The tool or tools called by the LLM."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -19,4 +19,12 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
         "tool_selection": "output_with_tool_calls",
     },
     labels=["promoted_dataset_evaluator"],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "available_tools": {"description": "TODO: Describe the available_tools field."},
+        "input": {"description": "TODO: Describe the input field."},
+        "tool_selection": {"description": "TODO: Describe the tool_selection field."},
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_tool_selection_classification_evaluator_config.py
@@ -21,7 +21,7 @@ TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=["promoted_dataset_evaluator"],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Determines whether an LLM selected the most appropriate tool or tools for a given task. It focuses on what tool was chosen rather than whether the invocation arguments were correct.",
     inputs={
         "available_tools": {"description": "TODO: Describe the available_tools field."},
         "input": {"description": "TODO: Describe the input field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="toxicity",
@@ -16,12 +22,12 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"toxic": 1.0, "non-toxic": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="safety_and_security",
+    scope=EvaluatorScope.SPAN,
+    category=EvaluatorCategory.SAFETY_AND_SECURITY,
     details="Classifies a single piece of text as toxic or non-toxic. Text is toxic when it makes hateful or discriminatory statements about a person or group, demeans or insults someone, uses abusive language directed at a person, or threatens or incites harm.",
     inputs={
-        "text": {
-            "description": "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
-        }
+        "text": EvaluatorInput(
+            description="The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
+        )
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -17,7 +17,11 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope="span",
-    category="response_quality",
+    category="safety_and_security",
     details="Classifies a single piece of text as toxic or non-toxic. Text is toxic when it makes hateful or discriminatory statements about a person or group, demeans or insults someone, uses abusive language directed at a person, or threatens or incites harm.",
-    inputs={"text": {"description": "TODO: Describe the text field."}},
+    inputs={
+        "text": {
+            "description": "The text to be evaluated for toxicty. This could be either an input (user message) or an output (LLM message)."
+        }
+    },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -16,4 +16,8 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"toxic": 1.0, "non-toxic": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={"text": {"description": "TODO: Describe the text field."}},
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_toxicity_classification_evaluator_config.py
@@ -18,6 +18,6 @@ TOXICITY_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Classifies a single piece of text as toxic or non-toxic. Text is toxic when it makes hateful or discriminatory statements about a person or group, demeans or insults someone, uses abusive language directed at a person, or threatens or incites harm.",
     inputs={"text": {"description": "TODO: Describe the text field."}},
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -1,7 +1,13 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInput,
+    EvaluatorScope,
+    PromptMessage,
+)
 
 USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="user_friction",
@@ -16,13 +22,13 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"friction": 1.0, "no_friction": 0.0},
     substitutions=None,
     labels=[],
-    scope="trace",
-    category="user_experience",
+    scope=EvaluatorScope.TRACE,
+    category=EvaluatorCategory.USER_EXPERIENCE,
     details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={
-        "conversation": {
-            "description": "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
-        },
-        "user_message": {"description": "The latest user message to be evaluated."},
+        "conversation": EvaluatorInput(
+            description="The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
+        ),
+        "user_message": EvaluatorInput(description="The latest user message to be evaluated."),
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -23,6 +23,7 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     substitutions=None,
     labels=[],
     scope=EvaluatorScope.TRACE,
+    recommended=True,
     category=EvaluatorCategory.USER_EXPERIENCE,
     details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={

--- a/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -18,7 +18,7 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     labels=[],
     scope="span",
     category="response_quality",
-    details="TODO: Add detailed guidance for this evaluator.",
+    details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={
         "conversation": {"description": "TODO: Describe the conversation field."},
         "user_message": {"description": "TODO: Describe the user_message field."},

--- a/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -16,11 +16,13 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"friction": 1.0, "no_friction": 0.0},
     substitutions=None,
     labels=[],
-    scope="span",
-    category="response_quality",
+    scope="trace",
+    category="user_experience",
     details="Classifies whether the latest user message expresses friction with an assistant's preceding behavior. It detects corrections, retries after an unsuccessful response, frustration, and challenges to unrequested or unexplained actions.",
     inputs={
-        "conversation": {"description": "TODO: Describe the conversation field."},
-        "user_message": {"description": "TODO: Describe the user_message field."},
+        "conversation": {
+            "description": "The complete conversational context, including user/assistant messages. Intermediate tool calls/results are optional but may help, especially those from the most recent turn."
+        },
+        "user_message": {"description": "The latest user message to be evaluated."},
     },
 )

--- a/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_user_friction_classification_evaluator_config.py
@@ -16,4 +16,11 @@ USER_FRICTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     choices={"friction": 1.0, "no_friction": 0.0},
     substitutions=None,
     labels=[],
+    scope="span",
+    category="response_quality",
+    details="TODO: Add detailed guidance for this evaluator.",
+    inputs={
+        "conversation": {"description": "TODO: Describe the conversation field."},
+        "user_message": {"description": "TODO: Describe the user_message field."},
+    },
 )

--- a/src/phoenix/server/api/helpers/classification_evaluator_configs.py
+++ b/src/phoenix/server/api/helpers/classification_evaluator_configs.py
@@ -12,6 +12,8 @@ from phoenix.server.api.helpers.substitutions import (
 
 def get_classification_evaluator_configs(
     labels: Optional[list[str]] = None,
+    *,
+    gallery_ready: bool = False,
 ) -> list[PydanticClassificationEvaluatorConfig]:
     """
     Load all CLASSIFICATION_EVALUATOR_CONFIG objects from __generated__.
@@ -20,9 +22,9 @@ def get_classification_evaluator_configs(
     '_CLASSIFICATION_EVALUATOR_CONFIG'. For configs with a `substitutions` mapping,
     expands simple placeholders into full Mustache blocks before returning.
 
-    If `labels` is not provided, all discovered evaluator configs are returned.
-    If `labels` is provided, only evaluator configs with at least one matching
-    label are returned.
+    If `gallery_ready` is true, only complete gallery configs are returned,
+    ordered by recommendation, category, and name. Otherwise, `labels` optionally
+    filters configs with at least one matching label while preserving discovery order.
     """
     configs = []
     substitutions = load_substitutions()
@@ -36,6 +38,16 @@ def get_classification_evaluator_configs(
                     config = expand_config_templates(config, substitutions)
                 configs.append(config)
 
+    if gallery_ready:
+        return sorted(
+            (config for config in configs if is_gallery_ready(config)),
+            key=lambda config: (
+                not config.recommended,
+                config.category.value if config.category else "",
+                config.name,
+            ),
+        )
+
     if labels:
         requested_labels = set(labels)
         configs = [
@@ -45,3 +57,7 @@ def get_classification_evaluator_configs(
         ]
 
     return configs
+
+
+def is_gallery_ready(config: PydanticClassificationEvaluatorConfig) -> bool:
+    return bool(config.scope and config.category and config.details is not None and config.inputs)

--- a/src/phoenix/server/api/helpers/classification_evaluator_configs.py
+++ b/src/phoenix/server/api/helpers/classification_evaluator_configs.py
@@ -12,28 +12,44 @@ from phoenix.server.api.helpers.substitutions import (
 
 def get_classification_evaluator_configs(
     labels: Optional[list[str]] = None,
+    *,
+    gallery_ready: bool = False,
 ) -> list[PydanticClassificationEvaluatorConfig]:
     """
     Load all CLASSIFICATION_EVALUATOR_CONFIG objects from __generated__.
 
     Automatically discovers all configs by looking for attributes ending with
-    '_CLASSIFICATION_EVALUATOR_CONFIG'. For configs with a `substitutions` mapping,
-    expands simple placeholders into full Mustache blocks for dataset evaluators.
+    '_CLASSIFICATION_EVALUATOR_CONFIG'.
 
-    If `labels` is provided, only evaluator configs with at least one matching
-    label are returned.
+    If `gallery_ready` is true, only complete gallery configs are returned,
+    ordered by recommendation, category, and name, without expanding dataset-only
+    substitutions. Otherwise, configs with substitutions are expanded and `labels`
+    optionally filters configs with at least one matching label while preserving
+    discovery order.
     """
     configs = []
-    substitutions = load_substitutions()
 
     for attr_name in dir(configs_module):
         if attr_name.endswith("_CLASSIFICATION_EVALUATOR_CONFIG"):
             config = getattr(configs_module, attr_name)
             if isinstance(config, PydanticClassificationEvaluatorConfig):
-                # Expand substitutions if the config has a substitutions mapping
-                if getattr(config, "substitutions", None):
-                    config = expand_config_templates(config, substitutions)
                 configs.append(config)
+
+    if gallery_ready:
+        return sorted(
+            (config for config in configs if is_gallery_ready(config)),
+            key=lambda config: (
+                not config.recommended,
+                config.category.value if config.category else "",
+                config.name,
+            ),
+        )
+
+    substitutions = load_substitutions()
+    configs = [
+        expand_config_templates(config, substitutions) if config.substitutions else config
+        for config in configs
+    ]
 
     if labels:
         requested_labels = set(labels)
@@ -46,22 +62,5 @@ def get_classification_evaluator_configs(
     return configs
 
 
-def get_evaluator_gallery_configs() -> list[PydanticClassificationEvaluatorConfig]:
-    """Load every evaluator config without applying dataset-only substitutions."""
-    configs = [
-        config
-        for attr_name in dir(configs_module)
-        if attr_name.endswith("_CLASSIFICATION_EVALUATOR_CONFIG")
-        and isinstance(
-            config := getattr(configs_module, attr_name),
-            PydanticClassificationEvaluatorConfig,
-        )
-    ]
-    return sorted(
-        configs,
-        key=lambda config: (
-            not config.recommended,
-            config.category.value if config.category else "",
-            config.name,
-        ),
-    )
+def is_gallery_ready(config: PydanticClassificationEvaluatorConfig) -> bool:
+    return bool(config.scope and config.category and config.details is not None and config.inputs)

--- a/src/phoenix/server/api/helpers/classification_evaluator_configs.py
+++ b/src/phoenix/server/api/helpers/classification_evaluator_configs.py
@@ -12,19 +12,16 @@ from phoenix.server.api.helpers.substitutions import (
 
 def get_classification_evaluator_configs(
     labels: Optional[list[str]] = None,
-    *,
-    gallery_ready: bool = False,
 ) -> list[PydanticClassificationEvaluatorConfig]:
     """
     Load all CLASSIFICATION_EVALUATOR_CONFIG objects from __generated__.
 
     Automatically discovers all configs by looking for attributes ending with
     '_CLASSIFICATION_EVALUATOR_CONFIG'. For configs with a `substitutions` mapping,
-    expands simple placeholders into full Mustache blocks before returning.
+    expands simple placeholders into full Mustache blocks for dataset evaluators.
 
-    If `gallery_ready` is true, only complete gallery configs are returned,
-    ordered by recommendation, category, and name. Otherwise, `labels` optionally
-    filters configs with at least one matching label while preserving discovery order.
+    If `labels` is provided, only evaluator configs with at least one matching
+    label are returned.
     """
     configs = []
     substitutions = load_substitutions()
@@ -38,16 +35,6 @@ def get_classification_evaluator_configs(
                     config = expand_config_templates(config, substitutions)
                 configs.append(config)
 
-    if gallery_ready:
-        return sorted(
-            (config for config in configs if is_gallery_ready(config)),
-            key=lambda config: (
-                not config.recommended,
-                config.category.value if config.category else "",
-                config.name,
-            ),
-        )
-
     if labels:
         requested_labels = set(labels)
         configs = [
@@ -59,5 +46,22 @@ def get_classification_evaluator_configs(
     return configs
 
 
-def is_gallery_ready(config: PydanticClassificationEvaluatorConfig) -> bool:
-    return bool(config.scope and config.category and config.details is not None and config.inputs)
+def get_evaluator_gallery_configs() -> list[PydanticClassificationEvaluatorConfig]:
+    """Load every evaluator config without applying dataset-only substitutions."""
+    configs = [
+        config
+        for attr_name in dir(configs_module)
+        if attr_name.endswith("_CLASSIFICATION_EVALUATOR_CONFIG")
+        and isinstance(
+            config := getattr(configs_module, attr_name),
+            PydanticClassificationEvaluatorConfig,
+        )
+    ]
+    return sorted(
+        configs,
+        key=lambda config: (
+            not config.recommended,
+            config.category.value if config.category else "",
+            config.name,
+        ),
+    )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -91,7 +91,6 @@ from phoenix.server.api.types.Evaluator import (
     CodeEvaluator,
     DatasetEvaluator,
     Evaluator,
-    EvaluatorKind,
     LLMEvaluator,
     ProjectEvaluator,
 )
@@ -208,7 +207,6 @@ def _to_gql_classification_evaluator_config(
             EvaluatorInputDescriptor(
                 name=input_name,
                 description=input_descriptor.description,
-                format=input_descriptor.format,
             )
             for input_name, input_descriptor in config.inputs.items()
         ]
@@ -225,7 +223,6 @@ def _to_gql_classification_evaluator_config(
         scope=EvaluatorScope(config.scope.value) if config.scope else None,
         recommended=config.recommended,
         category=EvaluatorCategory(config.category.value) if config.category else None,
-        kind=EvaluatorKind(config.kind.value),
         details=config.details,
         inputs=inputs,
     )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -17,6 +17,9 @@ from strawberry.scalars import JSON
 from strawberry.types import Info
 from typing_extensions import TypeAlias, assert_never
 
+from phoenix.__generated__.classification_evaluator_configs import (
+    ClassificationEvaluatorConfig as PydanticClassificationEvaluatorConfig,
+)
 from phoenix.config import (
     get_env_database_allocated_storage_capacity_gibibytes,
 )
@@ -72,7 +75,12 @@ from phoenix.server.api.types.AgentsConfig import AgentsConfig
 from phoenix.server.api.types.AgentSession import AgentSession, to_gql_agent_session
 from phoenix.server.api.types.AgentSkill import AgentSkill
 from phoenix.server.api.types.AnnotationConfig import AnnotationConfig, to_gql_annotation_config
-from phoenix.server.api.types.ClassificationEvaluatorConfig import ClassificationEvaluatorConfig
+from phoenix.server.api.types.ClassificationEvaluatorConfig import (
+    ClassificationEvaluatorConfig,
+    EvaluatorCategory,
+    EvaluatorInputDescriptor,
+    EvaluatorScope,
+)
 from phoenix.server.api.types.Dataset import Dataset
 from phoenix.server.api.types.DatasetExample import DatasetExample
 from phoenix.server.api.types.DatasetLabel import DatasetLabel
@@ -82,6 +90,7 @@ from phoenix.server.api.types.Evaluator import (
     CodeEvaluator,
     DatasetEvaluator,
     Evaluator,
+    EvaluatorKind,
     LLMEvaluator,
     ProjectEvaluator,
 )
@@ -160,6 +169,65 @@ from phoenix.utilities.template_formatters import TemplateFormatterError
 logger = logging.getLogger(__name__)
 
 initialize_playground_clients()
+
+
+def _to_gql_classification_evaluator_config(
+    config: PydanticClassificationEvaluatorConfig,
+) -> ClassificationEvaluatorConfig:
+    if config.optimization_direction == "maximize":
+        optimization_direction = OptimizationDirection.MAXIMIZE
+    elif config.optimization_direction == "minimize":
+        optimization_direction = OptimizationDirection.MINIMIZE
+    else:
+        optimization_direction = OptimizationDirection.NONE
+
+    gql_messages: list[PromptMessage] = []
+    for message in config.messages:
+        role_value = message.role.lower()
+        if role_value == "user":
+            role = PromptMessageRole.USER
+        elif role_value == "system":
+            role = PromptMessageRole.SYSTEM
+        elif role_value in ("ai", "assistant"):
+            role = PromptMessageRole.AI
+        elif role_value == "tool":
+            role = PromptMessageRole.TOOL
+        else:
+            role = PromptMessageRole.USER
+
+        content = type_cast(
+            list[ContentPart],
+            [TextContentPart(text=TextContentValue(text=message.content))],
+        )
+        gql_messages.append(PromptMessage(role=role, content=content))
+
+    inputs = (
+        [
+            EvaluatorInputDescriptor(
+                name=input_name,
+                description=input_descriptor.description,
+                format=input_descriptor.format,
+            )
+            for input_name, input_descriptor in config.inputs.items()
+        ]
+        if config.inputs is not None
+        else None
+    )
+    return ClassificationEvaluatorConfig(
+        name=config.name,
+        description=config.description,
+        optimization_direction=optimization_direction,
+        messages=gql_messages,
+        choices=JSON(config.choices),
+        labels=config.labels,
+        scope=EvaluatorScope(config.scope.value) if config.scope else None,
+        recommended=config.recommended,
+        category=EvaluatorCategory(config.category.value) if config.category else None,
+        kind=EvaluatorKind(config.kind.value),
+        details=config.details,
+        inputs=inputs,
+        docs_link=config.docs_link,
+    )
 
 
 @strawberry.input
@@ -1513,51 +1581,18 @@ class Query:
         info: Info[Context, None],
         labels: Optional[list[str]] = UNSET,
     ) -> list[ClassificationEvaluatorConfig]:
-        pydantic_configs = get_classification_evaluator_configs(
+        configs = get_classification_evaluator_configs(
             labels=labels if labels is not UNSET else None
         )
+        return [_to_gql_classification_evaluator_config(config) for config in configs]
 
-        gql_configs: list[ClassificationEvaluatorConfig] = []
-        for config in pydantic_configs:
-            if config.optimization_direction == "maximize":
-                optimization_direction = OptimizationDirection.MAXIMIZE
-            elif config.optimization_direction == "minimize":
-                optimization_direction = OptimizationDirection.MINIMIZE
-            else:
-                optimization_direction = OptimizationDirection.NONE
-
-            gql_messages: list[PromptMessage] = []
-            for msg in config.messages:
-                role_str = msg.role.lower()
-                if role_str == "user":
-                    role = PromptMessageRole.USER
-                elif role_str == "system":
-                    role = PromptMessageRole.SYSTEM
-                elif role_str in ("ai", "assistant"):
-                    role = PromptMessageRole.AI
-                elif role_str == "tool":
-                    role = PromptMessageRole.TOOL
-                else:
-                    # Default to USER if unknown role
-                    role = PromptMessageRole.USER
-
-                content = type_cast(
-                    list[ContentPart],
-                    [TextContentPart(text=TextContentValue(text=msg.content))],
-                )
-
-                gql_messages.append(PromptMessage(role=role, content=content))
-
-            gql_config = ClassificationEvaluatorConfig(
-                name=config.name,
-                description=config.description,
-                optimization_direction=optimization_direction,
-                messages=gql_messages,
-                choices=JSON(config.choices),
-            )
-            gql_configs.append(gql_config)
-
-        return gql_configs
+    @strawberry.field
+    async def evaluator_gallery_configs(
+        self,
+        info: Info[Context, None],
+    ) -> list[ClassificationEvaluatorConfig]:
+        configs = get_classification_evaluator_configs(gallery_ready=True)
+        return [_to_gql_classification_evaluator_config(config) for config in configs]
 
     @strawberry.field
     async def default_project_trace_retention_policy(

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -48,6 +48,7 @@ from phoenix.server.api.evaluators import (
 from phoenix.server.api.exceptions import BadRequest, NotFound, Unauthorized
 from phoenix.server.api.helpers.classification_evaluator_configs import (
     get_classification_evaluator_configs,
+    get_evaluator_gallery_configs,
 )
 from phoenix.server.api.helpers.experiment_run_filters import (
     ExperimentRunFilterConditionSyntaxError,
@@ -174,6 +175,7 @@ initialize_playground_clients()
 def _to_gql_classification_evaluator_config(
     config: PydanticClassificationEvaluatorConfig,
 ) -> ClassificationEvaluatorConfig:
+    """Convert a generated config to the GraphQL shape shared by both config queries."""
     if config.optimization_direction == "maximize":
         optimization_direction = OptimizationDirection.MAXIMIZE
     elif config.optimization_direction == "minimize":
@@ -1591,7 +1593,7 @@ class Query:
         self,
         info: Info[Context, None],
     ) -> list[ClassificationEvaluatorConfig]:
-        configs = get_classification_evaluator_configs(gallery_ready=True)
+        configs = get_evaluator_gallery_configs()
         return [_to_gql_classification_evaluator_config(config) for config in configs]
 
     @strawberry.field

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -48,7 +48,6 @@ from phoenix.server.api.evaluators import (
 from phoenix.server.api.exceptions import BadRequest, NotFound, Unauthorized
 from phoenix.server.api.helpers.classification_evaluator_configs import (
     get_classification_evaluator_configs,
-    get_evaluator_gallery_configs,
 )
 from phoenix.server.api.helpers.experiment_run_filters import (
     ExperimentRunFilterConditionSyntaxError,
@@ -1589,7 +1588,7 @@ class Query:
         self,
         info: Info[Context, None],
     ) -> list[ClassificationEvaluatorConfig]:
-        configs = get_evaluator_gallery_configs()
+        configs = get_classification_evaluator_configs(gallery_ready=True)
         return [_to_gql_classification_evaluator_config(config) for config in configs]
 
     @strawberry.field

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -228,7 +228,6 @@ def _to_gql_classification_evaluator_config(
         kind=EvaluatorKind(config.kind.value),
         details=config.details,
         inputs=inputs,
-        docs_link=config.docs_link,
     )
 
 

--- a/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
+++ b/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
@@ -5,7 +5,6 @@ import strawberry
 from strawberry.scalars import JSON
 
 from phoenix.db.types.annotation_configs import OptimizationDirection
-from phoenix.server.api.types.Evaluator import EvaluatorKind
 from phoenix.server.api.types.PromptVersionTemplate import PromptMessage
 
 
@@ -31,7 +30,6 @@ class EvaluatorCategory(Enum):
 class EvaluatorInputDescriptor:
     name: str
     description: str
-    format: Optional[str] = None
 
 
 @strawberry.type
@@ -45,6 +43,5 @@ class ClassificationEvaluatorConfig:
     scope: Optional[EvaluatorScope]
     recommended: bool
     category: Optional[EvaluatorCategory]
-    kind: EvaluatorKind
     details: Optional[str]
     inputs: Optional[list[EvaluatorInputDescriptor]]

--- a/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
+++ b/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
@@ -16,7 +16,9 @@ class EvaluatorScope(Enum):
     SESSION = "session"
 
 
-@strawberry.enum
+@strawberry.enum(
+    description="Stable category identifiers whose display labels are supplied by clients."
+)
 class EvaluatorCategory(Enum):
     GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
     AGENTS = "agents"

--- a/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
+++ b/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
@@ -1,10 +1,35 @@
+from enum import Enum
 from typing import Optional
 
 import strawberry
 from strawberry.scalars import JSON
 
 from phoenix.db.types.annotation_configs import OptimizationDirection
+from phoenix.server.api.types.Evaluator import EvaluatorKind
 from phoenix.server.api.types.PromptVersionTemplate import PromptMessage
+
+
+@strawberry.enum
+class EvaluatorScope(Enum):
+    SPAN = "span"
+    TRACE = "trace"
+    SESSION = "session"
+
+
+@strawberry.enum
+class EvaluatorCategory(Enum):
+    GROUNDING_AND_RETRIEVAL = "grounding_and_retrieval"
+    AGENTS = "agents"
+    RESPONSE_QUALITY = "response_quality"
+    SAFETY_AND_SECURITY = "safety_and_security"
+    USER_EXPERIENCE = "user_experience"
+
+
+@strawberry.type(name="EvaluatorInput")
+class EvaluatorInputDescriptor:
+    name: str
+    description: str
+    format: Optional[str] = None
 
 
 @strawberry.type
@@ -14,3 +39,11 @@ class ClassificationEvaluatorConfig:
     optimization_direction: OptimizationDirection
     messages: list[PromptMessage]
     choices: JSON
+    labels: list[str]
+    scope: Optional[EvaluatorScope]
+    recommended: bool
+    category: Optional[EvaluatorCategory]
+    kind: EvaluatorKind
+    details: Optional[str]
+    inputs: Optional[list[EvaluatorInputDescriptor]]
+    docs_link: Optional[str]

--- a/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
+++ b/src/phoenix/server/api/types/ClassificationEvaluatorConfig.py
@@ -48,4 +48,3 @@ class ClassificationEvaluatorConfig:
     kind: EvaluatorKind
     details: Optional[str]
     inputs: Optional[list[EvaluatorInputDescriptor]]
-    docs_link: Optional[str]

--- a/tests/unit/scripts/prompts/test_compile_prompts.py
+++ b/tests/unit/scripts/prompts/test_compile_prompts.py
@@ -29,119 +29,72 @@ def _config(**overrides: Any) -> dict[str, Any]:
     return config
 
 
-def test_gallery_metadata_survives_parsing(compiler_module: ModuleType) -> None:
+def test_gallery_metadata_contract(compiler_module: ModuleType) -> None:
     model = compiler_module.ClassificationEvaluatorConfig.model_validate(
         _config(
             scope="trace",
             recommended=True,
             category="response_quality",
             kind="CODE",
-            details="Use this to judge a response.",
+            details="Detailed guidance.",
+            substitutions={"unused_placeholder": "available_tools_list"},
             inputs={"input": {"description": "The user request.", "format": "text"}},
         )
     )
 
-    assert model.scope == "trace"
-    assert model.recommended is True
-    assert model.category == "response_quality"
-    assert model.kind == "CODE"
-    assert model.inputs["input"].description == "The user request."
-    assert model.inputs["input"].format == "text"
+    assert model.model_dump(mode="json", exclude_defaults=True) == {
+        **_config(),
+        "scope": "trace",
+        "recommended": True,
+        "category": "response_quality",
+        "kind": "CODE",
+        "details": "Detailed guidance.",
+        "substitutions": {"unused_placeholder": "available_tools_list"},
+        "inputs": {"input": {"description": "The user request.", "format": "text"}},
+    }
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
-    [("scope", "project"), ("category", "quality"), ("kind", "BUILTIN")],
+    "content",
+    ["{{input}} {{nested.value}}", "{input} {nested.value}"],
 )
-def test_invalid_metadata_enum_fails(compiler_module: ModuleType, field: str, value: str) -> None:
-    with pytest.raises(ValidationError):
-        compiler_module.ClassificationEvaluatorConfig.model_validate(_config(**{field: value}))
+def test_input_variables_match_template_format(
+    compiler_module: ModuleType,
+    content: str,
+) -> None:
+    inputs = {
+        "input": {"description": "Input"},
+        "nested": {"description": "Nested input"},
+    }
+    compiler_module.ClassificationEvaluatorConfig.model_validate(
+        _config(messages=[{"role": "user", "content": content}], inputs=inputs)
+    )
+
+    with pytest.raises(ValidationError, match="unused inputs"):
+        compiler_module.ClassificationEvaluatorConfig.model_validate(
+            _config(
+                messages=[{"role": "user", "content": content}],
+                inputs={**inputs, "unused": {"description": "Unused"}},
+            )
+        )
 
 
-def test_omitted_metadata_is_backward_compatible(compiler_module: ModuleType) -> None:
-    model = compiler_module.ClassificationEvaluatorConfig.model_validate(_config())
-
-    assert model.scope is None
-    assert model.recommended is False
-    assert model.category is None
-    assert model.kind == "LLM"
-    assert model.inputs is None
-
-
-def test_python_generator_emits_only_supplied_metadata() -> None:
+def test_python_generator_emits_gallery_metadata() -> None:
     module_path = Path(__file__).parents[4] / "scripts" / "prompts" / "compile_python_prompts.py"
     spec = spec_from_file_location("compile_python_prompts_generation", module_path)
     assert spec and spec.loader
     compiler_module = module_from_spec(spec)
     spec.loader.exec_module(compiler_module)
-
-    legacy_config = compiler_module.ClassificationEvaluatorConfig.model_validate(_config())
-    legacy_source = compiler_module.get_prompt_file_contents(legacy_config, "TEST_CONFIG")
-    assert "scope=" not in legacy_source
-    assert "recommended=" not in legacy_source
-
-    gallery_config = compiler_module.ClassificationEvaluatorConfig.model_validate(
+    config = compiler_module.ClassificationEvaluatorConfig.model_validate(
         _config(
             scope="span",
             category="response_quality",
             inputs={"input": {"description": "Input"}},
         )
     )
-    gallery_source = compiler_module.get_prompt_file_contents(gallery_config, "TEST_CONFIG")
-    assert "scope='span'" in gallery_source
-    assert "category='response_quality'" in gallery_source
-    assert "inputs={'input': {'description': 'Input'}}" in gallery_source
-    assert "<Evaluator" not in gallery_source
 
+    source = compiler_module.get_prompt_file_contents(config, "TEST_CONFIG")
 
-@pytest.mark.parametrize(
-    "content",
-    [
-        "Input: {{input}}; value: {{nested.value}}",
-        "Input: {input}; value: {nested.value}",
-    ],
-)
-def test_inputs_match_variables_for_supported_template_formats(
-    compiler_module: ModuleType,
-    content: str,
-) -> None:
-    model = compiler_module.ClassificationEvaluatorConfig.model_validate(
-        _config(
-            messages=[{"role": "user", "content": content}],
-            substitutions={"unused_placeholder": "available_tools_list"},
-            inputs={
-                "input": {"description": "Input"},
-                "nested": {"description": "Nested input"},
-            },
-        )
-    )
-
-    assert set(model.inputs) == {"input", "nested"}
-
-
-@pytest.mark.parametrize(
-    "inputs",
-    [
-        {"input": {"description": "Input"}, "unused": {"description": "Unused"}},
-        {},
-    ],
-)
-def test_inputs_must_exactly_match_source_variables(
-    compiler_module: ModuleType, inputs: dict[str, dict[str, str]]
-) -> None:
-    with pytest.raises(ValidationError):
-        compiler_module.ClassificationEvaluatorConfig.model_validate(_config(inputs=inputs))
-
-
-@pytest.mark.parametrize(
-    "inputs",
-    [
-        {"": {"description": "Input"}},
-        {"input": {"description": "  "}},
-    ],
-)
-def test_input_names_and_descriptions_must_not_be_empty(
-    compiler_module: ModuleType, inputs: dict[str, dict[str, str]]
-) -> None:
-    with pytest.raises(ValidationError):
-        compiler_module.ClassificationEvaluatorConfig.model_validate(_config(inputs=inputs))
+    assert "scope='span'" in source
+    assert "category='response_quality'" in source
+    assert "inputs={'input': {'description': 'Input'}}" in source

--- a/tests/unit/scripts/prompts/test_compile_prompts.py
+++ b/tests/unit/scripts/prompts/test_compile_prompts.py
@@ -38,7 +38,6 @@ def test_gallery_metadata_survives_parsing(compiler_module: ModuleType) -> None:
             kind="CODE",
             details="Use this to judge a response.",
             inputs={"input": {"description": "The user request.", "format": "text"}},
-            docs_link="https://example.com/evaluators/test",
         )
     )
 

--- a/tests/unit/scripts/prompts/test_compile_prompts.py
+++ b/tests/unit/scripts/prompts/test_compile_prompts.py
@@ -42,10 +42,10 @@ def test_gallery_metadata_survives_parsing(compiler_module: ModuleType) -> None:
         )
     )
 
-    assert model.scope.value == "trace"
+    assert model.scope == "trace"
     assert model.recommended is True
-    assert model.category.value == "response_quality"
-    assert model.kind.value == "CODE"
+    assert model.category == "response_quality"
+    assert model.kind == "CODE"
     assert model.inputs["input"].description == "The user request."
     assert model.inputs["input"].format == "text"
 
@@ -65,7 +65,7 @@ def test_omitted_metadata_is_backward_compatible(compiler_module: ModuleType) ->
     assert model.scope is None
     assert model.recommended is False
     assert model.category is None
-    assert model.kind.value == "LLM"
+    assert model.kind == "LLM"
     assert model.inputs is None
 
 
@@ -95,27 +95,29 @@ def test_python_generator_emits_only_supplied_metadata() -> None:
     assert "<Evaluator" not in gallery_source
 
 
-def test_inputs_match_direct_variables_and_substitutions(compiler_module: ModuleType) -> None:
+@pytest.mark.parametrize(
+    "content",
+    [
+        "Input: {{input}}; value: {{nested.value}}",
+        "Input: {input}; value: {nested.value}",
+    ],
+)
+def test_inputs_match_variables_for_supported_template_formats(
+    compiler_module: ModuleType,
+    content: str,
+) -> None:
     model = compiler_module.ClassificationEvaluatorConfig.model_validate(
         _config(
-            messages=[
-                {
-                    "role": "user",
-                    "content": (
-                        "{{input}} {{#items}}{{name}}{{/items}} {{^missing}}none{{/missing}} "
-                        "{{! ignored }} {{{.}}} {{output.value}} {{available_tools}}"
-                    ),
-                }
-            ],
-            substitutions={"available_tools": "available_tools_list"},
+            messages=[{"role": "user", "content": content}],
+            substitutions={"unused_placeholder": "available_tools_list"},
             inputs={
                 "input": {"description": "Input"},
-                "available_tools": {"description": "Available tools"},
+                "nested": {"description": "Nested input"},
             },
         )
     )
 
-    assert set(model.inputs) == {"input", "available_tools"}
+    assert set(model.inputs) == {"input", "nested"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/scripts/prompts/test_compile_prompts.py
+++ b/tests/unit/scripts/prompts/test_compile_prompts.py
@@ -35,10 +35,9 @@ def test_gallery_metadata_contract(compiler_module: ModuleType) -> None:
             scope="trace",
             recommended=True,
             category="response_quality",
-            kind="CODE",
             details="Detailed guidance.",
             substitutions={"unused_placeholder": "available_tools_list"},
-            inputs={"input": {"description": "The user request.", "format": "text"}},
+            inputs={"input": {"description": "The user request."}},
         )
     )
 
@@ -47,10 +46,9 @@ def test_gallery_metadata_contract(compiler_module: ModuleType) -> None:
         "scope": "trace",
         "recommended": True,
         "category": "response_quality",
-        "kind": "CODE",
         "details": "Detailed guidance.",
         "substitutions": {"unused_placeholder": "available_tools_list"},
-        "inputs": {"input": {"description": "The user request.", "format": "text"}},
+        "inputs": {"input": {"description": "The user request."}},
     }
 
 
@@ -90,9 +88,8 @@ def test_python_generator_emits_gallery_metadata() -> None:
             scope="span",
             recommended=True,
             category="response_quality",
-            kind="CODE",
             details="Detailed guidance.",
-            inputs={"input": {"description": "Input", "format": "text"}},
+            inputs={"input": {"description": "Input"}},
         )
     )
 
@@ -101,6 +98,5 @@ def test_python_generator_emits_gallery_metadata() -> None:
     assert "scope=EvaluatorScope.SPAN" in source
     assert "recommended=True" in source
     assert "category=EvaluatorCategory.RESPONSE_QUALITY" in source
-    assert "kind=EvaluatorKind.CODE" in source
     assert "details='Detailed guidance.'" in source
-    assert "inputs={'input': EvaluatorInput(description='Input', format='text')}" in source
+    assert "inputs={'input': EvaluatorInput(description='Input')}" in source

--- a/tests/unit/scripts/prompts/test_compile_prompts.py
+++ b/tests/unit/scripts/prompts/test_compile_prompts.py
@@ -1,0 +1,146 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.fixture(params=["compile_python_prompts", "compile_typescript_prompts"])
+def compiler_module(request: pytest.FixtureRequest) -> ModuleType:
+    module_path = Path(__file__).parents[4] / "scripts" / "prompts" / f"{request.param}.py"
+    spec = spec_from_file_location(request.param, module_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "name": "test_evaluator",
+        "description": "Test evaluator",
+        "optimization_direction": "maximize",
+        "messages": [{"role": "user", "content": "Input: {{input}}"}],
+        "choices": {"yes": 1, "no": 0},
+    }
+    config.update(overrides)
+    return config
+
+
+def test_gallery_metadata_survives_parsing(compiler_module: ModuleType) -> None:
+    model = compiler_module.ClassificationEvaluatorConfig.model_validate(
+        _config(
+            scope="trace",
+            recommended=True,
+            category="response_quality",
+            kind="CODE",
+            details="Use this to judge a response.",
+            inputs={"input": {"description": "The user request.", "format": "text"}},
+            docs_link="https://example.com/evaluators/test",
+        )
+    )
+
+    assert model.scope.value == "trace"
+    assert model.recommended is True
+    assert model.category.value == "response_quality"
+    assert model.kind.value == "CODE"
+    assert model.inputs["input"].description == "The user request."
+    assert model.inputs["input"].format == "text"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("scope", "project"), ("category", "quality"), ("kind", "BUILTIN")],
+)
+def test_invalid_metadata_enum_fails(compiler_module: ModuleType, field: str, value: str) -> None:
+    with pytest.raises(ValidationError):
+        compiler_module.ClassificationEvaluatorConfig.model_validate(_config(**{field: value}))
+
+
+def test_omitted_metadata_is_backward_compatible(compiler_module: ModuleType) -> None:
+    model = compiler_module.ClassificationEvaluatorConfig.model_validate(_config())
+
+    assert model.scope is None
+    assert model.recommended is False
+    assert model.category is None
+    assert model.kind.value == "LLM"
+    assert model.inputs is None
+
+
+def test_python_generator_emits_only_supplied_metadata() -> None:
+    module_path = Path(__file__).parents[4] / "scripts" / "prompts" / "compile_python_prompts.py"
+    spec = spec_from_file_location("compile_python_prompts_generation", module_path)
+    assert spec and spec.loader
+    compiler_module = module_from_spec(spec)
+    spec.loader.exec_module(compiler_module)
+
+    legacy_config = compiler_module.ClassificationEvaluatorConfig.model_validate(_config())
+    legacy_source = compiler_module.get_prompt_file_contents(legacy_config, "TEST_CONFIG")
+    assert "scope=" not in legacy_source
+    assert "recommended=" not in legacy_source
+
+    gallery_config = compiler_module.ClassificationEvaluatorConfig.model_validate(
+        _config(
+            scope="span",
+            category="response_quality",
+            inputs={"input": {"description": "Input"}},
+        )
+    )
+    gallery_source = compiler_module.get_prompt_file_contents(gallery_config, "TEST_CONFIG")
+    assert "scope='span'" in gallery_source
+    assert "category='response_quality'" in gallery_source
+    assert "inputs={'input': {'description': 'Input'}}" in gallery_source
+    assert "<Evaluator" not in gallery_source
+
+
+def test_inputs_match_direct_variables_and_substitutions(compiler_module: ModuleType) -> None:
+    model = compiler_module.ClassificationEvaluatorConfig.model_validate(
+        _config(
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        "{{input}} {{#items}}{{name}}{{/items}} {{^missing}}none{{/missing}} "
+                        "{{! ignored }} {{{.}}} {{output.value}} {{available_tools}}"
+                    ),
+                }
+            ],
+            substitutions={"available_tools": "available_tools_list"},
+            inputs={
+                "input": {"description": "Input"},
+                "available_tools": {"description": "Available tools"},
+            },
+        )
+    )
+
+    assert set(model.inputs) == {"input", "available_tools"}
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        {"input": {"description": "Input"}, "unused": {"description": "Unused"}},
+        {},
+    ],
+)
+def test_inputs_must_exactly_match_source_variables(
+    compiler_module: ModuleType, inputs: dict[str, dict[str, str]]
+) -> None:
+    with pytest.raises(ValidationError):
+        compiler_module.ClassificationEvaluatorConfig.model_validate(_config(inputs=inputs))
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        {"": {"description": "Input"}},
+        {"input": {"description": "  "}},
+    ],
+)
+def test_input_names_and_descriptions_must_not_be_empty(
+    compiler_module: ModuleType, inputs: dict[str, dict[str, str]]
+) -> None:
+    with pytest.raises(ValidationError):
+        compiler_module.ClassificationEvaluatorConfig.model_validate(_config(inputs=inputs))

--- a/tests/unit/scripts/prompts/test_compile_prompts.py
+++ b/tests/unit/scripts/prompts/test_compile_prompts.py
@@ -88,13 +88,19 @@ def test_python_generator_emits_gallery_metadata() -> None:
     config = compiler_module.ClassificationEvaluatorConfig.model_validate(
         _config(
             scope="span",
+            recommended=True,
             category="response_quality",
-            inputs={"input": {"description": "Input"}},
+            kind="CODE",
+            details="Detailed guidance.",
+            inputs={"input": {"description": "Input", "format": "text"}},
         )
     )
 
     source = compiler_module.get_prompt_file_contents(config, "TEST_CONFIG")
 
-    assert "scope='span'" in source
-    assert "category='response_quality'" in source
-    assert "inputs={'input': {'description': 'Input'}}" in source
+    assert "scope=EvaluatorScope.SPAN" in source
+    assert "recommended=True" in source
+    assert "category=EvaluatorCategory.RESPONSE_QUALITY" in source
+    assert "kind=EvaluatorKind.CODE" in source
+    assert "details='Detailed guidance.'" in source
+    assert "inputs={'input': EvaluatorInput(description='Input', format='text')}" in source

--- a/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
+++ b/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
@@ -10,7 +10,7 @@ from phoenix.__generated__.classification_evaluator_configs import (
 )
 from phoenix.server.api.helpers.classification_evaluator_configs import (
     get_classification_evaluator_configs,
-    is_gallery_ready,
+    get_evaluator_gallery_configs,
 )
 
 
@@ -43,23 +43,7 @@ def make_config(
     return _make_config
 
 
-def test_gallery_readiness_requires_complete_metadata(
-    make_config: Callable[..., ClassificationEvaluatorConfig],
-) -> None:
-    ready = make_config()
-    missing_scope = make_config(scope=None)
-    missing_category = make_config(category=None)
-    missing_details = make_config(details=None)
-    empty_inputs = make_config(inputs=None)
-
-    assert is_gallery_ready(ready)
-    assert not is_gallery_ready(missing_scope)
-    assert not is_gallery_ready(missing_category)
-    assert not is_gallery_ready(missing_details)
-    assert not is_gallery_ready(empty_inputs)
-
-
-def test_gallery_filter_ignores_labels_and_uses_stable_order(
+def test_gallery_includes_all_configs_and_uses_stable_order(
     make_config: Callable[..., ClassificationEvaluatorConfig],
 ) -> None:
     make_config(name="zeta", recommended=False, category="agents", labels=[])
@@ -72,12 +56,15 @@ def test_gallery_filter_ignores_labels_and_uses_stable_order(
     make_config(name="alpha", recommended=True, category="agents", labels=[])
     make_config(name="partial", scope=None, labels=["requested"])
 
-    gallery_configs = get_classification_evaluator_configs(labels=["requested"], gallery_ready=True)
+    gallery_configs = get_evaluator_gallery_configs()
+    test_configs = [
+        config for config in gallery_configs if config.name in {"alpha", "beta", "partial", "zeta"}
+    ]
 
-    assert [config.name for config in gallery_configs] == ["alpha", "beta", "zeta"]
+    assert [config.name for config in test_configs] == ["alpha", "beta", "zeta", "partial"]
 
 
-def test_gallery_expands_substitutions_before_returning_config(
+def test_gallery_preserves_raw_templates(
     make_config: Callable[..., ClassificationEvaluatorConfig],
 ) -> None:
     make_config(
@@ -87,10 +74,10 @@ def test_gallery_expands_substitutions_before_returning_config(
         inputs={"available_tools": {"description": "Available tools"}},
     )
 
-    gallery_configs = get_classification_evaluator_configs(gallery_ready=True)
+    gallery_configs = get_evaluator_gallery_configs()
     tools_config = next(config for config in gallery_configs if config.name == "tools")
 
-    assert "{{#output.available_tools}}" in tools_config.messages[0].content
+    assert tools_config.messages[0].content == "{{available_tools}}"
 
 
 def test_legacy_filter_and_order_are_unchanged(

--- a/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
+++ b/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
@@ -1,6 +1,3 @@
-from collections.abc import Callable
-from typing import Any
-
 import pytest
 
 import phoenix.__generated__.classification_evaluator_configs as configs_module
@@ -9,84 +6,50 @@ from phoenix.__generated__.classification_evaluator_configs import (
     PromptMessage,
 )
 from phoenix.server.api.helpers.classification_evaluator_configs import (
-    get_classification_evaluator_configs,
     get_evaluator_gallery_configs,
 )
 
 
-@pytest.fixture
-def make_config(
+def test_gallery_returns_all_configs_in_order_without_expanding_templates(
     monkeypatch: pytest.MonkeyPatch,
-) -> Callable[..., ClassificationEvaluatorConfig]:
-    config_index = 0
-
-    def _make_config(**overrides: Any) -> ClassificationEvaluatorConfig:
-        nonlocal config_index
-        config_index += 1
-        values: dict[str, Any] = {
-            "name": f"test_{config_index}",
-            "description": "Test evaluator",
-            "optimization_direction": "maximize",
-            "messages": [PromptMessage(role="user", content="{{input}}")],
-            "choices": {"yes": 1, "no": 0},
-            "scope": "span",
-            "category": "response_quality",
-            "details": "Test details",
-            "inputs": {"input": {"description": "Input"}},
-        }
-        values.update(overrides)
-        config = ClassificationEvaluatorConfig.model_validate(values)
-        attribute_name = f"TEST_{config_index}_CLASSIFICATION_EVALUATOR_CONFIG"
-        monkeypatch.setattr(configs_module, attribute_name, config, raising=False)
-        return config
-
-    return _make_config
-
-
-def test_gallery_includes_all_configs_and_uses_stable_order(
-    make_config: Callable[..., ClassificationEvaluatorConfig],
 ) -> None:
-    make_config(name="zeta", recommended=False, category="agents", labels=[])
-    make_config(
-        name="beta",
-        recommended=True,
-        category="response_quality",
-        labels=["not_requested"],
-    )
-    make_config(name="alpha", recommended=True, category="agents", labels=[])
-    make_config(name="partial", scope=None, labels=["requested"])
+    def make_config(name: str, *, recommended: bool) -> ClassificationEvaluatorConfig:
+        return ClassificationEvaluatorConfig.model_validate(
+            {
+                "name": name,
+                "description": "Test evaluator",
+                "optimization_direction": "maximize",
+                "messages": [PromptMessage(role="user", content="{{available_tools}}")],
+                "choices": {"yes": 1, "no": 0},
+                "substitutions": {"available_tools": "available_tools_list"},
+                "scope": "span",
+                "recommended": recommended,
+                "category": "agents",
+                "details": "Test details",
+                "inputs": {"available_tools": {"description": "Available tools"}},
+            }
+        )
 
-    gallery_configs = get_evaluator_gallery_configs()
-    test_configs = [
-        config for config in gallery_configs if config.name in {"alpha", "beta", "partial", "zeta"}
+    recommended = make_config("recommended", recommended=True)
+    standard = make_config("standard", recommended=False)
+    monkeypatch.setattr(
+        configs_module,
+        "TEST_RECOMMENDED_CLASSIFICATION_EVALUATOR_CONFIG",
+        recommended,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        configs_module,
+        "TEST_STANDARD_CLASSIFICATION_EVALUATOR_CONFIG",
+        standard,
+        raising=False,
+    )
+
+    configs = [
+        config
+        for config in get_evaluator_gallery_configs()
+        if config.name in {"recommended", "standard"}
     ]
 
-    assert [config.name for config in test_configs] == ["alpha", "beta", "zeta", "partial"]
-
-
-def test_gallery_preserves_raw_templates(
-    make_config: Callable[..., ClassificationEvaluatorConfig],
-) -> None:
-    make_config(
-        name="tools",
-        messages=[PromptMessage(role="user", content="{{available_tools}}")],
-        substitutions={"available_tools": "available_tools_list"},
-        inputs={"available_tools": {"description": "Available tools"}},
-    )
-
-    gallery_configs = get_evaluator_gallery_configs()
-    tools_config = next(config for config in gallery_configs if config.name == "tools")
-
-    assert tools_config.messages[0].content == "{{available_tools}}"
-
-
-def test_legacy_filter_and_order_are_unchanged(
-    make_config: Callable[..., ClassificationEvaluatorConfig],
-) -> None:
-    first = make_config(name="zeta", labels=["requested"])
-    second = make_config(name="alpha", labels=["requested"])
-    make_config(name="ignored", labels=[])
-
-    configs = get_classification_evaluator_configs(labels=["requested"])
-
-    assert [config.name for config in configs] == [first.name, second.name]
+    assert configs == [recommended, standard]
+    assert standard.messages[0].content == "{{available_tools}}"

--- a/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
+++ b/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
@@ -6,11 +6,11 @@ from phoenix.__generated__.classification_evaluator_configs import (
     PromptMessage,
 )
 from phoenix.server.api.helpers.classification_evaluator_configs import (
-    get_evaluator_gallery_configs,
+    get_classification_evaluator_configs,
 )
 
 
-def test_gallery_returns_all_configs_in_order_without_expanding_templates(
+def test_gallery_returns_complete_configs_in_order_without_expanding_templates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def make_config(name: str, *, recommended: bool) -> ClassificationEvaluatorConfig:
@@ -32,6 +32,7 @@ def test_gallery_returns_all_configs_in_order_without_expanding_templates(
 
     recommended = make_config("recommended", recommended=True)
     standard = make_config("standard", recommended=False)
+    incomplete = standard.model_copy(update={"name": "incomplete", "inputs": None})
     monkeypatch.setattr(
         configs_module,
         "TEST_RECOMMENDED_CLASSIFICATION_EVALUATOR_CONFIG",
@@ -44,11 +45,17 @@ def test_gallery_returns_all_configs_in_order_without_expanding_templates(
         standard,
         raising=False,
     )
+    monkeypatch.setattr(
+        configs_module,
+        "TEST_INCOMPLETE_CLASSIFICATION_EVALUATOR_CONFIG",
+        incomplete,
+        raising=False,
+    )
 
     configs = [
         config
-        for config in get_evaluator_gallery_configs()
-        if config.name in {"recommended", "standard"}
+        for config in get_classification_evaluator_configs(gallery_ready=True)
+        if config.name in {"recommended", "standard", "incomplete"}
     ]
 
     assert configs == [recommended, standard]

--- a/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
+++ b/tests/unit/server/api/helpers/test_classification_evaluator_configs.py
@@ -1,0 +1,105 @@
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+import phoenix.__generated__.classification_evaluator_configs as configs_module
+from phoenix.__generated__.classification_evaluator_configs import (
+    ClassificationEvaluatorConfig,
+    PromptMessage,
+)
+from phoenix.server.api.helpers.classification_evaluator_configs import (
+    get_classification_evaluator_configs,
+    is_gallery_ready,
+)
+
+
+@pytest.fixture
+def make_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[..., ClassificationEvaluatorConfig]:
+    config_index = 0
+
+    def _make_config(**overrides: Any) -> ClassificationEvaluatorConfig:
+        nonlocal config_index
+        config_index += 1
+        values: dict[str, Any] = {
+            "name": f"test_{config_index}",
+            "description": "Test evaluator",
+            "optimization_direction": "maximize",
+            "messages": [PromptMessage(role="user", content="{{input}}")],
+            "choices": {"yes": 1, "no": 0},
+            "scope": "span",
+            "category": "response_quality",
+            "details": "Test details",
+            "inputs": {"input": {"description": "Input"}},
+        }
+        values.update(overrides)
+        config = ClassificationEvaluatorConfig.model_validate(values)
+        attribute_name = f"TEST_{config_index}_CLASSIFICATION_EVALUATOR_CONFIG"
+        monkeypatch.setattr(configs_module, attribute_name, config, raising=False)
+        return config
+
+    return _make_config
+
+
+def test_gallery_readiness_requires_complete_metadata(
+    make_config: Callable[..., ClassificationEvaluatorConfig],
+) -> None:
+    ready = make_config()
+    missing_scope = make_config(scope=None)
+    missing_category = make_config(category=None)
+    missing_details = make_config(details=None)
+    empty_inputs = make_config(inputs=None)
+
+    assert is_gallery_ready(ready)
+    assert not is_gallery_ready(missing_scope)
+    assert not is_gallery_ready(missing_category)
+    assert not is_gallery_ready(missing_details)
+    assert not is_gallery_ready(empty_inputs)
+
+
+def test_gallery_filter_ignores_labels_and_uses_stable_order(
+    make_config: Callable[..., ClassificationEvaluatorConfig],
+) -> None:
+    make_config(name="zeta", recommended=False, category="agents", labels=[])
+    make_config(
+        name="beta",
+        recommended=True,
+        category="response_quality",
+        labels=["not_requested"],
+    )
+    make_config(name="alpha", recommended=True, category="agents", labels=[])
+    make_config(name="partial", scope=None, labels=["requested"])
+
+    gallery_configs = get_classification_evaluator_configs(labels=["requested"], gallery_ready=True)
+
+    assert [config.name for config in gallery_configs] == ["alpha", "beta", "zeta"]
+
+
+def test_gallery_expands_substitutions_before_returning_config(
+    make_config: Callable[..., ClassificationEvaluatorConfig],
+) -> None:
+    make_config(
+        name="tools",
+        messages=[PromptMessage(role="user", content="{{available_tools}}")],
+        substitutions={"available_tools": "available_tools_list"},
+        inputs={"available_tools": {"description": "Available tools"}},
+    )
+
+    gallery_configs = get_classification_evaluator_configs(gallery_ready=True)
+    tools_config = next(config for config in gallery_configs if config.name == "tools")
+
+    assert "{{#output.available_tools}}" in tools_config.messages[0].content
+
+
+def test_legacy_filter_and_order_are_unchanged(
+    make_config: Callable[..., ClassificationEvaluatorConfig],
+) -> None:
+    first = make_config(name="zeta", labels=["requested"])
+    second = make_config(name="alpha", labels=["requested"])
+    make_config(name="ignored", labels=[])
+
+    configs = get_classification_evaluator_configs(labels=["requested"])
+
+    assert [config.name for config in configs] == [first.name, second.name]

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -60,7 +60,11 @@ async def test_evaluator_gallery_configs_contract(
             "inputs": {"input": {"description": "The user request."}},
         }
     )
-    monkeypatch.setattr(queries, "get_evaluator_gallery_configs", lambda: [config])
+    monkeypatch.setattr(
+        queries,
+        "get_classification_evaluator_configs",
+        lambda *, gallery_ready: [config] if gallery_ready else [],
+    )
 
     response = await gql_client.execute(
         query="""

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -103,17 +103,12 @@ class TestEvaluatorGalleryConfigsQuery:
             labels=["legacy"],
         )
 
-        def get_configs(
-            labels: Optional[list[str]] = None,
-            *,
-            gallery_ready: bool = False,
-        ) -> list[ClassificationEvaluatorConfig]:
-            if gallery_ready:
-                return [ready]
+        def get_configs(labels: Optional[list[str]] = None) -> list[ClassificationEvaluatorConfig]:
             assert labels == ["legacy"]
             return [legacy]
 
         monkeypatch.setattr(queries, "get_classification_evaluator_configs", get_configs)
+        monkeypatch.setattr(queries, "get_evaluator_gallery_configs", lambda: [ready])
 
         response = await gql_client.execute(query=self._QUERY)
 

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -56,9 +56,8 @@ async def test_evaluator_gallery_configs_contract(
             "scope": "trace",
             "recommended": True,
             "category": "response_quality",
-            "kind": "LLM",
             "details": "Detailed guidance.",
-            "inputs": {"input": {"description": "The user request.", "format": "text"}},
+            "inputs": {"input": {"description": "The user request."}},
         }
     )
     monkeypatch.setattr(queries, "get_evaluator_gallery_configs", lambda: [config])
@@ -67,8 +66,8 @@ async def test_evaluator_gallery_configs_contract(
         query="""
           query {
             evaluatorGalleryConfigs {
-              name scope recommended category kind details
-              inputs { name description format }
+              name scope recommended category details
+              inputs { name description }
             }
           }
         """
@@ -81,9 +80,8 @@ async def test_evaluator_gallery_configs_contract(
                 "scope": "TRACE",
                 "recommended": True,
                 "category": "RESPONSE_QUALITY",
-                "kind": "LLM",
                 "details": "Detailed guidance.",
-                "inputs": [{"name": "input", "description": "The user request.", "format": "text"}],
+                "inputs": [{"name": "input", "description": "The user request."}],
             }
         ]
     }

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -57,7 +57,6 @@ class TestEvaluatorGalleryConfigsQuery:
           kind
           details
           inputs { name description format }
-          docsLink
         }
         classificationEvaluatorConfigs(labels: ["legacy"]) {
           name
@@ -91,7 +90,6 @@ class TestEvaluatorGalleryConfigsQuery:
                 "kind": "LLM",
                 "details": "Use for end-to-end response quality.",
                 "inputs": {"input": {"description": "The user request.", "format": "text"}},
-                "docs_link": "https://example.com/quality",
             }
         )
         legacy = ClassificationEvaluatorConfig(
@@ -139,7 +137,6 @@ class TestEvaluatorGalleryConfigsQuery:
                             "format": "text",
                         }
                     ],
-                    "docsLink": "https://example.com/quality",
                 }
             ],
             "classificationEvaluatorConfigs": [{"name": "legacy", "labels": ["legacy"]}],

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -36,111 +36,58 @@ from tests.unit.graphql import AsyncGraphQLClient
 _REDACTOR = Redactor(secret=SecretStr(""))
 
 
-class TestEvaluatorGalleryConfigsQuery:
-    _QUERY = """
-      query {
-        evaluatorGalleryConfigs {
-          name
-          description
-          optimizationDirection
-          messages {
-            role
-            content {
-              ... on TextContentPart { text { text } }
+async def test_evaluator_gallery_configs_contract(
+    gql_client: AsyncGraphQLClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from phoenix.__generated__.classification_evaluator_configs import (
+        ClassificationEvaluatorConfig,
+        PromptMessage,
+    )
+    from phoenix.server.api import queries
+
+    config = ClassificationEvaluatorConfig.model_validate(
+        {
+            "name": "quality",
+            "description": "Quality evaluator",
+            "optimization_direction": "maximize",
+            "messages": [PromptMessage(role="user", content="Review {{input}}")],
+            "choices": {"good": 1, "bad": 0},
+            "scope": "trace",
+            "recommended": True,
+            "category": "response_quality",
+            "kind": "LLM",
+            "details": "Detailed guidance.",
+            "inputs": {"input": {"description": "The user request.", "format": "text"}},
+        }
+    )
+    monkeypatch.setattr(queries, "get_evaluator_gallery_configs", lambda: [config])
+
+    response = await gql_client.execute(
+        query="""
+          query {
+            evaluatorGalleryConfigs {
+              name scope recommended category kind details
+              inputs { name description format }
             }
           }
-          choices
-          labels
-          scope
-          recommended
-          category
-          kind
-          details
-          inputs { name description format }
-        }
-        classificationEvaluatorConfigs(labels: ["legacy"]) {
-          name
-          labels
-        }
-      }
-    """
+        """
+    )
 
-    async def test_returns_enriched_gallery_configs_without_changing_legacy_query(
-        self,
-        gql_client: AsyncGraphQLClient,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        from phoenix.__generated__.classification_evaluator_configs import (
-            ClassificationEvaluatorConfig,
-            PromptMessage,
-        )
-        from phoenix.server.api import queries
-
-        ready = ClassificationEvaluatorConfig.model_validate(
+    assert response.data == {
+        "evaluatorGalleryConfigs": [
             {
                 "name": "quality",
-                "description": "Quality evaluator",
-                "optimization_direction": "maximize",
-                "messages": [PromptMessage(role="user", content="Review {{input}}")],
-                "choices": {"good": 1, "bad": 0},
-                "labels": ["promoted_dataset_evaluator"],
-                "scope": "trace",
+                "scope": "TRACE",
                 "recommended": True,
-                "category": "response_quality",
+                "category": "RESPONSE_QUALITY",
                 "kind": "LLM",
-                "details": "Use for end-to-end response quality.",
-                "inputs": {"input": {"description": "The user request.", "format": "text"}},
+                "details": "Detailed guidance.",
+                "inputs": [{"name": "input", "description": "The user request.", "format": "text"}],
             }
-        )
-        legacy = ClassificationEvaluatorConfig(
-            name="legacy",
-            description="Legacy evaluator",
-            optimization_direction="neutral",
-            messages=[PromptMessage(role="user", content="{{input}}")],
-            choices={"yes": 1, "no": 0},
-            labels=["legacy"],
-        )
-
-        def get_configs(labels: Optional[list[str]] = None) -> list[ClassificationEvaluatorConfig]:
-            assert labels == ["legacy"]
-            return [legacy]
-
-        monkeypatch.setattr(queries, "get_classification_evaluator_configs", get_configs)
-        monkeypatch.setattr(queries, "get_evaluator_gallery_configs", lambda: [ready])
-
-        response = await gql_client.execute(query=self._QUERY)
-
-        assert not response.errors
-        assert response.data == {
-            "evaluatorGalleryConfigs": [
-                {
-                    "name": "quality",
-                    "description": "Quality evaluator",
-                    "optimizationDirection": "MAXIMIZE",
-                    "messages": [
-                        {
-                            "role": "USER",
-                            "content": [{"text": {"text": "Review {{input}}"}}],
-                        }
-                    ],
-                    "choices": {"good": 1.0, "bad": 0.0},
-                    "labels": ["promoted_dataset_evaluator"],
-                    "scope": "TRACE",
-                    "recommended": True,
-                    "category": "RESPONSE_QUALITY",
-                    "kind": "LLM",
-                    "details": "Use for end-to-end response quality.",
-                    "inputs": [
-                        {
-                            "name": "input",
-                            "description": "The user request.",
-                            "format": "text",
-                        }
-                    ],
-                }
-            ],
-            "classificationEvaluatorConfigs": [{"name": "legacy", "labels": ["legacy"]}],
-        }
+        ]
+    }
+    assert not response.errors
 
 
 async def test_projects_omits_experiment_projects(

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -36,6 +36,121 @@ from tests.unit.graphql import AsyncGraphQLClient
 _REDACTOR = Redactor(secret=SecretStr(""))
 
 
+class TestEvaluatorGalleryConfigsQuery:
+    _QUERY = """
+      query {
+        evaluatorGalleryConfigs {
+          name
+          description
+          optimizationDirection
+          messages {
+            role
+            content {
+              ... on TextContentPart { text { text } }
+            }
+          }
+          choices
+          labels
+          scope
+          recommended
+          category
+          kind
+          details
+          inputs { name description format }
+          docsLink
+        }
+        classificationEvaluatorConfigs(labels: ["legacy"]) {
+          name
+          labels
+        }
+      }
+    """
+
+    async def test_returns_enriched_gallery_configs_without_changing_legacy_query(
+        self,
+        gql_client: AsyncGraphQLClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from phoenix.__generated__.classification_evaluator_configs import (
+            ClassificationEvaluatorConfig,
+            PromptMessage,
+        )
+        from phoenix.server.api import queries
+
+        ready = ClassificationEvaluatorConfig.model_validate(
+            {
+                "name": "quality",
+                "description": "Quality evaluator",
+                "optimization_direction": "maximize",
+                "messages": [PromptMessage(role="user", content="Review {{input}}")],
+                "choices": {"good": 1, "bad": 0},
+                "labels": ["promoted_dataset_evaluator"],
+                "scope": "trace",
+                "recommended": True,
+                "category": "response_quality",
+                "kind": "LLM",
+                "details": "Use for end-to-end response quality.",
+                "inputs": {"input": {"description": "The user request.", "format": "text"}},
+                "docs_link": "https://example.com/quality",
+            }
+        )
+        legacy = ClassificationEvaluatorConfig(
+            name="legacy",
+            description="Legacy evaluator",
+            optimization_direction="neutral",
+            messages=[PromptMessage(role="user", content="{{input}}")],
+            choices={"yes": 1, "no": 0},
+            labels=["legacy"],
+        )
+
+        def get_configs(
+            labels: Optional[list[str]] = None,
+            *,
+            gallery_ready: bool = False,
+        ) -> list[ClassificationEvaluatorConfig]:
+            if gallery_ready:
+                return [ready]
+            assert labels == ["legacy"]
+            return [legacy]
+
+        monkeypatch.setattr(queries, "get_classification_evaluator_configs", get_configs)
+
+        response = await gql_client.execute(query=self._QUERY)
+
+        assert not response.errors
+        assert response.data == {
+            "evaluatorGalleryConfigs": [
+                {
+                    "name": "quality",
+                    "description": "Quality evaluator",
+                    "optimizationDirection": "MAXIMIZE",
+                    "messages": [
+                        {
+                            "role": "USER",
+                            "content": [{"text": {"text": "Review {{input}}"}}],
+                        }
+                    ],
+                    "choices": {"good": 1.0, "bad": 0.0},
+                    "labels": ["promoted_dataset_evaluator"],
+                    "scope": "TRACE",
+                    "recommended": True,
+                    "category": "RESPONSE_QUALITY",
+                    "kind": "LLM",
+                    "details": "Use for end-to-end response quality.",
+                    "inputs": [
+                        {
+                            "name": "input",
+                            "description": "The user request.",
+                            "format": "text",
+                        }
+                    ],
+                    "docsLink": "https://example.com/quality",
+                }
+            ],
+            "classificationEvaluatorConfigs": [{"name": "legacy", "labels": ["legacy"]}],
+        }
+
+
 async def test_projects_omits_experiment_projects(
     gql_client: AsyncGraphQLClient,
     projects_with_and_without_experiments: Any,


### PR DESCRIPTION
## Summary

- Adds scope, recommended, category, kind, details, and inputs metadata to built-in evaluator configs.
- Defines gallery categories: grounding_and_retrieval, agents, response_quality, safety_and_security, and user_experience.
- The frontend should load built-in evaluators from the evaluatorGalleryConfigs GraphQL field, which returns all configs without expanding dataset substitutions.
- Updates the Python and TypeScript prompt compilers to validate and emit the metadata, and regenerates the config models shipped by Phoenix and phoenix-evals.

Review should focus on changes under `prompts/`, `scripts/prompts/`, and `src/phoenix/server/api/`.
