### PR TITLE
ci: release one combined release-please PR

### DIFF
--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -3,7 +3,9 @@ name: Sync uv.lock on Release PRs
 on:
   push:
     branches:
-      - "release-please--branches--main--components--arize-phoenix**"
+      # release-please suffixes the branch per component or per group depending
+      # on config. Match every shape so the sync cannot silently stop.
+      - "release-please--branches--main**"
 
 permissions:
   contents: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-    "separate-pull-requests": true,
+    "separate-pull-requests": false,
     "sequential-calls": true,
     "packages": {
         ".": {


### PR DESCRIPTION
## What

Flip `separate-pull-requests` to `false` so release-please opens **one** release PR covering every package, instead of one PR per package.

## Why

`.release-please-manifest.json` is a single JSON object holding all five versions on one line:

```json
{".":"20.3.0","packages/phoenix-evals":"3.4.0","packages/phoenix-otel":"0.17.1","packages/phoenix-client":"3.2.0","packages/phoenix-sqlean":"0.1.0"}
```

Every release PR rewrites that same line. Two open at once therefore conflict *by construction* — whichever merges second has to be regenerated before it can go in. Combining them removes the conflict instead of working around it.

## The lockfile trigger has to widen with it

`sync-lockfile-release-pr.yml` currently triggers on:

```
release-please--branches--main--components--arize-phoenix**
```

In combined mode release-please drops the `--components--<name>` suffix and names the branch `release-please--branches--main`. The old pattern would stop matching, and release PRs would ship a stale `uv.lock` — with no error anywhere. Widened to `release-please--branches--main**`, which matches both shapes.

This is the only reason the two files are in one PR: separating them would leave a window where the sync is silently dead.

## Note on the default

`separate-pull-requests: false` is release-please's default only for single-package repos — `manifest.ts` computes it as `Object.keys(repositoryConfig).length === 1`. With five packages it has to be set explicitly.

## After this merges

If #15487 is still open on the old branch name, close it *after* this lands (before, and release-please just recreates it):

```
gh pr close 15487 --delete-branch
```
