### PR TITLE
fix(docs): make RAG evaluation tutorial runnable on modern Phoenix

### DIFF
--- a/docs/phoenix/use-cases/rag-evaluation.mdx
+++ b/docs/phoenix/use-cases/rag-evaluation.mdx
@@ -44,7 +44,7 @@ There are five key stages within RAG, which will in turn be a part of any larger
 Now that we have understood the stages of RAG, let's build a pipeline. We will use [LlamaIndex](https://www.llamaindex.ai/) for RAG and [Phoenix Evals](/docs/phoenix/evaluation/llm-evals) for evaluation.
 
 ```python
-!pip install -qq "arize-phoenix[evals]" "openinference-instrumentation-llama-index" "llama-index" "llama-index-llms-openai" "openai>=1" gcsfs nest_asyncio scikit-learn 'httpx<0.28'
+!pip install -qq "arize-phoenix" "openinference-instrumentation-llama-index" "llama-index" "llama-index-llms-openai" "openai>=1" gcsfs nest_asyncio scikit-learn 'httpx<0.28'
 ```
 
 ```python expandable
@@ -421,13 +421,13 @@ retrieved_documents_relevance_df = await async_evaluate_dataframe(
 retrieved_documents_relevance_df.head()
 ```
 
-`async_evaluate_dataframe` returns the original columns alongside the evaluation results. Each `document_relevance_score` is a structured score, so we pull out its numeric value into an `eval_score` column to compute retrieval metrics. These metrics will help us understand how well the RAG system is performing.
+`async_evaluate_dataframe` returns the original columns alongside the evaluation results. Each `document_relevance_score` is a structured score, so we pull out its numeric value into an `eval_score` column to compute retrieval metrics.
 
 ```python
 documents_with_relevance_df = retrieved_documents_relevance_df.copy()
 documents_with_relevance_df["eval_score"] = documents_with_relevance_df[
     "document_relevance_score"
-].apply(lambda score: score["score"] if isinstance(score, dict) else score)
+].apply(lambda score: score.get("score") if isinstance(score, dict) else score)
 documents_with_relevance_df
 ```
 
@@ -592,7 +592,7 @@ qa_with_reference_df = (
 qa_with_reference_df
 ```
 
-Now that we have a dataset of the question, context, and response (`input`, `context`, and `output`), we now can measure how well the LLM is responding to the queries. For details on the QA correctness evaluation, see the [LLM Evals documentation](/docs/phoenix/evaluation/running-pre-tested-evals/q-and-a-on-retrieved-data).
+Now that we have a dataset of the question, context, and response (`input`, `context`, and `output`), we can now measure how well the LLM is responding to the queries. For details on the QA correctness evaluation, see the [LLM Evals documentation](/docs/phoenix/evaluation/running-pre-tested-evals/q-and-a-on-retrieved-data).
 
 ```python
 from phoenix.evals import LLM, async_evaluate_dataframe
@@ -613,7 +613,7 @@ The combined `results_df` contains a structured `correctness_score` and `faithfu
 
 ```python
 def extract_score(value):
-    return value["score"] if isinstance(value, dict) else value
+    return value.get("score") if isinstance(value, dict) else value
 
 
 qa_correctness_eval_df = pd.DataFrame({"score": results_df["correctness_score"].apply(extract_score)})

--- a/docs/phoenix/use-cases/rag-evaluation.mdx
+++ b/docs/phoenix/use-cases/rag-evaluation.mdx
@@ -44,7 +44,7 @@ There are five key stages within RAG, which will in turn be a part of any larger
 Now that we have understood the stages of RAG, let's build a pipeline. We will use [LlamaIndex](https://www.llamaindex.ai/) for RAG and [Phoenix Evals](/docs/phoenix/evaluation/llm-evals) for evaluation.
 
 ```python
-!pip install -qq "arize-phoenix[experimental,llama-index]>=2.0"
+!pip install -qq "arize-phoenix[evals]" "openinference-instrumentation-llama-index" "llama-index" "llama-index-llms-openai" "openai>=1" gcsfs nest_asyncio scikit-learn 'httpx<0.28'
 ```
 
 ```python expandable
@@ -60,9 +60,9 @@ from getpass import getpass
 
 import pandas as pd
 import phoenix as px
-from llama_index import SimpleDirectoryReader, VectorStoreIndex, set_global_handler
-from llama_index.llms import OpenAI
-from llama_index.node_parser import SimpleNodeParser
+from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.core.node_parser import SentenceSplitter
+from llama_index.llms.openai import OpenAI
 ```
 
 During this tutorial, we will capture all the data we need to evaluate our RAG pipeline using Phoenix Tracing. To enable this, simply start the phoenix application and instrument LlamaIndex.
@@ -108,7 +108,7 @@ documents = SimpleDirectoryReader("./data/paul_graham/").load_data()
 llm = OpenAI(model="gpt-4")
 
 # Build index with a chunk_size of 512
-node_parser = SimpleNodeParser.from_defaults(chunk_size=512)
+node_parser = SentenceSplitter.from_defaults(chunk_size=512)
 nodes = node_parser.get_nodes_from_documents(documents)
 vector_index = VectorStoreIndex(nodes)
 ```
@@ -161,10 +161,13 @@ Remember that we are using Phoenix Tracing to capture all the data we need to ev
 print("phoenix URL", px.active_session().url)
 ```
 
-We can access the traces by directly pulling the spans from the phoenix session.
+We can access the traces by directly pulling the spans using the Phoenix client.
 
 ```python
-spans_df = px.active_session().get_spans_dataframe()
+from phoenix.client import Client
+
+client = Client()
+spans_df = client.spans.get_spans_dataframe()
 ```
 
 ```python
@@ -264,10 +267,13 @@ llm = LLM(provider="openai", model="gpt-4o")
 
 
 async def generate_questions(row):
-    prompt = generate_questions_template.format(context=row["text"])
+    prompt = generate_questions_template.format(text=row["text"])
     response = await llm.async_generate_text(prompt=prompt)
+    # Models often wrap JSON in a Markdown code fence, so strip any backticks and a
+    # leading "json" language tag before parsing.
+    cleaned = response.strip().strip("`").removeprefix("json").strip()
     try:
-        return json.loads(response)
+        return json.loads(cleaned)
     except json.JSONDecodeError as e:
         return {"__error__": str(e)}
 
@@ -370,7 +376,7 @@ retrieved_documents_df = client.spans.get_spans_dataframe(
         "input.value",
     ).explode(
         "retrieval.documents",
-        reference="document.content",
+        document_text="document.content",
         document_score="document.score",
     )
 )
@@ -378,7 +384,7 @@ retrieved_documents_df = retrieved_documents_df.rename(columns={"input.value": "
 retrieved_documents_df
 ```
 
-|                                      |                                      | context.trace\_id                                 | input                                             | reference                                         | document\_score |
+|                                      |                                      | context.trace\_id                                 | input                                             | document\_text                                    | document\_score |
 | :----------------------------------- | :----------------------------------- | :------------------------------------------------- | :------------------------------------------------ | :------------------------------------------------ | :-------------- |
 | context.span\_id                     | document\_position                   |                                                   |                                                   |                                                   |                 |
 | b375be95-8e5e-4817-a29f-e18f7aaa3e98 | 0                                    | 20e0f915-e089-4e8e-8314-b68ffdffd7d1              | How does leaving YC affect the author's relati... | On one of them I realized I was ready to hand ... | 0.820411        |
@@ -415,12 +421,13 @@ retrieved_documents_relevance_df = await async_evaluate_dataframe(
 retrieved_documents_relevance_df.head()
 ```
 
-We can now combine the documents with the relevance evaluations to compute retrieval metrics. These metrics will help us understand how well the RAG system is performing.
+`async_evaluate_dataframe` returns the original columns alongside the evaluation results. Each `document_relevance_score` is a structured score, so we pull out its numeric value into an `eval_score` column to compute retrieval metrics. These metrics will help us understand how well the RAG system is performing.
 
 ```python
-documents_with_relevance_df = pd.concat(
-    [retrieved_documents_df, retrieved_documents_relevance_df.add_prefix("eval_")], axis=1
-)
+documents_with_relevance_df = retrieved_documents_relevance_df.copy()
+documents_with_relevance_df["eval_score"] = documents_with_relevance_df[
+    "document_relevance_score"
+].apply(lambda score: score["score"] if isinstance(score, dict) else score)
 documents_with_relevance_df
 ```
 
@@ -490,7 +497,9 @@ hit = pd.DataFrame(
 Let's now view the results in a combined dataframe.
 
 ```python
-retrievals_df = px.active_session().get_spans_dataframe("span_kind == 'RETRIEVER'")
+retrievals_df = client.spans.get_spans_dataframe(
+    query=SpanQuery().where("span_kind == 'RETRIEVER'")
+)
 rag_evaluation_dataframe = pd.concat(
     [
         retrievals_df["attributes.input.value"],
@@ -541,7 +550,7 @@ px_client.spans.log_span_annotations_dataframe(
     annotator_kind="LLM",
 )
 px_client.spans.log_document_annotations_dataframe(
-    dataframe=retrieved_documents_relevance_df,
+    dataframe=documents_with_relevance_df[["eval_score"]].rename(columns={"eval_score": "score"}),
     annotation_name="relevance",
     annotator_kind="LLM",
 )
@@ -558,26 +567,32 @@ from phoenix.client.types.spans import SpanQuery
 
 client = Client()
 
+# The query engine's top-level span holds the question (input) and the answer (output).
 root_df = client.spans.get_spans_dataframe(
-    query=SpanQuery().where("parent_id is None").select("input.value", "output.value")
-)
-root_df = root_df.rename(columns={"input.value": "input", "output.value": "output"})
+    query=SpanQuery()
+    .where("name == 'RetrieverQueryEngine.query'")
+    .select("input.value", "output.value", "trace_id")
+).rename(columns={"input.value": "input", "output.value": "output"})
 
+# The retriever span holds the documents that were used as context. We concatenate them into a
+# single string per span so we can evaluate each response against the context it was given.
 docs_df = client.spans.get_spans_dataframe(
     query=SpanQuery()
-    .where("span_kind == 'RETRIEVER'")
-    .select("parent_id")
-    .concat("retrieval.documents", reference="document.content")
+    .where("name == 'VectorIndexRetriever.retrieve'")
+    .select("trace_id")
+    .concat("retrieval.documents", context="document.content")
 )
-docs_df = docs_df.rename(columns={"parent_id": "span_id"})
 
-qa_with_reference_df = pd.concat([root_df, docs_df], axis=1, join="inner")
+# Join each answer to the context retrieved in the same trace.
+qa_with_reference_df = (
+    root_df.reset_index()
+    .merge(docs_df.reset_index()[["context.trace_id", "context"]], on="context.trace_id")
+    .set_index("context.span_id")
+)
 qa_with_reference_df
 ```
 
-174 rows × 3 columns
-
-Now that we have a dataset of the question, context, and response (input, reference, and output), we now can measure how well the LLM is responding to the queries. For details on the QA correctness evaluation, see the [LLM Evals documentation](/docs/phoenix/evaluation/running-pre-tested-evals/q-and-a-on-retrieved-data).
+Now that we have a dataset of the question, context, and response (`input`, `context`, and `output`), we now can measure how well the LLM is responding to the queries. For details on the QA correctness evaluation, see the [LLM Evals documentation](/docs/phoenix/evaluation/running-pre-tested-evals/q-and-a-on-retrieved-data).
 
 ```python
 from phoenix.evals import LLM, async_evaluate_dataframe
@@ -594,7 +609,17 @@ results_df = await async_evaluate_dataframe(
 )
 ```
 
+The combined `results_df` contains a structured `correctness_score` and `faithfulness_score` for each response. Let's pull out the numeric scores. Faithfulness measures whether the answer is grounded in the retrieved context, so we derive a hallucination score as `1 - faithfulness`.
+
 ```python
+def extract_score(value):
+    return value["score"] if isinstance(value, dict) else value
+
+
+qa_correctness_eval_df = pd.DataFrame({"score": results_df["correctness_score"].apply(extract_score)})
+hallucination_eval_df = pd.DataFrame(
+    {"score": 1 - results_df["faithfulness_score"].apply(extract_score)}
+)
 qa_correctness_eval_df.head()
 ```
 


### PR DESCRIPTION
Fixes #15357. The RAG evaluation tutorial mixed pre-0.10 LlamaIndex code with thecurrent `phoenix.evals` API and couldn't run end-to-end. This updates it to run top-to-bottom on Phoenix + LlamaIndex.