### PR TITLE
docs: restore redirects for the removed legacy evaluator pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2262,6 +2262,50 @@
       "destination": "/docs/phoenix/evaluation/pre-built-metrics/faithfulness"
     },
     {
+      "source": "/docs/phoenix/evaluation/pre-built-metrics/document-relevance",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics/retrieval-relevance"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/pre-built-metrics/retrieval-rag-relevance",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics/retrieval-relevance"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/pre-built-metrics/tool-calling-eval",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics/tool-selection"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/pre-built-metrics/q-and-a-on-retrieved-data",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/pre-built-metrics/summarization-eval",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/pre-built-metrics/sql-generation-eval",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/running-pre-tested-evals/retrieval-rag-relevance",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics/retrieval-relevance"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/running-pre-tested-evals/tool-calling-eval",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics/tool-selection"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/running-pre-tested-evals/q-and-a-on-retrieved-data",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/running-pre-tested-evals/summarization-eval",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
+    },
+    {
+      "source": "/docs/phoenix/evaluation/running-pre-tested-evals/sql-generation-eval",
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
+    },
+    {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/toxicity",
       "destination": "/docs/phoenix/evaluation/pre-built-metrics/toxicity"
     },

--- a/docs.json
+++ b/docs.json
@@ -2051,7 +2051,7 @@
     },
     {
       "source": "/docs/phoenix/tracing/integrations-tracing/openai-node-sdk",
-      "destination": "/docs/phoenix/integrations/llm-providers/openai/openai-node.js-sdk"
+      "destination": "/docs/phoenix/integrations/llm-providers/openai/openai-node-js-sdk"
     },
     {
       "source": "/docs/phoenix/tracing/integrations-tracing/flowise",
@@ -2315,39 +2315,39 @@
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/code-metrics",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/code-metrics"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/code-generation-eval",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/code-generation-eval"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/ai-vs-human-groundtruth",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/ai-vs-human-groundtruth"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/reference-link-evals",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/reference-link-evals"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/user-frustration",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/user-frustration"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics/user-friction"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/agent-path-convergence",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/agent-path-convergence"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/agent-planning",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/agent-planning"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/agent-reflection",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/agent-reflection"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/running-pre-tested-evals/audio-emotion-detection",
-      "destination": "/docs/phoenix/evaluation/legacy/archived-evals/audio-emotion-detection"
+      "destination": "/docs/phoenix/evaluation/pre-built-metrics"
     },
     {
       "source": "/docs/phoenix/evaluation/llm-evals/executors",


### PR DESCRIPTION
Twenty-one Phoenix docs URLs currently 404. Eleven are a regression from #14933; ten predate it. Found while investigating a card-link check failure on [Arize-ai/docs#861](https://github.com/Arize-ai/docs/pull/861), where five links from the AX `llm-as-a-judge` page broke.

## What actually happened

Nothing moved — the pages were **deleted**. `docs: remove legacy evaluator docs (#14933)` removed six pre-built-metric pages:

| Removed page | Status |
| --- | --- |
| `pre-built-metrics/document-relevance` | 404 |
| `pre-built-metrics/retrieval-rag-relevance` | 404 |
| `pre-built-metrics/tool-calling-eval` | 404 |
| `pre-built-metrics/q-and-a-on-retrieved-data` | 404 |
| `pre-built-metrics/summarization-eval` | 404 |
| `pre-built-metrics/sql-generation-eval` | 404 |

No redirects were added for them. The PR also **deleted** the five existing redirects that had pointed the older `evaluation/running-pre-tested-evals/*` URLs at those pages, so that older generation of URLs 404s too. (`running-pre-tested-evals/toxicity` still 308s correctly — that's the pattern the others lost.)

## Where each one should go

Each deleted page carried its own deprecation notice, so the destinations come from the pages themselves rather than from my reading of the metrics:

- **`document-relevance` and `retrieval-rag-relevance` → `retrieval-relevance`.** The RAG page's notice named Document Relevance as its successor, and #14933's own commit message says it used "the new retrieval relevance evaluator in place of document relevance".
- **`tool-calling-eval` → `tool-selection`**, the first of the two evaluators its notice named (Tool Selection and Tool Invocation).
- **`q-and-a-on-retrieved-data`, `summarization-eval`, `sql-generation-eval` → the SDK Eval Metrics index.** These three named no successor, and the current catalog has no equivalent metric. Landing on the catalog beats guessing — but if you'd rather map Q&A to Correctness or Faithfulness, say so and I'll change it.

The five `running-pre-tested-evals/*` entries point straight at the final destination rather than chaining through a removed page.

## Second commit: ten older dead redirects

Independent of #14933, found while tracing it, in a separate commit so it's easy to drop:

- Nine redirects sent `running-pre-tested-evals/{code-metrics, code-generation-eval, ai-vs-human-groundtruth, reference-link-evals, user-frustration, agent-path-convergence, agent-planning, agent-reflection, audio-emotion-detection}` to `evaluation/legacy/archived-evals/*` — pages deleted back in #12123. Every one resolved to a 404 by way of a 308. `user-frustration` has an exact successor in `user-friction`; the rest go to the catalog index.
- One typo: the OpenAI Node SDK redirect pointed at `openai-node.js-sdk`, with a literal dot, while the page is `openai-node-js-sdk`.

## Verification

- Every 404 above confirmed with a `curl -L` against the live site, not inferred from the repo.
- Every new destination confirmed to resolve 200 live and to exist as a page in `docs.json` navigation.
- No duplicate redirect sources, and no new redirect points at another redirect's source. JSON re-parsed after editing; 149 → 160 entries, and the ten repointings are in-place edits.

## Not covered

The `evaluation/legacy/archived-evals/*` URLs themselves have no redirects at all and still 404 — they were live in the pre-#12123 IA. Happy to add those too if you want them covered; I left them out since it's your call whether that generation of URLs still matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)