### PR TITLE
fix(auth): polish password reset and user management

### DIFF
--- a/js/app/src/pages/auth/ForgotPasswordForm.tsx
+++ b/js/app/src/pages/auth/ForgotPasswordForm.tsx
@@ -78,6 +78,7 @@ export function ForgotPasswordForm({
               name="email"
               isRequired
               type="email"
+              autoFocus
               onChange={onChange}
               onBlur={onBlur}
               value={value}

--- a/js/app/src/pages/auth/LoginForm.tsx
+++ b/js/app/src/pages/auth/LoginForm.tsx
@@ -104,6 +104,7 @@ export function LoginForm(props: LoginFormProps) {
                   name="email"
                   isRequired
                   type="email"
+                  autoFocus
                   onChange={onChange}
                   onBlur={onBlur}
                   value={value}
@@ -149,9 +150,11 @@ export function LoginForm(props: LoginFormProps) {
                   </TextField>
                 )}
               />
-              <Link id="forgot-password-link" to="/forgot-password">
-                Forgot your password?
-              </Link>
+              {window.Config.passwordResetEmailEnabled ? (
+                <Link id="forgot-password-link" to="/forgot-password">
+                  Forgot your password?
+                </Link>
+              ) : null}
             </div>
           </Flex>
           <Button

--- a/js/app/src/pages/auth/ResetPasswordForm.tsx
+++ b/js/app/src/pages/auth/ResetPasswordForm.tsx
@@ -46,7 +46,9 @@ export function ResetPasswordForm(props: {
   const [commit, isCommitting] = useMutation<ResetPasswordFormMutation>(graphql`
     mutation ResetPasswordFormMutation($input: PatchViewerInput!) {
       patchViewer(input: $input) {
-        __typename
+        user {
+          passwordNeedsReset
+        }
       }
     }
   `);
@@ -112,6 +114,7 @@ export function ResetPasswordForm(props: {
             type="password"
             name={name}
             isRequired
+            autoFocus
             isInvalid={invalid}
             onChange={onChange}
             onBlur={onBlur}

--- a/js/app/src/pages/auth/ResetPasswordWithTokenForm.tsx
+++ b/js/app/src/pages/auth/ResetPasswordWithTokenForm.tsx
@@ -101,6 +101,7 @@ export function ResetPasswordWithTokenForm({
               type="password"
               isRequired
               name={name}
+              autoFocus
               isInvalid={invalid}
               id="new-password"
               autoComplete="new-password"

--- a/js/app/src/pages/auth/__generated__/ResetPasswordFormMutation.graphql.ts
+++ b/js/app/src/pages/auth/__generated__/ResetPasswordFormMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f6b5abf2608deab38a81138f92e3185c>>
+ * @generated SignedSource<<c2bdcc44b6bc47ac9bac2d9a87a9ea25>>
  * @lightSyntaxTransform
  */
 
@@ -18,7 +18,9 @@ export type ResetPasswordFormMutation$variables = {
 };
 export type ResetPasswordFormMutation$data = {
   readonly patchViewer: {
-    readonly __typename: "UserMutationPayload";
+    readonly user: {
+      readonly passwordNeedsReset: boolean;
+    };
   };
 };
 export type ResetPasswordFormMutation = {
@@ -36,37 +38,49 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "UserMutationPayload",
-    "kind": "LinkedField",
-    "name": "patchViewer",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "__typename",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "passwordNeedsReset",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ResetPasswordFormMutation",
-    "selections": (v1/*:: as any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": "UserMutationPayload",
+        "kind": "LinkedField",
+        "name": "patchViewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              (v2/*:: as any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -75,19 +89,50 @@ return {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "ResetPasswordFormMutation",
-    "selections": (v1/*:: as any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": "UserMutationPayload",
+        "kind": "LinkedField",
+        "name": "patchViewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              (v2/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "d09af5e3a2a3d10f117373e25bef11e6",
+    "cacheID": "a4d59cbf9668e3ccbb7c9dd2ba101f33",
     "id": null,
     "metadata": {},
     "name": "ResetPasswordFormMutation",
     "operationKind": "mutation",
-    "text": "mutation ResetPasswordFormMutation(\n  $input: PatchViewerInput!\n) {\n  patchViewer(input: $input) {\n    __typename\n  }\n}\n"
+    "text": "mutation ResetPasswordFormMutation(\n  $input: PatchViewerInput!\n) {\n  patchViewer(input: $input) {\n    user {\n      passwordNeedsReset\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f8f5c30b0e00c17cdda7557c73c3c2d3";
+(node as any).hash = "1475962063a395b160c1b469d0d41ad7";
 
 export default node;

--- a/js/app/src/pages/settings/UsersTable.tsx
+++ b/js/app/src/pages/settings/UsersTable.tsx
@@ -73,7 +73,6 @@ const userTableRowCSS = css`
  */
 const usersTableContainerCSS = css`
   overflow: auto;
-  max-height: var(--global-dimension-size-6000);
 `;
 
 const isDefaultAdminUser = (user: { email: string | null; username: string }) =>

--- a/js/app/src/window.d.ts
+++ b/js/app/src/window.d.ts
@@ -14,6 +14,7 @@ declare global {
       platformVersion: string;
       authenticationEnabled: boolean;
       basicAuthDisabled: boolean;
+      passwordResetEmailEnabled: boolean;
       oAuth2Idps: OAuth2Idp[];
       ldapEnabled: boolean;
       /**

--- a/js/app/tests/auth-pages.spec.ts
+++ b/js/app/tests/auth-pages.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test("login focuses email and hides unavailable email reset", async ({
+  page,
+}) => {
+  await page.goto("/login");
+
+  await expect(page.getByLabel("Email")).toBeFocused();
+  await expect(
+    page.getByRole("link", { name: "Forgot your password?" })
+  ).toHaveCount(0);
+});
+
+test("password reset pages focus the first input", async ({ page }) => {
+  await page.goto("/reset-password");
+  await expect(page.getByLabel("Old Password")).toBeFocused();
+
+  await page.goto("/reset-password-with-token?token=test-token");
+  await expect(page.getByLabel("New Password")).toBeFocused();
+
+  await page.goto("/forgot-password");
+  await expect(page.getByLabel("Email")).toBeFocused();
+});

--- a/js/app/tests/settings-tables.spec.ts
+++ b/js/app/tests/settings-tables.spec.ts
@@ -16,6 +16,9 @@ test.describe("Settings Tables", () => {
 
     await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
 
+    const tableContainer = page.getByRole("table").locator("..");
+    await expect(tableContainer).toHaveCSS("max-height", "none");
+
     const userHeader = page.getByRole("columnheader", { name: "user" }).first();
     await clickSortableHeaderAndExpect(userHeader, "ascending");
   });

--- a/js/app/tests/settings-tables.spec.ts
+++ b/js/app/tests/settings-tables.spec.ts
@@ -16,8 +16,6 @@ test.describe("Settings Tables", () => {
 
     await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
 
-    const tableContainer = page.getByRole("table").locator("..");
-    await expect(tableContainer).toHaveCSS("max-height", "none");
 
     const userHeader = page.getByRole("columnheader", { name: "user" }).first();
     await clickSortableHeaderAndExpect(userHeader, "ascending");

--- a/js/app/tests/settings-tables.spec.ts
+++ b/js/app/tests/settings-tables.spec.ts
@@ -16,7 +16,6 @@ test.describe("Settings Tables", () => {
 
     await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
 
-
     const userHeader = page.getByRole("columnheader", { name: "user" }).first();
     await clickSortableHeaderAndExpect(userHeader, "ascending");
   });

--- a/js/app/tests/user-management.spec.ts
+++ b/js/app/tests/user-management.spec.ts
@@ -49,3 +49,55 @@ test("can create a user with viewer role", async ({ page }) => {
   // Check if the user is created
   await expect(page.getByRole("cell", { name: email })).toBeVisible();
 });
+
+test("a new user only needs to reset their password once", async ({
+  baseURL,
+  browser,
+  page,
+}) => {
+  if (!baseURL) {
+    throw new Error("Playwright baseURL must be configured.");
+  }
+
+  await page.goto("/settings/users");
+  await page.waitForURL("**/settings/users");
+  await page.getByRole("button", { name: "Add User" }).click();
+
+  const email = `password-reset-${randomUUID()}@localhost.com`;
+  const initialPassword = "initial123";
+  const newPassword = "updated123";
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Username").fill(email);
+  await page.getByLabel("Password", { exact: true }).fill(initialPassword);
+  await page.getByLabel("Confirm Password").fill(initialPassword);
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Add User" })
+    .click();
+  await expect(page.getByRole("cell", { name: email })).toBeVisible();
+
+  const userContext = await browser.newContext();
+  const userPage = await userContext.newPage();
+  try {
+    await userPage.goto(`${baseURL}/login`);
+    await userPage.getByLabel("Email").fill(email);
+    await userPage.getByLabel("Password").fill(initialPassword);
+    await userPage.getByRole("button", { name: "Log In" }).click();
+    await userPage.waitForURL("**/reset-password");
+
+    await userPage.getByLabel("Old Password").fill(initialPassword);
+    await userPage.getByLabel("New Password").fill(newPassword);
+    await userPage.getByLabel("Confirm Password").fill(newPassword);
+    await userPage.getByRole("button", { name: "Reset Password" }).click();
+    await userPage.waitForURL("**/login?message=password_reset");
+
+    await userPage.getByLabel("Email").fill(email);
+    await userPage.getByLabel("Password").fill(newPassword);
+    await userPage.getByRole("button", { name: "Log In" }).click();
+
+    await expect(userPage).toHaveURL(/\/projects(?:\?|$)/);
+    await expect(userPage.getByLabel("Old Password")).toHaveCount(0);
+  } finally {
+    await userContext.close();
+  }
+});

--- a/js/app/vitest.setup.ts
+++ b/js/app/vitest.setup.ts
@@ -56,6 +56,7 @@ export const baseWindowConfig = {
   authenticationEnabled: true,
   basename: "/",
   platformVersion: "1.0.0",
+  passwordResetEmailEnabled: false,
   agentAssistantDisabled: false,
   agentBashDisabled: false,
   mcpServerEnabled: true,

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -240,6 +240,8 @@ class AppConfig(NamedTuple):
     auth_error_messages: dict[AuthErrorCode, str]
     """ Mapping of auth error codes to user-friendly messages """
     oauth2_idps: Sequence[OAuth2Idp]
+    password_reset_email_enabled: bool = False
+    """ Whether password reset emails can be sent """
     basic_auth_disabled: bool = False
     ldap_enabled: bool = False
     """ Whether LDAP authentication is configured """
@@ -326,6 +328,7 @@ class Static(StaticFiles):
                     "manifest": self._web_manifest,
                     "authentication_enabled": self._app_config.authentication_enabled,
                     "oauth2_idps": self._app_config.oauth2_idps,
+                    "password_reset_email_enabled": self._app_config.password_reset_email_enabled,
                     "basic_auth_disabled": self._app_config.basic_auth_disabled,
                     "ldap_enabled": self._app_config.ldap_enabled,
                     "ldap_manual_user_creation_enabled": self._app_config.ldap_manual_user_creation_enabled,  # noqa: E501
@@ -1259,6 +1262,7 @@ def create_app(
                     authentication_enabled=authentication_enabled,
                     web_manifest_path=web_manifest_path,
                     oauth2_idps=oauth2_idps,
+                    password_reset_email_enabled=email_sender is not None,
                     basic_auth_disabled=basic_auth_disabled,
                     ldap_enabled=ldap_config is not None,
                     # Disable manual user creation when LDAP disabled or no email attr

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -135,6 +135,7 @@
               platformVersion: "{{platform_version}}",
               authenticationEnabled: Boolean("{{authentication_enabled}}" == "True"),
               oAuth2Idps: {{ oauth2_idps | tojson }},
+              passwordResetEmailEnabled: Boolean("{{password_reset_email_enabled}}" == "True"),
               basicAuthDisabled: Boolean("{{basic_auth_disabled}}" == "True"),
               ldapEnabled: Boolean("{{ldap_enabled}}" == "True"),
               ldapManualUserCreationEnabled: Boolean("{{ldap_manual_user_creation_enabled}}" == "True"),


### PR DESCRIPTION
# Summary

- Prevent duplicate forced password resets by updating Relay state after mutation.
- Hide email password reset when SMTP is unavailable.
- Autofocus the first field on auth forms.
- Remove the users table height constraint and add regression coverage.