### PR TITLE
docs(skills): weekly audit — 2026-08-19

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -450,9 +450,10 @@ Key root fields: `projects`, `datasets`, `prompts`, `evaluators`, `projectCount`
 ### Span filter expressions
 
 `Project.spans` takes a `filterCondition` — a Python expression over per-span
-values, the same language the UI's spans/traces filter bar compiles. Annotations
-are reached through three subscript accessors, and **the accessor picks the
-grain**:
+values, the same language the UI's **spans** filter bar compiles. (The traces
+tab compiles the separate trace-grain language below; the two are siblings, not
+the same expression at different scopes.) Annotations are reached through three
+subscript accessors, and **the accessor picks the grain**:
 
 | Accessor | Matches annotations on | Written by |
 | -------- | ---------------------- | ---------- |
@@ -476,9 +477,89 @@ px api graphql '{
 
 Picking the wrong accessor fails silently rather than erroring: filtering with
 `annotations[...]` for an annotation that was written at the trace grain joins
-against span annotations and matches nothing. `trace_annotations` is
-span-filter-only — a `sessionFilterCondition` that uses it fails to compile with
-`` `trace_annotations` is only available when filtering spans ``.
+against span annotations and matches nothing.
+
+Accessors are scoped per grain, and only the span filter accepts more than one:
+
+| Filter | Accepted annotation accessors |
+| ------ | ----------------------------- |
+| `filterCondition` (span) | `annotations[...]`, `evals[...]`, `trace_annotations[...]` |
+| `traceFilterCondition` (trace) | `trace_annotations[...]` |
+| `sessionFilterCondition` (session) | `session_annotations[...]` |
+
+An accessor used at the wrong grain is a compile error, not a silent miss —
+e.g. `annotations[...]` in a trace filter fails with `` `annotations[...]` is
+not available in the trace filter; use `trace_annotations[...]` for trace
+annotations, or iterate `span_annotations` for span-level annotations ``.
+
+### Trace filter expressions
+
+`Project.spans` also takes a `traceFilterCondition` — a trace-grain expression
+that keeps spans whose **trace** matches. It is the language the UI's traces
+table compiles, and it is the grain to reach for when the question is about
+whole traces ("which traces errored and took over a second") rather than
+individual spans. Pair it with `rootSpansOnly: true` for one row per trace:
+
+```bash
+px api graphql '{
+  projects(first: 1) { edges { node { spans(
+    first: 20
+    rootSpansOnly: true
+    traceFilterCondition: "error_count > 0 and latency_ms > 1000"
+  ) { edges { node { spanId name latencyMs } } } } } }
+}' | jq '.data.projects.edges[0].node.spans.edges[].node'
+```
+
+`traceFilterCondition` and the span-grain `filterCondition` are **not** mutually
+exclusive on `spans` — passing both narrows to matching spans inside matching
+traces.
+
+Discover names and check an expression the same way as for sessions:
+
+```bash
+px api graphql '{ projects(first: 1) { edges { node { traceFilterVocabulary {
+  name type category description iterableName } } } } }' \
+  | jq '.data.projects.edges[0].node.traceFilterVocabulary[] | {name, type, category}'
+
+px api graphql '{ projects(first: 1) { edges { node {
+  validateTraceFilterCondition(condition: "error_count > 0") {
+    isValid errorMessage warnings }
+} } } }'
+```
+
+Bound names: the intrinsics `trace_id`, `start_time`, `end_time`, `latency_ms`;
+the span-derived rollups `num_spans`, `error_count`, `token_count_prompt`,
+`token_count_completion`, `token_count_total`, `prompt_cost`,
+`completion_cost`, `total_cost`, `tool_span_count`, `llm_span_count`; the
+root-span reads `input`, `output`, `attributes["llm.model_name"]`, `user.id`,
+and `metadata["key"]`; `trace_annotations["name"]` for trace annotations; and
+the iterables `spans`, `trace_annotations`, `span_annotations`, and
+`span_cost_details` for comprehensions (`any` / `all` / `len` / `sum` / `max` /
+`min`). Inside a `spans` comprehension each element exposes `name`,
+`parent_id`, `span_kind`, `status_code`, `start_time`, `end_time`,
+`latency_ms`, the `cumulative_*` subtree rollups, and the relations
+`parent_span`, `children`, `siblings`, `annotations`, and `cost_details`:
+
+```python
+any(span.span_kind == "LLM" and span.latency_ms > 5000 for span in spans)
+any(span.parent_span.span_kind == "LLM" and span.span_kind == "TOOL" for span in spans)
+any(annotation.label == "hallucinated" for annotation in span_annotations)
+```
+
+Four rules the trace grain legislates, the first two of which differ from the
+span grain:
+
+- **Unknown names are rejected**, with a `did you mean "…"?` suggestion. Span
+  filters instead read an unknown name as an attribute path, so a typo there
+  matches nothing silently; here it fails loudly.
+- **Rollups are `0`, never null.** `error_count == 0` matches traces with no
+  errors; there is no missing case to test with `is None`.
+- **Datetime literals need an explicit offset** — `start_time >=
+  "2026-07-01T00:00:00Z"`. A naive literal is rejected, as at every grain.
+- **Root-grain reads follow the displayed root.** `input`, `output`,
+  `attributes[...]`, `user.id`, and `metadata[...]` bind to the same
+  representative span the traces table shows, so a predicate matches what you
+  see. A trace with no root candidate has no values for these.
 
 ### Session filter expressions
 
@@ -520,8 +601,8 @@ Commonly bound names: `session_id`, `start_time`, `end_time`, `duration_ms`,
 (with `user.id` and `metadata["key"]` accepted as proxies), the iterables
 `spans`, `traces`, `session_annotations`, and `span_annotations` for
 comprehensions (`any(...)` / `all(...)` / `len([...])`), and
-`annotations["name"].score|.label` for session annotations. Three rules the DSL
-legislates and an agent will otherwise get wrong:
+`session_annotations["name"].score|.label` for session annotations. Three rules
+the DSL legislates and an agent will otherwise get wrong:
 
 - **A missing value fails every comparison, in both directions.** A session with
   no recorded input matches neither `'x' in first_input` nor its negation. Target

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -144,14 +144,14 @@ Axial coding categorizes the entities you took notes on during open coding. Use 
 
 ## Wrapping up
 
-After axial coding finishes, share the Phoenix UI link with the user. The link points to the project's traces table filtered by the `coding_session_id` annotation. The search param is `spanFilterCondition`, and the traces tab compiles a **span** filter — so the accessor must match the grain the annotation was written at: `trace_annotations['coding_session_id']` for a trace-grain run, `annotations['coding_session_id']` for a span-grain run. Both mistakes fail silently (see [open-coding.md](open-coding.md#wrapping-up)). The UI route `/projects/:projectId` expects an encoded GraphQL node ID, not a project name — resolve it via `px project get`:
+After axial coding finishes, share the Phoenix UI link with the user. The link points to the project's **spans** table filtered by the `coding_session_id` annotation. The search param is `spanFilterCondition`, which only applies on the `/spans` tab — the traces tab compiles a trace filter it keeps in component state, so the same link at `/traces` renders unfiltered behind a "Traces now use trace-level filters" notice. The spans tab compiles a **span** filter, so the accessor must match the grain the annotation was written at: `trace_annotations['coding_session_id']` for a trace-grain run, `annotations['coding_session_id']` for a span-grain run. Both mistakes fail silently (see [open-coding.md](open-coding.md#wrapping-up)). The UI route `/projects/:projectId` expects an encoded GraphQL node ID, not a project name — resolve it via `px project get`:
 
 ```bash
 project_id=$(px project get "$PHOENIX_PROJECT" --format raw --no-progress | jq -r '.id')
-# Trace-grain run. For a span-grain run swap in annotations[...] and the /spans tab.
+# Trace-grain run. For a span-grain run swap in annotations[...].
 encoded=$(python3 -c 'import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))' \
   "trace_annotations['coding_session_id'].label == '$CODING_ANNOTATION_IDENTIFIER'")
-echo "Phoenix UI: $PHOENIX_ENDPOINT/projects/$project_id/traces?spanFilterCondition=$encoded"
+echo "Phoenix UI: $PHOENIX_ENDPOINT/projects/$project_id/spans?spanFilterCondition=$encoded"
 ```
 
 If the user wants to discard everything this run produced (open-coding notes, axial-coding labels, and `coding_session_id` annotations on the server, plus the local sidecars), three identifier-bound deletes handle the server side and one `rm` handles the local sidecars. **Confirm before running** — destructive. Each `px <entity>-annotations delete` call requires `--all` to authorize the unbounded sweep; `--identifier` only narrows. Set `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` first if not already exported:

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -218,19 +218,20 @@ The local sidecar is the handoff record for notes written this run. Inspect it d
 
 ## Wrapping up
 
-When the run is done, share the Phoenix UI link with the user. The link filters the project's traces page by the `coding_session_id` annotation written alongside each note. Two details the UI legislates, and both fail *silently* when you get them wrong:
+When the run is done, share the Phoenix UI link with the user. The link filters the project's **spans** page by the `coding_session_id` annotation written alongside each note. Three details the UI legislates:
 
-- **The search param is `spanFilterCondition`.** An unrecognized param is dropped and the user lands on an unfiltered table.
-- **The traces and spans tabs both compile a *span* filter**, so the annotation accessor has to match the grain the annotation was written at — `trace_annotations['coding_session_id']` for a trace-grain run (`px trace annotate`), `annotations['coding_session_id']` for a span-grain run (`px span annotate`). A grain mismatch joins the wrong annotation table and matches nothing.
+- **The search param is `spanFilterCondition`.** An unrecognized param is dropped silently and the user lands on an unfiltered table.
+- **Link to the `/spans` tab, not `/traces`.** The traces tab now compiles a *trace* filter that lives in component state with no URL param of its own. A link that carries `spanFilterCondition` to `/traces` leaves that table unfiltered and pops a "Traces now use trace-level filters" notice; the condition only takes effect once the user switches to Spans.
+- **The spans tab compiles a *span* filter**, so the annotation accessor has to match the grain the annotation was written at — `trace_annotations['coding_session_id']` for a trace-grain run (`px trace annotate`), `annotations['coding_session_id']` for a span-grain run (`px span annotate`). A grain mismatch joins the wrong annotation table and matches nothing, silently.
 
 The UI route `/projects/:projectId` expects an encoded GraphQL node ID, not a project name — resolve it via `px project get`:
 
 ```bash
 project_id=$(px project get "$PHOENIX_PROJECT" --format raw --no-progress | jq -r '.id')
-# Trace-grain run. For a span-grain run swap in annotations[...] and the /spans tab.
+# Trace-grain run. For a span-grain run swap in annotations[...].
 encoded=$(python3 -c 'import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))' \
   "trace_annotations['coding_session_id'].label == '$CODING_ANNOTATION_IDENTIFIER'")
-echo "Phoenix UI: $PHOENIX_ENDPOINT/projects/$project_id/traces?spanFilterCondition=$encoded"
+echo "Phoenix UI: $PHOENIX_ENDPOINT/projects/$project_id/spans?spanFilterCondition=$encoded"
 ```
 
 A session-grain run has no equivalent link: the sessions tab keeps its filter in


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-08-12 → 2026-08-19

**Audited against:** `origin/main` at `43e5fbf883c1c67a0401c3e40bec200a9462ffd1`
**Commits analyzed:** 40 (1 user-facing feature landing skill edits, 39 skipped or
internal)

One commit in this window changed a surface the three external-facing skills
describe: `954cba214` — `feat(traces): expression filter DSL (#14973)`. It adds a
third filter language at the trace grain, renames the session grain's annotation
accessor, and retires the traces tab's URL filter param. Two of those three are
breaking for text the `phoenix-cli` skill already shipped.

## Edits applied

### phoenix-cli

- `SKILL.md` — **new section "Trace filter expressions"** for the trace-grain DSL
  added in `954cba214`. Documents the `traceFilterCondition` argument on
  `Project.spans` (`src/phoenix/server/api/types/Project.py:617`, applied at
  `:642-651`; schema at `js/app/schema.graphql:2999`), the discovery fields
  `Project.traceFilterVocabulary(timeRange)`
  (`src/phoenix/server/api/types/Project.py:1488-1549`) and
  `Project.validateTraceFilterCondition(condition)`
  (`src/phoenix/server/api/types/Project.py:1361-1380`, returns
  `ValidationResult { isValid errorMessage warnings }` —
  `js/app/schema.graphql:5090-5094`). Bound names, iterables, and span element
  fields are transcribed from `src/phoenix/trace/dsl/trace_filter.py`:
  aggregates `:53-72`, intrinsics `:79-85`, span element fields `:127-149`,
  iterables and nested relations `:168-215`, bindings `:270-307`. The
  strict-unknown-name rule is `reject_unbound_names=True`
  (`trace_filter.py:282`, suggestion text at `filter.py:2741`); the
  "0, never null" rollup rule is stated in `TRACE_FILTER_DESCRIPTIONS`
  (`trace_filter.py:321-348`); the displayed-root contract is from
  `internal_docs/specs/trace-filter-dsl.md:38-60`. Comprehension examples are
  the ones the same PR shipped in
  `docs/phoenix/tracing/how-to-tracing/filter-expressions.mdx`.
- `SKILL.md` — **corrected a now-wrong session-filter binding.** The skill said
  session annotations are read with `annotations["name"].score|.label`. As of
  `954cba214` the session grain accepts only `session_annotations[...]`;
  `annotations`, `evals`, and `trace_annotations` are rejected with explicit
  compile errors (`src/phoenix/trace/dsl/session_filter.py:313-333`). An agent
  following the old text would have written an expression that no longer
  compiles.
- `SKILL.md` — replaced the "`trace_annotations` is span-filter-only" paragraph
  (and its quoted error message, which no longer exists) with a per-grain
  accessor table: span filters accept `annotations` / `evals` /
  `trace_annotations` (`src/phoenix/trace/dsl/filter.py:31`), trace filters only
  `trace_annotations` (`trace_filter.py:286`), session filters only
  `session_annotations` (`session_filter.py:313`). The new error text is quoted
  verbatim from `trace_filter.py:289-293`.
- `SKILL.md` — narrowed "the same language the UI's spans/traces filter bar
  compiles" to the spans bar only, with a pointer to the trace section. The
  traces tab now compiles the trace DSL, not the span DSL.
- `references/open-coding.md` — **fixed the shareable UI link.** The wrap-up
  step told agents to hand the user
  `/projects/$id/traces?spanFilterCondition=…`. That link no longer filters:
  `LegacyTraceFilterParamNotice`
  (`js/app/src/pages/project/ProjectPage.tsx:161-182`, active on the traces tab
  at `:370-371`) leaves the table unfiltered and raises "Traces now use
  trace-level filters" / "The span-level filter from this link still applies on
  the Spans tab" (pinned in
  `js/app/src/pages/project/__tests__/LegacyTraceFilterParamNotice.test.tsx:49-57`).
  The traces tab's own condition lives in component state with no URL param
  (`js/app/src/pages/project/TraceFiltersContext.tsx`), so there is nothing to
  deep-link at that grain. The link now targets `/spans`, which still reads
  `SPAN_FILTER_CONDITION_PARAM` (`js/app/src/constants/searchParams.ts:11`,
  consumed in `js/app/src/pages/project/SpanFiltersContext.tsx:115-143`) and
  whose span filter still accepts `trace_annotations[...]`, so both the
  trace-grain and span-grain coding runs keep working.
- `references/axial-coding.md` — same fix to the same link and the same
  accessor/tab explanation in its "Wrapping up" step.

### phoenix-tracing

No edits. See "Audit candidates that produced no edit" below.

### phoenix-evals

No edits. `packages/phoenix-evals` and `js/packages/phoenix-evals` had no source
changes in the window — only `00af92388` (`chore(main): release
arize-phoenix-evals 3.4.0`). That release's one feature, the hallucination
evaluator (`1aa1a8454`, 2026-08-03, before this window), is already documented in
`references/evaluators-pre-built.md:52-81` and
`references/common-mistakes-python.md:216-234`, and those snippets match
`packages/phoenix-evals/src/phoenix/evals/metrics/hallucination.py` today.

## Audit candidates that produced no edit

Each was tagged in triage and then read; here is why each was dropped.

- `443fddf82` `refactor(client): make ATIF span conversion composable` — tagged
  **tracing**. Public surface is unchanged: `__all__` is still
  `["upload_atif_trajectories_as_spans"]`
  (`packages/phoenix-client/src/phoenix/client/helpers/atif/__init__.py:27`) and
  its signature still matches
  `.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md:37-49`
  verbatim. The new `_convert_atif_trajectories_to_spans` and
  `_reparent_spans_under_common_parent` are private, and the commit says so
  explicitly ("Keep conversion and reparenting private; the Harbor integration
  will be the user-facing surface"). One user-visible behavior improvement —
  spans whose parent is absent from the batch are now adopted rather than left
  dangling — is a bug fix within behavior the skill already describes, so no
  text changed.
- `00130b13c` `refactor(client): add Harbor plugin to arize-phoenix-client` —
  tagged **tracing/evals**. `phoenix.client.harbor.PhoenixJobPlugin` is
  registered on the `harbor.plugins` entry point, but it is a non-functional
  scaffold: `on_job_start` raises `RuntimeError("The Phoenix Harbor plugin is
  configured but lifecycle orchestration is not implemented yet.")` and
  `trace_mode` carries a `# TODO: Implement trace export` marker
  (`packages/phoenix-client/src/phoenix/client/harbor/_plugin.py:39-47`).
  Documenting it now would teach an API that errors on use. **Worth revisiting
  once the trace path lands** — it is the intended user-facing ATIF surface.
- `2301e2dc1` `chore(deps): require openai>=3.1.0` — tagged **evals**. Floors
  `openai` for the `arize-phoenix` server's dev/container extras only, not for
  `arize-phoenix-evals`. The evals skill's `references/setup-python.md:22` says
  `pip install openai` with no pin, which stays correct.
- `aebe53fa2` `fix: handle missing annotation labels with pandas 3` — tagged
  **cli**. A one-line NaN guard in
  `src/phoenix/server/api/types/AnnotationSummary.py:49`. The GraphQL shape is
  unchanged; nothing in the skills describes the buggy behavior.
- `4090acd0d` `fix(cost): update built-in model token prices` — tagged **cli**
  (cost fields appear in CLI JSON). Data-only change to the built-in price
  table; no field names, units, or shapes moved.
- `cc06e6da5` `Update Cerebras model IDs` — tagged **tracing**. Changes
  `llama3.1-8b` → `gpt-oss-120b` in
  `js/app/src/components/project/integrationSnippets/cerebras.ts`, the in-app
  onboarding snippet. No skill in scope mentions Cerebras.
- `23fdeaa06` `chore(codegen): upgrade datamodel-code-generator to 0.72.2` —
  tagged **cli**. Regenerates
  `packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py`;
  diff is annotation-style churn, no added or renamed public models.
- `5c38cc7ff` `feat(server): add POST /traces/transfer` (2026-08-12, at the edge
  of the window; shipped in the `arize-phoenix-client` 3.2.0 release that landed
  in-window as `c2e46e586`) — tagged **cli**. REST-only. It adds generated
  request/response types but no client method and no CLI command (`grep` for
  `transfer` in `js/packages/phoenix-cli/src` and
  `packages/phoenix-client/src/phoenix/client` finds nothing outside the
  generated schema). Nothing for these three skills to wrap yet; flagged below
  as a docs-audit item instead.

## Skipped commits

Release/bookkeeping: `8f31d5d54`, `00af92388`, `a64519d48`, `4367f3fc2`,
`c2e46e586`, `733061c2b`, `016c8c2ed`, `d8538c75a`, `3f1eb7193`.
CI/build/deps/lint: `c2f071f0e`, `290f1ec5b`, `cc8eba270`, `023daf6ea`,
`1c63ff4fb`, `b6e796af2`, `a680699b3`, `752e800ac`, `9e685a8a3`.
Tests/scripts/schema assets: `d9d8993d0`, `cc73a9bb1`, `43e5fbf88`, `670e4c112`,
`16c6def58`.
Docs-only: `da1a76373`, `66c528c95`, `63e89b004`, `2050bd983`, `876c5a088`,
`d48c4beb2` (the 2026-08-12 audit itself).
Frontend-only: `70b01ceff` (annotation hover details), `bfed0a890` (app frame
refactor).
Internal agent tooling: `f46fcedac` (PXI gated-tool approval decision).

## Out-of-scope findings

- **`6a3f6627d` `feat(mcp): add read-only analytics SQL tools`** — a substantial
  new user-facing surface (`src/phoenix/server/mcp/sql/`, ~10k lines, spec in
  `internal_docs/specs/mcp-analytics-sql.md`) exposing allowlisted read-only SQL
  over Phoenix's schema through the built-in MCP server. It is neither CLI,
  client SDK, nor tracing/evals API, so none of the three skills own it — but it
  overlaps heavily with what `phoenix-cli` is for (ad-hoc trace analytics), and
  an agent that has the MCP server available should probably prefer it over
  hand-written GraphQL. Worth a maintainer decision on where it belongs.
- **`5c38cc7ff` `POST /traces/transfer`** — shipped as a REST endpoint with no
  Python-client method, no TS-client method, and no CLI command. If a wrapper is
  planned, `phoenix-cli` will want a section; if not, it is a `docs/phoenix`
  gap rather than a skill gap.
- **Python/TypeScript mirror check** — every candidate this window was
  Python-side or server-side. `js/packages/phoenix-client`,
  `js/packages/phoenix-evals`, and `js/packages/phoenix-otel` had no source
  commits in the window, so there is no missing TS mirror to chase. The trace
  filter DSL is a server-side language reachable only over GraphQL, so it has no
  runtime-specific counterpart.
