### PR TITLE
fix(mcp): keep dashes in prompt names on upsert-prompt

### DIFF
--- a/js/.changeset/mcp-prompt-name-dashes.md
+++ b/js/.changeset/mcp-prompt-name-dashes.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-mcp": patch
+---
+
+Stop `upsert-prompt` from stripping dashes out of prompt names. The server's prompt name identifier accepts `[a-z0-9_-]`, so `article-summarizer` is now stored under that name instead of `articlesummarizer`. Leading and trailing separators are trimmed as well, so names like `_draft` no longer reach the API and fail validation there.

--- a/js/packages/phoenix-mcp/src/promptSchemas.ts
+++ b/js/packages/phoenix-mcp/src/promptSchemas.ts
@@ -29,10 +29,16 @@ export const getPromptVersionSchema = z.object({
 });
 
 /**
- * Name transformation applied to prompt names:
+ * Name transformation applied to prompt names, producing a value that
+ * satisfies the server-side prompt name identifier
+ * (`^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$`, see `phoenix.db.types.identifier`):
  * - lowercase
- * - spaces → underscores
- * - strip non-alphanumeric / non-underscore characters
+ * - whitespace runs → underscores
+ * - strip characters outside `[a-z0-9_-]`
+ * - trim leading and trailing separators
+ *
+ * Dashes survive because the identifier pattern accepts them, matching
+ * `getIdentifier` in the Phoenix UI.
  */
 const promptNameSchema = z
   .string()
@@ -40,7 +46,8 @@ const promptNameSchema = z
     val
       .toLowerCase()
       .replace(/\s+/g, "_")
-      .replace(/[^\w_]/g, "")
+      .replace(/[^a-z0-9_-]/g, "")
+      .replace(/^[_-]+|[_-]+$/g, "")
   )
   .refine((val) => val.length > 0, {
     message: "Name cannot be empty after transformation",

--- a/js/packages/phoenix-mcp/test/promptSchemas.test.ts
+++ b/js/packages/phoenix-mcp/test/promptSchemas.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { createPromptSchema } from "../src/promptSchemas";
+
+/**
+ * Server-side prompt name identifier pattern.
+ *
+ * Mirrors `Identifier` in `src/phoenix/db/types/identifier.py`, which the
+ * `POST /v1/prompts` request body validates `name` against.
+ */
+const SERVER_IDENTIFIER_PATTERN = /^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$/;
+
+const normalizeName = (name: string): string =>
+  createPromptSchema.parse({ name, template: "hello" }).name;
+
+describe("createPromptSchema name normalization", () => {
+  it("keeps dashes, which the server identifier pattern allows", () => {
+    expect(normalizeName("article-summarizer")).toBe("article-summarizer");
+  });
+
+  it("leaves an already-valid identifier untouched", () => {
+    expect(normalizeName("email_generator")).toBe("email_generator");
+  });
+
+  it("lowercases and joins whitespace runs with underscores", () => {
+    expect(normalizeName("My  Prompt")).toBe("my_prompt");
+  });
+
+  it("drops characters outside the identifier set", () => {
+    expect(normalizeName("foo!bar?")).toBe("foobar");
+  });
+
+  it("trims leading and trailing separators", () => {
+    expect(normalizeName("_draft")).toBe("draft");
+    expect(normalizeName("draft-")).toBe("draft");
+    expect(normalizeName("--my-prompt__")).toBe("my-prompt");
+  });
+
+  it.each([
+    "article-summarizer",
+    "email_generator",
+    "My  Prompt",
+    "foo!bar?",
+    "_draft",
+    "draft-",
+    "--my-prompt__",
+    "  spaced out name  ",
+    "Résumé Reviewer",
+  ])("produces a server-valid identifier for %j", (name) => {
+    expect(normalizeName(name)).toMatch(SERVER_IDENTIFIER_PATTERN);
+  });
+
+  it("rejects a name with no identifier characters left", () => {
+    expect(() => normalizeName("!!!")).toThrow();
+  });
+});


### PR DESCRIPTION
`upsert-prompt` normalized names with `.replace(/[^\w_]/g, "")`. `\w` is `[A-Za-z0-9_]`, so every dash was deleted and `article-summarizer` became `articlesummarizer`. The server's prompt name identifier is `^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$` (`src/phoenix/db/types/identifier.py:7`), which accepts dashes, and six tool descriptions in `promptTools.ts` use `article-summarizer` as the example name. Create it over MCP, read it back with `get-prompt "article-summarizer"`, and you get a 404.

The same transform left leading and trailing separators in place, so `_draft` passed the zod schema and failed `Identifier` validation at the API with a 422.

Mapping dashes to underscores was the other option. It yields a valid name but not the requested one, so the round trip breaks the same way. Preserving the dash is the only choice where `upsert-prompt(n)` and `get-prompt(n)` agree.

Whitespace keeps mapping to `_` rather than `-`, so this is not an exact match for `getIdentifier` in `js/app/src/utils/identifierUtils.ts:101`. Aligning it would rename space-separated prompts callers create today.

Residual limitation: the transform rewrites the caller's name silently instead of rejecting it, so `upsert-prompt("My Prompt")` stores `my_prompt`.

From `js/`: `pnpm run test` passes every package suite, phoenix-mcp at 40 tests (25 before). `pnpm run fmt:check` on the pinned oxfmt 0.58.0 reports no diff. `pnpm run lint` reports 0 warnings. Reverting `promptSchemas.ts` and rerunning fails 5 of the new assertions.
