### PR TITLE
fix(docs): drop the code-block fade smear and the accent focus-ring rectangle

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -173,10 +173,26 @@ html.dark {
   text-underline-offset: 3px;
 }
 
+/* Drawn as an outline rather than a box-shadow. An outline follows the
+   element's own border-radius, leaves any real shadow intact, and — because
+   Tailwind's `outline-hidden!` utility carries `!important` from inside a
+   cascade layer — lets a widget that suppresses its own ring keep it
+   suppressed. Mintlify's assistant textarea does exactly that: the box-shadow
+   could not be opted out of, so it drew a hard-cornered accent rectangle inside
+   the input's rounded border, on top of the brand border Mintlify already
+   draws there. The box-shadow version also set `border-radius`, squaring off
+   the ring on every focused link, button and card it touched.
+
+   `html.dark` repeats the color only to outrank Mintlify's own
+   `html.dark :focus-visible`, which would otherwise supply the outline color
+   in dark mode. */
 :focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--px-accent-line);
-  border-radius: var(--px-radius-sm);
+  outline: 2px solid var(--px-accent-line);
+  outline-offset: 2px;
+}
+
+html.dark :focus-visible {
+  outline-color: var(--px-accent-line);
 }
 
 ::selection {
@@ -350,6 +366,24 @@ html.dark .code-block-background {
 #content :not(pre) > code {
   background: var(--px-chip);
   border-radius: var(--px-radius-sm);
+}
+
+/* A code block without a `<CodeGroup>` puts its copy and Ask AI buttons over the
+   code itself, and Mintlify backs them with a right-edge fade whose colors are
+   written inline from the Shiki theme (`#FFFFFF` / `#0D1117`). Those cannot
+   track `--px-code-bg`, so the fade reads as a smear across the code field
+   rather than a fade into it. Grouped blocks keep their fade — their buttons
+   live in the tab strip, so nothing overlaps the code. */
+.code-block:has([data-floating-buttons]) [data-fade-overlay] {
+  background-image: none;
+}
+
+/* Mintlify pairs that fade with bare button icons, and gives the icons their own
+   chip when a block has no fade — a state its markup never reaches here, since
+   the overlay element stays in the DOM. Applied by hand so a long line scrolling
+   past passes behind an opaque chip rather than colliding with the glyphs. */
+[data-floating-buttons] button {
+  background: var(--px-chip);
 }
 
 /* Code inside a callout sits on the page background, not the code surface — the


### PR DESCRIPTION
Ports the two brand-CSS fixes from [Arize-ai/docs#861](https://github.com/Arize-ai/docs/pull/861) to the Phoenix docs. Same stylesheet structure, `--px-*` tokens instead of `--ax-*`, same two artifacts — both from Mintlify styles whose colors are fixed while ours are token-driven.

## Code-block fade

A code block outside a `<CodeGroup>` floats its copy and Ask AI buttons over the code itself, and Mintlify backs them with a right-edge fade whose colors it writes **inline** from the Shiki theme — `#FFFFFF` in light, `#0D1117` in dark. Those can't track `--px-code-bg` (`#F1F2F3` / `#050506`), so instead of fading into the code field the overlay painted a mismatched band across it, right behind the buttons.

Removed on those blocks, scoped via `.code-block:has([data-floating-buttons])` — that attribute appears **only** on ungrouped blocks, so `<CodeGroup>` blocks are untouched (their buttons sit in the tab strip and never overlap the code).

Mintlify pairs "no fade" with a chip behind each button icon (`bg-gray-100` / `bg-gray-800`), but gates it on the overlay being absent from the DOM — a state CSS can't reach, since the element is still rendered. So the chip is applied by hand with `--px-chip`; without it a long line scrolling past collided with the icon glyphs.

## Focus ring

The global rule was:

```css
:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--px-accent-line); border-radius: var(--px-radius-sm); }
```

A `box-shadow` can't be opted out of by a widget, and setting `border-radius` mutated geometry on focus — so every focus ring on the site was squared off regardless of the element's own radius.

Most visibly, it drew a hard-cornered cyan rectangle **inside** the AI assistant's 16px-rounded input, on top of the 1px brand border Mintlify already draws there on focus. Mintlify explicitly opts that textarea out of focus rings (`outline-hidden!`, `focus:ring-0`), but our unlayered rule beat Tailwind's layered utilities.

Now drawn as an outline:

```css
:focus-visible { outline: 2px solid var(--px-accent-line); outline-offset: 2px; }
html.dark :focus-visible { outline-color: var(--px-accent-line); }
```

An outline follows each element's own radius, leaves real shadows intact, and respects `outline-hidden!` — `!important` inside a cascade layer outranks our unlayered rule. The `html.dark` line exists only to outrank Mintlify's own `html.dark :focus-visible`, which would otherwise supply the color in dark mode.

## Verification

The assistant panel doesn't render under `mint dev` (it needs Mintlify's hosted service), so the ring was only reproducible in production. Checked on the live Phoenix docs with headless Chromium, against `/docs/phoenix/agent-assisted-setup`:

- Before: textarea computed `box-shadow: rgba(0,157,210,0.55) 0 0 0 3px` with `border-radius: 2px`, inside a container whose border is `rgb(0,118,158)` — the rectangle-in-a-rounded-box artifact.
- After: textarea computes `outline-style: none` and no ring; container keeps Mintlify's brand border. Radius no longer forced.
- Code blocks: overlay `background-image` goes `linear-gradient(…)` → `none`, and the button chip resolves to `#E9EAEC` in light / `#1E2226` in dark against a `#F1F2F3` / `#050506` field. Verified on all 5 ungrouped blocks on that page, both modes.
- Both the copy and Ask AI buttons are `<button>` elements in that row, so both pick up the chip.

Note for reviewers checking locally: `mint dev` inlines a stale copy of `style.css` next to the fresh one, so the old focus ring can still compute in the browser until you restart it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)