### PR TITLE
test: CI canary — base + openai 3.x compatibility only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ dev = [
   "mypy-boto3-bedrock-runtime",
   "nest-asyncio",  # for executor testing
   "numpy",
-  "openai",
+  "openai>=3.1.0,<4",
   "openinference-semantic-conventions>=0.1.26",
   "openinference-instrumentation>=0.1.44",
   "opentelemetry-exporter-otlp",
@@ -216,7 +216,7 @@ container = [
   "google-genai>=1.50.0 ; python_version >= '3.10'",
   "google-genai ; python_version < '3.10'",
   "prometheus-client",
-  "openai>=2.14.0",
+  "openai>=3.1.0,<4",
   "azure-identity>=1.18.0",  # MSAL-backed in-memory token cache for ManagedIdentityCredential
   "aiohttp",  # used by azure-identity via azure.core.pipeline.transport
   # Note: when updating opentelemetry dependencies, all packages must use versions
@@ -443,13 +443,13 @@ exclude-newer = "3 days"
 # member — it is a setup.py C extension — so it resolves from PyPI and needs
 # this to be installable at all on the day it publishes.
 exclude-newer-package = { arize-phoenix-client = "2099-12-31T00:00:00Z", arize-phoenix-evals = "2099-12-31T00:00:00Z", arize-phoenix-otel = "2099-12-31T00:00:00Z", arize-phoenix-sqlean = "2099-12-31T00:00:00Z" }
-# litellm 1.83.x hard-pins `openai==2.24.0` and `python-dotenv==1.0.1`, which
-# conflict with pydantic-ai (needs openai>=2.29.0) and fastmcp (needs
-# python-dotenv>=1.1.0). Override the over-restrictive pins so resolution
-# succeeds; phoenix uses litellm purely as a client library and does not
-# exercise the pinned-version code paths.
+# litellm bounds shared dependencies below what the rest of the tree needs: it
+# caps `openai<3` while phoenix and pydantic-ai require openai 3, and it has
+# capped `python-dotenv` below the `>=1.1.0` fastmcp requires. Overriding is safe
+# because phoenix uses litellm purely as a client library and never reaches the
+# code paths those bounds guard.
 override-dependencies = [
-  "openai>=2.30.0",
+  "openai>=3.1.0,<4",
   "python-dotenv>=1.1.0",
 ]
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,7 +10,7 @@ pytest-randomly
 pytest-rerunfailures
 deepdiff==8.6.2
 anthropic
-openai>=2.14.0
+openai>=3.1.0,<4
 pystache
 PyYAML
 aioboto3

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -102,6 +102,7 @@ from phoenix.server.api.types.GenerativeProvider import (
 from phoenix.utilities.json import jsonify
 
 if TYPE_CHECKING:
+    import httpx2
     from anthropic import AsyncAnthropic
     from anthropic.lib.streaming import AsyncMessageStreamManager
     from anthropic.types import MessageParam, TextBlockParam, ToolUseBlockParam
@@ -2963,19 +2964,27 @@ LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO = SpanAttributes.LLM_TOKEN_COUNT_COMPLE
 
 
 class _HttpxClient(wrapt.ObjectProxy):  # type: ignore
+    """Records the outgoing request URL on the span without altering the request.
+
+    Provider SDKs disagree on their HTTP library: the openai SDK is built on httpx2, the
+    others on httpx. Both are accepted because only ``request.url`` is read.
+    """
+
     def __init__(
         self,
-        wrapped: httpx.AsyncClient,
+        wrapped: httpx.AsyncClient | httpx2.AsyncClient,
         span: OTelSpan,
     ):
         super().__init__(wrapped)
         self._self_span = span
 
-    async def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+    async def send(
+        self, request: httpx.Request | httpx2.Request, **kwargs: Any
+    ) -> httpx.Response | httpx2.Response:
         self._self_span.set_attribute(URL_FULL, str(request.url))
         self._self_span.set_attribute(URL_PATH, request.url.path.removeprefix(self.base_url.path))
         response = await self.__wrapped__.send(request, **kwargs)
-        return cast(httpx.Response, response)
+        return cast("httpx.Response | httpx2.Response", response)
 
 
 CustomProviderId: TypeAlias = int

--- a/tests/unit/server/agents/test_model_factory.py
+++ b/tests/unit/server/agents/test_model_factory.py
@@ -1,5 +1,6 @@
 import base64
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -108,6 +109,11 @@ class TestCustomProviderModels:
             def __init__(self, **kwargs: Any) -> None:
                 self.kwargs = kwargs
                 self.base_url = kwargs.get("base_url", "https://example.test/v1")
+                # pydantic-ai reads the resource attribute matching the model class
+                # while constructing the model, so a stand-in client must expose the
+                # attribute for every ``openai_api_type`` under test.
+                self.chat = SimpleNamespace(completions=object())
+                self.responses = object()
 
         monkeypatch.setattr(openai, "AsyncOpenAI", DummyAsyncOpenAI)
 

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -2,11 +2,10 @@ import json
 import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
-import httpx
+import httpx2
 import pytest
-import respx
 from openai import AsyncOpenAI
 from openinference.semconv.trace import (
     MessageAttributes,
@@ -2314,22 +2313,44 @@ class TestLLMEvaluator:
         return Tracer(span_cost_calculator=span_cost_calculator)
 
     @pytest.fixture
-    def openai_streaming_client(
+    def openai_streaming_client_factory(
         self,
         openai_api_key: str,
-    ) -> "OpenAIChatCompletionsClient":
-        @asynccontextmanager
-        async def create_openai_client() -> Any:
-            yield AsyncOpenAI(api_key=openai_api_key, max_retries=0)
+    ) -> Callable[
+        [Optional[httpx2.AsyncClient]],
+        "OpenAIChatCompletionsClient",
+    ]:
+        def create_client(
+            http_client: Optional[httpx2.AsyncClient],
+        ) -> "OpenAIChatCompletionsClient":
+            @asynccontextmanager
+            async def create_openai_client() -> Any:
+                yield AsyncOpenAI(
+                    api_key=openai_api_key,
+                    max_retries=0,
+                    http_client=http_client,
+                )
 
-        client_factory = LLMClientFactory(
-            create_openai_client, openai_rate_limit_key(openai_api_key, None)
-        )
-        return OpenAIChatCompletionsClient(
-            client_factory=client_factory,
-            model_name="gpt-4o-mini",
-            provider="openai",
-        )
+            client_factory = LLMClientFactory(
+                create_openai_client, openai_rate_limit_key(openai_api_key, None)
+            )
+            return OpenAIChatCompletionsClient(
+                client_factory=client_factory,
+                model_name="gpt-4o-mini",
+                provider="openai",
+            )
+
+        return create_client
+
+    @pytest.fixture
+    def openai_streaming_client(
+        self,
+        openai_streaming_client_factory: Callable[
+            [Optional[httpx2.AsyncClient]],
+            "OpenAIChatCompletionsClient",
+        ],
+    ) -> "OpenAIChatCompletionsClient":
+        return openai_streaming_client_factory(None)
 
     @pytest.fixture
     def llm_evaluator_prompt_version(self) -> models.PromptVersion:
@@ -2389,29 +2410,41 @@ class TestLLMEvaluator:
         )
 
     @pytest.fixture
-    def llm_evaluator(
+    def llm_evaluator_factory(
         self,
         llm_evaluator_prompt_version: models.PromptVersion,
         output_config: CategoricalOutputConfig,
-        openai_streaming_client: "OpenAIChatCompletionsClient",
-    ) -> LLMEvaluator:
+    ) -> Callable[["OpenAIChatCompletionsClient"], LLMEvaluator]:
         template = llm_evaluator_prompt_version.template
         assert isinstance(template, PromptChatTemplate)
         tools = llm_evaluator_prompt_version.tools
         assert tools is not None
 
-        return LLMEvaluator(
-            name="correctness",
-            description="Evaluates correctness",
-            template=template,
-            template_format=llm_evaluator_prompt_version.template_format,
-            tools=tools,
-            invocation_parameters=llm_evaluator_prompt_version.invocation_parameters,
-            model_provider=llm_evaluator_prompt_version.model_provider,
-            llm_client=openai_streaming_client,
-            output_configs=[output_config],
-            prompt_name="test-prompt",
-        )
+        def create_evaluator(
+            openai_streaming_client: "OpenAIChatCompletionsClient",
+        ) -> LLMEvaluator:
+            return LLMEvaluator(
+                name="correctness",
+                description="Evaluates correctness",
+                template=template,
+                template_format=llm_evaluator_prompt_version.template_format,
+                tools=tools,
+                invocation_parameters=llm_evaluator_prompt_version.invocation_parameters,
+                model_provider=llm_evaluator_prompt_version.model_provider,
+                llm_client=openai_streaming_client,
+                output_configs=[output_config],
+                prompt_name="test-prompt",
+            )
+
+        return create_evaluator
+
+    @pytest.fixture
+    def llm_evaluator(
+        self,
+        llm_evaluator_factory: Callable[["OpenAIChatCompletionsClient"], LLMEvaluator],
+        openai_streaming_client: "OpenAIChatCompletionsClient",
+    ) -> LLMEvaluator:
+        return llm_evaluator_factory(openai_streaming_client)
 
     @pytest.fixture
     def input_mapping(self) -> EvaluatorInputMappingInput:
@@ -3248,7 +3281,11 @@ class TestLLMEvaluator:
         db: DbSessionFactory,
         project: models.Project,
         tracer: Tracer,
-        llm_evaluator: LLMEvaluator,
+        llm_evaluator_factory: Callable[["OpenAIChatCompletionsClient"], LLMEvaluator],
+        openai_streaming_client_factory: Callable[
+            [Optional[httpx2.AsyncClient]],
+            "OpenAIChatCompletionsClient",
+        ],
         output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
     ) -> None:
@@ -3275,14 +3312,15 @@ class TestLLMEvaluator:
                 },
             }
         )
-        with respx.mock:
-            respx.post("https://api.openai.com/v1/chat/completions").mock(
-                return_value=httpx.Response(
-                    200,
-                    content=text_response_body,
-                    headers={"content-type": "application/json"},
-                )
+        transport = httpx2.MockTransport(
+            lambda request: httpx2.Response(
+                200,
+                content=text_response_body,
+                headers={"content-type": "application/json"},
             )
+        )
+        async with httpx2.AsyncClient(transport=transport) as http_client:
+            llm_evaluator = llm_evaluator_factory(openai_streaming_client_factory(http_client))
             evaluation_results = await llm_evaluator.evaluate(
                 context={"input": "What is 2 + 2?", "output": "4"},
                 input_mapping=input_mapping.to_orm(),
@@ -3427,7 +3465,11 @@ class TestLLMEvaluator:
         db: DbSessionFactory,
         project: models.Project,
         tracer: Tracer,
-        llm_evaluator: LLMEvaluator,
+        llm_evaluator_factory: Callable[["OpenAIChatCompletionsClient"], LLMEvaluator],
+        openai_streaming_client_factory: Callable[
+            [Optional[httpx2.AsyncClient]],
+            "OpenAIChatCompletionsClient",
+        ],
         output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
     ) -> None:
@@ -3464,14 +3506,15 @@ class TestLLMEvaluator:
                 },
             }
         )
-        with respx.mock:
-            respx.post("https://api.openai.com/v1/chat/completions").mock(
-                return_value=httpx.Response(
-                    200,
-                    content=tool_call_response_body,
-                    headers={"content-type": "application/json"},
-                )
+        transport = httpx2.MockTransport(
+            lambda request: httpx2.Response(
+                200,
+                content=tool_call_response_body,
+                headers={"content-type": "application/json"},
             )
+        )
+        async with httpx2.AsyncClient(transport=transport) as http_client:
+            llm_evaluator = llm_evaluator_factory(openai_streaming_client_factory(http_client))
             evaluation_results = await llm_evaluator.evaluate(
                 context={"input": "What is 2 + 2?", "output": "4"},
                 input_mapping=input_mapping.to_orm(),

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -4,6 +4,7 @@ import json
 from typing import Any, AsyncIterator, Union
 
 import httpx
+import httpx2
 import pytest
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionChunk as OpenAIChatCompletionChunk
@@ -17,6 +18,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCalls, FunctionModel
+from starlette.types import ASGIApp
 from strawberry.relay import GlobalID
 
 import phoenix.server.api.routers.v1.chat_completions as chat_completions_module
@@ -64,11 +66,12 @@ def build_model_spy(monkeypatch: pytest.MonkeyPatch) -> _BuildModelSpy:
 
 
 @pytest.fixture
-def openai_client(httpx_client: httpx.AsyncClient) -> AsyncOpenAI:
+def openai_client(asgi_app: ASGIApp) -> AsyncOpenAI:
     return AsyncOpenAI(
         base_url="http://test/v1",
         api_key="sk-unused",  # the app under test runs with authentication disabled
-        http_client=httpx_client,
+        # the openai SDK is httpx2-based; the shared httpx fixture cannot back its transport
+        http_client=httpx2.AsyncClient(transport=httpx2.ASGITransport(app=asgi_app)),
         max_retries=0,  # surface the first response instead of retrying 5xx
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,7 @@ members = [
     "arize-phoenix-otel",
 ]
 overrides = [
-    { name = "openai", specifier = ">=2.30.0" },
+    { name = "openai", specifier = ">=3.1.0,<4" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]
 
@@ -732,7 +732,7 @@ requires-dist = [
     { name = "modal", marker = "extra == 'container'", specifier = ">=1.2.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.2.0" },
     { name = "numpy" },
-    { name = "openai", marker = "extra == 'container'", specifier = ">=2.14.0" },
+    { name = "openai", marker = "extra == 'container'", specifier = ">=3.1.0,<4" },
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
     { name = "openinference-instrumentation-openai", specifier = ">=0.1.41" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.26" },
@@ -821,7 +821,7 @@ dev = [
     { name = "mypy-protobuf", specifier = ">=5.0.0" },
     { name = "nest-asyncio" },
     { name = "numpy" },
-    { name = "openai" },
+    { name = "openai", specifier = ">=3.1.0,<4" },
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.26" },
     { name = "opentelemetry-exporter-otlp" },
@@ -4922,21 +4922,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.53.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/9b/d45911bf9abfc5a754d800d79fe56e4dcf6e7b679d6ff4b7e9689b56bc02/openai-3.1.0.tar.gz", hash = "sha256:3ae7190da63f718727f9c525740d3f713e85553d2bf1d0cc9247346bd9063a4d", size = 1131016, upload-time = "2026-08-14T23:49:46.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/45/84b9e909968c0f4c3112a828bba9aa8be6a5ee322fcb3d781145ee53d88e/openai-3.1.0-py3-none-any.whl", hash = "sha256:f06d5a5c8d06a0aead3a67d33fe5a3c3c31540a0f7a8017b02ba8cd99bc5c736", size = 1670762, upload-time = "2026-08-14T23:49:43.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Do not merge. Temporary CI canary isolating a postgres unit-test hang.

This branch is `version-online-evals` plus only the two cherry-picks from main that adapt tests to openai 3.x (#15479, #15482). It exists to answer one question: does the postgres unit-test job hang on the feature-branch base once the openai 3.x test fixes are present, independent of any other change?

Context: postgres unit jobs began timing out at the 60-minute cap on branches that carry the openai 3.x fixes over the feature-branch base, while main with the same fixes stays green. The suite reaches ~99% with no failures, then hangs in async teardown.

Will be closed and deleted after one CI run either way.