### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -73,7 +73,7 @@
 ### Advanced Tracing
 
 - [Cost Tracking](https://arize.com/docs/phoenix/tracing/how-to-tracing/cost-tracking): Monitor LLM token usage and cost trends
-- [Filter Expressions](https://arize.com/docs/phoenix/tracing/how-to-tracing/filter-expressions): Filter spans and sessions with Python-style filter expressions — operators, attribute/annotation access, session aggregates and comprehensions; where filters work and how to discover field names
+- [Filter Expressions](https://arize.com/docs/phoenix/tracing/how-to-tracing/filter-expressions): Filter spans and sessions with Python-style expressions — operators, attribute and annotation access, session aggregates
 - [Advanced Configuration](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced): Configure batching, gRPC transport, custom instrumentation, and performance tuning
 - [Masking Span Attributes](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes): Hide sensitive data in traces via environment variables
 - [Modifying Spans](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/modifying-spans): Use SpanProcessors to filter or enrich spans
@@ -190,7 +190,7 @@
 - [Dataset Evaluators](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/how-to-dataset-evaluators): Attach evaluators to datasets for automatic scoring
 - [Repetitions](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions): Run multiple iterations for statistical confidence
 - [Splits](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/splits): Organize datasets into train/test/validation splits
-- [Eval CI with pytest](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/eval-ci-with-pytest): Run LLM evals as pytest tests, record them as Phoenix experiments, and gate CI on the pytest exit code with arize-phoenix-client[pytest]
+- [Eval CI with pytest](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/eval-ci-with-pytest): Run evals as pytest tests with arize-phoenix-client[pytest], recorded as experiments and gating CI
 - [Run Experiments in the Background](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background): Start Playground experiments that keep running after you close the browser
 
 ## Prompt Engineering
@@ -363,6 +363,7 @@
 
 ### Python Frameworks — Additional
 
+- [AG2 Integration](https://arize.com/docs/phoenix/integrations/python/ag2): Connect AG2 (formerly AutoGen) conversable agents and group chats to Phoenix
 - [Agent Spec Integration](https://arize.com/docs/phoenix/integrations/python/agentspec): Connect Open Agent Spec agentic systems to Phoenix
 - [Agno Integration](https://arize.com/docs/phoenix/integrations/python/agno): Connect Agno model-agnostic Python agents to Phoenix
 - [AutoGen Integration](https://arize.com/docs/phoenix/integrations/python/autogen): Connect AutoGen multi-agent conversations to Phoenix
@@ -388,6 +389,7 @@
 
 - [Amazon Bedrock Integration](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock): Pick a Bedrock tracing or evals path across Python, TypeScript, and Agents
 - [Anthropic Integration](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic): Pick an Anthropic Claude tracing or evals path across Python, TypeScript, and Go
+- [Cohere Integration](https://arize.com/docs/phoenix/integrations/llm-providers/cohere): Trace Cohere chat, search, and RAG model calls in Phoenix
 - [Google GenAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai): Pick a Google GenAI and Gemini tracing or evals path
 - [Groq Integration](https://arize.com/docs/phoenix/integrations/llm-providers/groq): Trace Groq's low-latency LPU inference calls in Phoenix
 - [LiteLLM Integration](https://arize.com/docs/phoenix/integrations/llm-providers/litellm): Trace and evaluate calls routed through LiteLLM's unified 100+ model interface
@@ -571,7 +573,7 @@
 
 ### REST API — Chat Completions
 
-- [OpenAI-Compatible Chat Completions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/chat-completions/openai-compatible-chat-completions): POST /v1/chat/completions — OpenAI wire-format proxy; model is `{provider}:{model_name}` (or `custom:{provider_id}:{model_name}`), provider credentials resolved server-side, `stream: true` for SSE chunks, no tool calling
+- [OpenAI-Compatible Chat Completions](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/chat-completions/openai-compatible-chat-completions): POST /v1/chat/completions — OpenAI wire-format proxy with server-resolved credentials; model is `{provider}:{model_name}`, `stream: true` for SSE, no tool calling
 
 ### REST API — Datasets
 
@@ -740,21 +742,21 @@
 - [More Evaluation Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Index of notebook examples for faithfulness, toxicity, and retrieval relevance evals
 - [Creating a Custom LLM Evaluator with a Benchmark Dataset](https://arize.com/docs/phoenix/cookbook/evaluation/creating-a-custom-llm-evaluator-with-a-benchmark-dataset): Build an LLM-as-a-Judge evaluator and validate it against a labeled benchmark
 - [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Score router choices, tool calls, and answers for a data-querying agent
-- [Trace-level Evaluation: Beyond Input/Output Checks](https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation): Evaluate an agent's intermediate reasoning, tool selection, and decision path — not just its final answer.
-- [Session-level Evaluation: Scoring the Whole Conversation](https://arize.com/docs/phoenix/cookbook/evaluation/session-level-evaluation): Evaluate a multi-turn session as a whole - coherence, goal completion, and user frustration that turn-by-turn checks miss.
-- [Designing Realtime Guardrails: Input, Output, and the Cost of Blocking](https://arize.com/docs/phoenix/cookbook/guardrails/designing-realtime-guardrails): Decide what to guard at input vs. output, trade latency against coverage, and layer guardrails without blocking real users.
-- [Evaluate RAG](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag): Building a RAG pipeline and evaluating it with Phoenix Evals
+- [Trace-level Evaluation: Beyond Input/Output Checks](https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation): Evaluate an agent's intermediate reasoning, tool selection, and decision path — not just its final answer
+- [Session-level Evaluation: Scoring the Whole Conversation](https://arize.com/docs/phoenix/cookbook/evaluation/session-level-evaluation): Evaluate a multi-turn session as a whole — coherence, goal completion, and frustration that turn-by-turn checks miss
+- [Designing Realtime Guardrails: Input, Output, and the Cost of Blocking](https://arize.com/docs/phoenix/cookbook/guardrails/designing-realtime-guardrails): Decide what to guard at input vs. output, trade latency against coverage, and layer guardrails without blocking real users
+- [Evaluate RAG](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag): Build a RAG pipeline and score its retrieval and answer quality with Phoenix Evals
 - [OpenAI Agents SDK Cookbook](https://arize.com/docs/phoenix/cookbook/evaluation/openai-agents-sdk-cookbook): Instrument an OpenAI Agents SDK app and evaluate its handoffs and tool calls
 - [Relevance Classification Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/relevance-classification-evaluation): Evaluate the relevance of documents retrieved by RAG applications using Phoenix's evaluation framework
 - [Using Ragas to Evaluate a Math Problem-Solving Agent](https://arize.com/docs/phoenix/cookbook/evaluation/using-ragas-to-evaluate-a-math-problem-solving-agent): Score agent reasoning steps with Ragas metrics and log results to Phoenix
 - [Jailbreak and Prompt Injection Defense](https://arize.com/docs/phoenix/cookbook/guardrails/jailbreak-and-prompt-injection-defense): Red-team an assistant across a taxonomy of jailbreak and injection attacks, then score Attack Success Rate per defense
 - [Aligning LLM Evals with Human Feedback (TypeScript)](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/aligning-llm-evals-with-human-annotations-typescript): Tune a custom Mastra-agent evaluator until it agrees with human annotations
-- [Using Human Annotations for Eval Driven Development](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/using-human-annotations-for-eval-driven-development): How to leverage human annotations to build evaluations and experiments that improve your system
+- [Using Human Annotations for Eval Driven Development](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/using-human-annotations-for-eval-driven-development): Turn human annotations into evaluators and experiments that measurably improve your system
 - [Chain of Thought Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/chain-of-thought-prompting): Measure whether step-by-step reasoning prompts beat direct answers on your dataset
 - [Few Shot Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/few-shot-prompting): Compare zero-shot, one-shot, and few-shot prompt variants in an experiment
 - [LLM-as-a-Judge Prompt Optimization](https://arize.com/docs/phoenix/cookbook/prompt-engineering/llm-as-a-judge-prompt-optimization): Iterate on a judge's prompt until its scores track human labels
-- [Optimizing Coding Agent Prompts - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/optimizing-coding-agent-prompts-prompt-learning): Optimizing coding agent prompts and tracking coding agent improvement
-- [Optimizing Prompts for LLM Classification - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-learning-optimizing-prompts-for-classification): Using Prompt Learning to boost accuracy on a classification dataset
+- [Optimizing Coding Agent Prompts - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/optimizing-coding-agent-prompts-prompt-learning): Apply Prompt Learning to a coding agent and track its improvement across iterations
+- [Optimizing Prompts for LLM Classification - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-learning-optimizing-prompts-for-classification): Boost accuracy on a classification dataset with Prompt Learning
 - [Prompt Optimization Techniques](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-optimization): Benchmark meta-prompting, few-shot, and gradient-style prompt optimizers side by side
 - [ReAct Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/react-prompting): Build and evaluate a reason-then-act prompting loop with tool calls
 - [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): Build and trace an agentic RAG system using LlamaIndex's ReAct agent with vector and SQL query tools

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/chat-completions/openai-compatible-chat-completions.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/chat-completions/openai-compatible-chat-completions.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/chat/completions
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/update-an-experiment-by-id.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/update-an-experiment-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/experiments/{experiment_id}
+---


### PR DESCRIPTION
## Summary

Audited `docs/phoenix/llms.txt` against the full docs tree (`docs.json` navigation ∩ `.mdx` files on disk). Added the two nav-published pages that were missing, tightened descriptions that were over-long or that restated their title, and fixed two broken links the index already carried.

## Coverage audit

The symmetric difference between nav-published page paths and the URLs in `llms.txt` came back with **13 entries, all now accounted for**:

**Nav pages absent from `llms.txt` (9) — all intentional exclusions per the skill's rules:**

| Page | Reason |
| --- | --- |
| `agent-assisted-setup` | For AI coding agents, not doc consumers |
| `end-to-end-features-notebook` | Colab notebook link |
| `phoenix-demo` | Interactive demo, not fetchable content |
| `documentation/jp`, `documentation/zh` | Translated pages |
| `resources/github`, `resources/openinference` | Bare external links (frontmatter `url:` stubs, no page body) |
| `resources/python-api`, `resources/typescript-api` | Link stubs that redirect into the SDK reference already indexed |

**`llms.txt` entries not in sidebar nav (4) — all valid, kept:**

`get-started`, `evaluation/concepts-evals/evaluation-types`, `evaluation/concepts-evals/building-your-own-evals`, and `evaluation/concepts-evals/evaluating-multi-agent-systems` all have real `.mdx` files on disk and are live redirect destinations in `docs.json`. They resolve by URL; they're just not in the sidebar tree.

Net: **692 of 701 nav-published pages indexed (98.7%)** — 100% of pages eligible for inclusion, well above the AFDocs 80% threshold. No duplicate URLs; all 701 entry lines are well-formed per the llmstxt.org link format.

## Changes

### Added entries (2)

Both are provider/framework landing pages whose `*-tracing` child was already indexed but whose overview page was not — the only two integration index pages missing from the "— Additional" groups.

- **AG2 Integration** → `integrations/python/ag2`
- **Cohere Integration** → `integrations/llm-providers/cohere`

### Removed entries (0)

Nothing was stale.

### Description edits (10)

Trimmed entries over the 5–20 word guidance and rewrote descriptions that carried no signal beyond the title:

- **Filter Expressions**, **Eval CI with pytest**, **OpenAI-Compatible Chat Completions** — each ran 28–35 words; trimmed while keeping the distinguishing detail (operators/aggregates, the `[pytest]` extra, the model-string format).
- **Optimizing Coding Agent Prompts** — description restated the title verbatim; now says what you actually do.
- **Optimizing Prompts for LLM Classification**, **Evaluate RAG** — gerund phrasing (“Using…”, “Building…”) → imperative.
- **Using Human Annotations for Eval Driven Development** — dropped the “How to leverage…” filler opener.
- **Trace-level Evaluation**, **Session-level Evaluation**, **Designing Realtime Guardrails** — dropped trailing periods for consistency with the rest of the file; normalized a hyphen to an em dash.

## Also fixed: two broken REST API nav entries

`docs.json` listed two API-reference pages that had **no backing `.mdx` file**, so both nav entries — and the corresponding `llms.txt` links, which already existed — resolved to nothing:

- `sdk-api-reference/rest-api/api-reference/chat-completions/openai-compatible-chat-completions`
- `sdk-api-reference/rest-api/api-reference/experiments/update-an-experiment-by-id`

Both correspond to real operations in `schemas/openapi.json` (`POST /v1/chat/completions`, `PATCH /v1/experiments/{experiment_id}`), so I added the missing stubs following the same one-line `openapi:` frontmatter pattern every sibling page uses. Fixing these was preferable to deleting `llms.txt` entries for endpoints that genuinely ship.

## Verification

- Symmetric-difference audit against `docs.json` nav ∩ disk `.mdx` files (above).
- No duplicate URLs: `grep … | sort | uniq -d` returns empty.
- All 701 list lines match `- [Title](url): description`.
- ⚠️ The `phoenix-cli` parser tests (`pnpm test -- --grep "docs"`) could **not** be run — `pnpm` requires approval in this environment. The structural checks above are a substitute, not a replacement; CI should confirm.
