### PR TITLE
fix(evals): do not echo submitted tool JSON in evaluator prompt validation errors

### DIFF
--- a/src/phoenix/server/api/helpers/evaluators.py
+++ b/src/phoenix/server/api/helpers/evaluators.py
@@ -56,7 +56,7 @@ def validate_evaluator_prompt_and_configs(
         raise ValueError(_LLMEvaluatorPromptErrorMessage.TOOL_CHOICE_REQUIRED)
     if isinstance(prompt_tools.tool_choice, PromptToolChoiceSpecificFunctionTool):
         if not prompt_tools.tools or not isinstance(prompt_tools.tools[0], PromptToolFunction):
-            raise ValueError(f"Tool {prompt_tools.tools[0]} is not a function tool")
+            raise ValueError(_LLMEvaluatorPromptErrorMessage.FUNCTION_TOOLS_REQUIRED)
         if prompt_tools.tool_choice.function_name != prompt_tools.tools[0].function.name:
             raise ValueError(
                 _LLMEvaluatorPromptErrorMessage.TOOL_CHOICE_SPECIFIC_FUNCTION_NAME_MUST_MATCH_DEFINED_FUNCTION_NAME
@@ -66,7 +66,7 @@ def validate_evaluator_prompt_and_configs(
     tools_by_name: dict[str, PromptToolFunction] = {}
     for tool in prompt_tools.tools:
         if not isinstance(tool, PromptToolFunction):
-            raise ValueError(f"Tool {tool} is not a function tool")
+            raise ValueError(_LLMEvaluatorPromptErrorMessage.FUNCTION_TOOLS_REQUIRED)
         tools_by_name[tool.function.name] = tool
 
     # Validate each config against its matched tool
@@ -231,6 +231,7 @@ def _parse_pydantic_validation_error(
 class _LLMEvaluatorPromptErrorMessage:
     RESPONSE_FORMAT_NOT_SUPPORTED = "Response format is not supported for evaluator prompts"
     TOOLS_REQUIRED = "Evaluator prompts require tools"
+    FUNCTION_TOOLS_REQUIRED = "Evaluator prompts require function tools"
     EXACTLY_ONE_TOOL_REQUIRED = "Evaluator prompts require exactly one tool"
     TOOL_COUNT_MUST_MATCH_CONFIG_COUNT = (
         "Number of prompt tool definitions must match number of output configs"

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -46,6 +46,7 @@ from phoenix.db.types.prompts import (
     PromptToolChoiceZeroOrMore,
     PromptToolFunction,
     PromptToolFunctionDefinition,
+    PromptToolRaw,
     PromptTools,
     TextContentPart,
 )
@@ -276,6 +277,22 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
             match=_LLMEvaluatorPromptErrorMessage.TOOL_CHOICE_SPECIFIC_FUNCTION_NAME_MUST_MATCH_DEFINED_FUNCTION_NAME,
         ):
             validate_consistent_llm_evaluator_and_prompt_version(prompt_version, output_config)
+
+    def test_raw_tool_error_does_not_echo_submitted_json(
+        self,
+        output_config: CategoricalOutputConfig,
+        prompt_version: models.PromptVersion,
+    ) -> None:
+        assert prompt_version.tools is not None
+        prompt_version.tools.tools = [
+            PromptToolRaw(type="raw", raw={"api_key": "secret", "type": "web_search"})
+        ]
+        with pytest.raises(
+            ValueError,
+            match=f"^{_LLMEvaluatorPromptErrorMessage.FUNCTION_TOOLS_REQUIRED}$",
+        ) as error:
+            validate_consistent_llm_evaluator_and_prompt_version(prompt_version, output_config)
+        assert "secret" not in str(error.value)
 
     def test_function_parameters_type_not_object_raises(
         self,


### PR DESCRIPTION
## Summary


`validate_consistent_llm_evaluator_and_prompt_version` rejected non-function tools with `f"Tool {tool} is not a function tool"`, embedding the entire tool object in the error. For a `PromptToolRaw`, that echoes the submitted raw JSON — including any secrets it carries (e.g. API keys) — back through the API error surface.

## Changes

- Replace both f-string raises with a constant `FUNCTION_TOOLS_REQUIRED` message ("Evaluator prompts require function tools")
- Add regression test `test_raw_tool_error_does_not_echo_submitted_json` asserting the secret does not appear in the error

## Testing

`pytest tests/unit/server/api/helpers/test_evaluators.py -k TestValidateConsistentLLMEvaluatorAndPromptVersion` — 28 passed