### PR TITLE
fix(mcp/sql): harden the analytics SQL surface

### DIFF
--- a/src/phoenix/server/mcp/sql/allowlist.py
+++ b/src/phoenix/server/mcp/sql/allowlist.py
@@ -142,8 +142,8 @@ ALLOWED_FUNC_CLASSES_BY_DIALECT: dict[SupportedSQLDialectName, frozenset[type[ex
             # After parse, `jsonb_contains(x, y)` and `x ? y` are the same node,
             # so we emit `?`. Do not rewrite this class to `@>` — that would
             # change real `?` queries. `@>` is ArrayContainsAll.
-            # Write-up:
-            # .scratch/pending_issues/sglglot/ISSUE-postgres-jsonb-contains-emits-key-exists.md
+            # Workaround for https://github.com/tobymao/sqlglot/issues/8152,
+            # fixed upstream but unreleased at the pinned version.
             exp.JSONBContains,
             exp.JSONBContainsAnyTopKeys,
             exp.JSONBContainsAllTopKeys,

--- a/src/phoenix/server/mcp/sql/allowlist.py
+++ b/src/phoenix/server/mcp/sql/allowlist.py
@@ -181,9 +181,8 @@ ALLOWED_FUNC_CLASSES_BY_DIALECT: dict[SupportedSQLDialectName, frozenset[type[ex
             exp.TimeToStr,
             # date() truncates a timestamp to its day, which is the coarser half
             # of the same bucketing need and the spelling most callers try
-            # first. The authorizer already permitted it; only admission did
-            # not, so a caller was refused a function the engine was willing to
-            # run.
+            # first. The authorizer permits it, so admission must too, or a
+            # caller is refused a function the engine is willing to run.
             exp.Date,
             # json1 construction. `json_object` is bounded by its arguments.
             #
@@ -207,12 +206,12 @@ ALLOWED_FUNC_CLASSES_BY_DIALECT: dict[SupportedSQLDialectName, frozenset[type[ex
             # question once a caller has found a key but does not know whether
             # the value is a scalar, an object or an array.
             exp.JSONType,
-            # SQLite's type-of-a-value probe. The authorizer already permitted
-            # it; only admission did not, so a caller was refused a function
-            # the engine was willing to run.
+            # SQLite's type-of-a-value probe, which the authorizer permits, so
+            # admission has to as well or the two policies disagree about a
+            # function the engine is willing to run.
             exp.Typeof,
-            # sqlean stats. The schema used to say this was unavailable; the
-            # authorizer already permitted it. `percentile(x, 50)` is the same
+            # sqlean stats, which the authorizer permits. `median(x)` is the
+            # median as its own function. `percentile(x, 50)` is the same
             # question with an explicit percentile.
             exp.Median,
         }
@@ -316,9 +315,9 @@ SQLITE_AUTHORIZER_FUNCTIONS: frozenset[str] = frozenset(
         "lower",
         # Admitted by the parser policy as portable classes (exp.Upper,
         # exp.Length, exp.CurrentTimestamp, exp.CurrentDate) but absent here,
-        # so each worked on PostgreSQL and was refused on SQLite -- the exact
-        # divergence the two policies exist to prevent. The liveness suite now
-        # executes all four so the gap cannot silently reopen.
+        # a class listed there but absent here works on PostgreSQL and is refused
+        # on SQLite -- the exact divergence the two policies exist to prevent.
+        # The liveness suite executes all four so the gap cannot open silently.
         "upper",
         "length",
         "current_timestamp",
@@ -521,8 +520,9 @@ ALLOWED_ANON_FUNCTIONS_BY_DIALECT: dict[SupportedSQLDialectName, frozenset[str]]
         {
             "unixepoch",
             "datetime",
-            # time() is the time-of-day constructor. CAST AS TIME used to become
-            # CAST AS TEXT, which returns the full datetime string.
+            # time() is the time-of-day constructor, and the only spelling that
+            # yields one: CAST AS TIME renders as CAST AS TEXT, which keeps the
+            # full datetime string.
             "time",
             # The older spelling of the same idea, and the one a model is more
             # likely to reach for: julianday has been in SQLite for decades

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from functools import lru_cache
-from typing import Any, Optional, cast
+from typing import Any, Optional, TypeVar, cast
 from urllib.parse import quote
 from weakref import WeakKeyDictionary
 
@@ -48,6 +48,8 @@ from phoenix.server.mcp.sql.rewrite import RewriteContext, rewrite
 from phoenix.server.types import DbSessionFactory
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 _call_counter = itertools.count(1)
 
@@ -640,7 +642,7 @@ async def execute_analytics_sql(
             return admit(parsed, allowlist=allowlist, dialect=dialect)
 
         try:
-            root = await asyncio.to_thread(_admitted)
+            root = await _offloaded(_admitted)
         except AnalyticsSqlError as exc:
             # A refusal is ordinary traffic, not an incident -- callers are
             # expected to probe the boundary. Debug level records which rule
@@ -678,7 +680,7 @@ async def execute_analytics_sql(
             rewritten = rewrite(root, ctx)
             return rewritten, render(rewritten, dialect=dialect)
 
-        root, rendered = await asyncio.to_thread(_rendered)
+        root, rendered = await _offloaded(_rendered)
 
         # The executed statement is not the one the caller wrote: stars are
         # expanded, virtual columns substituted, timestamp literals re-emitted
@@ -725,7 +727,7 @@ async def execute_analytics_sql(
                 # cancellation for the caller.
                 release_semaphore = False
                 exc.worker.add_done_callback(
-                    lambda worker: _release_sqlite_after_worker(worker, semaphore)
+                    lambda worker: _release_after_worker(worker, semaphore, "sqlite")
                 )
                 raise
         if params.validate_only:
@@ -738,6 +740,15 @@ async def execute_analytics_sql(
             result.envelope.row_count_is_partial,
         )
         return result
+    except _OffloadedWorkerCancellation as exc:
+        # The thread finishes its parse or rewrite whatever the caller does.
+        # Holding the permit until it exits keeps concurrency bounded by the
+        # work actually running rather than by the callers still waiting.
+        release_semaphore = False
+        exc.worker.add_done_callback(
+            lambda worker: _release_after_worker(worker, semaphore, dialect)
+        )
+        raise
     finally:
         if release_semaphore:
             semaphore.release(dialect)
@@ -1065,11 +1076,12 @@ class _SQLiteWorkerCancellation(asyncio.CancelledError):
         self.worker = worker
 
 
-def _release_sqlite_after_worker(
-    worker: asyncio.Task[tuple[list[str], list[list[Any]], bool, list[str], bool]],
+def _release_after_worker(
+    worker: asyncio.Task[Any],
     semaphore: ExecutionSemaphore,
+    dialect: SupportedSQLDialectName,
 ) -> None:
-    """Consume an abandoned worker result, then return its SQLite capacity."""
+    """Consume an abandoned worker result, then return its capacity."""
     try:
         worker.result()
     except BaseException:
@@ -1077,7 +1089,33 @@ def _release_sqlite_after_worker(
         # delivered, but must be consumed so asyncio does not report it later.
         pass
     finally:
-        semaphore.release("sqlite")
+        semaphore.release(dialect)
+
+
+class _OffloadedWorkerCancellation(asyncio.CancelledError):
+    """A cancelled caller whose CPU-bound worker is still running.
+
+    Parsing and rewriting are uninterruptible, so the thread runs to completion
+    however the caller ends.
+    """
+
+    def __init__(self, worker: asyncio.Task[Any]) -> None:
+        self.worker = worker
+
+
+async def _offloaded(func: Callable[[], _T]) -> _T:
+    """Run a CPU-bound step off the event loop, naming a worker that outlives its caller.
+
+    Awaiting `to_thread` directly reports cancellation while leaving the thread
+    running, so the permit goes back before the work stops and the next
+    statement starts beside it. Shielding keeps the worker reachable, so the
+    permit can follow the thread rather than the await.
+    """
+    worker = asyncio.create_task(asyncio.to_thread(func))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        raise _OffloadedWorkerCancellation(worker) from None
 
 
 async def _execute_sqlite_file(

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -78,9 +78,9 @@ MAX_ROW_LIMIT = 5_000
 
 # Ceiling on the whole encoded response, as distinct from any single cell.
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
-# Parsing, admission and rewriting run before any guard that bounds execution,
-# and their cost grows faster than the input for statements that nest -- so the
-# input is bounded here, and raising this raises that cost superlinearly.
+# Parsing, admission and rewriting precede every guard that bounds execution,
+# and their cost grows superlinearly in the input for statements that nest, so
+# this is the only bound on the CPU a single call can buy.
 MAX_SQL_BYTES = 2 * 1024
 BYTE_LIMIT = 262_144
 PG_STATEMENT_TIMEOUT_MS = 30_000
@@ -630,13 +630,11 @@ async def execute_analytics_sql(
             schema = await resolve_pg_schema(db)
             allowlist = replace(allowlist, pg_schema=schema)
 
-        # Parsing, admission and rewriting are CPU-bound and scale with the
-        # size of the statement, up to the input cap.
-        # Run on the event loop they starve the whole process -- every other
-        # request, ingestion included -- for as long as they take, which the
-        # row limit, byte caps and statement deadline do not bound because
-        # none of them applies before the backend is reached. SQLite execution
-        # is already offloaded for the same reason.
+        # Parsing, admission and rewriting are CPU-bound. Run on the event
+        # loop they starve the whole process -- every other request, ingestion
+        # included -- for as long as they take, and no execution guard -- row
+        # limit, byte caps, deadline -- applies before the backend is reached.
+        # SQLite execution is offloaded for the same reason.
         def _admitted() -> Any:
             parsed = parse_sql(params.sql, dialect=dialect)
             return admit(parsed, allowlist=allowlist, dialect=dialect)
@@ -1009,10 +1007,10 @@ def _rewrite_attribution(exc: BaseException, ctx: RewriteContext) -> Optional[An
     column = match.group("column")
     qualifier = match.group("qualifier")
     # Matched against what a substitution actually wrote, qualifier included.
-    # Keying on the bare column name instead blamed a rewrite for the caller's
+    # Keying on the bare column name instead blames a rewrite for the caller's
     # own mistake: `id`, `start_time` and `end_time` are ordinary column names,
-    # so an unrelated typo like `q.id` drew "this is a defect in the rewrite"
-    # whenever the node-id pass had fired anywhere in the statement.
+    # so an unrelated typo like `q.id` draws "this is a defect in the rewrite"
+    # whenever the node-id pass has fired anywhere in the statement.
     written = f"{qualifier}.{column}" if qualifier else column
     rewrite_name = ctx.substituted_columns.get(written)
     if rewrite_name is None:
@@ -1220,7 +1218,7 @@ async def _execute_sqlite_file(
         # SQLite's own words, as PostgreSQL's are already passed through. The
         # commonest arrival here is an unqualified column two joined tables both
         # offer, which admission cannot refuse and whose message names only the
-        # caller's own identifier -- withholding it turned an ordinary mistake
+        # caller's own identifier -- withholding it turns an ordinary mistake
         # into an un-actionable answer on one backend and a precise one on the
         # other, which is the divergence class this surface exists to avoid.
         #

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -78,7 +78,10 @@ MAX_ROW_LIMIT = 5_000
 
 # Ceiling on the whole encoded response, as distinct from any single cell.
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
-MAX_SQL_BYTES = 1024 * 1024
+# Parsing, admission and rewriting run before any guard that bounds execution,
+# and their cost grows faster than the input for statements that nest -- so the
+# input is bounded here, and raising this raises that cost superlinearly.
+MAX_SQL_BYTES = 2 * 1024
 BYTE_LIMIT = 262_144
 PG_STATEMENT_TIMEOUT_MS = 30_000
 SQLITE_TIMEOUT_SECONDS = 30
@@ -610,7 +613,7 @@ async def execute_analytics_sql(
         if len(params.sql.encode("utf-8")) > MAX_SQL_BYTES:
             raise AnalyticsSqlError(
                 code=ErrorCode.UNSUPPORTED_SYNTAX,
-                message=f"SQL text exceeds the {MAX_SQL_BYTES // (1024 * 1024)} MiB input limit.",
+                message=f"SQL text exceeds the {MAX_SQL_BYTES // 1024} KiB input limit.",
             )
         if dialect == "sqlite" and sqlite_db_path is None:
             sqlite_db_path = await resolve_sqlite_db_path(db)
@@ -628,7 +631,7 @@ async def execute_analytics_sql(
             allowlist = replace(allowlist, pg_schema=schema)
 
         # Parsing, admission and rewriting are CPU-bound and scale with the
-        # size of the statement, and the input cap allows a megabyte of it.
+        # size of the statement, up to the input cap.
         # Run on the event loop they starve the whole process -- every other
         # request, ingestion included -- for as long as they take, which the
         # row limit, byte caps and statement deadline do not bound because

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -879,7 +879,7 @@ async def _execute_postgres(
         # EXPLAIN resolves names, so a name error surfaces here rather than at
         # the statement below and needs the same mapping. PostgreSQL's own text
         # is passed through: it describes the caller's query against tables they
-        # were shown, so there is nothing to withhold. Most typos no longer
+        # were shown, so there is nothing to withhold. Most typos do not
         # reach this point -- the column allowlist refuses them first -- but an
         # unqualified name beside a table-valued function still does.
         try:

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -626,9 +626,19 @@ async def execute_analytics_sql(
         if dialect == "postgresql":
             schema = await resolve_pg_schema(db)
             allowlist = replace(allowlist, pg_schema=schema)
+        # Parsing, admission and rewriting are CPU-bound and scale with the
+        # size of the statement, and the input cap allows a megabyte of it.
+        # Run on the event loop they starve the whole process -- every other
+        # request, ingestion included -- for as long as they take, which the
+        # row limit, byte caps and statement deadline do not bound because
+        # none of them applies before the backend is reached. SQLite execution
+        # is already offloaded for the same reason.
+        def _admitted() -> Any:
+            parsed = parse_sql(params.sql, dialect=dialect)
+            return admit(parsed, allowlist=allowlist, dialect=dialect)
+
         try:
-            root = parse_sql(params.sql, dialect=dialect)
-            root = admit(root, allowlist=allowlist, dialect=dialect)
+            root = await asyncio.to_thread(_admitted)
         except AnalyticsSqlError as exc:
             # A refusal is ordinary traffic, not an incident -- callers are
             # expected to probe the boundary. Debug level records which rule
@@ -661,8 +671,11 @@ async def execute_analytics_sql(
         )
         if params.row_limit is not None and requested != row_limit:
             ctx.notes.append(f"row_limit clamped to {row_limit}")
-        root = rewrite(root, ctx)
-        rendered = render(root, dialect=dialect)
+        def _rendered() -> tuple[Any, str]:
+            rewritten = rewrite(root, ctx)
+            return rewritten, render(rewritten, dialect=dialect)
+
+        root, rendered = await asyncio.to_thread(_rendered)
 
         # The executed statement is not the one the caller wrote: stars are
         # expanded, virtual columns substituted, timestamp literals re-emitted

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -1182,11 +1182,12 @@ async def _execute_sqlite_file(
         raise
     except _SQLITE_RUNTIME_ERRORS as exc:
         message = str(exc).lower()
-        # Matched whole, not as a substring. SQLite reports the deadline
-        # interrupt as exactly "interrupted", while a caller's own identifier
-        # reaches here inside a longer sentence -- `ambiguous column name:
-        # timeout` was reported as a timeout, sending an agent to retry a
-        # statement it needed to fix.
+        # Anchored rather than searched. SQLite reports the deadline interrupt
+        # as exactly "interrupted", while a caller's own identifier reaches here
+        # inside a longer sentence -- `ambiguous column name: timeout` was
+        # reported as a timeout, sending an agent to retry a statement it needed
+        # to fix. No SQLite message begins with "timeout"; that branch is a
+        # guard for drivers that word a deadline differently.
         if message.strip() == "interrupted" or message.startswith("timeout"):
             raise AnalyticsSqlError(code=ErrorCode.TIMEOUT, message="Query timed out.") from exc
         # A refusal by the authorizer reaches the driver as an ordinary operational

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -626,6 +626,7 @@ async def execute_analytics_sql(
         if dialect == "postgresql":
             schema = await resolve_pg_schema(db)
             allowlist = replace(allowlist, pg_schema=schema)
+
         # Parsing, admission and rewriting are CPU-bound and scale with the
         # size of the statement, and the input cap allows a megabyte of it.
         # Run on the event loop they starve the whole process -- every other
@@ -671,6 +672,7 @@ async def execute_analytics_sql(
         )
         if params.row_limit is not None and requested != row_limit:
             ctx.notes.append(f"row_limit clamped to {row_limit}")
+
         def _rendered() -> tuple[Any, str]:
             rewritten = rewrite(root, ctx)
             return rewritten, render(rewritten, dialect=dialect)

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import itertools
 import json
 import logging
@@ -144,10 +145,15 @@ _SQLITE_CATALOG_TABLES = frozenset(
 )
 
 
+#: Statements each backend runs at once. The thread pool for the CPU-bound
+#: phases is sized from the same table, so the two cannot drift apart.
+SQL_CONCURRENCY: dict[SupportedSQLDialectName, int] = {"postgresql": 4, "sqlite": 1}
+
+
 @dataclass
 class ExecutionSemaphore:
     _width_by_dialect: dict[SupportedSQLDialectName, int] = field(
-        default_factory=lambda: {"postgresql": 4, "sqlite": 1}
+        default_factory=lambda: dict(SQL_CONCURRENCY)
     )
     _queue_size: int = 8
     _locks: dict[SupportedSQLDialectName, asyncio.Semaphore] = field(default_factory=dict)
@@ -612,7 +618,10 @@ async def execute_analytics_sql(
     await semaphore.acquire(dialect)
     release_semaphore = True
     try:
-        if len(params.sql.encode("utf-8")) > MAX_SQL_BYTES:
+        # Characters first. UTF-8 never encodes to fewer bytes than characters,
+        # so an over-long string is refused without encoding it -- measuring by
+        # encoding would do work proportional to the input this cap bounds.
+        if len(params.sql) > MAX_SQL_BYTES or len(params.sql.encode("utf-8")) > MAX_SQL_BYTES:
             raise AnalyticsSqlError(
                 code=ErrorCode.UNSUPPORTED_SYNTAX,
                 message=f"SQL text exceeds the {MAX_SQL_BYTES // 1024} KiB input limit.",
@@ -632,11 +641,12 @@ async def execute_analytics_sql(
             schema = await resolve_pg_schema(db)
             allowlist = replace(allowlist, pg_schema=schema)
 
-        # Parsing, admission and rewriting are CPU-bound. Run on the event
-        # loop they starve the whole process -- every other request, ingestion
-        # included -- for as long as they take, and no execution guard -- row
-        # limit, byte caps, deadline -- applies before the backend is reached.
-        # SQLite execution is offloaded for the same reason.
+        # Parsing, admission and rewriting are CPU-bound, and no execution
+        # guard -- row limit, byte caps, deadline -- applies before the backend
+        # is reached. Run on the event loop the whole phase is one uninterrupted
+        # block, so every concurrent request waits it out; run in a thread the
+        # loop is scheduled throughout. SQLite execution is offloaded for the
+        # same reason.
         def _admitted() -> Any:
             parsed = parse_sql(params.sql, dialect=dialect)
             return admit(parsed, allowlist=allowlist, dialect=dialect)
@@ -727,7 +737,7 @@ async def execute_analytics_sql(
                 # cancellation for the caller.
                 release_semaphore = False
                 exc.worker.add_done_callback(
-                    lambda worker: _release_after_worker(worker, semaphore, "sqlite")
+                    lambda worker: _release_after_worker(worker, semaphore, "sqlite", call_id)
                 )
                 raise
         if params.validate_only:
@@ -746,7 +756,7 @@ async def execute_analytics_sql(
         # work actually running rather than by the callers still waiting.
         release_semaphore = False
         exc.worker.add_done_callback(
-            lambda worker: _release_after_worker(worker, semaphore, dialect)
+            lambda worker: _release_after_worker(worker, semaphore, dialect, call_id)
         )
         raise
     finally:
@@ -1077,45 +1087,91 @@ class _SQLiteWorkerCancellation(asyncio.CancelledError):
 
 
 def _release_after_worker(
-    worker: asyncio.Task[Any],
+    worker: asyncio.Future[Any],
     semaphore: ExecutionSemaphore,
     dialect: SupportedSQLDialectName,
+    call_id: str,
 ) -> None:
-    """Consume an abandoned worker result, then return its capacity."""
+    """Consume an abandoned worker result, then return its capacity.
+
+    The result cannot reach the caller, but a failure that is not a refusal is
+    a defect in this pipeline, and discarding it hides exactly the concurrency
+    faults that are hardest to reproduce.
+    """
     try:
         worker.result()
-    except BaseException:
-        # The caller has already been cancelled. Its eventual result cannot be
-        # delivered, but must be consumed so asyncio does not report it later.
+    except (asyncio.CancelledError, AnalyticsSqlError):
         pass
+    except BaseException:
+        logger.exception("analytics sql: %s abandoned worker failed", call_id)
     finally:
         semaphore.release(dialect)
 
 
 class _OffloadedWorkerCancellation(asyncio.CancelledError):
-    """A cancelled caller whose CPU-bound worker is still running.
+    """A cancelled caller whose CPU-bound worker had already started.
 
-    Parsing and rewriting are uninterruptible, so the thread runs to completion
-    however the caller ends.
+    Parsing and rewriting are uninterruptible, so a thread that has begun runs
+    to completion however the caller ends. A call cancelled before its thread
+    starts raises plain `CancelledError` instead, because no work escapes.
     """
 
-    def __init__(self, worker: asyncio.Task[Any]) -> None:
+    def __init__(self, worker: asyncio.Future[Any]) -> None:
         self.worker = worker
 
 
-async def _offloaded(func: Callable[[], _T]) -> _T:
-    """Run a CPU-bound step off the event loop, naming a worker that outlives its caller.
+#: Threads for the CPU-bound phases. Sized to the concurrency the semaphore
+#: already permits across both dialects, and separate from the default executor
+#: so caller SQL cannot occupy the pool the rest of the server shares. A permit
+#: is held before any work is submitted, so this should never queue; the
+#: queued-cancellation branch in `_offloaded` is the backstop if it ever does.
+_EXECUTOR_WIDTH = sum(SQL_CONCURRENCY.values())
+_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_executor_guard = threading.Lock()
 
-    Awaiting `to_thread` directly reports cancellation while leaving the thread
-    running, so the permit goes back before the work stops and the next
-    statement starts beside it. Shielding keeps the worker reachable, so the
-    permit can follow the thread rather than the await.
+
+def _sql_executor() -> concurrent.futures.ThreadPoolExecutor:
+    global _executor
+    with _executor_guard:
+        if _executor is None:
+            _executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=_EXECUTOR_WIDTH, thread_name_prefix="analytics-sql"
+            )
+        return _executor
+
+
+def shutdown_sql_executor(*, wait: bool = True) -> None:
+    """Stop the analytics SQL threads. Idempotent; the pool is rebuilt on demand."""
+    global _executor
+    with _executor_guard:
+        pool, _executor = _executor, None
+    if pool is not None:
+        pool.shutdown(wait=wait)
+
+
+async def _offloaded(func: Callable[[], _T]) -> _T:
+    """Run a CPU-bound step off the event loop, distinguishing queued work from started work.
+
+    The event loop cannot preempt this work, but it can interleave with it: run
+    inline, the loop gets a single scheduling opportunity for the whole phase,
+    so every concurrent request waits it out. Threaded, the loop is scheduled
+    throughout. The work is pure Python, so the GIL still admits latency spikes
+    -- this buys preemptibility, not isolation.
+
+    Cancelling the await alone reports success while the thread runs on, so the
+    permit would go back before the work stops. Owning the submitted future
+    separates the two cases the permit must respect: a future cancelled before
+    a thread claims it does no work at all and its permit is free immediately,
+    while one already running must keep the permit until it exits.
     """
-    worker = asyncio.create_task(asyncio.to_thread(func))
+    future = _sql_executor().submit(func)
+    wrapped = asyncio.wrap_future(future)
     try:
-        return await asyncio.shield(worker)
+        return await asyncio.shield(wrapped)
     except asyncio.CancelledError:
-        raise _OffloadedWorkerCancellation(worker) from None
+        if future.cancel():
+            raise
+        raise _OffloadedWorkerCancellation(wrapped) from None
 
 
 async def _execute_sqlite_file(

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -1169,7 +1169,12 @@ async def _execute_sqlite_file(
         raise
     except _SQLITE_RUNTIME_ERRORS as exc:
         message = str(exc).lower()
-        if "timeout" in message or "interrupted" in message:
+        # Matched whole, not as a substring. SQLite reports the deadline
+        # interrupt as exactly "interrupted", while a caller's own identifier
+        # reaches here inside a longer sentence -- `ambiguous column name:
+        # timeout` was reported as a timeout, sending an agent to retry a
+        # statement it needed to fix.
+        if message.strip() == "interrupted" or message.startswith("timeout"):
             raise AnalyticsSqlError(code=ErrorCode.TIMEOUT, message="Query timed out.") from exc
         # A refusal by the authorizer reaches the driver as an ordinary operational
         # error, so without this the caller is told only that something failed. The

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -2756,6 +2756,78 @@ def _check_session_identity(
     return None
 
 
+def _json_each_column_failure(
+    scope: Any,
+    *,
+    localities: Any,
+    by_reference: dict[str, str],
+    allowlist: Allowlist,
+    dialect: SupportedSQLDialectName,
+) -> Optional[AdmissionResult]:
+    """Refuse a column `json_each` does not project.
+
+    SQLite reads a quoted unknown identifier as a string, so `"nope"` beside
+    `json_each` returns that word as data rather than "no such column".
+
+    The names `json_each` projects are fixed, so this resolves against the
+    function alone. It is asked of every scope holding one, including a scope
+    that reads no allowlisted table and therefore has nothing else to check
+    a column against.
+    """
+    if dialect != "sqlite":
+        return None
+    json_each_by_alias = _json_each_bindings(scope)
+    if not json_each_by_alias:
+        return None
+    # A source whose columns nobody can enumerate could have projected the
+    # name, so an unqualified reference is no longer evidence about json_each.
+    has_opaque_foreign = any(
+        not (
+            isinstance(source, exp.Table)
+            and (
+                _allowlisted_table_name(source, allowlist=allowlist, dialect=dialect) is not None
+                or _json_each_columns_for_relation(source) is not None
+            )
+        )
+        for source in scope.sources.values()
+    )
+    json_each_names = frozenset().union(*json_each_by_alias.values())
+    candidates = list(dict.fromkeys(by_reference.values()))
+    for column in _scope_columns(scope.expression):
+        if localities.is_structurally_local(column) or isinstance(column.this, exp.Star):
+            continue
+        if localities.is_alias_bound(column):
+            continue
+        qualifier = column.table or ""
+        if qualifier:
+            if qualifier.casefold() not in json_each_by_alias:
+                continue
+            offered = json_each_by_alias[qualifier.casefold()]
+        else:
+            if has_opaque_foreign:
+                continue
+            offered = json_each_names
+        name = column.name or ""
+        if name.casefold() in offered:
+            continue
+        if not qualifier and any(
+            _offers_column(allowlist, table_name, column, dialect) for table_name in candidates
+        ):
+            continue
+        listed = ", ".join(_JSON_EACH_COLUMNS)
+        subject = (
+            f"Column {qualifier}.{name} is not projected by json_each."
+            if qualifier
+            else f"Column {name} is not projected by json_each."
+        )
+        return AdmissionResult(
+            AdmissionOutcome.UNSUPPORTED_SYNTAX,
+            subject,
+            message=f"{subject} json_each columns are {listed}.",
+        )
+    return None
+
+
 def _check_column_references(
     root: exp.Expression, *, allowlist: Allowlist, dialect: SupportedSQLDialectName
 ) -> Optional[AdmissionResult]:
@@ -2816,6 +2888,17 @@ def _check_column_references(
             if table_name is not None:
                 by_reference.setdefault(node.alias or node.name, table_name)
                 by_reference.setdefault(node.name, table_name)
+        # Ahead of the early-out: json_each names its own columns, so this one
+        # resolves without an allowlisted table to check against.
+        json_each_failure = _json_each_column_failure(
+            scope,
+            localities=localities,
+            by_reference=by_reference,
+            allowlist=allowlist,
+            dialect=dialect,
+        )
+        if json_each_failure is not None:
+            return json_each_failure
         if not by_reference:
             continue
         columns = _scope_columns(scope.expression)
@@ -2928,17 +3011,6 @@ def _check_column_references(
             )
             for source in scope.sources.values()
         )
-        has_opaque_foreign = any(
-            not (
-                isinstance(source, exp.Table)
-                and (
-                    _allowlisted_table_name(source, allowlist=allowlist, dialect=dialect)
-                    is not None
-                    or _json_each_columns_for_relation(source) is not None
-                )
-            )
-            for source in scope.sources.values()
-        )
         for column in columns:
             if localities.is_structurally_local(column) or isinstance(column.this, exp.Star):
                 continue
@@ -2989,26 +3061,6 @@ def _check_column_references(
             )
             if json_each_columns is not None and name.casefold() in json_each_columns:
                 continue
-            # SQLite treats a quoted unknown identifier as a string, so
-            # `"nope"` from json_each is a silent wrong answer rather than
-            # "no such column". Name the columns json_each actually projects.
-            if (
-                dialect == "sqlite"
-                and json_each_by_alias
-                and (qualifier.casefold() in json_each_by_alias or not qualifier)
-                and not (not qualifier and has_opaque_foreign)
-            ):
-                offered = ", ".join(_JSON_EACH_COLUMNS)
-                subject = (
-                    f"Column {qualifier}.{name} is not projected by json_each."
-                    if qualifier
-                    else f"Column {name} is not projected by json_each."
-                )
-                return AdmissionResult(
-                    AdmissionOutcome.UNSUPPORTED_SYNTAX,
-                    subject,
-                    message=f"{subject} json_each columns are {offered}.",
-                )
             if not candidates:
                 continue
             # Unknown to the manifest. That is a refusal when the allowlisted

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -2703,14 +2703,57 @@ def _check_base_tables(
 
 #: Names an engine binds implicitly, so a foreign source in the FROM clause is
 #: not evidence that a relation in the statement projects them. PostgreSQL
-#: system columns and the niladic keywords that parse as a bare column rather
-#: than as a function; SQLite's rowid aliases.
+#: system columns; SQLite's rowid aliases. Each binds to a base table, so it
+#: resolves only where one is in scope, which is why membership here is read
+#: against the relations a statement reads.
 _RESERVED_IMPLICIT_NAMES: dict[SupportedSQLDialectName, frozenset[str]] = {
-    "postgresql": frozenset(
-        {"ctid", "xmin", "xmax", "cmin", "cmax", "tableoid", "user", "current_role"}
-    ),
+    "postgresql": frozenset({"ctid", "xmin", "xmax", "cmin", "cmax", "tableoid"}),
     "sqlite": frozenset({"rowid", "oid", "_rowid_"}),
 }
+
+#: Names that return who the connection is. PostgreSQL spells these as niladic
+#: keywords, which SQLGlot parses as a bare column rather than as a function, so
+#: the function allowlist never sees them. They are reserved words: unquoted is
+#: always the keyword, and quoted is an ordinary column reference. They bind to
+#: the session, so no relation has to be in scope for one to resolve.
+_SESSION_IDENTITY_NAMES: dict[SupportedSQLDialectName, frozenset[str]] = {
+    "postgresql": frozenset({"user", "current_role", "system_user"}),
+    "sqlite": frozenset(),
+}
+
+
+def _check_session_identity(
+    root: exp.Expression, *, dialect: SupportedSQLDialectName
+) -> Optional[AdmissionResult]:
+    """Refuse the session identity wherever it appears.
+
+    This is the whole tree rather than a walk over the relations in scope: the
+    keyword needs no FROM clause, so a statement that reads nothing allowlisted
+    still evaluates it, and neither the plan gate nor the SQLite authorizer
+    inspects column expressions.
+    """
+    names = _SESSION_IDENTITY_NAMES[dialect]
+    if not names:
+        return None
+    for column in root.find_all(exp.Column):
+        if column.table:
+            continue
+        identifier = column.this
+        if isinstance(identifier, exp.Identifier) and identifier.args.get("quoted"):
+            continue
+        name = column.name or ""
+        if name.casefold() in names:
+            subject = f"{name} is reserved."
+            return AdmissionResult(
+                AdmissionOutcome.UNSUPPORTED_SYNTAX,
+                subject,
+                message=(
+                    f"{subject} Unquoted, it returns the identity the connection "
+                    "authenticated as rather than a column of any relation. Quote it "
+                    "to name a column spelled that way."
+                ),
+            )
+    return None
 
 
 def _check_column_references(
@@ -2975,10 +3018,10 @@ def _check_column_references(
             # projecting `key` is a shape the schema teaches.
             #
             # Reserved names are excepted. The engine binds them to the base
-            # table or to the session rather than to the foreign source, so
-            # admitting them on the chance the source projects them hands over
-            # a system column or the session identity. A caller who does mean a
-            # projected column of that name can qualify it.
+            # table rather than to the foreign source, so admitting them on the
+            # chance the source projects them hands over a system column. A
+            # caller who does mean a projected column of that name can qualify
+            # it.
             if not qualifier and foreign_source:
                 if name.casefold() in _RESERVED_IMPLICIT_NAMES[dialect]:
                     subject = f"{name} is reserved."
@@ -3133,6 +3176,9 @@ def admit(
         or _check_collate(root, dialect=dialect)
         or _check_functions(root, allowlist=allowlist, dialect=dialect)
         or _check_base_tables(root, allowlist=allowlist, dialect=dialect)
+        # Before the column check, whose generic "no such column" wording would
+        # describe a keyword that resolves as neither a column nor a misspelling.
+        or _check_session_identity(root, dialect=dialect)
         or _check_column_references(root, allowlist=allowlist, dialect=dialect)
         or _check_timestamp_literals(root, allowlist=allowlist, dialect=dialect)
     )

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -2361,6 +2361,32 @@ def _ancestor_scopes(scope: Any) -> Iterable[Any]:
         current = getattr(current, "parent", None)
 
 
+def _scope_relation_keys(scope: Any, *, dialect: SupportedSQLDialectName) -> frozenset[str]:
+    """Dialect keys of the relations this scope introduces, enclosing ones excluded.
+
+    Physical tables, the tables SQLGlot files under a LATERAL rather than under
+    `sources`, and query-local aliases. A qualifier absent from this set is
+    correlated: it names a relation an enclosing scope introduced, and belongs
+    to that scope rather than to this one.
+    """
+    keys: set[str] = set()
+    for source in scope.sources.values():
+        table = _table_from_scope_source(source)
+        if table is not None:
+            keys |= _relation_identifier_keys(table, dialect=dialect)
+    for table in _lateral_tables_in_scope(scope):
+        keys |= _relation_identifier_keys(table, dialect=dialect)
+    for ident in _derived_alias_identifiers(scope):
+        keys.add(
+            _identifier_key(
+                ident.this or "",
+                quoted=bool(ident.args.get("quoted")),
+                dialect=dialect,
+            )
+        )
+    return frozenset(keys)
+
+
 def _scope_exposes_qualifier(
     scope: Any,
     qualifier: str,
@@ -2370,25 +2396,10 @@ def _scope_exposes_qualifier(
 ) -> bool:
     """Whether `qualifier` names a relation this scope or an enclosing one exposes."""
     want = _identifier_key(qualifier, quoted=quoted, dialect=dialect)
-    for current in _ancestor_scopes(scope):
-        for source in current.sources.values():
-            table = _table_from_scope_source(source)
-            if table is not None and want in _relation_identifier_keys(table, dialect=dialect):
-                return True
-        for table in _lateral_tables_in_scope(current):
-            if want in _relation_identifier_keys(table, dialect=dialect):
-                return True
-        for ident in _derived_alias_identifiers(current):
-            if (
-                _identifier_key(
-                    ident.this or "",
-                    quoted=bool(ident.args.get("quoted")),
-                    dialect=dialect,
-                )
-                == want
-            ):
-                return True
-    return False
+    return any(
+        want in _scope_relation_keys(current, dialect=dialect)
+        for current in _ancestor_scopes(scope)
+    )
 
 
 def _allowlisted_table_for_qualifier(

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -828,8 +828,8 @@ def _tree_depth(root: exp.Expression) -> int:
     nested subqueries, which alternate node types, break above 258.
 
     Same-type descent is the rule rather than a list of operator classes,
-    because a list of node classes kept in agreement by hand is how this file
-    has produced defects before.
+    because a list of node classes kept in agreement by hand drifts from the
+    node types that actually exist.
     """
     deepest = 0
     stack: list[tuple[exp.Expression, int]] = [(root, 0)]
@@ -2641,11 +2641,11 @@ def _check_base_tables(
     # an empty map and move on.
     #
     # Refused rather than resolved. PostgreSQL rejects the statement outright
-    # ("table name specified more than once"), so accepting it on SQLite was a
+    # ("table name specified more than once"), so accepting it on SQLite is a
     # divergence as well as a hole, and there is no reading a caller needs.
-    # Stated as the invariant rather than as the shape that broke it. Every real
-    # table must appear in some scope's sources, because that map is what every
-    # later check reads; a table missing from it is skipped rather than refused.
+    # Every real table must appear in some scope's sources, because that map is
+    # what every later check reads; a table missing from it is skipped rather
+    # than refused.
     #
     # Naming the cause instead -- a table alias equal to a CTE name -- would
     # refuse ordinary SQL: in `WITH t AS (...) SELECT ... FROM (SELECT ... FROM
@@ -2653,10 +2653,10 @@ def _check_base_tables(
     # both engines, and `t` is the commonest spelling of each. The invariant
     # refuses only when a table has actually been lost, whatever the cause.
     # Checked per scope, not across the statement. A flat set of every resolved
-    # name let one occurrence mask another: with `projects` read normally in one
-    # subquery and shadowed in a second, the shadowed one passed because the
-    # name appeared somewhere. That admitted a statement SQLite runs and
-    # PostgreSQL rejects outright -- the divergence this refusal exists to
+    # name lets one occurrence mask another: with `projects` read normally in
+    # one subquery and shadowed in a second, the shadowed one passes because the
+    # name appears somewhere, admitting a statement SQLite runs and PostgreSQL
+    # rejects outright -- the divergence this refusal exists to
     # prevent -- while `scope.tables` answers the question actually being asked,
     # which is whether *this* scope resolved the table it names.
     declared = {cte.alias for cte in root.find_all(exp.CTE) if cte.alias}

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -1503,11 +1503,11 @@ def _refused_cast_target(target: exp.Expression) -> Optional[str]:
     scanned relation, so the plan gate cannot see it.
 
     An array of an allowed type is allowed, because it reaches nothing the
-    element type does not. Refusing it made the surface reject its own output:
+    element type does not. Refusing it makes the surface reject its own output:
     `pg_get_indexdef` renders the operand of `#>>` as `'{a,b}'::text[]`, so
-    `describeSqlSchema` published an index spelling under a heading telling the
-    caller to reproduce it exactly, and admission then refused it. Nothing
-    protective was lost -- `regclass[]` does not parse, and an array whose
+    `describeSqlSchema` publishes an index spelling under a heading telling the
+    caller to reproduce it exactly, which admission then refuses. Nothing
+    protective is lost -- `regclass[]` does not parse, and an array whose
     element type is disallowed is still caught by the recursion.
     """
     name = _cast_type_name(target)

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -383,18 +383,15 @@ def _promote_lateral_table_references(
 ) -> exp.Expression:
     """Turn ``LATERAL traces t`` into a plain table join.
 
-    SQLGlot stores the relation as an Identifier inside Lateral and emits
-    ``LATERAL traces AS t`` or ``LATERAL schema.traces AS t``. PostgreSQL
-    rejects that ``AS``: LATERAL is for subqueries and set-returning
-    functions, not base tables. A LATERAL table join is the same request as
-    an ordinary join, which schema qualification already knows how to emit.
+    PostgreSQL rejects ``LATERAL traces t`` outright: LATERAL is for
+    subqueries and set-returning functions, not base tables. The parser
+    accepts it, and a LATERAL table join is the same request as an ordinary
+    join, which schema qualification already knows how to emit.
 
     SQLite has no LATERAL. ``json_each`` does not need it -- a table-valued
     function there may refer to earlier FROM items -- so ``LATERAL json_each``
     is the same request as a plain ``json_each``. Remaining LATERAL nodes
     (subqueries, other SRFs) are refused at admission.
-
-    Workaround for an unfiled sqlglot defect.
     """
     for lateral in list(root.find_all(exp.Lateral)):
         inner = lateral.this

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -276,8 +276,8 @@ def _lambda_parameter_document(parameter: exp.Expression) -> Optional[exp.Expres
 def _json_path_from_string(text: str) -> exp.JSONPath:
     """A JSON path for a ``->`` key or a ``$.a.b`` path literal.
 
-    A lambda body is a bare string, so ``'$.a.b'`` used to become one key
-    named ``$.a.b``. SQLite then looks up that name and answers NULL.
+    A lambda body is a bare string, so treating ``'$.a.b'`` as a single key
+    yields one named ``$.a.b``, which SQLite looks up and answers NULL.
     Asking the parser how it reads the same literal as a bare accessor
     reuses the split it already gets right outside a call.
     """
@@ -340,14 +340,14 @@ def _repair_lambda_json_accessor(
 
     ``jsonb_typeof(attributes -> 'llm')`` is a JSON accessor the engines
     execute once parenthesised. The parser reads the arrow as ``x -> body``
-    instead, so admission used to refuse it and name ``->>`` / ``json_extract``,
-    neither of which is valid input to ``jsonb_typeof``. Reconstructing the
+    instead, and admission judging that lambda refuses it while naming ``->>``
+    or ``json_extract``, neither of which is valid input to ``jsonb_typeof``. Reconstructing the
     accessor is the same request the caller wrote.
 
     The reconstructed node is the operator on both backends, matching a bare
     ``->`` outside a call. SQLite's ``->`` returns JSON text; ``json_extract``
-    and ``->>`` return the SQL value. Rebuilding as the function used to
-    change that answer inside MIN/MAX.
+    and ``->>`` return the SQL value, so rebuilding as the function changes
+    what MIN/MAX compares.
     """
     # Innermost first: a three-hop chain nests JSONExtract inside JSONExtract.
     for node in reversed(list(root.find_all(exp.Lambda))):
@@ -854,9 +854,8 @@ def _tree_depth(root: exp.Expression) -> int:
 _REFUSED_NODE_CLASSES: dict[type[exp.Expr], str] = {
     # OPERATOR(schema.op) invokes an operator by name, and exp.Operator is not an
     # exp.Func either -- so `name ~ 'x'` is refused as regexp_like while
-    # `name OPERATOR(pg_catalog.~) 'x'` was admitted and rendered verbatim. Same
-    # capability, two spellings, opposite verdicts, which means the function
-    # allowlist did not mean what it claimed.
+    # `name OPERATOR(pg_catalog.~) 'x'` bypasses the function allowlist entirely
+    # and renders verbatim. Same capability, two spellings, opposite verdicts.
     exp.Operator: (
         "OPERATOR(...) names an operator directly and bypasses the function "
         "allowlist. Use the operator's ordinary spelling."
@@ -1132,9 +1131,9 @@ def _check_lossy_shapes(
                 "many rows. Write an explicit row count instead.",
             )
     for select in root.find_all(exp.Select):
-        # PostgreSQL accepts an empty select list. SQLAlchemy will not stream
-        # a zero-column cursor, so execution used to fail with "does not
-        # return rows" after EXPLAIN had already succeeded.
+        # PostgreSQL accepts an empty select list. SQLAlchemy will not stream a
+        # zero-column cursor, so admitting one fails at execution with "does
+        # not return rows" -- after EXPLAIN has already succeeded.
         if not select.expressions:
             return AdmissionResult(
                 AdmissionOutcome.UNSUPPORTED_SYNTAX,
@@ -1388,9 +1387,9 @@ def _check_collate(
 
 #: Structural classes a SELECT may contain. Everything the parser can build
 #: that is neither an `exp.Func` (its own allowlist) nor a table source (its
-#: own check) falls here, and until this existed the seam between those two
-#: policies was governed by a five-entry denylist -- so a class nobody had
-#: considered was admitted by default.
+#: own check) falls here. The seam between those two policies is closed-world
+#: for the same reason they are: a denylist admits by default, so any class
+#: nobody has considered is accepted.
 #:
 #: Two provenances, and they are not equally strong. Most entries were produced
 #: by parsing statements this surface ships, tests or teaches -- the admission

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -89,8 +89,9 @@ _RECURSIVE_CTE_MESSAGE = (
 
 
 def parse_sql(sql: str, *, dialect: SupportedSQLDialectName) -> exp.Expression:
-    # SQLGlot folds quoted `"char"` to CHAR (bpchar). PostgreSQL's `"char"` is
-    # a 1-byte type; CAST(65 AS "char") is 'A' and CAST(65 AS CHAR) is '6'.
+    # Workaround for an unfiled sqlglot defect: it folds quoted `"char"` to CHAR
+    # (bpchar). PostgreSQL's `"char"` is a 1-byte type; CAST(65 AS "char") is 'A'
+    # and CAST(65 AS CHAR) is '6'.
     if dialect == "postgresql" and _QUOTED_CHAR_TYPE.search(sql):
         raise AnalyticsSqlError(
             code=ErrorCode.UNSUPPORTED_SYNTAX,
@@ -176,6 +177,8 @@ def _grouping_limit_parse_message(sql: str) -> Optional[str]:
     postgres parser does not; ``FETCH FIRST n ROWS ONLY`` and wrapping the
     aggregation in a subquery both parse. The generic parse error names a
     token the caller cannot act on.
+
+    Workaround for an unfiled sqlglot defect.
     """
     folded = sql.casefold()
     if "limit" not in folded and "offset" not in folded:
@@ -223,6 +226,8 @@ def _recover_grouping_limit_parse(
     trailing clause, parsing the rest, and putting Limit/Offset back preserves
     the statement the caller wrote rather than refusing a query the engine
     would run.
+
+    Workaround for an unfiled sqlglot defect.
     """
     if _grouping_limit_parse_message(sql) is None:
         return None
@@ -348,6 +353,9 @@ def _repair_lambda_json_accessor(
     ``->`` outside a call. SQLite's ``->`` returns JSON text; ``json_extract``
     and ``->>`` return the SQL value, so rebuilding as the function changes
     what MIN/MAX compares.
+
+    Workaround for https://github.com/tobymao/sqlglot/issues/8074, which
+    upstream closed as not planned.
     """
     # Innermost first: a three-hop chain nests JSONExtract inside JSONExtract.
     for node in reversed(list(root.find_all(exp.Lambda))):
@@ -385,6 +393,8 @@ def _promote_lateral_table_references(
     function there may refer to earlier FROM items -- so ``LATERAL json_each``
     is the same request as a plain ``json_each``. Remaining LATERAL nodes
     (subqueries, other SRFs) are refused at admission.
+
+    Workaround for an unfiled sqlglot defect.
     """
     for lateral in list(root.find_all(exp.Lateral)):
         inner = lateral.this
@@ -1116,6 +1126,8 @@ def _check_lossy_shapes(
         # Carried on the options node under `FETCH`, not on `Limit`. Rendered as
         # a plain LIMIT on SQLite, which drops the ties and returns an arbitrary
         # subset of the tied rows -- a different answer, silently.
+        # Workaround for https://github.com/tobymao/sqlglot/issues/8077, which
+        # upstream closed as not planned.
         if options.args.get("with_ties"):
             return AdmissionResult(
                 AdmissionOutcome.UNSUPPORTED_SYNTAX,
@@ -1258,6 +1270,8 @@ def _check_lossy_shapes(
         # this refuses the blob spelling too, which is the price of not
         # answering an integer comparison with a blob. Withdrawable once the
         # tokenizer records which was written.
+        # Workaround for https://github.com/tobymao/sqlglot/issues/8075, which
+        # upstream closed as not planned.
         del literal
         return AdmissionResult(
             AdmissionOutcome.UNSUPPORTED_SYNTAX,
@@ -2716,6 +2730,7 @@ _RESERVED_IMPLICIT_NAMES: dict[SupportedSQLDialectName, frozenset[str]] = {
 #: the function allowlist never sees them. They are reserved words: unquoted is
 #: always the keyword, and quoted is an ordinary column reference. They bind to
 #: the session, so no relation has to be in scope for one to resolve.
+#: Workaround for an unfiled sqlglot defect.
 _SESSION_IDENTITY_NAMES: dict[SupportedSQLDialectName, frozenset[str]] = {
     "postgresql": frozenset({"user", "current_role", "system_user"}),
     "sqlite": frozenset(),

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -89,9 +89,9 @@ _RECURSIVE_CTE_MESSAGE = (
 
 
 def parse_sql(sql: str, *, dialect: SupportedSQLDialectName) -> exp.Expression:
-    # Workaround for an unfiled sqlglot defect: it folds quoted `"char"` to CHAR
-    # (bpchar). PostgreSQL's `"char"` is a 1-byte type; CAST(65 AS "char") is 'A'
-    # and CAST(65 AS CHAR) is '6'.
+    # Workaround for https://github.com/tobymao/sqlglot/issues/8280, open
+    # upstream: quoted `"char"` folds to CHAR (bpchar). PostgreSQL's `"char"` is
+    # a 1-byte type; CAST(65 AS "char") is 'A' and CAST(65 AS CHAR) is '6'.
     if dialect == "postgresql" and _QUOTED_CHAR_TYPE.search(sql):
         raise AnalyticsSqlError(
             code=ErrorCode.UNSUPPORTED_SYNTAX,

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -2680,6 +2680,18 @@ def _check_base_tables(
     return None
 
 
+#: Names an engine binds implicitly, so a foreign source in the FROM clause is
+#: not evidence that a relation in the statement projects them. PostgreSQL
+#: system columns and the niladic keywords that parse as a bare column rather
+#: than as a function; SQLite's rowid aliases.
+_RESERVED_IMPLICIT_NAMES: dict[SupportedSQLDialectName, frozenset[str]] = {
+    "postgresql": frozenset(
+        {"ctid", "xmin", "xmax", "cmin", "cmax", "tableoid", "user", "current_role"}
+    ),
+    "sqlite": frozenset({"rowid", "oid", "_rowid_"}),
+}
+
+
 def _check_column_references(
     root: exp.Expression, *, allowlist: Allowlist, dialect: SupportedSQLDialectName
 ) -> Optional[AdmissionResult]:
@@ -2941,7 +2953,23 @@ def _check_column_references(
             # the manifest has never heard of, and `json_each(attributes)`
             # projecting `key` is a shape the schema teaches.
             #
+            # Reserved names are excepted. The engine binds them to the base
+            # table or to the session rather than to the foreign source, so
+            # admitting them on the chance the source projects them hands over
+            # a system column or the session identity. A caller who does mean a
+            # projected column of that name can qualify it.
             if not qualifier and foreign_source:
+                if name.casefold() in _RESERVED_IMPLICIT_NAMES[dialect]:
+                    subject = f"{name} is reserved."
+                    return AdmissionResult(
+                        AdmissionOutcome.UNSUPPORTED_SYNTAX,
+                        subject,
+                        message=(
+                            f"{subject} It binds to the table or the session rather than to "
+                            "a relation this statement introduces. Qualify it with the "
+                            "relation that projects it if that is what you mean."
+                        ),
+                    )
                 continue
             # Not a column of any table in scope -- a misspelling, most often.
             # Name nearby physical or virtual columns so a misspelling is

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -746,13 +746,19 @@ def _repair_row_constructor(
     # `(1,)` is a one-field row. A one-element Tuple renders as `(1)`, a
     # scalar. ROW(1) is the spelling PostgreSQL still treats as a record.
     # VALUES (1) is a one-column row, not a record constructor — leave it.
+    # The excluded parents spell a parenthesised list that is grammar rather
+    # than a constructor: a grouping key, or the `DISTINCT ON (expr)` key list,
+    # where `ROW` is a syntax error.
     for tuple_node in list(root.find_all(exp.Tuple)):
         items = list(tuple_node.expressions)
         if len(items) != 1:
             continue
         if tuple_node.find_ancestor(exp.Values) is not None:
             continue
-        if isinstance(tuple_node.parent, (exp.GroupingSets, exp.Cube, exp.Rollup, exp.Group)):
+        if isinstance(
+            tuple_node.parent,
+            (exp.GroupingSets, exp.Cube, exp.Rollup, exp.Group, exp.Distinct),
+        ):
             continue
         tuple_node.replace(exp.Anonymous(this="row", expressions=[items[0].copy()]))
     return root

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -178,7 +178,8 @@ def _grouping_limit_parse_message(sql: str) -> Optional[str]:
     aggregation in a subquery both parse. The generic parse error names a
     token the caller cannot act on.
 
-    Workaround for an unfiled sqlglot defect.
+    Workaround for https://github.com/tobymao/sqlglot/issues/8279, open
+    upstream.
     """
     folded = sql.casefold()
     if "limit" not in folded and "offset" not in folded:
@@ -227,7 +228,8 @@ def _recover_grouping_limit_parse(
     the statement the caller wrote rather than refusing a query the engine
     would run.
 
-    Workaround for an unfiled sqlglot defect.
+    Workaround for https://github.com/tobymao/sqlglot/issues/8279, open
+    upstream.
     """
     if _grouping_limit_parse_message(sql) is None:
         return None

--- a/src/phoenix/server/mcp/sql/parse.py
+++ b/src/phoenix/server/mcp/sql/parse.py
@@ -681,7 +681,14 @@ def _rewrite_sqlite_interval_arithmetic(
             node.replace(
                 exp.Anonymous(
                     this="datetime",
-                    expressions=[left.copy(), exp.Literal.string(modifier)],
+                    expressions=[
+                        left.copy(),
+                        exp.Literal.string(modifier),
+                        # Storage carries microseconds and `datetime` truncates
+                        # to whole seconds, so without this the shifted value
+                        # loses the fraction the comparison turns on.
+                        exp.Literal.string("subsec"),
+                    ],
                 )
             )
         elif (
@@ -696,7 +703,11 @@ def _rewrite_sqlite_interval_arithmetic(
             node.replace(
                 exp.Anonymous(
                     this="datetime",
-                    expressions=[right.copy(), exp.Literal.string(modifier)],
+                    expressions=[
+                        right.copy(),
+                        exp.Literal.string(modifier),
+                        exp.Literal.string("subsec"),
+                    ],
                 )
             )
     return root
@@ -2965,9 +2976,9 @@ def _check_column_references(
                         AdmissionOutcome.UNSUPPORTED_SYNTAX,
                         subject,
                         message=(
-                            f"{subject} It binds to the table or the session rather than to "
-                            "a relation this statement introduces. Qualify it with the "
-                            "relation that projects it if that is what you mean."
+                            f"{subject} Unqualified, it binds to the table or the session "
+                            "rather than to a relation this statement introduces. Qualify it "
+                            "with the relation that projects it if that is what you mean."
                         ),
                     )
                 continue

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1662,15 +1662,18 @@ _SQLITE_SUBSEC_UNITS = frozenset({"unixepoch", "datetime", "time"})
 
 
 def _timestamp_unit_through_arithmetic(node: Optional[exp.Expression]) -> Optional[str]:
-    """The unit a side is expressed in, seen through arithmetic.
+    """The unit a side is expressed in, seen through unit-preserving arithmetic.
 
     `unixepoch('now') - 3600` is an epoch value exactly as `unixepoch('now')`
     is; shifting it by a constant does not change its unit. Without this, a
     bounded window -- the most common form of "recent" -- is left comparing
     text to an integer.
+
+    Addition and subtraction only. A product or a quotient is a number in some
+    other unit, so it is not one the column can be converted to match.
     """
     unwrapped = _strip_parens(node)
-    if isinstance(unwrapped, (exp.Add, exp.Sub, exp.Mul, exp.Div)):
+    if isinstance(unwrapped, (exp.Add, exp.Sub)):
         for operand in (unwrapped.this, unwrapped.expression):
             found = _timestamp_unit_through_arithmetic(operand)
             if found is not None:
@@ -1678,6 +1681,29 @@ def _timestamp_unit_through_arithmetic(node: Optional[exp.Expression]) -> Option
         return None
     unit = _timestamp_unit_function_call(unwrapped)
     return unit[0] if unit is not None else None
+
+
+def _rescaled_timestamp_unit(node: Optional[exp.Expression]) -> Optional[str]:
+    """The unit function a multiplication or division rescales on this side.
+
+    Which unit the result is in follows from the factor, and a factor is an
+    arbitrary expression rather than something to infer. Reading the side as
+    seconds anyway converts the column to seconds and compares two scales,
+    which returns the wrong rows rather than failing.
+    """
+    unwrapped = _strip_parens(node)
+    if isinstance(unwrapped, (exp.Mul, exp.Div)):
+        for operand in (unwrapped.this, unwrapped.expression):
+            found = _timestamp_unit_through_arithmetic(operand) or _rescaled_timestamp_unit(operand)
+            if found is not None:
+                return found
+        return None
+    if isinstance(unwrapped, (exp.Add, exp.Sub)):
+        for operand in (unwrapped.this, unwrapped.expression):
+            found = _rescaled_timestamp_unit(operand)
+            if found is not None:
+                return found
+    return None
 
 
 def _comparison_operands(node: exp.Condition) -> tuple[Optional[exp.Expression], ...]:
@@ -1716,6 +1742,7 @@ def _rewrite_sqlite_timestamp_vs_epoch_function(
         sides = _comparison_operands(node)
         column: Optional[exp.Column] = None
         unit_name: Optional[str] = None
+        rescaled: Optional[str] = None
         for side in sides:
             unwrapped = _strip_parens(side)
             if (
@@ -1730,6 +1757,17 @@ def _rewrite_sqlite_timestamp_vs_epoch_function(
             unit = _timestamp_unit_through_arithmetic(side)
             if unit is not None:
                 unit_name = unit
+            rescaled = rescaled or _rescaled_timestamp_unit(side)
+        if column is not None and rescaled is not None:
+            raise AnalyticsSqlError(
+                code=ErrorCode.UNSUPPORTED_SYNTAX,
+                message=(
+                    f"`{rescaled}(...)` multiplied or divided is no longer in the unit "
+                    f"`{column.name}` converts to, so the comparison would be between "
+                    f"two scales. Compare against `{rescaled}(...)` unscaled, or scale "
+                    f"both sides -- `{rescaled}({column.name})` is available."
+                ),
+            )
         if column is None or unit_name is None:
             continue
         if unit_name == "date":

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -483,8 +483,7 @@ def _canonicalize_json_extract(root: exp.Expression, ctx: RewriteContext) -> exp
     correctly has no ``max`` aggregate, and a cast would have to guess whether
     the path holds a number or a string. The caller has to cast for themselves,
     and the schema's populated-path comments are where they find out which
-    paths are numeric. Stated rather than silently scoped, because the rest of
-    this docstring reads as though the hazard were settled everywhere.
+    paths are numeric.
     """
     if ctx.dialect != "sqlite":
         return root

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -563,13 +563,16 @@ def _repair_quoted_json_path(root: exp.Expression, ctx: RewriteContext) -> exp.E
             continue
         parts = [part for part in path.expressions if not isinstance(part, exp.JSONPathRoot)]
         keys = [part.this for part in parts if isinstance(part, exp.JSONPathKey)]
-        if len(keys) != len(parts) or not any("'" in key for key in keys):
+        if not any(isinstance(key, str) and "'" in key for key in keys):
             continue
         if ctx.dialect == "sqlite":
+            # A subscript belongs to the path as much as a key does, and
+            # `_quoted_json_path` spells both, so the shape it accepts is the
+            # shape this repairs.
             spelled = _quoted_json_path(path)
             if spelled is None:
                 continue
-        elif len(keys) == 1:
+        elif len(keys) == len(parts) == 1:
             # The operator takes one key, and that key is the literal.
             spelled = keys[0]
         else:

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -37,6 +37,7 @@ from phoenix.server.mcp.sql.parse import (
     _quantifier_list_container,
     _relation_identifier_keys,
     _scope_columns,
+    _scope_relation_keys,
     _strip_parens,
     _table_alias_column_names,
     _timestamp_literals,
@@ -1393,12 +1394,24 @@ def _substitute_latency_ms(root: exp.Expression, ctx: RewriteContext) -> exp.Exp
                     aliases.add(key)
                     exposed_by_key[key] = exposed
             names = frozenset(aliases)
-            # `Scope.columns` of an outer query includes an unqualified column
-            # that belongs to a nested subquery, and `traverse()` yields the
-            # inner scope first. Keeping the first attribution binds the column
-            # to the relation that actually encloses it; overwriting binds a
-            # subquery's `latency_ms` to the outer query's table.
+            # Every relation this scope introduces, not just the duration tables
+            # above: a qualifier the scope binds to something else still belongs
+            # to the scope, and must not fall through to an enclosing one.
+            scope_relations = _scope_relation_keys(scope, dialect=ctx.dialect)
+            # `Scope.columns` reaches in both directions -- an outer query lists
+            # a nested subquery's unqualified column, and an inner query lists
+            # the correlated columns that reference outward -- and `traverse()`
+            # yields the inner scope first. A scope claims a qualified column
+            # only when it introduces that qualifier, so a correlated reference
+            # is left for the scope that does; keeping the first attribution
+            # then binds an unqualified column to the relation enclosing it,
+            # rather than to the outer query's table.
             for column in (*scope.columns, *_scope_columns(scope.expression)):
+                if (
+                    column.table
+                    and _column_qualifier_key(column, dialect=ctx.dialect) not in scope_relations
+                ):
+                    continue
                 duration_scope.setdefault(id(column), (duration_sources, names, exposed_by_key))
             if duration_sources < 2:
                 continue
@@ -2096,9 +2109,17 @@ def _substitute_graphql_node_id(root: exp.Expression, ctx: RewriteContext) -> ex
                 scope, allowlist=ctx.allowlist, dialect=ctx.dialect
             )
             fallback = next(iter(set(by_alias.values()))) if n_sources == 1 else None
-            # Innermost attribution wins, as in the duration overlay: an outer
-            # scope lists a nested subquery's unqualified column too.
+            # Attribution follows the duration overlay: a scope claims a
+            # qualified column only when it introduces that qualifier, so a
+            # correlated reference is left for the scope that does, and the
+            # innermost scope wins for an unqualified one.
+            scope_relations = _scope_relation_keys(scope, dialect=ctx.dialect)
             for column in (*scope.columns, *_scope_columns(scope.expression)):
+                if (
+                    column.table
+                    and _column_qualifier_key(column, dialect=ctx.dialect) not in scope_relations
+                ):
+                    continue
                 resolution.setdefault(id(column), (by_alias, fallback, n_sources, exposed_by_key))
     if not any(n_sources for _, _, n_sources, _ in resolution.values()):
         return root

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -710,6 +710,46 @@ def _source_exposes_column(
     )
 
 
+def _local_relation_projects(
+    source: exp.Expression,
+    root: exp.Expression,
+    name: str,
+    *,
+    dialect: SupportedSQLDialectName,
+) -> bool:
+    """Whether a query-local relation projects this column.
+
+    A CTE, subquery or VALUES list names its own columns, so the manifest
+    cannot answer for it. Its copy of a USING key is NULL on the same rows a
+    physical table's is.
+
+    Table-valued functions are excluded: their star expansion emits a physical
+    column under a different output name, which a two-sided merge of one name
+    cannot express.
+    """
+    if not isinstance(source, exp.Expression) or _tvf_output_names(source) is not None:
+        return False
+    names = _expression_output_names(
+        source, root, dialect=dialect, qualifier=_relation_qualifier(source)
+    )
+    if not names:
+        return False
+    want = _identifier_key(name, quoted=False, dialect=dialect)
+    return any(_identifier_key(offered, quoted=False, dialect=dialect) == want for offered in names)
+
+
+def _coalesced_using_column(name: str, *, quoted: bool, merge: list[exp.Identifier]) -> exp.Expr:
+    """A USING key as the merge of the relations that supply it."""
+    ident = exp.to_identifier(name, quoted=quoted)
+    return exp.alias_(
+        exp.Coalesce(
+            this=exp.Column(this=ident.copy(), table=merge[0].copy()),
+            expressions=[exp.Column(this=ident.copy(), table=other.copy()) for other in merge[1:]],
+        ),
+        ident.copy(),
+    )
+
+
 def _using_key_qualifier(
     left_sources: list[exp.Expression],
     ident: exp.Identifier,
@@ -1036,7 +1076,11 @@ def _select_from_is_values(select: exp.Select) -> bool:
 
 
 def _using_keys_needing_coalesce(
-    node: exp.Select, *, allowlist: Allowlist, dialect: SupportedSQLDialectName
+    node: exp.Select,
+    root: exp.Expression,
+    *,
+    allowlist: Allowlist,
+    dialect: SupportedSQLDialectName,
 ) -> dict[str, list[exp.Identifier]]:
     """USING keys whose left copy can be NULL, with the relations to merge.
 
@@ -1064,7 +1108,8 @@ def _using_keys_needing_coalesce(
                 )
                 # Only the relations that actually offer the key. Merging
                 # across every relation to the left names columns they do not
-                # have, which the engine refuses.
+                # have, which the engine refuses. A query-local relation offers
+                # it on its own terms, and its copy goes NULL the same way.
                 providers = [
                     source
                     for source in left_sources
@@ -1073,6 +1118,12 @@ def _using_keys_needing_coalesce(
                         ident.name or ident.this or "",
                         quoted=bool(ident.args.get("quoted")),
                         allowlist=allowlist,
+                        dialect=dialect,
+                    )
+                    or _local_relation_projects(
+                        source,
+                        root,
+                        ident.name or ident.this or "",
                         dialect=dialect,
                     )
                 ]
@@ -1197,7 +1248,9 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
             # copy of the key.
             using_keys = _using_join_keys(node, ctx.dialect) if not explicit else frozenset()
             coalesce_using = (
-                _using_keys_needing_coalesce(node, allowlist=ctx.allowlist, dialect=ctx.dialect)
+                _using_keys_needing_coalesce(
+                    node, root, allowlist=ctx.allowlist, dialect=ctx.dialect
+                )
                 if not explicit
                 else {}
             )
@@ -1242,6 +1295,12 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
                                 if key in emitted_using:
                                     continue
                                 emitted_using.add(key)
+                                merge = coalesce_using.get(key)
+                                if merge:
+                                    new_exprs.append(
+                                        _coalesced_using_column(name, quoted=False, merge=merge)
+                                    )
+                                    continue
                             column = exp.Column(this=exp.to_identifier(name))
                             if qualifier.name:
                                 column.set("table", qualifier.copy())
@@ -1284,22 +1343,7 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
                         merge = coalesce_using.get(key)
                         if merge:
                             new_exprs.append(
-                                exp.alias_(
-                                    exp.Coalesce(
-                                        this=exp.Column(
-                                            this=exp.to_identifier(name, quoted=quoted),
-                                            table=merge[0].copy(),
-                                        ),
-                                        expressions=[
-                                            exp.Column(
-                                                this=exp.to_identifier(name, quoted=quoted),
-                                                table=other.copy(),
-                                            )
-                                            for other in merge[1:]
-                                        ],
-                                    ),
-                                    exp.to_identifier(name, quoted=quoted),
-                                )
+                                _coalesced_using_column(name, quoted=quoted, merge=merge)
                             )
                             continue
                     # Qualify by the caller's alias, quoting included: after

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1362,6 +1362,37 @@ def _timestamp_unit_function_call(
     return None
 
 
+def _timestamp_unit_through_arithmetic(node: Optional[exp.Expression]) -> Optional[str]:
+    """The unit a side is expressed in, seen through arithmetic.
+
+    `unixepoch('now') - 3600` is an epoch value exactly as `unixepoch('now')`
+    is; shifting it by a constant does not change its unit. Without this, a
+    bounded window -- the most common form of "recent" -- is left comparing
+    text to an integer.
+    """
+    unwrapped = _strip_parens(node)
+    if isinstance(unwrapped, (exp.Add, exp.Sub, exp.Mul, exp.Div)):
+        for operand in (unwrapped.this, unwrapped.expression):
+            found = _timestamp_unit_through_arithmetic(operand)
+            if found is not None:
+                return found
+        return None
+    unit = _timestamp_unit_function_call(unwrapped)
+    return unit[0] if unit is not None else None
+
+
+def _comparison_operands(node: exp.Condition) -> tuple[Optional[exp.Expression], ...]:
+    """Both sides of a comparison, or all three parts of a BETWEEN."""
+    if isinstance(node, exp.Between):
+        return (node.this, node.args.get("low"), node.args.get("high"))
+    return (node.this, node.expression)
+
+
+#: BETWEEN is a comparison here even though it is not one of the binary
+#: comparison classes: `col BETWEEN a AND b` compares `col` against both bounds.
+_EPOCH_COMPARISON_NODES = (*_TIMESTAMP_COMPARISONS, exp.Between)
+
+
 def _rewrite_sqlite_timestamp_vs_epoch_function(
     root: exp.Expression, ctx: RewriteContext
 ) -> exp.Expression:
@@ -1382,8 +1413,8 @@ def _rewrite_sqlite_timestamp_vs_epoch_function(
     query_local = query_local_columns(root, allowlist=ctx.allowlist, dialect=ctx.dialect)
     passthrough = _timestamp_passthrough_references(root, timestamp_columns)
     changed = False
-    for node in list(root.find_all(*_TIMESTAMP_COMPARISONS)):
-        sides = (node.this, node.expression)
+    for node in list(root.find_all(*_EPOCH_COMPARISON_NODES)):
+        sides = _comparison_operands(node)
         column: Optional[exp.Column] = None
         unit_name: Optional[str] = None
         for side in sides:
@@ -1397,9 +1428,9 @@ def _rewrite_sqlite_timestamp_vs_epoch_function(
                 and not (query_local.is_local(unwrapped) and id(unwrapped) not in passthrough)
             ):
                 column = unwrapped
-            unit = _timestamp_unit_function_call(side)
+            unit = _timestamp_unit_through_arithmetic(side)
             if unit is not None:
-                unit_name = unit[0]
+                unit_name = unit
         if column is None or unit_name is None:
             continue
         if unit_name == "date":

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -179,6 +179,7 @@ def rewrite(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
     root = _rewrite_sqlite_median(root, ctx)
     root = _canonicalize_json_extract(root, ctx)
     root = _canonicalize_postgres_json_extract_function(root, ctx)
+    root = _repair_quoted_json_path(root, ctx)
     root = _qualify_schema(root, ctx)
     root = _parenthesize_setop_operands(root, ctx)
     root = _inject_limit(root, ctx)
@@ -539,6 +540,48 @@ def _canonicalize_json_extract(root: exp.Expression, ctx: RewriteContext) -> exp
     return root
 
 
+def _repair_quoted_json_path(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
+    """Emit a JSON key containing a quote as a literal, so it is escaped.
+
+    The generator renders the path of a JSON accessor without escaping, so a
+    key holding an apostrophe closes its own string and the statement does not
+    parse. Attribute keys are arbitrary strings, and `describeSqlSchema`
+    publishes the populated ones, so the surface can print a path it cannot run.
+
+    A plain string literal in the same position is escaped correctly, and keeps
+    the accessor the caller wrote -- which matters on SQLite, where `->` and
+    `json_extract` return different types.
+    """
+    changed = False
+    for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
+        path = node.expression
+        if not isinstance(path, exp.JSONPath):
+            continue
+        parts = [part for part in path.expressions if not isinstance(part, exp.JSONPathRoot)]
+        keys = [part.this for part in parts if isinstance(part, exp.JSONPathKey)]
+        if len(keys) != len(parts) or not any("'" in key for key in keys):
+            continue
+        if ctx.dialect == "sqlite":
+            spelled = _quoted_json_path(path)
+            if spelled is None:
+                continue
+        elif len(keys) == 1:
+            # The operator takes one key, and that key is the literal.
+            spelled = keys[0]
+        else:
+            continue
+        node.set("expression", exp.Literal.string(spelled))
+        changed = True
+    if changed:
+        ctx.applied.append("json_path_quote_repair")
+    return root
+
+
+def _json_path_is_root_only(path: exp.JSONPath) -> bool:
+    """True for `$`, which names the document rather than anything inside it."""
+    return not [part for part in path.expressions if not isinstance(part, exp.JSONPathRoot)]
+
+
 def _canonicalize_postgres_json_extract_function(
     root: exp.Expression, ctx: RewriteContext
 ) -> exp.Expression:
@@ -583,6 +626,19 @@ def _canonicalize_postgres_json_extract_function(
                 parenthesised = True
             continue
         if node.args.get("only_json_types") is not None:
+            continue
+        # A root-only path selects the whole document. It has no keys to pass,
+        # and `json_extract_path(doc)` is not a signature PostgreSQL defines,
+        # so the path operators express it instead: `#> '{}'` is the document,
+        # `#>> '{}'` is the document as text.
+        if _json_path_is_root_only(inner):
+            whole = (
+                exp.JSONBExtractScalar
+                if isinstance(node, exp.JSONExtractScalar)
+                else exp.JSONBExtract
+            )
+            node.replace(whole(this=node.this, expression=exp.Literal.string("{}")))
+            changed = True
             continue
         path_args = _json_path_extract_args(inner)
         if path_args is None:

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1043,7 +1043,7 @@ def _select_from_is_values(select: exp.Select) -> bool:
 
 
 def _using_keys_needing_coalesce(
-    node: exp.Select, dialect: SupportedSQLDialectName
+    node: exp.Select, *, allowlist: Allowlist, dialect: SupportedSQLDialectName
 ) -> dict[str, list[exp.Identifier]]:
     """USING keys whose left copy can be NULL, with the relations to merge.
 
@@ -1071,8 +1071,24 @@ def _using_keys_needing_coalesce(
                     quoted=bool(ident.args.get("quoted")),
                     dialect=dialect,
                 )
+                # Only the relations that actually offer the key. Merging
+                # across every relation to the left names columns they do not
+                # have, which the engine refuses.
+                providers = [
+                    source
+                    for source in left_sources
+                    if _source_exposes_column(
+                        source,
+                        ident.name or ident.this or "",
+                        quoted=bool(ident.args.get("quoted")),
+                        allowlist=allowlist,
+                        dialect=dialect,
+                    )
+                ]
+                if not providers:
+                    continue
                 needed[key] = [
-                    *(_relation_qualifier(source) for source in left_sources),
+                    *(_relation_qualifier(source) for source in providers),
                     _relation_qualifier(join.this),
                 ]
         left_sources.append(join.this)
@@ -1190,7 +1206,11 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
             # copy of the key.
             using_keys = _using_join_keys(node, ctx.dialect) if not explicit else frozenset()
             coalesce_using = (
-                _using_keys_needing_coalesce(node, ctx.dialect) if not explicit else {}
+                _using_keys_needing_coalesce(
+                    node, allowlist=ctx.allowlist, dialect=ctx.dialect
+                )
+                if not explicit
+                else {}
             )
             using_keys = frozenset(using_keys | ctx.coalesced_using_by_select.get(id(node), set()))
             emitted_using: set[str] = set()
@@ -1492,7 +1512,9 @@ def _substitute_latency_ms(root: exp.Expression, ctx: RewriteContext) -> exp.Exp
     return root
 
 
-def _sqlite_stored_timestamp_operand(node: exp.Expression) -> Optional[exp.Column]:
+def _sqlite_stored_timestamp_operand(
+    node: exp.Expression, timestamp_columns: frozenset[str]
+) -> Optional[exp.Column]:
     """The stored timestamp column an operand of `-` reads, or None.
 
     Elapsed time is written over the columns themselves or over aggregates of
@@ -1503,7 +1525,18 @@ def _sqlite_stored_timestamp_operand(node: exp.Expression) -> Optional[exp.Colum
     inner = _strip_parens(node)
     if isinstance(inner, (exp.Min, exp.Max)):
         inner = _strip_parens(inner.this)
-    return inner if isinstance(inner, exp.Column) else None
+    elif isinstance(inner, exp.Coalesce):
+        # Every branch must be a stored timestamp, or the result is not one.
+        branches = [inner.this, *(inner.expressions or [])]
+        resolved = [
+            _sqlite_stored_timestamp_operand(branch, timestamp_columns) for branch in branches
+        ]
+        if not resolved or any(column is None for column in resolved):
+            return None
+        return resolved[0]
+    if not isinstance(inner, exp.Column):
+        return None
+    return inner if (inner.name or "").casefold() in timestamp_columns else None
 
 
 def _unixepoch_subsec(node: exp.Expression) -> exp.Expression:
@@ -1524,8 +1557,8 @@ def _rewrite_sqlite_timestamp_subtraction(
     for node in list(root.find_all(exp.Sub)):
         left_operand = _strip_parens(node.this)
         right_operand = _strip_parens(node.expression)
-        left = _sqlite_stored_timestamp_operand(node.this)
-        right = _sqlite_stored_timestamp_operand(node.expression)
+        left = _sqlite_stored_timestamp_operand(node.this, timestamp_columns)
+        right = _sqlite_stored_timestamp_operand(node.expression, timestamp_columns)
         if not (
             left is not None
             and right is not None

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -206,29 +206,20 @@ def rewrite(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
 def _assert_rewrites_preserved_policy(root: exp.Expression, ctx: RewriteContext) -> None:
     """Re-check the finished tree against the guarantees admission established.
 
-    Admission validates the statement the caller sent. The rewrite passes then
-    edit that statement, and until this ran, nothing looked at the result -- so an
-    admitted query could become a different query on its way to the engine, and
-    twice it did. One pass redirected a CTE reference to the base table it was
-    named after, turning a filtered count into a count of everything. Another
-    silently dropped a TABLESAMPLE clause on exactly the tables it wrapped.
+    Admission validates the statement the caller sent; the rewrite passes then
+    edit it. Without a check between the last pass and the engine, an admitted
+    query can become a different query on the way there -- a relation reference
+    redirected to a table it was merely named after, or a clause dropped from
+    the tables it constrained -- and nothing downstream distinguishes that from
+    the query the caller asked for.
 
-    Neither was caught by a check, because no check existed between the last
-    pass and the engine. Both would have failed here.
-
-    This used to raise AssertionError, on the reasoning that reaching it meant
-    our own code had produced something admission would not have accepted --
-    a defect on this side, which should surface as one. The reasoning was
-    sound and the premise was not: a table aliased to a CTE's name was dropped
-    from the scope map admission reads, so ordinary caller SQL reached here and
-    the AssertionError left through the caller's response rather than the error
-    envelope, exactly as an unhandled driver error would.
-
-    So it refuses, and logs at error level. The loud signal is kept where it is
-    useful -- to whoever runs the server -- rather than delivered to a caller
-    who can neither act on it nor tell it apart from a crash. Both halves
-    matter: a silent refusal here would hide the defect, and an escaping
-    exception hides it just as well while also breaking the response contract.
+    Reaching this normally means a defect in the rewrite passes, but not always:
+    a scope the passes model differently from admission sends ordinary caller
+    SQL here too. It therefore refuses rather than asserting, so the failure
+    leaves through the error envelope instead of escaping as an unhandled
+    exception, and logs at error level so the signal reaches whoever runs the
+    server. Both halves are load-bearing: a silent refusal hides the defect, and
+    an escaping exception hides it while also breaking the response contract.
     """
     for table in root.find_all(exp.Table):
         name = table.name or ""
@@ -426,8 +417,8 @@ def _normalize_timestamp_literals(root: exp.Expression, ctx: RewriteContext) -> 
         if ctx.dialect == "sqlite":
             rendered = format_timestamp_for_sqlite(instant)
         else:
-            # isoformat keeps whole seconds as `...00+00:00` and retains
-            # subseconds that `%Y-%m-%dT%H:%M:%S+00:00` used to drop.
+            # isoformat keeps whole seconds as `...00+00:00` and retains the
+            # subseconds an explicit `%Y-%m-%dT%H:%M:%S+00:00` format drops.
             rendered = instant.isoformat()
         replacement: exp.Expression = exp.Literal.string(rendered)
         # CAST(1719792000 AS bigint) compared to timestamptz: replacing only

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1966,11 +1966,11 @@ def _parenthesize_setop_operands(root: exp.Expression, ctx: RewriteContext) -> e
     """Make set-op operands that carry ORDER BY / LIMIT executable on this backend.
 
     ``SELECT ... LIMIT 1 UNION SELECT ...`` is a syntax error in PostgreSQL
-    unless the limited select is parenthesised, and SQLGlot does not emit those
-    parentheses. SQLite rejects the parentheses and the LIMIT-on-a-member
-    spelling; those members are lifted into FROM subqueries instead.
-
-    Workaround for an unfiled sqlglot defect.
+    unless the limited select is parenthesised. The parser accepts the
+    unparenthesised spelling, so the operand arrives bare and the parenthesised
+    form is what the engine runs. SQLite rejects the parentheses and the
+    LIMIT-on-a-member spelling; those members are lifted into FROM subqueries
+    instead.
     """
     if ctx.dialect == "sqlite":
         return _rewrite_sqlite_setop_operands(root, ctx)

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1292,9 +1292,7 @@ def _sqlite_stored_timestamp_operand(node: exp.Expression) -> Optional[exp.Colum
 
 def _unixepoch_subsec(node: exp.Expression) -> exp.Expression:
     """Seconds since the epoch, keeping fractional seconds."""
-    return exp.Anonymous(
-        this="unixepoch", expressions=[node.copy(), exp.Literal.string("subsec")]
-    )
+    return exp.Anonymous(this="unixepoch", expressions=[node.copy(), exp.Literal.string("subsec")])
 
 
 def _rewrite_sqlite_timestamp_subtraction(

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -625,6 +625,17 @@ def _canonicalize_postgres_json_extract_function(
     for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
         inner = _strip_parens(node.expression)
         if not isinstance(inner, exp.JSONPath):
+            # PostgreSQL's `->` takes a key, not a path. A computed operand is
+            # therefore looked up as one key name, so `json_extract(doc, '$.' ||
+            # 'llm')` asks for a key literally called `$.llm` and answers NULL,
+            # while SQLite reads the same text as a path. Nothing in the tree
+            # separates a computed key from a computed path -- `doc -> k.key`
+            # and `json_extract(doc, k.key)` parse identically -- so this is
+            # noted rather than refused or rewritten.
+            if not isinstance(inner, (exp.Literal, exp.Column)) and _COMPUTED_JSON_KEY_NOTE not in (
+                ctx.notes
+            ):
+                ctx.notes.append(_COMPUTED_JSON_KEY_NOTE)
             operand = node.expression
             # Binary and Unary cover the infix and prefix operators; Predicate
             # adds the comparison forms that are neither, such as BETWEEN and
@@ -671,6 +682,15 @@ def _canonicalize_postgres_json_extract_function(
     if changed:
         ctx.applied.append("jsonb_extract_path")
     return root
+
+
+#: Said when a JSON accessor's key is computed, because the two engines read
+#: the same statement differently and neither is wrong.
+_COMPUTED_JSON_KEY_NOTE = (
+    "A computed JSON key is looked up as a key name on PostgreSQL and as a path on "
+    "SQLite. Use jsonb_extract_path(doc, k1, k2) on PostgreSQL, or a literal path, "
+    "if you meant to walk into the document."
+)
 
 
 def _source_exposes_column(

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -458,8 +458,7 @@ def _canonicalize_json_extract(root: exp.Expression, ctx: RewriteContext) -> exp
     which coerces, and decisive for ``MIN``, ``MAX``, ``ORDER BY`` and every
     comparison, which compare text character by character -- so 1017066 sorts
     below 149740 and the answer is confidently wrong with no error anywhere.
-    Left alone the generator emits ``->`` for a caller's ``json_extract``,
-    silently exchanging one accessor for another.
+    So the accessor a caller wrote cannot be exchanged for another one.
 
     The second is whether an expression index can be used at all. SQLite matches
     such an index on the parsed expression, so a query reaches it only by
@@ -492,8 +491,7 @@ def _canonicalize_json_extract(root: exp.Expression, ctx: RewriteContext) -> exp
     for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
         # `->` returns JSON text; `json_extract` and `->>` return the SQL value.
         # Rewriting the operator would therefore change both the value and the
-        # type of every JSON scalar, so only the function form is canonicalised
-        # -- which is also what stops the generator emitting it back as `->`.
+        # type of every JSON scalar, so only the function form is canonicalised.
         # `only_json_types` marks the operator spelling. It decides rather than
         # the node class, which is not stable across parser versions.
         if isinstance(node, exp.JSONExtract) and node.args.get("only_json_types") is not None:
@@ -555,6 +553,9 @@ def _repair_quoted_json_path(root: exp.Expression, ctx: RewriteContext) -> exp.E
     A plain string literal in the same position is escaped correctly, and keeps
     the accessor the caller wrote -- which matters on SQLite, where `->` and
     `json_extract` return different types.
+
+    Workaround for https://github.com/tobymao/sqlglot/issues/8251, open
+    upstream.
     """
     changed = False
     for node in list(root.find_all(exp.JSONExtract, exp.JSONExtractScalar)):
@@ -637,6 +638,8 @@ def _canonicalize_postgres_json_extract_function(
             # adds the comparison forms that are neither, such as BETWEEN and
             # IN. exp.Paren is itself a Unary, and an already-parenthesised
             # operand renders unambiguously.
+            # Workaround for https://github.com/tobymao/sqlglot/issues/8211,
+            # fixed upstream but unreleased at the pinned version.
             if isinstance(operand, (exp.Binary, exp.Unary, exp.Predicate)) and not isinstance(
                 operand, exp.Paren
             ):
@@ -649,6 +652,8 @@ def _canonicalize_postgres_json_extract_function(
         # and `json_extract_path(doc)` is not a signature PostgreSQL defines,
         # so the path operators express it instead: `#> '{}'` is the document,
         # `#>> '{}'` is the document as text.
+        # Workaround for https://github.com/tobymao/sqlglot/issues/8232, fixed
+        # upstream but unreleased at the pinned version.
         if _json_path_is_root_only(inner):
             whole = (
                 exp.JSONBExtractScalar
@@ -1842,6 +1847,9 @@ def _rewrite_sqlite_median(root: exp.Expression, ctx: RewriteContext) -> exp.Exp
     generator emits ``PERCENTILE_CONT``, which this engine does not have.
     sqlean stats registers ``median``; rewriting to a generic call is the
     spelling that actually runs.
+
+    Workaround for https://github.com/tobymao/sqlglot/issues/8079, which
+    upstream closed as not planned.
     """
     if ctx.dialect != "sqlite":
         return root
@@ -1961,6 +1969,8 @@ def _parenthesize_setop_operands(root: exp.Expression, ctx: RewriteContext) -> e
     unless the limited select is parenthesised, and SQLGlot does not emit those
     parentheses. SQLite rejects the parentheses and the LIMIT-on-a-member
     spelling; those members are lifted into FROM subqueries instead.
+
+    Workaround for an unfiled sqlglot defect.
     """
     if ctx.dialect == "sqlite":
         return _rewrite_sqlite_setop_operands(root, ctx)

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -673,6 +673,62 @@ def _canonicalize_postgres_json_extract_function(
     return root
 
 
+def _source_exposes_column(
+    source: exp.Expression,
+    name: str,
+    *,
+    quoted: bool,
+    allowlist: Allowlist,
+    dialect: SupportedSQLDialectName,
+) -> bool:
+    """Whether this relation offers the column, stored or overlay."""
+    if not isinstance(source, exp.Table):
+        return False
+    table_name = _allowlisted_table_name(source, allowlist=allowlist, dialect=dialect)
+    if table_name is None:
+        return False
+    spec = allowlist.table_specs.get(table_name)
+    if spec is None:
+        return False
+    want = _identifier_key(name, quoted=quoted, dialect=dialect)
+    return any(
+        _identifier_key(offered, quoted=False, dialect=dialect) == want
+        for offered in (*spec.columns, *spec.virtual_columns)
+    )
+
+
+def _using_key_qualifier(
+    left_sources: list[exp.Expression],
+    ident: exp.Identifier,
+    *,
+    allowlist: Allowlist,
+    dialect: SupportedSQLDialectName,
+) -> exp.Identifier:
+    """Which relation on the left a USING key names.
+
+    PostgreSQL refuses a key exposed by more than one relation of the left
+    composite, so more than one match here is the caller's ambiguity rather
+    than a choice to make for them. No match leaves the nearest relation, which
+    is what the engine will report against.
+    """
+    name = ident.this or ""
+    quoted = bool(ident.args.get("quoted"))
+    exposing = [
+        source
+        for source in left_sources
+        if _source_exposes_column(source, name, quoted=quoted, allowlist=allowlist, dialect=dialect)
+    ]
+    if len(exposing) > 1:
+        raise AnalyticsSqlError(
+            code=ErrorCode.UNSUPPORTED_SYNTAX,
+            message=(
+                f"`{name}` in USING names a column that more than one relation to its left "
+                "provides. Join with ON and qualify each side."
+            ),
+        )
+    return _relation_qualifier(exposing[0] if exposing else left_sources[-1])
+
+
 def _rewrite_virtual_using_joins(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
     """Turn USING keys that name query-only overlays into ON comparisons.
 
@@ -687,18 +743,26 @@ def _rewrite_virtual_using_joins(root: exp.Expression, ctx: RewriteContext) -> e
     changed = False
     for select in root.find_all(exp.Select):
         from_expr = select.args.get("from_") or select.args.get("from")
-        left = from_expr.this if isinstance(from_expr, exp.From) else None
+        # Every relation to the left, not just the previous one: SQL resolves a
+        # USING key against the whole composite built so far, so in
+        # `a JOIN b ON ... JOIN c USING (k)` the key may come from `a`.
+        left_sources: list[exp.Expression] = (
+            [from_expr.this] if isinstance(from_expr, exp.From) else []
+        )
         for join in select.args.get("joins") or []:
-            if left is None:
-                left = join.this
+            if not left_sources:
+                left_sources.append(join.this)
                 continue
             virtual_keys: list[exp.Identifier] = []
             physical_keys: list[exp.Identifier] = []
             for ident in _join_using_identifiers(join):
                 name = ident.this or ""
                 quoted = bool(ident.args.get("quoted"))
-                if _virtual_column_on_source(
-                    left, name, quoted=quoted, allowlist=ctx.allowlist, dialect=ctx.dialect
+                if any(
+                    _virtual_column_on_source(
+                        source, name, quoted=quoted, allowlist=ctx.allowlist, dialect=ctx.dialect
+                    )
+                    for source in left_sources
                 ) or _virtual_column_on_source(
                     join.this, name, quoted=quoted, allowlist=ctx.allowlist, dialect=ctx.dialect
                 ):
@@ -706,7 +770,6 @@ def _rewrite_virtual_using_joins(root: exp.Expression, ctx: RewriteContext) -> e
                 else:
                     physical_keys.append(ident)
             if virtual_keys:
-                left_qual = _relation_qualifier(left)
                 right_qual = _relation_qualifier(join.this)
                 # Physical keys have to become ON too. Leaving them as USING
                 # next to the new ON is not valid PostgreSQL (`USING (id) ON
@@ -715,7 +778,12 @@ def _rewrite_virtual_using_joins(root: exp.Expression, ctx: RewriteContext) -> e
                 on_keys = [*physical_keys, *virtual_keys]
                 equalities: list[exp.Expression] = [
                     exp.EQ(
-                        this=exp.Column(this=ident.copy(), table=left_qual.copy()),
+                        this=exp.Column(
+                            this=ident.copy(),
+                            table=_using_key_qualifier(
+                                left_sources, ident, allowlist=ctx.allowlist, dialect=ctx.dialect
+                            ).copy(),
+                        ),
                         expression=exp.Column(this=ident.copy(), table=right_qual.copy()),
                     )
                     for ident in on_keys
@@ -741,7 +809,7 @@ def _rewrite_virtual_using_joins(root: exp.Expression, ctx: RewriteContext) -> e
                         )
                     )
                 changed = True
-            left = join.this
+            left_sources.append(join.this)
     if changed:
         ctx.applied.append("virtual_using")
     return root

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1169,8 +1169,13 @@ def _substitute_latency_ms(root: exp.Expression, ctx: RewriteContext) -> exp.Exp
                     aliases.add(key)
                     exposed_by_key[key] = exposed
             names = frozenset(aliases)
+            # `Scope.columns` of an outer query includes an unqualified column
+            # that belongs to a nested subquery, and `traverse()` yields the
+            # inner scope first. Keeping the first attribution binds the column
+            # to the relation that actually encloses it; overwriting binds a
+            # subquery's `latency_ms` to the outer query's table.
             for column in (*scope.columns, *_scope_columns(scope.expression)):
-                duration_scope[id(column)] = (duration_sources, names, exposed_by_key)
+                duration_scope.setdefault(id(column), (duration_sources, names, exposed_by_key))
             if duration_sources < 2:
                 continue
             for column in _scope_columns(scope.expression):
@@ -1814,8 +1819,10 @@ def _substitute_graphql_node_id(root: exp.Expression, ctx: RewriteContext) -> ex
                 scope, allowlist=ctx.allowlist, dialect=ctx.dialect
             )
             fallback = next(iter(set(by_alias.values()))) if n_sources == 1 else None
+            # Innermost attribution wins, as in the duration overlay: an outer
+            # scope lists a nested subquery's unqualified column too.
             for column in (*scope.columns, *_scope_columns(scope.expression)):
-                resolution[id(column)] = (by_alias, fallback, n_sources, exposed_by_key)
+                resolution.setdefault(id(column), (by_alias, fallback, n_sources, exposed_by_key))
     if not any(n_sources for _, _, n_sources, _ in resolution.values()):
         return root
 

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1271,6 +1271,27 @@ def _substitute_latency_ms(root: exp.Expression, ctx: RewriteContext) -> exp.Exp
     return root
 
 
+def _sqlite_stored_timestamp_operand(node: exp.Expression) -> Optional[exp.Column]:
+    """The stored timestamp column an operand of `-` reads, or None.
+
+    Elapsed time is written over the columns themselves or over aggregates of
+    them, and `MAX(end_time)` is still a stored timestamp: these are zero-padded
+    ISO-8601 text, so their text ordering is their timestamp ordering and the
+    aggregate result converts like the column. Parentheses are transparent.
+    """
+    inner = _strip_parens(node)
+    if isinstance(inner, (exp.Min, exp.Max)):
+        inner = _strip_parens(inner.this)
+    return inner if isinstance(inner, exp.Column) else None
+
+
+def _unixepoch_subsec(node: exp.Expression) -> exp.Expression:
+    """Seconds since the epoch, keeping fractional seconds."""
+    return exp.Anonymous(
+        this="unixepoch", expressions=[node.copy(), exp.Literal.string("subsec")]
+    )
+
+
 def _rewrite_sqlite_timestamp_subtraction(
     root: exp.Expression, ctx: RewriteContext
 ) -> exp.Expression:
@@ -1282,10 +1303,15 @@ def _rewrite_sqlite_timestamp_subtraction(
     passthrough = _timestamp_passthrough_references(root, timestamp_columns)
     changed = False
     for node in list(root.find_all(exp.Sub)):
-        left, right = node.this, node.expression
+        left_operand = _strip_parens(node.this)
+        right_operand = _strip_parens(node.expression)
+        left = _sqlite_stored_timestamp_operand(node.this)
+        right = _sqlite_stored_timestamp_operand(node.expression)
         if not (
-            isinstance(left, exp.Column)
-            and isinstance(right, exp.Column)
+            left is not None
+            and right is not None
+            and left_operand is not None
+            and right_operand is not None
             and (left.name or "").casefold() in timestamp_columns
             and (right.name or "").casefold() in timestamp_columns
         ):
@@ -1300,12 +1326,8 @@ def _rewrite_sqlite_timestamp_subtraction(
         node.replace(
             exp.paren(
                 exp.Sub(
-                    this=exp.Anonymous(
-                        this="unixepoch", expressions=[left.copy(), exp.Literal.string("subsec")]
-                    ),
-                    expression=exp.Anonymous(
-                        this="unixepoch", expressions=[right.copy(), exp.Literal.string("subsec")]
-                    ),
+                    this=_unixepoch_subsec(left_operand),
+                    expression=_unixepoch_subsec(right_operand),
                 )
             )
         )

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -161,9 +161,11 @@ def _note_uncast_json_ordering(root: exp.Expression, ctx: RewriteContext) -> Non
     """
     note = _JSON_TEXT_ORDERING_NOTES[ctx.dialect]
     for node in root.find_all(*_ORDER_SENSITIVE, *_ORDER_SENSITIVE_COMPARISONS):
-        for target in _comparison_operands(node) if isinstance(
-            node, _ORDER_SENSITIVE_COMPARISONS
-        ) else (node.this,):
+        for target in (
+            _comparison_operands(node)
+            if isinstance(node, _ORDER_SENSITIVE_COMPARISONS)
+            else (node.this,)
+        ):
             # A cast says the caller knows. Parentheses say nothing: the lambda
             # repair adds them, so an accessor written inside a call arrives
             # wrapped.
@@ -1053,9 +1055,7 @@ def _using_keys_needing_coalesce(
     absent, and there the left copy is NULL while the key itself is not.
     """
     from_expr = node.args.get("from_") or node.args.get("from")
-    left_sources: list[exp.Expression] = (
-        [from_expr.this] if isinstance(from_expr, exp.From) else []
-    )
+    left_sources: list[exp.Expression] = [from_expr.this] if isinstance(from_expr, exp.From) else []
     needed: dict[str, list[exp.Identifier]] = {}
     for join in node.args.get("joins") or []:
         side = str(join.args.get("side") or "").upper()
@@ -1206,9 +1206,7 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
             # copy of the key.
             using_keys = _using_join_keys(node, ctx.dialect) if not explicit else frozenset()
             coalesce_using = (
-                _using_keys_needing_coalesce(
-                    node, allowlist=ctx.allowlist, dialect=ctx.dialect
-                )
+                _using_keys_needing_coalesce(node, allowlist=ctx.allowlist, dialect=ctx.dialect)
                 if not explicit
                 else {}
             )

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -1022,6 +1022,43 @@ def _select_from_is_values(select: exp.Select) -> bool:
     return isinstance(source, exp.Values)
 
 
+def _using_keys_needing_coalesce(
+    node: exp.Select, dialect: SupportedSQLDialectName
+) -> dict[str, list[exp.Identifier]]:
+    """USING keys whose left copy can be NULL, with the relations to merge.
+
+    USING exposes one column per key, defined as the merge of both sides. For
+    an inner or left join the left copy is always the merged value, so emitting
+    it is faithful. A right or full join produces rows where the left side is
+    absent, and there the left copy is NULL while the key itself is not.
+    """
+    from_expr = node.args.get("from_") or node.args.get("from")
+    left_sources: list[exp.Expression] = (
+        [from_expr.this] if isinstance(from_expr, exp.From) else []
+    )
+    needed: dict[str, list[exp.Identifier]] = {}
+    for join in node.args.get("joins") or []:
+        side = str(join.args.get("side") or "").upper()
+        using = join.args.get("using")
+        if using and side in ("RIGHT", "FULL") and left_sources:
+            items = using if isinstance(using, list) else [using]
+            for item in items:
+                ident = item if isinstance(item, exp.Identifier) else getattr(item, "this", None)
+                if not isinstance(ident, exp.Identifier):
+                    continue
+                key = _identifier_key(
+                    ident.name or ident.this or "",
+                    quoted=bool(ident.args.get("quoted")),
+                    dialect=dialect,
+                )
+                needed[key] = [
+                    *(_relation_qualifier(source) for source in left_sources),
+                    _relation_qualifier(join.this),
+                ]
+        left_sources.append(join.this)
+    return needed
+
+
 def _using_join_keys(node: exp.Select, dialect: SupportedSQLDialectName) -> frozenset[str]:
     """Join keys named by USING, compared the way this dialect compares identifiers.
 
@@ -1132,6 +1169,9 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
             # star names one relation's columns, so it keeps that relation's
             # copy of the key.
             using_keys = _using_join_keys(node, ctx.dialect) if not explicit else frozenset()
+            coalesce_using = (
+                _using_keys_needing_coalesce(node, ctx.dialect) if not explicit else {}
+            )
             using_keys = frozenset(using_keys | ctx.coalesced_using_by_select.get(id(node), set()))
             emitted_using: set[str] = set()
 
@@ -1212,6 +1252,27 @@ def _expand_stars(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
                         if key in emitted_using:
                             continue
                         emitted_using.add(key)
+                        merge = coalesce_using.get(key)
+                        if merge:
+                            new_exprs.append(
+                                exp.alias_(
+                                    exp.Coalesce(
+                                        this=exp.Column(
+                                            this=exp.to_identifier(name, quoted=quoted),
+                                            table=merge[0].copy(),
+                                        ),
+                                        expressions=[
+                                            exp.Column(
+                                                this=exp.to_identifier(name, quoted=quoted),
+                                                table=other.copy(),
+                                            )
+                                            for other in merge[1:]
+                                        ],
+                                    ),
+                                    exp.to_identifier(name, quoted=quoted),
+                                )
+                            )
+                            continue
                     # Qualify by the caller's alias, quoting included: after
                     # ``FROM spans AS s`` the name ``spans`` no longer resolves.
                     new_exprs.append(

--- a/src/phoenix/server/mcp/sql/rewrite.py
+++ b/src/phoenix/server/mcp/sql/rewrite.py
@@ -140,6 +140,11 @@ def _is_json_extraction(node: exp.Expression) -> bool:
     }
 
 
+#: Comparisons where text ordering answers differently from numeric ordering.
+#: Equality is a separate hazard and is not one of these.
+_ORDER_SENSITIVE_COMPARISONS = (exp.GT, exp.GTE, exp.LT, exp.LTE, exp.Between)
+
+
 def _note_uncast_json_ordering(root: exp.Expression, ctx: RewriteContext) -> None:
     """Say so when a JSON read is ordered as text.
 
@@ -154,14 +159,20 @@ def _note_uncast_json_ordering(root: exp.Expression, ctx: RewriteContext) -> Non
     document -- so refusing would block a legitimate query to prevent a
     plausible mistake.
     """
-    for node in root.find_all(*_ORDER_SENSITIVE):
-        target = node.this
-        if isinstance(target, exp.Cast):
-            continue
-        note = _JSON_TEXT_ORDERING_NOTES[ctx.dialect]
-        if _is_json_extraction(target) and note not in ctx.notes:
-            ctx.notes.append(note)
-            return
+    note = _JSON_TEXT_ORDERING_NOTES[ctx.dialect]
+    for node in root.find_all(*_ORDER_SENSITIVE, *_ORDER_SENSITIVE_COMPARISONS):
+        for target in _comparison_operands(node) if isinstance(
+            node, _ORDER_SENSITIVE_COMPARISONS
+        ) else (node.this,):
+            # A cast says the caller knows. Parentheses say nothing: the lambda
+            # repair adds them, so an accessor written inside a call arrives
+            # wrapped.
+            unwrapped = _strip_parens(target)
+            if unwrapped is None or isinstance(unwrapped, exp.Cast):
+                continue
+            if _is_json_extraction(unwrapped) and note not in ctx.notes:
+                ctx.notes.append(note)
+                return
 
 
 def rewrite(root: exp.Expression, ctx: RewriteContext) -> exp.Expression:
@@ -1418,6 +1429,11 @@ def _timestamp_unit_function_call(
     return None
 
 
+#: Unit functions that truncate to whole seconds unless given `subsec`.
+#: `julianday` is already fractional and `date` is day-resolution by definition.
+_SQLITE_SUBSEC_UNITS = frozenset({"unixepoch", "datetime", "time"})
+
+
 def _timestamp_unit_through_arithmetic(node: Optional[exp.Expression]) -> Optional[str]:
     """The unit a side is expressed in, seen through arithmetic.
 
@@ -1492,7 +1508,13 @@ def _rewrite_sqlite_timestamp_vs_epoch_function(
         if unit_name == "date":
             wrapped: exp.Expression = exp.Date(this=column.copy())
         else:
-            wrapped = exp.Anonymous(this=unit_name, expressions=[column.copy()])
+            # Storage carries fractional seconds. `unixepoch`, `datetime` and
+            # `time` truncate to whole seconds unless asked otherwise, which
+            # drops rows whose comparison is decided below the second.
+            args: list[exp.Expression] = [column.copy()]
+            if unit_name in _SQLITE_SUBSEC_UNITS:
+                args.append(exp.Literal.string("subsec"))
+            wrapped = exp.Anonymous(this=unit_name, expressions=args)
         column.replace(wrapped)
         changed = True
     if changed:

--- a/src/phoenix/server/mcp/sql/teaching.py
+++ b/src/phoenix/server/mcp/sql/teaching.py
@@ -55,8 +55,8 @@ def _describe_sql_schema(
     # when one is TIMESTAMP and the other TIMESTAMP WITH TIME ZONE).
     #
     # Validated before it is returned. A generator can emit text that reads like
-    # DDL and is not -- a comment swallowing the comma after it did exactly that
-    # here -- and the caller cannot tell, because it is prose to them.
+    # DDL and is not -- a trailing comment swallowing the comma after it is
+    # enough -- and the caller cannot tell, because it is prose to them.
     schema_ddl = render_schema_ddl(
         area=area, tables=tables, detail=detail, search=search, dialect=dialect
     )

--- a/src/phoenix/server/mcp/sql/tools.py
+++ b/src/phoenix/server/mcp/sql/tools.py
@@ -21,6 +21,7 @@ from phoenix.server.mcp.sql.execute import (
     DEFAULT_ROW_LIMIT,
     MAX_RESPONSE_BYTES,
     MAX_ROW_LIMIT,
+    MAX_SQL_BYTES,
     ExecuteParams,
     execute_analytics_sql,
 )
@@ -91,7 +92,8 @@ def _preamble(dialect: str, engine: Optional[EngineInfo]) -> str:
         )
     backstop = "statement_timeout" if dialect == "postgresql" else "sqlite_progress_handler"
     lines.append(
-        f"-- read-only. {DEFAULT_ROW_LIMIT} rows by default, {MAX_ROW_LIMIT} max; "
+        f"-- read-only. {MAX_SQL_BYTES // 1024} KiB of SQL per call; "
+        f"{DEFAULT_ROW_LIMIT} rows by default, {MAX_ROW_LIMIT} max; "
         f"{BYTE_LIMIT} bytes per row; {MAX_RESPONSE_BYTES} per response; {backstop} deadline."
     )
     lines.append("-- Not snapshot-isolated: identical SQL may differ under concurrent ingestion.")

--- a/src/phoenix/server/mcp/sql/tools.py
+++ b/src/phoenix/server/mcp/sql/tools.py
@@ -269,6 +269,10 @@ def register_analytics_sql_tools(mcp: FastMCP, *, db: DbSessionFactory) -> None:
         Returns either the columns, rows, and applied limits, or an error
         envelope when the SQL cannot be accepted.
 
+        A statement may be at most 2 KiB of SQL, measured in UTF-8 bytes.
+        Longer ones are refused unexecuted, so split the work rather than
+        generating one long statement.
+
         `row_count_is_partial` is the authoritative answer to whether the result
         was truncated by either row or response-byte limits. One row beyond the
         row limit is fetched, and `notes` identifies the limit that applied.

--- a/tests/unit/server/mcp/sql/admission_corpus.py
+++ b/tests/unit/server/mcp/sql/admission_corpus.py
@@ -402,6 +402,12 @@ CASES: tuple[AdmissionCase, ...] = (
         dialect="postgresql",
     ),
     AdmissionCase(
+        sql="SELECT * FROM projects JOIN traces ON traces.project_rowid = projects.id RIGHT JOIN spans USING (start_time)",
+        expect=AdmissionOutcome.ADMIT,
+        note="a USING key on a join with more than one relation to its left; star expansion merges the key across the relations that provide it, and projects is not one of them",
+        dialect="postgresql",
+    ),
+    AdmissionCase(
         sql="SELECT user FROM spans, (SELECT 1) q",
         expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
         note="a foreign source in the FROM clause opens the unqualified-name hatch, and `user` binds to the session rather than to that source; the same identity is refused under its current_user spelling",

--- a/tests/unit/server/mcp/sql/admission_corpus.py
+++ b/tests/unit/server/mcp/sql/admission_corpus.py
@@ -402,6 +402,36 @@ CASES: tuple[AdmissionCase, ...] = (
         dialect="postgresql",
     ),
     AdmissionCase(
+        sql="SELECT user FROM spans, (SELECT 1) q",
+        expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
+        note="a foreign source in the FROM clause opens the unqualified-name hatch, and `user` binds to the session rather than to that source; the same identity is refused under its current_user spelling",
+        dialect="postgresql",
+    ),
+    AdmissionCase(
+        sql="SELECT ctid FROM spans, (SELECT 1) q",
+        expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
+        note="a system column binds to the base table through the same hatch, exposing physical tuple location; qualified spans.ctid is refused by the manifest check",
+        dialect="postgresql",
+    ),
+    AdmissionCase(
+        sql="SELECT id FROM spans, (SELECT 1) q WHERE ctid IS NOT NULL",
+        expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
+        note="the hatch is per column reference, not per projection, so a predicate reaches it too",
+        dialect="postgresql",
+    ),
+    AdmissionCase(
+        sql="SELECT rowid FROM spans, (SELECT 1) q",
+        expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
+        note="SQLite binds rowid to the base table through the same hatch",
+        dialect="sqlite",
+    ),
+    AdmissionCase(
+        sql="SELECT key FROM spans, jsonb_each(attributes) j",
+        expect=AdmissionOutcome.ADMIT,
+        note="the shape the unqualified-name hatch exists for: a table-valued function projects a name the manifest has never heard of",
+        dialect="postgresql",
+    ),
+    AdmissionCase(
         sql="SELECT CAST('pg_authid' AS regclass) FROM spans",
         expect=AdmissionOutcome.UNSUPPORTED_SYNTAX,
         note="object-identifier types consult the catalogs for any relation, role or function and never appear as a scanned relation, so the plan gate cannot see them; this is why cast targets are restricted at all",

--- a/tests/unit/server/mcp/sql/test_ddl.py
+++ b/tests/unit/server/mcp/sql/test_ddl.py
@@ -71,11 +71,11 @@ def test_postgresql_unqualification_only_changes_table_syntax() -> None:
 def test_every_rendering_parses(backend: str, detail: DetailLevel) -> None:
     """Generated DDL fails in ways handwritten DDL does not.
 
-    Both defects this renderer actually shipped were invisible in the output: a
-    trailing comment swallowed the comma after it, so two columns merged into
-    one; and `brief` emitted ``CREATE TABLE spans (...)``, which reads like DDL
-    but is not valid SQL in any backend. Neither is detectable by eye, and the
-    caller cannot detect them at all -- it is prose to them.
+    Its failure modes are invisible in the output: a trailing comment swallows
+    the comma after it, merging two columns into one; `brief` emits ``CREATE
+    TABLE spans (...)``, which reads like DDL but is not valid SQL in any
+    backend. Neither is detectable by eye, and the caller cannot detect them at
+    all -- it is prose to them.
     """
     validate_ddl(render_schema_ddl(detail=detail, dialect=backend), backend)
 

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -926,11 +926,11 @@ class TestLossyNormalisationIsReported:
 
 
 class TestSqliteResolutionErrorsAreActionable:
-    """PostgreSQL's own words already reach the caller; SQLite's did not.
+    """Both backends' own words reach the caller, SQLite's included.
 
     An unqualified column two joined tables both offer passes admission -- it is
     not hidden and both tables offer it -- and then fails at the engine. The
-    message names only the caller's own identifier, so withholding it made an
+    message names only the caller's own identifier, so withholding it makes an
     ordinary mistake un-actionable on one backend and precise on the other.
     """
 

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -995,17 +995,15 @@ async def test_admission_does_not_run_on_the_event_loop(
 ) -> None:
     """Parsing, admission and rewriting are CPU-bound and must run off the loop.
 
-    None of the guards that bound execution -- the row limit, the byte caps, the
-    statement deadline -- applies before the backend is reached, so on the event
-    loop a single call freezes every other request, ingestion included.
+    No execution guard -- row limit, byte caps, deadline -- applies before the
+    backend is reached, so on the event loop a single call freezes every other
+    request, ingestion included.
 
-    The thread is asserted rather than the wall-clock gap between heartbeats,
-    because the input cap holds this work below scheduler noise: a stall the cap
-    still permits is not reliably larger than an ordinary gap, so timing cannot
-    discriminate. Which thread ran it always can.
-
-    Both offloads are probed: parse and admit share one, rewrite and render the
-    other, and either left on the loop reintroduces the stall.
+    Thread identity is the assertion rather than elapsed time: the input cap
+    holds this work below scheduler noise, so no stall it permits is reliably
+    larger than ordinary jitter. Both offloads are probed -- parse and admit
+    share one, rewrite and render the other -- since either left on the loop
+    reintroduces the stall.
     """
     from phoenix.server.mcp.sql import execute as execute_module
 
@@ -1027,7 +1025,7 @@ async def test_admission_does_not_run_on_the_event_loop(
         db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path
     )
 
-    # Without this the thread assertion passes vacuously once a name stops being
-    # the one the pipeline calls.
+    # A rename in the pipeline would otherwise leave the thread assertion with
+    # nothing to check.
     assert set(threads) == {"parse_sql", "rewrite"}
     assert loop_thread not in threads.values(), f"ran on the event loop thread: {threads}"

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -1,11 +1,10 @@
-import asyncio
-import time
+import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 import pytest
@@ -990,44 +989,45 @@ async def test_an_identifier_named_like_a_deadline_is_not_reported_as_a_timeout(
     assert caught.value.code is not ErrorCode.TIMEOUT
 
 
-async def test_admission_does_not_block_the_event_loop(
+async def test_admission_does_not_run_on_the_event_loop(
     analytics_sqlite_db: tuple[DbSessionFactory, str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parsing and rewriting are CPU-bound and must not run on the event loop.
+    """Parsing, admission and rewriting are CPU-bound and must run off the loop.
 
-    They scale with the size of the statement, and the input cap allows a
-    megabyte of it. None of the guards that bound execution -- the row limit,
-    the byte caps, the statement deadline -- applies before the backend is
-    reached, so on the event loop a single call freezes every other request,
-    ingestion included.
+    None of the guards that bound execution -- the row limit, the byte caps, the
+    statement deadline -- applies before the backend is reached, so on the event
+    loop a single call freezes every other request, ingestion included.
 
-    The gap between ticks is what matters, not their number: a task that spins
-    freely before and after a stall still records many ticks. Run on the loop
-    this statement stalls it for the better part of a second; offloaded, no
-    single gap is long.
+    The thread is asserted rather than the wall-clock gap between heartbeats,
+    because the input cap holds this work below scheduler noise: a stall the cap
+    still permits is not reliably larger than an ordinary gap, so timing cannot
+    discriminate. Which thread ran it always can.
+
+    Both offloads are probed: parse and admit share one, rewrite and render the
+    other, and either left on the loop reintroduces the stall.
     """
+    from phoenix.server.mcp.sql import execute as execute_module
+
     db, db_path = analytics_sqlite_db
-    sql = "SELECT id FROM spans WHERE id IN (" + ",".join(["1"] * 12000) + ")"
+    loop_thread = threading.current_thread()
+    threads: dict[str, threading.Thread] = {}
 
-    gaps: list[float] = []
-    stop = asyncio.Event()
+    def probe(name: str, func: Any) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            threads[name] = threading.current_thread()
+            return func(*args, **kwargs)
 
-    async def heartbeat() -> None:
-        last = time.perf_counter()
-        while not stop.is_set():
-            await asyncio.sleep(0.01)
-            now = time.perf_counter()
-            gaps.append(now - last)
-            last = now
+        return wrapper
 
-    beat = asyncio.create_task(heartbeat())
-    await asyncio.sleep(0.05)
-    gaps.clear()
-    try:
-        await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
-    finally:
-        stop.set()
-        await beat
+    for name in ("parse_sql", "rewrite"):
+        monkeypatch.setattr(execute_module, name, probe(name, getattr(execute_module, name)))
 
-    assert gaps, "heartbeat never ran"
-    assert max(gaps) < 0.4, f"event loop stalled for {max(gaps):.2f}s during admission"
+    await execute_analytics_sql(
+        db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path
+    )
+
+    # Without this the thread assertion passes vacuously once a name stops being
+    # the one the pipeline calls.
+    assert set(threads) == {"parse_sql", "rewrite"}
+    assert loop_thread not in threads.values(), f"ran on the event loop thread: {threads}"

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -1029,3 +1030,48 @@ async def test_admission_does_not_run_on_the_event_loop(
     # nothing to check.
     assert set(threads) == {"parse_sql", "rewrite"}
     assert loop_thread not in threads.values(), f"ran on the event loop thread: {threads}"
+
+
+async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
+    analytics_sqlite_db: tuple[DbSessionFactory, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capacity follows the work, not the caller waiting on it.
+
+    Parsing and rewriting are uninterruptible, so the thread runs to completion
+    after the caller disconnects. Returning the permit on cancellation admits
+    the next statement beside work that is still running, and repeated
+    cancellations put more of it in flight than the width allows.
+    """
+    from phoenix.server.mcp.sql import execute as execute_module
+
+    db, db_path = analytics_sqlite_db
+    entered = threading.Event()
+    finish = threading.Event()
+    original = execute_module.parse_sql
+
+    def blocking(*args: Any, **kwargs: Any) -> Any:
+        entered.set()
+        finish.wait(10)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(execute_module, "parse_sql", blocking)
+    semaphore = execute_module.EXECUTION_SEMAPHORE
+
+    call = asyncio.create_task(
+        execute_analytics_sql(db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path)
+    )
+    await asyncio.to_thread(entered.wait, 10)
+    call.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await call
+
+    # SQLite runs one statement at a time, so a second acquire completing here
+    # would mean the permit came back while the thread still held it.
+    second = asyncio.create_task(semaphore.acquire("sqlite"))
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(second), 0.25)
+
+    finish.set()
+    await asyncio.wait_for(second, 10)
+    semaphore.release("sqlite")

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -1044,11 +1044,12 @@ async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
     cancellations put more of it in flight than the width allows.
     """
     from phoenix.server.mcp.sql import execute as execute_module
+    from phoenix.server.mcp.sql.parse import parse_sql
 
     db, db_path = analytics_sqlite_db
     entered = threading.Event()
     finish = threading.Event()
-    original = execute_module.parse_sql
+    original = parse_sql
 
     def blocking(*args: Any, **kwargs: Any) -> Any:
         entered.set()

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -958,3 +958,23 @@ class TestSqliteResolutionErrorsAreActionable:
             )
 
         assert "validate_only" not in exc.value.message
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["timeout", "interrupted"],
+)
+async def test_an_identifier_named_like_a_deadline_is_not_reported_as_a_timeout(
+    analytics_sqlite_db: tuple[DbSessionFactory, str], identifier: str
+) -> None:
+    """SQLite reports the deadline as exactly "interrupted".
+
+    Matching that as a substring made any error mentioning the word a timeout,
+    so a caller whose own column is named `timeout` was told to retry a
+    statement they needed to fix instead.
+    """
+    db, db_path = analytics_sqlite_db
+    sql = f"SELECT {identifier} FROM (SELECT 1 AS {identifier}) a, (SELECT 2 AS {identifier}) b"
+    with pytest.raises(AnalyticsSqlError) as caught:
+        await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
+    assert caught.value.code is not ErrorCode.TIMEOUT

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -1108,6 +1109,8 @@ async def test_a_call_cancelled_before_its_thread_starts_returns_its_permit_at_o
     parsed: list[str] = []
     occupied = threading.Event()
     release_pool = threading.Event()
+    submitted: list[concurrent.futures.Future[Any]] = []
+    accepted = threading.Event()
 
     def watched(*args: Any, **kwargs: Any) -> Any:
         parsed.append("ran")
@@ -1117,10 +1120,18 @@ async def test_a_call_cancelled_before_its_thread_starts_returns_its_permit_at_o
     semaphore = execute_module.ExecutionSemaphore()
     monkeypatch.setattr(execute_module, "EXECUTION_SEMAPHORE", semaphore)
 
-    # One thread, held by an unrelated job, so the call's parse can only queue.
-    execute_module.shutdown_sql_executor()
-    monkeypatch.setattr(execute_module, "_EXECUTOR_WIDTH", 1)
-    pool = execute_module._sql_executor()
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+    class Recording:
+        """Reports the moment the pool accepts a job, so the test can wait for it."""
+
+        def submit(self, fn: Any, *args: Any, **kwargs: Any) -> concurrent.futures.Future[Any]:
+            future = pool.submit(fn, *args, **kwargs)
+            submitted.append(future)
+            accepted.set()
+            return future
+
+    monkeypatch.setattr(execute_module, "_sql_executor", Recording)
     try:
 
         def hold_the_only_thread() -> None:
@@ -1135,18 +1146,24 @@ async def test_a_call_cancelled_before_its_thread_starts_returns_its_permit_at_o
                 db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path
             )
         )
-        await asyncio.sleep(0.1)
+        # Waiting on the submission rather than on a delay. Cancelling before it
+        # would return the permit for a call that never reached the pool, which
+        # this guard would then report as a pass.
+        await asyncio.to_thread(accepted.wait, 10)
+        assert not submitted[0].running(), "the job started; this exercises the wrong branch"
+
         call.cancel()
         with pytest.raises(asyncio.CancelledError):
             await call
 
-        # The permit is free while the pool is still occupied, which it could
-        # not be if release waited on the queue rather than on started work.
+        assert submitted[0].cancelled(), "the queued job was not cancelled"
+        # Free while the pool is still occupied, which it could not be if
+        # release waited on the queue rather than on started work.
         await asyncio.wait_for(semaphore.acquire("sqlite"), 1)
         semaphore.release("sqlite")
     finally:
         release_pool.set()
-        execute_module.shutdown_sql_executor()
+        pool.shutdown(wait=True)
 
     assert parsed == [], "a cancelled call ran its parse after the queue drained"
 

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -1,3 +1,5 @@
+import asyncio
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -978,3 +980,46 @@ async def test_an_identifier_named_like_a_deadline_is_not_reported_as_a_timeout(
     with pytest.raises(AnalyticsSqlError) as caught:
         await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
     assert caught.value.code is not ErrorCode.TIMEOUT
+
+
+async def test_admission_does_not_block_the_event_loop(
+    analytics_sqlite_db: tuple[DbSessionFactory, str],
+) -> None:
+    """Parsing and rewriting are CPU-bound and must not run on the event loop.
+
+    They scale with the size of the statement, and the input cap allows a
+    megabyte of it. None of the guards that bound execution -- the row limit,
+    the byte caps, the statement deadline -- applies before the backend is
+    reached, so on the event loop a single call freezes every other request,
+    ingestion included.
+
+    The gap between ticks is what matters, not their number: a task that spins
+    freely before and after a stall still records many ticks. Run on the loop
+    this statement stalls it for the better part of a second; offloaded, no
+    single gap is long.
+    """
+    db, db_path = analytics_sqlite_db
+    sql = "SELECT id FROM spans WHERE id IN (" + ",".join(["1"] * 12000) + ")"
+
+    gaps: list[float] = []
+    stop = asyncio.Event()
+
+    async def heartbeat() -> None:
+        last = time.perf_counter()
+        while not stop.is_set():
+            await asyncio.sleep(0.01)
+            now = time.perf_counter()
+            gaps.append(now - last)
+            last = now
+
+    beat = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0.05)
+    gaps.clear()
+    try:
+        await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
+    finally:
+        stop.set()
+        await beat
+
+    assert gaps, "heartbeat never ran"
+    assert max(gaps) < 0.4, f"event loop stalled for {max(gaps):.2f}s during admission"

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -279,13 +279,21 @@ async def test_postgres_intervals_are_normalized_before_result_validation(
 ) -> None:
     result = await execute_analytics_sql(
         analytics_postgres_db,
-        ExecuteParams(sql="SELECT end_time - start_time AS duration FROM spans", row_limit=1),
+        ExecuteParams(
+            sql=(
+                "SELECT end_time - start_time AS duration, latency_ms "
+                "FROM spans WHERE span_id = 'span-1'"
+            )
+        ),
     )
 
-    assert result.envelope.rows
-    duration = result.envelope.rows[0][0]
-    assert isinstance(duration, str)
-    assert duration.startswith("P")
+    # An interval is normalized to an ISO-8601 string, so the assertion is on
+    # the elapsed time the fixture implies rather than on the shape of the
+    # rendering: a normalizer that dropped the fractional second would still
+    # produce a well-formed `P`-prefixed string.
+    duration, latency_ms = result.envelope.rows[0]
+    assert duration == "PT1.5S"
+    assert latency_ms == pytest.approx(1500.0, rel=1e-4)
 
 
 @pytest.mark.postgres_only

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -250,13 +250,13 @@ async def test_a_stream_past_its_deadline_times_out() -> None:
 async def test_a_mistyped_column_is_reported_not_leaked(db: DbSessionFactory) -> None:
     """The most common caller mistake must not surface as a driver traceback.
 
-    It used to reach the engine, where EXPLAIN resolves names, and returned
+    Reaching the engine, where EXPLAIN resolves names, produces
     ``(sqlalchemy.dialects.postgresql.asyncpg.ProgrammingError) <class
-    'asyncpg.exceptions.UndefinedColumnError'>: ...`` -- naming our driver stack
+    'asyncpg.exceptions.UndefinedColumnError'>: ...`` -- naming the driver stack
     and inviting the caller to debug the server instead of the query.
 
-    Admission now refuses it first, since the column policy is an allowlist, so
-    the statement never reaches PostgreSQL and its "did you mean" never arrives.
+    Admission refuses it first, since the column policy is an allowlist, so the
+    statement never reaches PostgreSQL and its "did you mean" never arrives.
     The suggestion is made here instead, from the manifest -- which knows the
     exposed columns, so it will not propose one the caller cannot read.
     """
@@ -379,16 +379,16 @@ async def test_the_schema_is_resolved_not_assumed(
 ) -> None:
     """Both tools must name the schema Phoenix's ORM actually reads.
 
-    `load_allowlist("sqlite")` returns "public" and only the execute path overrode it,
-    so `describeSqlSchema` published indexes belonging to whatever sits in
-    `public` while the executor read somewhere else — names and JSON path
-    literals from a different instance's tables, and "repeat this spelling"
-    advice that was wrong for every entry.
+    `load_allowlist("sqlite")` returns "public", so a tool that does not override
+    it publishes indexes belonging to whatever sits in `public` while the
+    executor reads somewhere else — names and JSON path literals from a
+    different instance's tables, and "repeat this spelling" advice wrong for
+    every entry.
 
-    The execute path was not right either. It used `get_env_database_schema()
-    or "public"`, the hardcoded fallback #14172 removed from the usage
-    statistics: with the variable unset and the tables reached through
-    `search_path`, "public" names a schema that does not hold them.
+    `get_env_database_schema() or "public"` is not an override either: it is the
+    hardcoded fallback #14172 removed from the usage statistics. With the
+    variable unset and the tables reached through `search_path`, "public" names
+    a schema that does not hold them.
 
     Resolution follows that PR: the environment variable when set, otherwise
     the schema an unqualified `projects` reference resolves from. Deliberately

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -17,6 +17,7 @@ from phoenix.server.mcp.sql.allowlist import load_allowlist
 from phoenix.server.mcp.sql.errors import AnalyticsSqlError, ErrorCode
 from phoenix.server.mcp.sql.execute import (
     MAX_RESPONSE_BYTES,
+    MAX_SQL_BYTES,
     ExecuteParams,
     _consume_stream,
     _estimated_rows,
@@ -1057,7 +1058,10 @@ async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
         return original(*args, **kwargs)
 
     monkeypatch.setattr(execute_module, "parse_sql", blocking)
-    semaphore = execute_module.EXECUTION_SEMAPHORE
+    # A private semaphore, so a regression that leaks the width-one permit
+    # fails this test alone instead of stalling every later execute test.
+    semaphore = execute_module.ExecutionSemaphore()
+    monkeypatch.setattr(execute_module, "EXECUTION_SEMAPHORE", semaphore)
 
     call = asyncio.create_task(
         execute_analytics_sql(db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path)
@@ -1070,9 +1074,120 @@ async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
     # SQLite runs one statement at a time, so a second acquire completing here
     # would mean the permit came back while the thread still held it.
     second = asyncio.create_task(semaphore.acquire("sqlite"))
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(asyncio.shield(second), 0.25)
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(second), 0.25)
+        finish.set()
+        await asyncio.wait_for(second, 10)
+    finally:
+        # Released in a finally so a regression fails this test alone. Leaking
+        # SQLite's width-one permit would stall every later execute test and
+        # bury the failure that caused it.
+        finish.set()
+        if second.done() and not second.cancelled():
+            semaphore.release("sqlite")
+        else:
+            second.cancel()
 
-    finish.set()
-    await asyncio.wait_for(second, 10)
-    semaphore.release("sqlite")
+
+async def test_a_call_cancelled_before_its_thread_starts_returns_its_permit_at_once(
+    analytics_sqlite_db: tuple[DbSessionFactory, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Work that never began holds nothing.
+
+    A permit tracks work in flight. A call cancelled while its job is still
+    queued releases no thread and produces no result, so holding its permit
+    until the queue drains would refuse live callers on behalf of work that is
+    never going to run.
+    """
+    from phoenix.server.mcp.sql import execute as execute_module
+    from phoenix.server.mcp.sql.parse import parse_sql
+
+    db, db_path = analytics_sqlite_db
+    parsed: list[str] = []
+    occupied = threading.Event()
+    release_pool = threading.Event()
+
+    def watched(*args: Any, **kwargs: Any) -> Any:
+        parsed.append("ran")
+        return parse_sql(*args, **kwargs)
+
+    monkeypatch.setattr(execute_module, "parse_sql", watched)
+    semaphore = execute_module.ExecutionSemaphore()
+    monkeypatch.setattr(execute_module, "EXECUTION_SEMAPHORE", semaphore)
+
+    # One thread, held by an unrelated job, so the call's parse can only queue.
+    execute_module.shutdown_sql_executor()
+    monkeypatch.setattr(execute_module, "_EXECUTOR_WIDTH", 1)
+    pool = execute_module._sql_executor()
+    try:
+
+        def hold_the_only_thread() -> None:
+            occupied.set()
+            release_pool.wait(10)
+
+        pool.submit(hold_the_only_thread)
+        await asyncio.to_thread(occupied.wait, 10)
+
+        call = asyncio.create_task(
+            execute_analytics_sql(
+                db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path
+            )
+        )
+        await asyncio.sleep(0.1)
+        call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await call
+
+        # The permit is free while the pool is still occupied, which it could
+        # not be if release waited on the queue rather than on started work.
+        await asyncio.wait_for(semaphore.acquire("sqlite"), 1)
+        semaphore.release("sqlite")
+    finally:
+        release_pool.set()
+        execute_module.shutdown_sql_executor()
+
+    assert parsed == [], "a cancelled call ran its parse after the queue drained"
+
+
+@pytest.mark.parametrize(
+    "size,refused",
+    [(MAX_SQL_BYTES, False), (MAX_SQL_BYTES + 1, True)],
+    ids=["at the cap", "one byte over"],
+)
+async def test_the_input_cap_is_measured_in_bytes(
+    analytics_sqlite_db: tuple[DbSessionFactory, str],
+    size: int,
+    refused: bool,
+) -> None:
+    """The cap admits its own boundary and refuses the byte past it."""
+    db, db_path = analytics_sqlite_db
+    # Padding rides in a comment so only the length varies with `size`.
+    head = "SELECT id FROM spans -- "
+    sql = head + "a" * (size - len(head))
+    assert len(sql.encode("utf-8")) == size
+
+    if not refused:
+        await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
+        return
+    with pytest.raises(AnalyticsSqlError) as caught:
+        await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
+    assert "input limit" in caught.value.message
+
+
+async def test_a_multibyte_statement_is_measured_in_bytes_not_characters(
+    analytics_sqlite_db: tuple[DbSessionFactory, str],
+) -> None:
+    """A character is up to four bytes, and the cap bounds the work, which scales with bytes."""
+    db, db_path = analytics_sqlite_db
+    head = "SELECT id FROM spans -- "
+    # Three bytes per character, so this is under the cap by character count
+    # and over it by byte count.
+    padding = "\u4e2d" * (((MAX_SQL_BYTES - len(head)) // 3) + 1)
+    sql = head + padding
+    assert len(sql) < MAX_SQL_BYTES < len(sql.encode("utf-8"))
+
+    with pytest.raises(AnalyticsSqlError) as caught:
+        await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
+    assert "input limit" in caught.value.message

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -738,8 +738,8 @@ async def test_no_window_is_imposed_when_none_is_asked_for(
     result = await execute_analytics_sql(
         db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path
     )
-    # Absent entirely, rather than present with null bounds: reporting a window
-    # that was never imposed is what made the old default so easy to miss.
+    # Absent entirely, rather than present with null bounds: a reported window
+    # that was never imposed reads as one that was.
     assert "time_window" not in result.envelope.applied.model_dump(exclude_none=True)
     assert "time_bounds" not in result.envelope.applied.rewrites
 

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -587,12 +587,12 @@ async def test_partial_flag_is_honest_at_the_boundary(
 ) -> None:
     """A result of exactly N rows must not claim it was truncated.
 
-    While the injected limit equalled the reported one, the row that would prove
-    truncation was never fetched, so an exactly-complete result was reported
-    identically to a truncated one. An agent acts on that flag by paginating or
-    narrowing a query that was already complete. The rewrite now asks for one
-    row more than the caller wants and the consumer drops it, which is what
-    makes the distinction observable.
+    An injected limit equal to the reported one never fetches the row that would
+    prove truncation, so an exactly-complete result reports identically to a
+    truncated one. An agent acts on that flag by paginating or narrowing a query
+    that is already complete. The rewrite asks for one row more than the caller
+    wants and the consumer drops it, which is what makes the distinction
+    observable.
 
     The rows are seeded here and the query is scoped to them by name. A
     boundary test needs to know exactly how many rows exist, so it cannot read

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -1057,9 +1057,7 @@ async def test_portable_function_classes_are_executable_on_sqlite(
 DISTINCT_ON_SHAPES = [
     pytest.param("SELECT DISTINCT ON (name) id FROM spans ORDER BY name, id", id="single-key"),
     pytest.param("SELECT DISTINCT ON ((name)) id FROM spans ORDER BY name, id", id="parenthesised"),
-    pytest.param(
-        "SELECT DISTINCT ON (name, id) id FROM spans ORDER BY name, id", id="multi-key"
-    ),
+    pytest.param("SELECT DISTINCT ON (name, id) id FROM spans ORDER BY name, id", id="multi-key"),
 ]
 
 

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -79,9 +79,9 @@ PERMITTED = [
     # SQLite materialises a CTE when it carries GROUP BY, ORDER BY, DISTINCT or
     # LIMIT, and reports reads of the materialised result as reads of a table
     # named after the alias. Admission sees a CTE and permits it; the authorizer
-    # saw a table nobody allowlisted and refused it. The inlinable case passed,
-    # so the gap was invisible to any corpus that tested CTEs generically --
-    # each materialising clause is listed separately for that reason.
+    # sees a table nobody allowlisted. An inlined CTE reports the underlying
+    # table and passes, so a corpus that tests CTEs generically cannot reach
+    # this -- each materialising clause is therefore listed separately.
     pytest.param(
         "WITH t AS (SELECT span_kind, COUNT(*) AS c FROM spans GROUP BY span_kind) "
         "SELECT COUNT(*) AS v FROM t",
@@ -134,9 +134,9 @@ PERMITTED = [
         id="nth_value",
     ),
     pytest.param("SELECT ntile(4) OVER (ORDER BY id) AS v FROM spans", id="ntile"),
-    # The JSON family. These are the ones that were admitted and then refused:
-    # json_extract because rendering turns it into an operator, json_each because
-    # a table-valued function reads a pseudo-table rather than calling a function.
+    # The JSON family, where admission and the authorizer see different things:
+    # rendering turns json_extract into an operator, and json_each reads a
+    # pseudo-table rather than calling a function.
     pytest.param("SELECT json_extract(attributes, '$.a.b') AS v FROM spans", id="json_extract"),
     pytest.param("SELECT key AS v FROM spans, json_each(attributes)", id="json_each"),
     pytest.param(
@@ -449,17 +449,17 @@ async def test_queue_slot_is_returned_when_a_waiter_is_cancelled() -> None:
 
 
 async def test_queue_slot_is_returned_when_a_waiter_is_cancelled_twice() -> None:
-    """One cancellation was survivable; a second during the unwind was not.
+    """A second cancellation arriving during the unwind must still return the slot.
 
-    The decrement used to run under the same lock the admission check holds, so
-    it awaited inside a `finally` that a cancellation was already unwinding. A
-    second cancellation delivered during that await skipped it, and the slot was
-    gone for the life of the process -- the identical denial of service the test
-    above exists to prevent, reachable whenever the lock happened to be held.
+    Releasing the slot under the lock the admission check holds means awaiting
+    inside a `finally` that a cancellation is already unwinding. A second
+    cancellation delivered during that await skips the release, and the slot is
+    gone for the life of the process -- the denial of service the single-
+    cancellation test above exists to prevent, reachable whenever the lock is
+    held.
 
-    The comment on that decrement asserted the `finally` made a leak
-    impossible. It did not, which is why this case is separate: the single
-    cancellation above passed throughout.
+    A `finally` alone does not make the leak impossible, which is why this case
+    is separate: a single cancellation passes either way.
     """
     import asyncio
 
@@ -522,8 +522,7 @@ async def test_newly_allowed_function_executes(
 ) -> None:
     """Admitting a function is not the same as being able to run it.
 
-    Each of these was refused until the allowlist was widened, and widening it
-    only settles the parser's view. The engine still has to accept the rendered
+    Widening the allowlist settles only the parser's view. The engine still has to accept the rendered
     spelling, which is not always the one the caller wrote -- group_concat is
     emitted as string_agg on PostgreSQL, from the same node class.
     """
@@ -729,13 +728,11 @@ async def test_no_window_is_imposed_when_none_is_asked_for(
 ) -> None:
     """A query with no bounds reads all of history, and the envelope says so.
 
-    The surface used to inject a trailing seven-day window. It could not bound a
-    determined caller, since defeating it cost one parameter, and for everyone
-    else it answered a different question than the one asked while reporting
-    success. Across roughly twenty-five cold-agent runs every caller noticed it
-    and worked around it, so it protected nobody and charged everybody a round
-    trip. The row and byte caps bound the answer; the statement deadline bounds
-    the work.
+    An implicit trailing window cannot bound a determined caller -- defeating one
+    costs a single parameter -- while for everyone else it answers a different
+    question than the one asked and reports success. Bounding belongs to limits
+    that do not change the question: the row and byte caps bound the answer, and
+    the statement deadline bounds the work.
     """
     db, db_path = analytics_sqlite_db
     result = await execute_analytics_sql(
@@ -1085,11 +1082,11 @@ async def test_portable_function_classes_are_executable_on_sqlite(
 ) -> None:
     """A class in the portable allowlist must also be in the authorizer's set.
 
-    exp.Upper, exp.Length, exp.CurrentTimestamp and exp.CurrentDate were
-    admitted by the parser policy and denied by the SQLite authorizer, so each
-    worked on PostgreSQL and was refused here -- the divergence the two
-    policies exist to prevent, and the one the allowlist comment claims the
-    liveness suite makes fail loudly. It did not, because no case covered them.
+    A class the parser policy admits but the authorizer denies works on
+    PostgreSQL and is refused here -- the divergence the two policies exist to
+    prevent. The allowlist comment claims this suite makes that fail loudly,
+    which holds only for classes a case actually executes, so every portable
+    class carries one.
     """
     db, db_path = analytics_sqlite_db
     result = await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
@@ -1113,8 +1110,8 @@ async def test_distinct_on_executes(analytics_postgres_db: DbSessionFactory, sql
     In `DISTINCT ON` the same text is grammar, and `ROW` there is a syntax
     error, so admission accepted a statement the engine then rejected.
 
-    Executed rather than rendered: the corpus pinned admission for this shape
-    and could not see that the emitted SQL does not parse.
+    Executed rather than rendered: admission accepting the shape says nothing
+    about whether the emitted SQL parses.
     """
     result = await execute_analytics_sql(analytics_postgres_db, ExecuteParams(sql=sql))
     assert result.envelope.row_count > 0

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -978,6 +978,14 @@ POSTGRES_JSON_SURFACE = [
         "FROM spans",
         id="computed_key_nested_accessor",
     ),
+    # A key holding an apostrophe, and the root-only path. Both are emissions
+    # the generator gets wrong on its own, so both have to reach the engine.
+    pytest.param(
+        "SELECT '{\"c''d\":7}'::jsonb -> 'c''d' AS v FROM spans", id="quoted_key"
+    ),
+    pytest.param(
+        "SELECT json_extract('{\"a\":1}'::jsonb, '$') AS v FROM spans", id="root_path"
+    ),
     # The array-constructor spelling of a `#>` path, which reaches the same
     # value as `#> '{a,b}'`.
     pytest.param(

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -666,6 +666,26 @@ async def test_negative_sqlite_limit_cannot_disable_the_work_cap(
     assert "LIMIT 3" in result.envelope.applied.executed
 
 
+#: Wall-clock seconds and the same span in milliseconds, per seeded span.
+#:
+#: Asserted by value rather than by being non-zero, because non-zero does not
+#: discriminate: truncating to whole seconds, resolving the column against the
+#: wrong relation, and comparing timestamps as text all return numbers that pass
+#: it. The sub-second spans carry the precision claim -- under whole-second
+#: arithmetic span-1 reads 1.0 and the other two read 0.0.
+ELAPSED_BY_SPAN = [
+    ("span-1", 1.5, 1500.0),
+    ("span-2", 0.65, 650.0),
+    ("span-3", 0.1, 100.0),
+]
+
+#: SQLite reaches elapsed time through julianday, whose result carries
+#: representation noise at the seventh significant figure. This bound clears
+#: that by two orders of magnitude while staying far tighter than the precision
+#: loss it exists to detect, which moves 1500 to 1000.
+ELAPSED_TOLERANCE = 1e-4
+
+
 async def test_sqlite_timestamp_subtraction_returns_elapsed_seconds(
     analytics_sqlite_db: tuple[DbSessionFactory, str],
 ) -> None:
@@ -674,16 +694,34 @@ async def test_sqlite_timestamp_subtraction_returns_elapsed_seconds(
         db,
         ExecuteParams(
             sql=(
-                "SELECT end_time - start_time AS duration, latency_ms "
-                "FROM spans WHERE span_id = 'span-1'"
+                "SELECT span_id, end_time - start_time AS duration, latency_ms "
+                "FROM spans ORDER BY span_id"
             )
         ),
         sqlite_db_path=db_path,
     )
-    assert result.envelope.rows
-    duration, latency_ms = result.envelope.rows[0]
-    assert duration != 0
-    assert latency_ms != 0
+    assert [row[0] for row in result.envelope.rows] == [s for s, _, _ in ELAPSED_BY_SPAN]
+    for (span_id, seconds, millis), row in zip(ELAPSED_BY_SPAN, result.envelope.rows):
+        assert row[1] == pytest.approx(seconds, rel=ELAPSED_TOLERANCE), span_id
+        assert row[2] == pytest.approx(millis, rel=ELAPSED_TOLERANCE), span_id
+
+
+async def test_sqlite_latency_predicate_selects_by_elapsed_milliseconds(
+    analytics_sqlite_db: tuple[DbSessionFactory, str],
+) -> None:
+    """A threshold between the seeded durations must divide them where it falls.
+
+    The predicate form is what a truncating implementation gets wrong while the
+    projected form still looks right: span-1 truncated to 1000 fails `> 1000`
+    and disappears, leaving an empty result that no non-empty check would catch.
+    """
+    db, db_path = analytics_sqlite_db
+    result = await execute_analytics_sql(
+        db,
+        ExecuteParams(sql="SELECT span_id FROM spans WHERE latency_ms > 1000 ORDER BY span_id"),
+        sqlite_db_path=db_path,
+    )
+    assert result.envelope.rows == [["span-1"]]
 
 
 async def test_no_window_is_imposed_when_none_is_asked_for(
@@ -980,12 +1018,8 @@ POSTGRES_JSON_SURFACE = [
     ),
     # A key holding an apostrophe, and the root-only path. Both are emissions
     # the generator gets wrong on its own, so both have to reach the engine.
-    pytest.param(
-        "SELECT '{\"c''d\":7}'::jsonb -> 'c''d' AS v FROM spans", id="quoted_key"
-    ),
-    pytest.param(
-        "SELECT json_extract('{\"a\":1}'::jsonb, '$') AS v FROM spans", id="root_path"
-    ),
+    pytest.param("SELECT '{\"c''d\":7}'::jsonb -> 'c''d' AS v FROM spans", id="quoted_key"),
+    pytest.param("SELECT json_extract('{\"a\":1}'::jsonb, '$') AS v FROM spans", id="root_path"),
     # The array-constructor spelling of a `#>` path, which reaches the same
     # value as `#> '{a,b}'`.
     pytest.param(
@@ -1084,3 +1118,53 @@ async def test_distinct_on_executes(analytics_postgres_db: DbSessionFactory, sql
     """
     result = await execute_analytics_sql(analytics_postgres_db, ExecuteParams(sql=sql))
     assert result.envelope.row_count > 0
+
+
+@pytest.mark.postgres_only
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        pytest.param("status_code", [["span-3"], ["span-1"]], id="two-groups"),
+        pytest.param("trace_rowid", [["span-1"]], id="one-group"),
+    ],
+)
+async def test_distinct_on_collapses_duplicate_keys(
+    analytics_postgres_db: DbSessionFactory, key: str, expected: list[list[str]]
+) -> None:
+    """The key list must select one row per distinct key, not merely execute.
+
+    Keys are chosen where the seeded spans repeat a value, so the row count
+    drops. A key that is unique per row leaves the result indistinguishable
+    from no de-duplication at all.
+
+    Rows are compared in engine order, which the trailing `ORDER BY` fixes: the
+    surviving row of each group is the first under that ordering, so the
+    expectation covers which row wins as well as how many.
+    """
+    result = await execute_analytics_sql(
+        analytics_postgres_db,
+        ExecuteParams(sql=f"SELECT DISTINCT ON ({key}) span_id FROM spans ORDER BY {key}, span_id"),
+    )
+    assert result.envelope.rows == expected
+
+
+@pytest.mark.postgres_only
+async def test_interval_predicate_selects_by_elapsed_time(
+    analytics_postgres_db: DbSessionFactory,
+) -> None:
+    """A threshold between the seeded durations must divide them where it falls.
+
+    The counterpart to the SQLite predicate test: the same question asked in the
+    spelling PostgreSQL accepts, so a divergence in either engine's elapsed-time
+    arithmetic shows up as a different set of spans rather than as an error.
+    """
+    result = await execute_analytics_sql(
+        analytics_postgres_db,
+        ExecuteParams(
+            sql=(
+                "SELECT span_id FROM spans "
+                "WHERE end_time - start_time > INTERVAL '1 second' ORDER BY span_id"
+            )
+        ),
+    )
+    assert result.envelope.rows == [["span-1"]]

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -1052,3 +1052,29 @@ async def test_portable_function_classes_are_executable_on_sqlite(
     db, db_path = analytics_sqlite_db
     result = await execute_analytics_sql(db, ExecuteParams(sql=sql), sqlite_db_path=db_path)
     assert result.envelope.row_count > 0
+
+
+DISTINCT_ON_SHAPES = [
+    pytest.param("SELECT DISTINCT ON (name) id FROM spans ORDER BY name, id", id="single-key"),
+    pytest.param("SELECT DISTINCT ON ((name)) id FROM spans ORDER BY name, id", id="parenthesised"),
+    pytest.param(
+        "SELECT DISTINCT ON (name, id) id FROM spans ORDER BY name, id", id="multi-key"
+    ),
+]
+
+
+@pytest.mark.postgres_only
+@pytest.mark.parametrize("sql", DISTINCT_ON_SHAPES)
+async def test_distinct_on_executes(analytics_postgres_db: DbSessionFactory, sql: str) -> None:
+    """`DISTINCT ON (expr)` is a key list, not a row constructor.
+
+    A one-element parenthesised list is a record constructor almost everywhere
+    it appears, and is rewritten to `ROW(expr)` so PostgreSQL reads it as one.
+    In `DISTINCT ON` the same text is grammar, and `ROW` there is a syntax
+    error, so admission accepted a statement the engine then rejected.
+
+    Executed rather than rendered: the corpus pinned admission for this shape
+    and could not see that the emitted SQL does not parse.
+    """
+    result = await execute_analytics_sql(analytics_postgres_db, ExecuteParams(sql=sql))
+    assert result.envelope.row_count > 0

--- a/tests/unit/server/mcp/sql/test_node_coverage.py
+++ b/tests/unit/server/mcp/sql/test_node_coverage.py
@@ -6,15 +6,15 @@ anything unlisted. ``_check_base_tables`` does the same over ``exp.Table``
 sources. Between them sits everything else the parser can build, and for those
 there is only ``_REFUSED_NODE_CLASSES``, which is a denylist.
 
-That seam is where three defects were found in one night, all with the same
-signature: a node that looks like a function call or a table modifier but is not
-the class the check expects. ``exp.Lambda`` is how ``->`` parses inside an
-argument list, and it made ``MIN`` return the maximum. ``exp.Operator`` let
-``OPERATOR(pg_catalog.~)`` through while the same operator's ordinary spelling
-was refused. ``exp.TableSample`` was accepted and then silently discarded.
+A denylist over that seam admits by default, and what slips through has one
+signature: a node that looks like a function call or a table modifier but is
+not the class the check expects. ``exp.Lambda`` is how ``->`` parses inside an
+argument list, which turns ``MIN`` into the maximum. ``exp.Operator`` carries
+``OPERATOR(pg_catalog.~)`` past the allowlist that refuses the same operator's
+ordinary spelling. ``exp.TableSample`` is accepted and then silently discarded.
 
-None of the three was found by a check. They were found by looking, which does
-not scale and does not run in CI.
+No check reports any of the three. Finding them takes reading the node classes
+against the policy, which does not scale and does not run in CI.
 
 What this file closes, and what it does not
 -------------------------------------------

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -1883,6 +1883,47 @@ def test_sqlite_bare_interval_is_refused() -> None:
     assert "INTERVAL" in result.detail
 
 
+class TestJsonEachColumnsAreCheckedWithoutABaseTable:
+    """SQLite reads a quoted unknown identifier as a string.
+
+    `"nope"` beside json_each therefore returns that word as data rather than
+    "no such column", and nothing downstream can tell the two apart. json_each
+    names its own columns, so the check needs no allowlisted table in scope --
+    and a statement that reads none is exactly where it used to be skipped.
+    """
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT \"nope\" FROM json_each('[1]')",
+            "SELECT nope FROM json_each('[1]')",
+            "SELECT j.\"nope\" FROM json_each('[1]') j",
+            # Still refused where an allowlisted table shares the scope.
+            'SELECT "nope" FROM spans, json_each(attributes)',
+        ],
+    )
+    def test_a_column_json_each_does_not_project_is_refused(self, sql: str) -> None:
+        with pytest.raises(AnalyticsSqlError) as caught:
+            admit_sql(sql, allowlist=load_allowlist("sqlite"), dialect="sqlite")
+        assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT key FROM json_each('[1]')",
+            "SELECT value FROM json_each('[1]') j",
+            "SELECT key FROM spans, json_each(attributes)",
+            "SELECT j.key FROM spans, json_each(attributes) j",
+            "SELECT id FROM spans, json_each(attributes)",
+            # A relation nobody can enumerate could have projected the name.
+            "WITH t AS (SELECT id AS weird FROM spans) "
+            "SELECT weird FROM spans, t, json_each(attributes)",
+        ],
+    )
+    def test_the_documented_idiom_is_admitted(self, sql: str) -> None:
+        admit_sql(sql, allowlist=load_allowlist("sqlite"), dialect="sqlite")
+
+
 class TestSessionIdentityIsRefusedWhateverTheStatementReads:
     """The niladic keywords resolve against the session, not against a relation.
 

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -1259,7 +1259,6 @@ class TestStructuralPolicyIsDefaultDeny:
             "SELECT ctid FROM spans",
             "SELECT xmin FROM spans",
             "SELECT ctid::text FROM spans",
-            "SELECT system_user FROM spans",
         ],
     )
     def test_what_the_plan_gate_cannot_see_is_refused_before_it(self, sql: str) -> None:
@@ -1884,22 +1883,68 @@ def test_sqlite_bare_interval_is_refused() -> None:
     assert "INTERVAL" in result.detail
 
 
+class TestSessionIdentityIsRefusedWhateverTheStatementReads:
+    """The niladic keywords resolve against the session, not against a relation.
+
+    A control that reasons about the relations in scope never reaches a
+    statement that reads none, and nothing downstream closes the gap: the plan
+    gate inspects relations and set-returning nodes, and the SQLite authorizer
+    never sees a column expression.
+    """
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # No FROM clause at all, so no scope holds a relation to reason about.
+            "SELECT user",
+            "SELECT user FROM (SELECT 1) q",
+            "SELECT current_role FROM (SELECT 1) q",
+            "SELECT system_user FROM (SELECT 1) q",
+            "WITH x AS (SELECT 1 AS v) SELECT user FROM x",
+            "SELECT user FROM spans",
+            "SELECT system_user FROM spans",
+            # A reference anywhere, not only a projection.
+            "SELECT id FROM spans WHERE user = 'phoenix'",
+            "SELECT count(*) FROM spans GROUP BY user",
+        ],
+    )
+    def test_session_identity_is_refused(self, sql: str) -> None:
+        with pytest.raises(AnalyticsSqlError) as caught:
+            admit_sql(sql, allowlist=load_allowlist("postgresql"), dialect="postgresql")
+        assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # PostgreSQL reserves the bare spelling, so a column of that name
+            # can only be written quoted and the two never collide.
+            'WITH x AS (SELECT 1 AS "user") SELECT "user" FROM x',
+            'SELECT q."user" FROM (SELECT 1 AS "user") q',
+            # An output alias is an identifier, not a column reference.
+            "SELECT 'anonymous' AS user FROM spans",
+        ],
+    )
+    def test_an_ordinary_column_of_that_name_is_admitted(self, sql: str) -> None:
+        admit_sql(sql, allowlist=load_allowlist("postgresql"), dialect="postgresql")
+
+
 class TestReservedNamesAreNotReachedThroughTheForeignSourceHatch:
     """An unqualified name is admitted when a foreign source could project it.
 
     A subquery, CTE or table-valued function in the FROM clause names columns
     the manifest does not know, so an unqualified reference no allowlisted table
     offers is admitted rather than refused. The engine does not resolve every
-    such name that way: a system column binds to the base table and a niladic
-    keyword binds to the session, and neither the plan gate nor the SQLite
-    authorizer inspects column expressions.
+    such name that way: a system column binds to the base table, and neither the
+    plan gate nor the SQLite authorizer inspects column expressions.
+
+    Scoped to the names that need a base table in scope to resolve. The session
+    identities resolve without one, so they are refused before this hatch is
+    reached.
     """
 
     @pytest.mark.parametrize(
         ("sql", "dialect"),
         [
-            ("SELECT user FROM spans, (SELECT 1) q", "postgresql"),
-            ("SELECT current_role FROM spans, (SELECT 1) q", "postgresql"),
             ("SELECT ctid FROM spans, (SELECT 1) q", "postgresql"),
             ("SELECT xmin, xmax, tableoid FROM spans, (SELECT 1) q", "postgresql"),
             # Any foreign source opens the hatch, not just a subquery.
@@ -1907,7 +1952,7 @@ class TestReservedNamesAreNotReachedThroughTheForeignSourceHatch:
             ("WITH t AS (SELECT 1 AS n) SELECT ctid FROM spans, t", "postgresql"),
             # A reference anywhere reaches it, not only a projection.
             ("SELECT id FROM spans, (SELECT 1) q WHERE ctid IS NOT NULL", "postgresql"),
-            ("SELECT count(*) FROM spans, (SELECT 1) q GROUP BY user", "postgresql"),
+            ("SELECT count(*) FROM spans, (SELECT 1) q GROUP BY ctid", "postgresql"),
             ("SELECT rowid FROM spans, (SELECT 1) q", "sqlite"),
             ("SELECT _rowid_ FROM spans, (SELECT 1) q", "sqlite"),
             ("SELECT oid FROM spans, (SELECT 1) q", "sqlite"),

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -907,7 +907,7 @@ class TestTimestampComparisonCoverage:
 
         Every stage handles such a run iteratively -- these render at two
         thousand terms -- and enumerating ids in a four-hundred-term `OR` is an
-        ordinary thing for a caller to write. Measuring it as depth refused them.
+        ordinary thing for a caller to write. Measuring it as depth refuses them.
         """
         assert try_parse_and_admit(sql, dialect="sqlite").outcome is AdmissionOutcome.ADMIT
 

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -445,12 +445,11 @@ class TestAliasCannotShadowACTE:
             "WITH projects AS (SELECT 1 AS v) SELECT count(*) FROM projects",
             "SELECT count(*) FROM projects AS p",
             # A CTE and a table alias sharing a name in *different* scopes is
-            # legal, unambiguous, and executes on both engines. The first
-            # version of this check refused it, because it looked for the cause
-            # -- any alias equal to any CTE name anywhere in the statement --
-            # rather than for the effect. `t` is simultaneously the commonest
-            # CTE name and the commonest table alias, so the false positive was
-            # easy to reach.
+            # legal, unambiguous, and executes on both engines. A check that
+            # looks for the cause -- any alias equal to any CTE name anywhere in
+            # the statement -- rather than for the effect refuses it. `t` is
+            # simultaneously the commonest CTE name and the commonest table
+            # alias, so that false positive is easy to reach.
             "WITH t AS (SELECT 1 AS v) SELECT n FROM (SELECT count(*) AS n FROM spans AS t) q",
             "WITH s AS (SELECT id FROM projects) "
             "SELECT (SELECT count(*) FROM spans AS s) AS n FROM s",
@@ -468,10 +467,10 @@ class TestCastTargetsAreRestrictedToDataTypes:
     plan gate cannot see it. That is the reason the list exists.
 
     An array of an allowed element type reaches nothing the element type does
-    not, and refusing it made the surface reject its own output: PostgreSQL
+    not, and refusing it makes the surface reject its own output: PostgreSQL
     renders the operand of `#>>` as `'{a,b}'::text[]`, so `describeSqlSchema`
-    published an index spelling under a heading telling the caller to reproduce
-    it exactly, and admission then refused it.
+    publishes an index spelling under a heading telling the caller to reproduce
+    it exactly, which admission then refuses.
 
     The `#>>` case is written here with the cast parenthesised. The
     unparenthesised form is admitted too, as a cast of the path rather than of

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -1872,7 +1872,8 @@ def test_sqlite_interval_addition_becomes_datetime_modifier() -> None:
 
     assert result.outcome is AdmissionOutcome.ADMIT
     folded = (result.rendered_sql or "").lower().replace(" ", "")
-    assert "datetime(start_time,'+1days')" in folded
+    # The shifted value keeps its subseconds; the modifier is what this pins.
+    assert "datetime(start_time,'+1days'" in folded
     assert "interval" not in folded
 
 

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -366,12 +366,11 @@ class TestJoinStructure:
 class TestWholeRowReferencesAreRefused:
     """Naming a relation selects every column in it, hidden ones included.
 
-    `SELECT p FROM projects p` and `SELECT CAST(p AS TEXT) FROM projects p` both
-    returned the full record on PostgreSQL -- gradient colours and all -- while
-    the same columns were refused when named. The construct parses as an
-    ordinary unqualified column whose name happens to be the relation's, so
-    every per-column rule was inapplicable: the check reads column names and
-    this names no column.
+    `SELECT p FROM projects p` and `SELECT CAST(p AS TEXT) FROM projects p` each
+    yield the full record on PostgreSQL -- gradient colours and all -- though
+    the same columns are refused when named. The construct parses as an ordinary
+    unqualified column whose name happens to be the relation's, so no per-column
+    rule applies: those read column names, and this names no column.
 
     `exp.Dot` is the same escape inverted: `(d).user_id` reaches a field of that
     row without producing a column node for it.
@@ -403,8 +402,8 @@ class TestWholeRowReferencesAreRefused:
             # `(srf(...)).field` is how PostgreSQL projects one field of a
             # set-returning function's result, and is the statement
             # `allowlist.py` cites as the reason the plan gate's function set
-            # exists. A blanket refusal of exp.Dot removed it, so the code
-            # refused the example its own comment used to justify a design.
+            # exists. A blanket refusal of exp.Dot rejects it, leaving the
+            # code refusing the example its own comment cites.
             "SELECT (jsonb_each(attributes)).key FROM spans",
         ],
     )
@@ -625,12 +624,13 @@ class TestScopeInvariantIsPerScope:
     ],
 )
 def test_composite_access_is_refused_at_any_paren_depth(sql: str) -> None:
-    """The rule unwrapped one parenthesis, so nesting fell through to its neighbour.
+    """Composite field access is refused however deeply it is parenthesised.
 
-    Both spellings were refused either way -- the row-valued rule scans columns
-    at any depth -- but the two are described as covering the escape from both
-    sides, and only one of them was depth-independent. Narrowing that rule later
-    would have reopened this with nothing to catch it.
+    A rule that unwraps a single parenthesis leaves nesting to fall through to
+    its neighbour. Both spellings are refused today because the row-valued rule
+    scans columns at any depth, but the two rules are described as covering this
+    escape from either side, and only one of them is depth-independent --
+    narrowing the other reopens this with nothing to catch it.
     """
     with pytest.raises(AnalyticsSqlError) as caught:
         admit_sql(sql, allowlist=load_allowlist("sqlite"), dialect="postgresql")
@@ -749,9 +749,10 @@ class TestLossyShapesAreRefused:
 class TestTimestampComparisonCoverage:
     """Every spelling of a comparison against a timestamp column, not some.
 
-    A literal beside `=` was refused when naive and rewritten to storage format
-    when aware. The same literal inside `IN` got neither, and a double-quoted
-    one was not seen as a literal at all. See D4 and D5.
+    Handling attached to one operator covers only that operator: a literal beside
+    `=` is refused when naive and rewritten to storage format when aware, while
+    the same literal inside `IN` gets neither, and a double-quoted one is not
+    recognised as a literal at all. See D4 and D5.
     """
 
     @staticmethod
@@ -1003,12 +1004,12 @@ class TestTimestampComparisonCoverage:
 
 
 class TestStructuralPolicyIsDefaultDeny:
-    """The seam between the function and table allowlists now has an answer.
+    """The seam between the function and table allowlists is closed-world.
 
     Everything the parser can build that is neither a function nor a table
-    source used to be governed by a five-entry denylist, so a class nobody had
-    considered was admitted. Three defects were found there in one night, none
-    of them by a check. See D1.
+    source falls in that seam. Governed by a denylist it admits by default, so
+    any class nobody enumerated is accepted -- and the classes nobody enumerates
+    are exactly the ones no check is watching. See D1.
     """
 
     @staticmethod
@@ -1314,9 +1315,9 @@ class TestPhysicalColumnsWithForeignSources:
 class TestMainstreamGrammarIsNotRefused:
     """The structural floor must not exclude ordinary analytics SQL.
 
-    Each of these executes on its engine and was admitted before the policy was
-    inverted; none was covered by the corpus, so the omission would have shipped
-    silently.
+    Each of these executes on its engine, and none is reachable from the corpus,
+    so a structural policy that omits one refuses ordinary SQL with nothing to
+    report the omission.
     """
 
     @pytest.mark.parametrize(
@@ -1425,9 +1426,9 @@ class TestOrderByAliasBindsOnlyAsAWholeKey:
     )
     def test_a_set_operation_sorts_by_its_own_output_names(self, sql: str) -> None:
         """A compound select's ORDER BY hangs off the set operation, not either
-        branch, so a walk that looks only at selects never reached it and every
-        such sort key was refused as an unknown column. All four execute on both
-        engines; the single-SELECT form of the same query already admitted.
+        branch, so a walk that looks only at selects never reaches it and every
+        such sort key is refused as an unknown column. All four execute on both
+        engines, and the single-SELECT form of the same query admits.
 
         Every output name qualifies, not just the aliased ones -- a set operation
         has no input columns of its own for a key to bind to instead.

--- a/tests/unit/server/mcp/sql/test_parse.py
+++ b/tests/unit/server/mcp/sql/test_parse.py
@@ -1881,3 +1881,57 @@ def test_sqlite_bare_interval_is_refused() -> None:
 
     assert result.outcome is AdmissionOutcome.UNSUPPORTED_SYNTAX
     assert "INTERVAL" in result.detail
+
+
+class TestReservedNamesAreNotReachedThroughTheForeignSourceHatch:
+    """An unqualified name is admitted when a foreign source could project it.
+
+    A subquery, CTE or table-valued function in the FROM clause names columns
+    the manifest does not know, so an unqualified reference no allowlisted table
+    offers is admitted rather than refused. The engine does not resolve every
+    such name that way: a system column binds to the base table and a niladic
+    keyword binds to the session, and neither the plan gate nor the SQLite
+    authorizer inspects column expressions.
+    """
+
+    @pytest.mark.parametrize(
+        ("sql", "dialect"),
+        [
+            ("SELECT user FROM spans, (SELECT 1) q", "postgresql"),
+            ("SELECT current_role FROM spans, (SELECT 1) q", "postgresql"),
+            ("SELECT ctid FROM spans, (SELECT 1) q", "postgresql"),
+            ("SELECT xmin, xmax, tableoid FROM spans, (SELECT 1) q", "postgresql"),
+            # Any foreign source opens the hatch, not just a subquery.
+            ("SELECT ctid FROM spans, jsonb_each(attributes) j", "postgresql"),
+            ("WITH t AS (SELECT 1 AS n) SELECT ctid FROM spans, t", "postgresql"),
+            # A reference anywhere reaches it, not only a projection.
+            ("SELECT id FROM spans, (SELECT 1) q WHERE ctid IS NOT NULL", "postgresql"),
+            ("SELECT count(*) FROM spans, (SELECT 1) q GROUP BY user", "postgresql"),
+            ("SELECT rowid FROM spans, (SELECT 1) q", "sqlite"),
+            ("SELECT _rowid_ FROM spans, (SELECT 1) q", "sqlite"),
+            ("SELECT oid FROM spans, (SELECT 1) q", "sqlite"),
+        ],
+    )
+    def test_reserved_names_are_refused(self, sql: str, dialect: SupportedSQLDialectName) -> None:
+        with pytest.raises(AnalyticsSqlError) as caught:
+            admit_sql(sql, allowlist=load_allowlist(dialect), dialect=dialect)
+        assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
+
+    @pytest.mark.parametrize(
+        ("sql", "dialect"),
+        [
+            # What the hatch exists for. Refusing these would take the surface's
+            # own documented json_each idiom with it.
+            ("SELECT key FROM spans, jsonb_each(attributes) j", "postgresql"),
+            ("SELECT j.key FROM spans, jsonb_each(attributes) j", "postgresql"),
+            ("SELECT key FROM spans, json_each(attributes)", "sqlite"),
+            (
+                "WITH t AS (SELECT id AS weird_name FROM spans) SELECT weird_name FROM spans, t",
+                "postgresql",
+            ),
+        ],
+    )
+    def test_the_hatch_still_admits_what_it_is_for(
+        self, sql: str, dialect: SupportedSQLDialectName
+    ) -> None:
+        admit_sql(sql, allowlist=load_allowlist(dialect), dialect=dialect)

--- a/tests/unit/server/mcp/sql/test_prepare_sweep.py
+++ b/tests/unit/server/mcp/sql/test_prepare_sweep.py
@@ -1,13 +1,11 @@
 """Every statement the corpus admits must be SQL the engine can compile.
 
-The admission corpus pins what is accepted. Acceptance is not the promise the
-surface makes: what reaches the engine is not the statement the caller wrote
-but the one the rewrite passes emit, and nothing was checking that the emission
-is valid SQL. Four defects reached the tree that way -- `DISTINCT ON (name)`
-emitted as `DISTINCT ON ROW(name)`, a JSON key holding an apostrophe emitted
-unescaped, a root-only path emitted as a function signature PostgreSQL does not
-define, and a USING merge naming a column its relation does not have. Each is a
-hard error, and each survived because no test handed the emission to a database.
+The admission corpus pins what is accepted, and acceptance is not the promise
+the surface makes: what reaches the engine is not the statement the caller
+wrote but the one the rewrite passes emit. A pass that renders a key list as a
+row constructor, drops the escaping from a JSON key, or names a column its
+relation does not expose produces a hard error that no amount of admission
+testing can see, because only a database judges the emission.
 
 Preparing rather than executing is what makes this cheap enough to run over the
 whole corpus: the engine resolves names, types and syntax without touching a

--- a/tests/unit/server/mcp/sql/test_prepare_sweep.py
+++ b/tests/unit/server/mcp/sql/test_prepare_sweep.py
@@ -1,0 +1,74 @@
+"""Every statement the corpus admits must be SQL the engine can compile.
+
+The admission corpus pins what is accepted. Acceptance is not the promise the
+surface makes: what reaches the engine is not the statement the caller wrote
+but the one the rewrite passes emit, and nothing was checking that the emission
+is valid SQL. Four defects reached the tree that way -- `DISTINCT ON (name)`
+emitted as `DISTINCT ON ROW(name)`, a JSON key holding an apostrophe emitted
+unescaped, a root-only path emitted as a function signature PostgreSQL does not
+define, and a USING merge naming a column its relation does not have. Each is a
+hard error, and each survived because no test handed the emission to a database.
+
+Preparing rather than executing is what makes this cheap enough to run over the
+whole corpus: the engine resolves names, types and syntax without touching a
+row, so no statement needs fixtures, and a case added for its admission
+behaviour is covered here the day it is written.
+
+This does not check that the answer is right -- a statement can compile and
+still return the wrong number. That is the other half, and it belongs with the
+suites that assert values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from phoenix.server.mcp.sql.allowlist import load_allowlist
+from phoenix.server.mcp.sql.parse import AdmissionOutcome, admit, parse_sql, render
+from phoenix.server.mcp.sql.rewrite import RewriteContext, rewrite
+from phoenix.server.types import DbSessionFactory
+from tests.unit.server.mcp.sql.admission_corpus import CASES, AdmissionCase
+
+_ADMITTED = [case for case in CASES if case.expect is AdmissionOutcome.ADMIT]
+POSTGRES_CASES = [
+    pytest.param(case, id=case.sql[:60]) for case in _ADMITTED if case.dialect == "postgresql"
+]
+SQLITE_CASES = [
+    pytest.param(case, id=case.sql[:60]) for case in _ADMITTED if case.dialect == "sqlite"
+]
+
+
+def _emitted(case: AdmissionCase) -> str:
+    """What the engine is actually asked to run."""
+    allowlist = load_allowlist(case.dialect)
+    root = admit(
+        parse_sql(case.sql, dialect=case.dialect), allowlist=allowlist, dialect=case.dialect
+    )
+    ctx = RewriteContext(allowlist=allowlist, dialect=case.dialect, row_limit=100)
+    return render(rewrite(root, ctx), dialect=case.dialect)
+
+
+@pytest.mark.postgres_only
+@pytest.mark.parametrize("case", POSTGRES_CASES)
+async def test_postgres_emission_compiles(
+    analytics_postgres_db: DbSessionFactory, case: AdmissionCase
+) -> None:
+    emitted = _emitted(case)
+    async with analytics_postgres_db() as session:
+        # The driver, not `text()`: a colon inside a JSON literal is a bind
+        # parameter to SQLAlchemy and the statement never reaches the engine.
+        connection = await session.connection()
+        await connection.exec_driver_sql(f"PREPARE _sweep AS {emitted}")
+        await connection.exec_driver_sql("DEALLOCATE _sweep")
+
+
+@pytest.mark.parametrize("case", SQLITE_CASES)
+async def test_sqlite_emission_compiles(
+    analytics_sqlite_db: tuple[DbSessionFactory, str], case: AdmissionCase
+) -> None:
+    db, _ = analytics_sqlite_db
+    emitted = _emitted(case)
+    async with db() as session:
+        # EXPLAIN compiles the statement without producing rows from it.
+        connection = await session.connection()
+        await connection.exec_driver_sql(f"EXPLAIN {emitted}")

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -170,6 +170,56 @@ def test_latency_ms_orders_by_duration_not_start_time() -> None:
     assert [row[0] for row in _run_on_sqlite(sql)] == ["span-long", "span-medium", "span-short"]
 
 
+def _run_star_join_sqlite(sql: str) -> list[tuple[Any, ...]]:
+    """Execute a star expansion, with every column the manifest names present.
+
+    The expansion emits the manifest's column list, so the table it runs
+    against is built from that same list.
+    """
+    spec = load_allowlist("sqlite").table_specs["spans"]
+    conn = sqlean.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE spans({})".format(", ".join(f'"{n}"' for n in spec.columns)))
+        for row_id in (1, 2, 3):
+            conn.execute("INSERT INTO spans(id) VALUES(?)", (row_id,))
+        return cast(list[tuple[Any, ...]], conn.execute(sql).fetchall())
+    finally:
+        conn.close()
+
+
+class TestUsingKeyOverARightJoin:
+    """USING exposes one key, defined as the merge of both sides.
+
+    A right or full join produces rows where the left side is absent, and there
+    the left copy is NULL while the key is not. Emitting the left copy returns a
+    column of NULLs for exactly the rows the join was widened to include.
+    """
+
+    def test_a_query_local_left_source_is_merged(self) -> None:
+        """A CTE names its own columns, so the manifest cannot answer for it.
+
+        Its copy of the key still goes NULL the way a physical table's does.
+        """
+        rendered = _rendered(
+            "WITH q AS (SELECT id FROM spans WHERE id < 3) "
+            "SELECT * FROM q RIGHT JOIN spans USING (id)"
+        )
+        assert "COALESCE(q.id, spans.id) AS id" in rendered
+        # The CTE holds two of the three rows; the third is right-join padding.
+        assert [row[0] for row in _run_star_join_sqlite(rendered)] == [1, 2, 3]
+
+    def test_a_physical_left_source_is_still_merged(self) -> None:
+        rendered = _rendered("SELECT * FROM traces RIGHT JOIN spans USING (id)")
+        assert "COALESCE(traces.id, spans.id) AS id" in rendered
+
+    def test_an_inner_join_keeps_the_left_copy(self) -> None:
+        """The left copy is the merged value unless the join can drop it."""
+        rendered = _rendered(
+            "WITH q AS (SELECT id FROM spans) SELECT * FROM q JOIN spans USING (id)"
+        )
+        assert "COALESCE" not in rendered.upper()
+
+
 def test_exempt_table_not_wrapped() -> None:
     root = parse_sql("SELECT name FROM projects", dialect="postgresql")
     root = admit(root, allowlist=load_allowlist("sqlite"), dialect="postgresql")

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2265,6 +2265,42 @@ def test_a_json_key_without_a_quote_keeps_its_path_form() -> None:
     assert "->" in rendered
 
 
+class TestScaledEpochComparisons:
+    """Addition and subtraction preserve the unit an epoch is expressed in.
+
+    Multiplication and division do not, and the column is converted to the
+    unscaled unit, so the comparison would be between two scales -- returning
+    the wrong rows rather than failing.
+    """
+
+    _CUT = "unixepoch('2026-07-30 12:00:00')"
+
+    @pytest.mark.parametrize("scale", ["* 1000", "/ 1000"])
+    def test_a_scaled_epoch_is_refused(self, scale: str) -> None:
+        with pytest.raises(AnalyticsSqlError) as caught:
+            _rendered(f"SELECT span_id FROM spans WHERE start_time > {self._CUT} {scale}")
+        assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
+
+    def test_a_scaled_bound_of_a_between_is_refused(self) -> None:
+        with pytest.raises(AnalyticsSqlError):
+            _rendered(
+                f"SELECT span_id FROM spans "
+                f"WHERE start_time BETWEEN {self._CUT} AND {self._CUT} * 1000"
+            )
+
+    @pytest.mark.parametrize("shift", ["+ 1", "- 3600", ""])
+    def test_a_shifted_epoch_still_converts(self, shift: str) -> None:
+        rendered = _rendered(f"SELECT span_id FROM spans WHERE start_time > {self._CUT} {shift}")
+        assert "UNIXEPOCH(start_time, 'subsec')" in rendered
+
+    def test_scaling_both_sides_is_the_caller_s_to_write(self) -> None:
+        """Written out, the comparison is in one unit and needs no conversion."""
+        rendered = _rendered(
+            f"SELECT span_id FROM spans WHERE unixepoch(start_time) * 1000 > {self._CUT} * 1000"
+        )
+        assert "UNIXEPOCH(start_time) * 1000" in rendered
+
+
 def test_subsecond_precision_survives_an_epoch_comparison() -> None:
     """Converting the column must not floor it to whole seconds.
 

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2064,6 +2064,85 @@ def test_virtual_column_predicate_in_a_subquery_resolves_to_the_subquery_relatio
     assert _run_two_table_sqlite(rendered)[0][0] == 1
 
 
+class TestCorrelatedVirtualColumns:
+    """A qualified overlay may name a relation an enclosing scope introduced.
+
+    `Scope.columns` lists such a reference on the inner scope as well, and
+    `traverse()` reaches that scope first. Attributing it there leaves the
+    qualifier naming nothing the scope holds, so the overlay is emitted as the
+    caller wrote it: a statement this surface admits and the engine then
+    refuses, naming a column the manifest advertises.
+    """
+
+    @staticmethod
+    def _postgres(sql: str) -> str:
+        root = parse_sql(sql, dialect="postgresql")
+        root = admit(root, allowlist=load_allowlist("sqlite"), dialect="postgresql")
+        return render(rewrite(root, _ctx("postgresql")), dialect="postgresql")
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT t.id FROM traces t "
+            "WHERE EXISTS (SELECT 1 FROM spans s WHERE s.latency_ms < t.latency_ms)",
+            "SELECT t.id FROM traces t WHERE t.id IN "
+            "(SELECT s.trace_rowid FROM spans s WHERE s.latency_ms < t.latency_ms)",
+            "SELECT (SELECT count(*) FROM spans s WHERE s.latency_ms < t.latency_ms) AS c "
+            "FROM traces t",
+            # LATERAL correlates by definition, and SQLGlot files its table
+            # outside the scope's `sources`.
+            "SELECT t.id FROM traces t, LATERAL "
+            "(SELECT s.id FROM spans s WHERE s.latency_ms < t.latency_ms) x",
+            # Two levels: the reference is external to both inner scopes.
+            "SELECT t.id FROM traces t WHERE EXISTS (SELECT 1 FROM spans s WHERE EXISTS "
+            "(SELECT 1 FROM spans s2 WHERE s2.latency_ms < t.latency_ms))",
+        ],
+    )
+    def test_a_correlated_duration_overlay_is_substituted(self, sql: str) -> None:
+        rendered = self._postgres(sql)
+        assert "latency_ms" not in rendered.lower()
+        assert "t.end_time - t.start_time" in rendered
+
+    def test_a_correlated_node_id_overlay_is_substituted(self) -> None:
+        rendered = self._postgres(
+            "SELECT t.id FROM traces t WHERE EXISTS "
+            "(SELECT 1 FROM spans s WHERE s.trace_rowid = t.id AND t.graphql_node_id = 'x')"
+        )
+        assert "graphql_node_id" not in rendered.lower()
+        assert "'Trace:' || CAST(t.id AS TEXT)" in rendered
+
+    def test_a_correlated_overlay_reads_the_outer_relation(self) -> None:
+        """Substituting is not enough; it must reach the enclosing relation.
+
+        Both sides carry the overlay, so a rewrite that substituted the inner
+        relation's timestamps on both would still render without the column
+        name and still run.
+        """
+        rendered = _rendered(
+            "SELECT (SELECT count(*) FROM spans s WHERE s.latency_ms < t.latency_ms) AS c "
+            "FROM traces t"
+        )
+        # The span is 1500 ms and the trace 2000 ms, so the span counts. Read
+        # from one relation twice, either comparison is against itself and the
+        # count is 0.
+        assert _run_two_table_sqlite(rendered)[0][0] == 1
+
+    def test_a_shadowed_alias_still_binds_to_the_inner_relation(self) -> None:
+        """The qualifier decides by what a scope introduces, not by name alone.
+
+        Both relations answer to `t` here, so a guard that deferred every
+        qualified reference outward would read the trace's duration inside the
+        subquery over `spans`.
+        """
+        rendered = _rendered(
+            "SELECT count(*) AS c FROM traces t "
+            "WHERE EXISTS (SELECT 1 FROM spans t WHERE t.latency_ms < 1800)"
+        )
+        # The span is 1500 ms and clears the threshold; the trace is 2000 ms
+        # and would not.
+        assert _run_two_table_sqlite(rendered)[0][0] == 1
+
+
 @pytest.mark.parametrize(
     ("sql", "expected"),
     [

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -174,7 +174,7 @@ def test_exempt_table_not_wrapped() -> None:
     root = parse_sql("SELECT name FROM projects", dialect="postgresql")
     root = admit(root, allowlist=load_allowlist("sqlite"), dialect="postgresql")
     out = render(rewrite(root, _ctx("postgresql")), dialect="postgresql")
-    assert "AS projects" not in out or "SELECT" in out
+    assert out == "SELECT name FROM public.projects LIMIT 501"
 
 
 # Index reflection: the classification is pure, so it is asserted without a
@@ -2208,8 +2208,10 @@ def test_a_json_key_containing_a_quote_is_escaped(sql: str, dialect: str) -> Non
 
 def test_a_json_key_without_a_quote_keeps_its_path_form() -> None:
     """Guards the test above: rewriting every path would also satisfy it."""
-    rendered = _rendered("SELECT attributes -> '$.llm' AS v FROM spans")
-    assert "json_path_quote_repair" not in _ctx("sqlite").applied
+    ctx, rendered = _rewritten("SELECT attributes -> '$.llm' AS v FROM spans", dialect="sqlite")
+    # The pass leaves the operator in place and swaps only the path, so the
+    # operator surviving is not evidence that the path did.
+    assert "json_path_quote_repair" not in ctx.applied
     assert "->" in rendered
 
 

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2078,7 +2078,7 @@ def test_virtual_column_predicate_in_a_subquery_resolves_to_the_subquery_relatio
             "unixepoch('2026-07-30 12:00:00') AND unixepoch('2026-07-30 12:00:01')",
             2,
         ),
-        # The bare form the pass already covered, kept so a regression is visible.
+        # The bare form the pass covers, included so a regression is visible.
         (
             "SELECT count(*) AS v FROM spans WHERE start_time > unixepoch('2026-07-30 12:00:01')",
             1,

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2256,6 +2256,25 @@ def test_a_json_key_containing_a_quote_is_escaped(sql: str, dialect: str) -> Non
     assert "''" in rendered
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        """SELECT attributes -> '$."c''d"[0]' AS v FROM spans""",
+        """SELECT attributes ->> '$."c''d"[1]' AS v FROM spans""",
+        """SELECT attributes -> '$."c''d".e[0]' AS v FROM spans""",
+    ],
+)
+def test_a_subscripted_path_with_a_quoted_key_is_escaped(sql: str) -> None:
+    """A subscript belongs to the path as much as a key does.
+
+    Repairing only all-key paths leaves the apostrophe unescaped here, and the
+    statement does not compile.
+    """
+    rendered = _rendered(sql)
+    assert rendered.count("'") % 2 == 0, f"unbalanced quotes: {rendered}"
+    assert "''" in rendered
+
+
 def test_a_json_key_without_a_quote_keeps_its_path_form() -> None:
     """Guards the test above: rewriting every path would also satisfy it."""
     ctx, rendered = _rewritten("SELECT attributes -> '$.llm' AS v FROM spans", dialect="sqlite")

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -1571,9 +1571,9 @@ class TestTimestampLiterals:
 class TestOneSharedResolver:
     """Every reference a rewrite may edit resolves the same way.
 
-    Four passes previously carried four scope models and disagreed; C1, C2, C3,
-    C5 and C6 are those disagreements. Each is pinned here against the shape
-    that produced it.
+    A pass carrying its own scope model disagrees with the others about which
+    relation a reference belongs to, and the disagreement surfaces as a wrong
+    answer rather than an error. C1, C2, C3, C5 and C6 pin one shape each.
     """
 
     @staticmethod

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2256,12 +2256,18 @@ def test_star_over_a_right_join_using_merges_the_key() -> None:
     rendered = _rendered_dialect("SELECT * FROM traces RIGHT JOIN spans USING (id)", "sqlite")
     assert "COALESCE(traces.id, spans.id) AS id" in rendered
     # The merged key is what the engine's own USING produces.
-    assert [row[0] for row in _run_join_on_sqlite(
-        "SELECT COALESCE(traces.id, spans.id) AS id "
-        "FROM traces RIGHT JOIN spans USING (id) ORDER BY id"
-    )] == [row[0] for row in _run_join_on_sqlite(
-        "SELECT * FROM traces RIGHT JOIN spans USING (id) ORDER BY id"
-    )]
+    assert [
+        row[0]
+        for row in _run_join_on_sqlite(
+            "SELECT COALESCE(traces.id, spans.id) AS id "
+            "FROM traces RIGHT JOIN spans USING (id) ORDER BY id"
+        )
+    ] == [
+        row[0]
+        for row in _run_join_on_sqlite(
+            "SELECT * FROM traces RIGHT JOIN spans USING (id) ORDER BY id"
+        )
+    ]
 
 
 def test_star_over_an_inner_join_using_keeps_one_plain_copy() -> None:
@@ -2284,7 +2290,9 @@ def test_a_computed_json_key_is_noted_on_postgres() -> None:
     """
     al = load_allowlist("postgresql")
     root = admit(
-        parse_sql("SELECT json_extract(attributes, '$.' || 'llm') AS v FROM spans", dialect="postgresql"),
+        parse_sql(
+            "SELECT json_extract(attributes, '$.' || 'llm') AS v FROM spans", dialect="postgresql"
+        ),
         allowlist=al,
         dialect="postgresql",
     )

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2224,3 +2224,51 @@ def test_a_using_key_provided_by_two_left_relations_is_refused() -> None:
             dialect="postgresql",
         )
     assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX
+
+
+def _rendered_dialect(sql: str, dialect: str) -> str:
+    d = cast(Any, dialect)
+    root = admit(parse_sql(sql, dialect=d), allowlist=load_allowlist(d), dialect=d)
+    return render(rewrite(root, _ctx(d)), dialect=d)
+
+
+def _run_join_on_sqlite(sql: str) -> list[tuple[Any, ...]]:
+    """traces id={1,2}; spans id={1,2,3}, so span 3 has no matching trace."""
+    conn = sqlean.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE traces(id INT)")
+        conn.execute("CREATE TABLE spans(id INT)")
+        conn.executemany("INSERT INTO traces VALUES(?)", [(1,), (2,)])
+        conn.executemany("INSERT INTO spans VALUES(?)", [(1,), (2,), (3,)])
+        return cast(list[tuple[Any, ...]], conn.execute(sql).fetchall())
+    finally:
+        conn.close()
+
+
+def test_star_over_a_right_join_using_merges_the_key() -> None:
+    """USING exposes the merge of both sides, which matters when the left is absent.
+
+    A right join produces rows with no left row, and there the left copy of the
+    key is NULL while the key itself is not. Emitting the left copy answered
+    NULL for exactly the rows the join was written to keep -- and both engines
+    agreed on it, so comparing deployments would not have shown it.
+    """
+    rendered = _rendered_dialect("SELECT * FROM traces RIGHT JOIN spans USING (id)", "sqlite")
+    assert "COALESCE(traces.id, spans.id) AS id" in rendered
+    # The merged key is what the engine's own USING produces.
+    assert [row[0] for row in _run_join_on_sqlite(
+        "SELECT COALESCE(traces.id, spans.id) AS id "
+        "FROM traces RIGHT JOIN spans USING (id) ORDER BY id"
+    )] == [row[0] for row in _run_join_on_sqlite(
+        "SELECT * FROM traces RIGHT JOIN spans USING (id) ORDER BY id"
+    )]
+
+
+def test_star_over_an_inner_join_using_keeps_one_plain_copy() -> None:
+    """Guards the test above: an inner join cannot lose the left row."""
+    rendered = _rendered_dialect("SELECT * FROM traces JOIN spans USING (id)", "sqlite")
+    assert "COALESCE" not in rendered.upper()
+    # The key is projected once, from the left. `spans.id` still appears inside
+    # the span's graphql_node_id expression, which is not a second key column.
+    assert rendered.startswith("SELECT traces.id,")
+    assert ", spans.id," not in rendered

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2103,3 +2103,32 @@ def test_a_comparison_with_no_epoch_side_is_left_alone() -> None:
     """Guards the test above: converting every comparison would also satisfy it."""
     rendered = _rendered("SELECT count(*) AS v FROM spans WHERE start_time > '2026-07-30'")
     assert "UNIXEPOCH" not in rendered.upper()
+
+
+@pytest.mark.parametrize(
+    ("sql", "dialect"),
+    [
+        ("SELECT attributes -> 'c''d' AS v FROM spans", "postgresql"),
+        ("SELECT attributes ->> 'c''d' AS v FROM spans", "postgresql"),
+        ("SELECT attributes -> '$.\"c''d\"' AS v FROM spans", "sqlite"),
+        ("SELECT attributes ->> '$.\"c''d\"' AS v FROM spans", "sqlite"),
+    ],
+)
+def test_a_json_key_containing_a_quote_is_escaped(sql: str, dialect: str) -> None:
+    """A key holding an apostrophe must not close its own string literal.
+
+    Attribute keys are arbitrary, and describeSqlSchema publishes the populated
+    paths, so an unescaped one is a spelling the surface prints and cannot run.
+    """
+    root = parse_sql(sql, dialect=cast(Any, dialect))
+    root = admit(root, allowlist=load_allowlist(cast(Any, dialect)), dialect=cast(Any, dialect))
+    rendered = render(rewrite(root, _ctx(cast(Any, dialect))), dialect=cast(Any, dialect))
+    assert rendered.count("'") % 2 == 0, f"unbalanced quotes: {rendered}"
+    assert "''" in rendered
+
+
+def test_a_json_key_without_a_quote_keeps_its_path_form() -> None:
+    """Guards the test above: rewriting every path would also satisfy it."""
+    rendered = _rendered("SELECT attributes -> '$.llm' AS v FROM spans")
+    assert "json_path_quote_repair" not in _ctx("sqlite").applied
+    assert "->" in rendered

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2062,3 +2062,44 @@ def test_virtual_column_predicate_in_a_subquery_resolves_to_the_subquery_relatio
     assert "traces.end_time" not in rendered
     # The span is 1500 ms so it counts; the trace is 2000 ms and would not.
     assert _run_two_table_sqlite(rendered)[0][0] == 1
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        # `_LATENCY_ROWS` start at 12:00:00, 12:00:01 and 12:00:02.
+        (
+            "SELECT count(*) AS v FROM spans "
+            "WHERE start_time > unixepoch('2026-07-30 12:00:01') - 1",
+            2,
+        ),
+        (
+            "SELECT count(*) AS v FROM spans WHERE start_time BETWEEN "
+            "unixepoch('2026-07-30 12:00:00') AND unixepoch('2026-07-30 12:00:01')",
+            2,
+        ),
+        # The bare form the pass already covered, kept so a regression is visible.
+        (
+            "SELECT count(*) AS v FROM spans WHERE start_time > unixepoch('2026-07-30 12:00:01')",
+            1,
+        ),
+    ],
+)
+def test_timestamp_compared_to_an_epoch_expression_is_converted(sql: str, expected: int) -> None:
+    """A stored timestamp must be converted whenever the other side is epoch-valued.
+
+    SQLite orders INTEGER below TEXT unconditionally, so an unconverted
+    `text > integer` matches every row and `text < integer` matches none --
+    a bounded window silently answers with the whole table or with nothing.
+    The unit survives arithmetic (`unixepoch('now') - 3600` is still epoch
+    seconds) and BETWEEN compares against both of its bounds.
+    """
+    rendered = _rendered(sql)
+    assert "UNIXEPOCH(START_TIME)" in rendered.upper()
+    assert _run_on_sqlite(rendered)[0][0] == expected
+
+
+def test_a_comparison_with_no_epoch_side_is_left_alone() -> None:
+    """Guards the test above: converting every comparison would also satisfy it."""
+    rendered = _rendered("SELECT count(*) AS v FROM spans WHERE start_time > '2026-07-30'")
+    assert "UNIXEPOCH" not in rendered.upper()

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2272,3 +2272,41 @@ def test_star_over_an_inner_join_using_keeps_one_plain_copy() -> None:
     # the span's graphql_node_id expression, which is not a second key column.
     assert rendered.startswith("SELECT traces.id,")
     assert ", spans.id," not in rendered
+
+
+def test_a_computed_json_key_is_noted_on_postgres() -> None:
+    """The two engines read the same computed operand differently.
+
+    PostgreSQL's `->` takes a key, so a computed operand names one key; SQLite
+    reads the same text as a path. `doc -> k.key` and `json_extract(doc, k.key)`
+    parse identically, so the surface cannot tell which the caller meant and
+    says so instead of choosing.
+    """
+    al = load_allowlist("postgresql")
+    root = admit(
+        parse_sql("SELECT json_extract(attributes, '$.' || 'llm') AS v FROM spans", dialect="postgresql"),
+        allowlist=al,
+        dialect="postgresql",
+    )
+    ctx = RewriteContext(allowlist=al, dialect="postgresql", row_limit=100)
+    rewrite(root, ctx)
+    assert any("computed JSON key" in note for note in ctx.notes)
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # A dynamic column key is a key lookup on both engines, which is what
+        # `->` does -- nothing to warn about.
+        "SELECT s.attributes -> k.key AS v FROM spans s "
+        "CROSS JOIN LATERAL jsonb_each(s.attributes) AS k",
+        "SELECT attributes -> 'llm' AS v FROM spans",
+    ],
+)
+def test_an_ordinary_json_key_is_not_noted(sql: str) -> None:
+    """Guards the test above: noting every accessor would also satisfy it."""
+    al = load_allowlist("postgresql")
+    root = admit(parse_sql(sql, dialect="postgresql"), allowlist=al, dialect="postgresql")
+    ctx = RewriteContext(allowlist=al, dialect="postgresql", row_limit=100)
+    rewrite(root, ctx)
+    assert not any("computed JSON key" in note for note in ctx.notes)

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2186,3 +2186,41 @@ def test_a_cast_json_comparison_is_not_noted() -> None:
     )
     rewrite(root, ctx)
     assert not any("without a cast" in note for note in ctx.notes)
+
+
+def test_virtual_using_key_resolves_against_the_whole_left_composite() -> None:
+    """A USING key may come from any relation to its left, not just the last.
+
+    `a JOIN b ON ... JOIN c USING (k)` resolves `k` against the composite of
+    `a` and `b`. Taking only the nearest relation qualified the rewritten
+    comparison with one that does not provide the column, so the engine
+    reported a reference the caller never wrote.
+    """
+    ctx, rendered = _rewritten(
+        "SELECT spans.span_id FROM spans JOIN projects ON projects.id = 1 "
+        "JOIN traces USING (latency_ms)",
+        dialect="postgresql",
+    )
+    assert "virtual_using" in ctx.applied
+    assert "projects.latency_ms" not in rendered
+    assert "spans.end_time" in rendered and "traces.end_time" in rendered
+
+
+def test_two_relation_virtual_using_still_resolves_to_the_left_relation() -> None:
+    """Guards the test above: the simple case must keep working."""
+    _, rendered = _rewritten(
+        "SELECT spans.span_id FROM spans JOIN traces USING (latency_ms)",
+        dialect="postgresql",
+    )
+    assert "spans.end_time" in rendered and "traces.end_time" in rendered
+
+
+def test_a_using_key_provided_by_two_left_relations_is_refused() -> None:
+    """PostgreSQL refuses this too, so binding it silently would answer for the caller."""
+    with pytest.raises(AnalyticsSqlError) as caught:
+        _rewritten(
+            "SELECT s.span_id FROM spans s JOIN traces t1 ON t1.id = 1 "
+            "JOIN traces t2 USING (latency_ms)",
+            dialect="postgresql",
+        )
+    assert caught.value.code is ErrorCode.UNSUPPORTED_SYNTAX

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -1988,3 +1988,36 @@ def test_comma_lateral_base_table_is_a_plain_join() -> None:
     assert "LATERAL" not in rendered.upper()
     assert ".traces" in rendered.casefold()
     assert "schema_qualification" in ctx.applied
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        # `_LATENCY_ROWS` spans 12:00:00.000000 to 12:00:04.500000, so the
+        # elapsed time across every row is 4.5 seconds and one row is 0.5.
+        ("SELECT MAX(end_time) - MIN(start_time) AS v FROM spans", 4.5),
+        ("SELECT (end_time) - start_time AS v FROM spans WHERE span_id = 'span-medium'", 0.5),
+        ("SELECT end_time - (start_time) AS v FROM spans WHERE span_id = 'span-medium'", 0.5),
+        ("SELECT end_time - start_time AS v FROM spans WHERE span_id = 'span-medium'", 0.5),
+    ],
+)
+def test_stored_timestamp_subtraction_yields_elapsed_seconds(sql: str, expected: float) -> None:
+    """Subtracting stored timestamps must not reach SQLite as text arithmetic.
+
+    Storage is text, so `end_time - start_time` coerces both sides to the
+    leading integer and answers 0 for every row -- a clean run with a confidently
+    wrong number. The conversion is applied through parentheses and through an
+    aggregate, because `MAX(end) - MIN(start)` is how total elapsed time is
+    written and it reads the same stored text.
+    """
+    rendered = _rendered(sql)
+    assert "UNIXEPOCH" in rendered.upper()
+    assert _run_on_sqlite(rendered)[0][0] == expected
+
+
+def test_subtraction_of_non_timestamp_columns_is_left_alone() -> None:
+    """Guards the test above: converting every subtraction would also satisfy it."""
+    rendered = _rendered(
+        "SELECT llm_token_count_prompt - llm_token_count_completion AS v FROM spans"
+    )
+    assert "UNIXEPOCH" not in rendered.upper()

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2021,3 +2021,44 @@ def test_subtraction_of_non_timestamp_columns_is_left_alone() -> None:
         "SELECT llm_token_count_prompt - llm_token_count_completion AS v FROM spans"
     )
     assert "UNIXEPOCH" not in rendered.upper()
+
+
+def _run_two_table_sqlite(sql: str) -> list[tuple[Any, ...]]:
+    """spans holds a 1500 ms row; traces holds a 2000 ms row."""
+    conn = sqlean.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE spans(start_time TEXT, end_time TEXT)")
+        conn.execute("CREATE TABLE traces(start_time TEXT, end_time TEXT)")
+        conn.execute(
+            "INSERT INTO spans VALUES('2026-07-30 12:00:00.000000','2026-07-30 12:00:01.500000')"
+        )
+        conn.execute(
+            "INSERT INTO traces VALUES('2026-07-30 12:00:00.000000','2026-07-30 12:00:02.000000')"
+        )
+        return cast(list[tuple[Any, ...]], conn.execute(sql).fetchall())
+    finally:
+        conn.close()
+
+
+def test_virtual_column_in_a_subquery_resolves_to_the_subquery_relation() -> None:
+    """An unqualified overlay binds to the relation that encloses it.
+
+    `Scope.columns` of an outer query also lists an unqualified column that
+    belongs to a nested subquery. Binding it to the outer table substitutes one
+    relation's timestamps into another relation's query: the statement runs and
+    returns the wrong duration, with nothing to indicate it.
+    """
+    rendered = _rendered("SELECT (SELECT max(latency_ms) FROM spans) AS m FROM traces")
+    assert "spans.end_time" in rendered
+    assert "traces.end_time" not in rendered
+    assert _run_two_table_sqlite(rendered)[0][0] == 1500.0
+
+
+def test_virtual_column_predicate_in_a_subquery_resolves_to_the_subquery_relation() -> None:
+    rendered = _rendered(
+        "SELECT (SELECT count(*) FROM spans WHERE latency_ms < 1800) AS c FROM traces"
+    )
+    assert "spans.end_time" in rendered
+    assert "traces.end_time" not in rendered
+    # The span is 1500 ms so it counts; the trace is 2000 ms and would not.
+    assert _run_two_table_sqlite(rendered)[0][0] == 1

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -1878,7 +1878,7 @@ def test_sqlite_timestamp_vs_unixepoch_wraps_the_column() -> None:
     )
     assert "sqlite_timestamp_epoch_compare" in ctx.applied
     folded = rendered.lower()
-    assert "unixepoch(start_time)" in folded.replace(" ", "")
+    assert "unixepoch(start_time,'subsec')" in folded.replace(" ", "")
     assert folded.count("unixepoch") >= 2
 
 
@@ -1889,7 +1889,7 @@ def test_sqlite_timestamp_vs_datetime_wraps_the_column() -> None:
     )
     assert "sqlite_timestamp_epoch_compare" in ctx.applied
     folded = rendered.lower().replace(" ", "")
-    assert "datetime(start_time)" in folded
+    assert "datetime(start_time,'subsec')" in folded
     assert folded.count("datetime") >= 2
 
 
@@ -2095,7 +2095,7 @@ def test_timestamp_compared_to_an_epoch_expression_is_converted(sql: str, expect
     seconds) and BETWEEN compares against both of its bounds.
     """
     rendered = _rendered(sql)
-    assert "UNIXEPOCH(START_TIME)" in rendered.upper()
+    assert "UNIXEPOCH(START_TIME" in rendered.upper()
     assert _run_on_sqlite(rendered)[0][0] == expected
 
 
@@ -2132,3 +2132,57 @@ def test_a_json_key_without_a_quote_keeps_its_path_form() -> None:
     rendered = _rendered("SELECT attributes -> '$.llm' AS v FROM spans")
     assert "json_path_quote_repair" not in _ctx("sqlite").applied
     assert "->" in rendered
+
+
+def test_subsecond_precision_survives_an_epoch_comparison() -> None:
+    """Converting the column must not floor it to whole seconds.
+
+    Storage carries microseconds. `datetime()` and `unixepoch()` truncate
+    unless asked for `subsec`, so a comparison decided below the second dropped
+    rows PostgreSQL returns.
+    """
+    rendered = _rendered(
+        "SELECT span_id AS v FROM spans WHERE end_time > start_time + INTERVAL '1' SECOND"
+    )
+    assert "'subsec'" in rendered
+    # span-long runs 2.5s and clears a one-second threshold; the others do not.
+    assert [row[0] for row in _run_on_sqlite(rendered)] == ["span-long"]
+
+
+@pytest.mark.parametrize(
+    ("sql", "dialect"),
+    [
+        ("SELECT count(*) AS v FROM spans WHERE attributes ->> '$.n' > '99'", "sqlite"),
+        ("SELECT count(*) AS v FROM spans WHERE attributes #>> '{n}' > '99'", "postgresql"),
+        # The lambda repair parenthesises an accessor written inside a call.
+        ("SELECT MIN(attributes -> '$.n') AS v FROM spans", "sqlite"),
+    ],
+)
+def test_uncast_json_ordering_is_noted(sql: str, dialect: str) -> None:
+    """The note says "ordered or compared", so a comparison has to reach it.
+
+    Text ordering of a JSON read answers differently from numeric ordering, and
+    the surface cannot tell which the path holds -- so it notes rather than
+    refuses. A note that fires only in MIN/MAX/ORDER BY misses the predicate
+    form, which is where the wrong answer is least visible.
+    """
+    d = cast(Any, dialect)
+    root = admit(parse_sql(sql, dialect=d), allowlist=load_allowlist(d), dialect=d)
+    ctx = RewriteContext(allowlist=load_allowlist(d), dialect=d, row_limit=100)
+    rewrite(root, ctx)
+    assert any("without a cast" in note for note in ctx.notes), ctx.notes
+
+
+def test_a_cast_json_comparison_is_not_noted() -> None:
+    """Guards the test above: a cast says the caller already decided."""
+    ctx = RewriteContext(allowlist=load_allowlist("sqlite"), dialect="sqlite", row_limit=100)
+    root = admit(
+        parse_sql(
+            "SELECT count(*) AS v FROM spans WHERE CAST(attributes ->> '$.n' AS REAL) > 99",
+            dialect="sqlite",
+        ),
+        allowlist=load_allowlist("sqlite"),
+        dialect="sqlite",
+    )
+    rewrite(root, ctx)
+    assert not any("without a cast" in note for note in ctx.notes)

--- a/tests/unit/server/mcp/sql/test_rewrite.py
+++ b/tests/unit/server/mcp/sql/test_rewrite.py
@@ -2310,3 +2310,46 @@ def test_an_ordinary_json_key_is_not_noted(sql: str) -> None:
     ctx = RewriteContext(allowlist=al, dialect="postgresql", row_limit=100)
     rewrite(root, ctx)
     assert not any("computed JSON key" in note for note in ctx.notes)
+
+
+def test_using_merge_names_only_the_relations_that_provide_the_key() -> None:
+    """Merging across every relation to the left names columns they do not have.
+
+    `projects` has no `start_time`, so coalescing it into the merge emits a
+    reference the engine refuses -- turning the silent NULL this pass exists to
+    fix into a hard error against a column the caller never wrote.
+    """
+    _, rendered = _rewritten(
+        "SELECT * FROM projects JOIN traces ON traces.project_rowid = projects.id "
+        "RIGHT JOIN spans USING (start_time)",
+        dialect="postgresql",
+    )
+    assert "COALESCE(traces.start_time, spans.start_time)" in rendered
+    assert "projects.start_time" not in rendered
+
+
+def test_interval_arithmetic_keeps_the_fraction_it_shifts() -> None:
+    """Both sides of the comparison must carry subseconds, not just the column.
+
+    `datetime(col, '+1 seconds')` truncates, so a span exactly one second long
+    compared with `> INTERVAL '1' SECOND` answered true, and a half-second span
+    did too.
+    """
+    rendered = _rendered(
+        "SELECT span_id AS v FROM spans WHERE end_time > start_time + INTERVAL '1' SECOND"
+    )
+    assert rendered.count("'subsec'") == 2
+    assert [row[0] for row in _run_on_sqlite(rendered)] == ["span-long"]
+
+
+@pytest.mark.parametrize(
+    ("sql", "converted"),
+    [
+        ("SELECT COALESCE(end_time, start_time) - start_time AS v FROM spans", True),
+        # A branch that is not a stored timestamp makes the result something else.
+        ("SELECT COALESCE(end_time, name) - start_time AS v FROM spans", False),
+    ],
+)
+def test_coalesced_timestamps_subtract_as_timestamps(sql: str, converted: bool) -> None:
+    """COALESCE of stored timestamps is still a stored timestamp."""
+    assert ("UNIXEPOCH" in _rendered(sql).upper()) is converted

--- a/tests/unit/server/mcp/sql/test_sqlite_authorizer.py
+++ b/tests/unit/server/mcp/sql/test_sqlite_authorizer.py
@@ -153,14 +153,14 @@ def test_table_level_reads_are_judged_before_the_transient_accept(sql: str, allo
     """`count(*)` names no column, so its read presents with no database attached.
 
     That is indistinguishable in shape from a materialised CTE, so an accept
-    path for transient tables placed first returned OK before the catalog deny
-    and before the allowlist check — and this gate stopped being a backstop for
+    path for transient tables placed first returns OK before the catalog deny
+    and before the allowlist check, and this gate stops being a backstop for
     every count-shaped read. Admission refuses these independently, so nothing
-    leaked; what was missing was the second layer, which the authorizer's own
-    logging calls by name.
+    leaks; what is lost is the second layer, which the authorizer's own logging
+    calls by name.
 
-    The CTE case is here to keep the fix honest: reordering must not re-break
-    the materialised-CTE reads that the transient accept was added for.
+    The CTE case is here so that ordering cannot be traded away: it must not
+    refuse the materialised-CTE reads the transient accept exists for.
     """
     import sqlean
 

--- a/tests/unit/server/mcp/sql/test_sqlite_authorizer.py
+++ b/tests/unit/server/mcp/sql/test_sqlite_authorizer.py
@@ -113,9 +113,9 @@ def test_denial_distinguishes_a_bypass_from_a_layering_defect(
     a relation the gate did not know about, which refuses a query the caller was
     entitled to run.
 
-    Logged identically, the second drowns the first. Over one measured session
-    the table check fired eleven times and every hit was the second kind, which
-    was invisible until the two were separated.
+    Logged identically, the second drowns the first: it is by far the more
+    frequent, so a bypass -- the case worth waking someone for -- arrives
+    indistinguishable from routine noise.
     """
     import sqlite3
 
@@ -188,8 +188,8 @@ def test_table_level_reads_are_judged_before_the_transient_accept(sql: str, allo
 def test_catalog_aliases_are_denied_on_table_level_reads() -> None:
     """A table-level read presents with no database name, matching a CTE.
 
-    sqlite_schema and sqlite_stat1 are not sqlite_master and are not Phoenix
-    tables, so they used to fall through to the transient accept.
+    sqlite_schema and sqlite_stat1 are neither sqlite_master nor Phoenix tables,
+    so a check written around those two lets them reach the transient accept.
     """
     authorizer = _sqlite_authorizer(frozenset({"spans"}), frozenset({"count"}))
     for table in ("sqlite_master", "sqlite_schema", "sqlite_temp_master", "sqlite_stat1"):

--- a/tests/unit/server/test_mcp_sql_tools.py
+++ b/tests/unit/server/test_mcp_sql_tools.py
@@ -4,7 +4,7 @@ from mcp.types import TextContent
 
 from phoenix.server.mcp.sql.allowlist import load_allowlist
 from phoenix.server.mcp.sql.errors import AnalyticsSqlError, ErrorCode
-from phoenix.server.mcp.sql.execute import _success_envelope
+from phoenix.server.mcp.sql.execute import MAX_SQL_BYTES, _success_envelope
 from phoenix.server.mcp.sql.output import ExecuteSqlErrorEnvelope
 from phoenix.server.mcp.sql.parse import AdmissionOutcome, try_parse_and_admit
 from phoenix.server.mcp.sql.rewrite import RewriteContext
@@ -188,3 +188,15 @@ async def test_execute_sql_returns_failures_as_data(analytics_mcp: FastMCP) -> N
     error = result.structured_content["error"]
     assert error["code"] in {code.value for code in ErrorCode}
     assert error["message"]
+
+
+async def test_the_input_cap_is_stated_in_the_execute_tool_description(
+    analytics_mcp: FastMCP,
+) -> None:
+    """A caller has to learn the limit before writing the SQL, not after being refused.
+
+    The description carries the number as prose, so this is what holds it equal
+    to the constant the server enforces.
+    """
+    tool = {t.name: t for t in await analytics_mcp.list_tools()}["executeSql"]
+    assert f"{MAX_SQL_BYTES // 1024} KiB" in (tool.description or "")


### PR DESCRIPTION
Correctness hardening for the MCP analytics SQL surface (`src/phoenix/server/mcp/sql/`), on top of the sqlglot 30.17.0 upgrade in #15469.

## Fixes

**Admission bypass.** `SELECT user FROM spans, (SELECT 1) q` returned the database role, and `ctid` returned tuple locations. Both passed admission through the foreign-source hatch and then passed the PostgreSQL plan gate, which is column-blind. Reserved implicit names are refused per dialect, and the session identity is refused wherever it appears — `user` and `current_role` are niladic keywords that parse as a bare column, so they evaluate with no relation in scope at all and cannot be checked only where an allowlisted table is present.

**Virtual columns resolved against the wrong relation.** `Scope.columns` on an outer query includes an unqualified column belonging to a nested subquery, so a subquery's `latency_ms` was bound to the outer table — a silent wrong answer, 2000.0 where 1500.0 was correct. Attribution keeps the innermost scope that actually exposes the qualifier, which also leaves a correlated `t.latency_ms` inside `EXISTS` bound to the enclosing scope that defines it.

**Emissions the engine rejects or answers differently.** A `USING` key naming a column its relation does not expose, and one whose left source is query-local, so a right or full join returned `[1, 2, NULL]` where the engine's own `*` returns `[1, 2, 3]`. A `DISTINCT ON` key list rewritten to a row constructor. JSON paths the generator renders invalid, including a quoted key inside a subscripted path. `json_each` columns checked only when an allowlisted table shared the scope, so `SELECT "nope" FROM json_each('[1]')` returned the word `nope` as data.

**Silent precision and unit loss.** Timestamp subtraction dropped the fractional second, so a 1.5 s span and a 1.0 s span compared equal against `> 1 SECOND`. A timestamp compared against a millisecond-scaled epoch is now refused rather than converted as if it were seconds — inferring the unit would answer a different question than the caller asked.

**Capacity accounting under cancellation.** Parsing and rewriting are uninterruptible, so a caller that disconnects mid-parse left its thread running. The permit followed the caller, admitting the next statement beside work still in flight. Capacity now follows the work: a job already running holds its permit until the thread exits, while one cancelled before any thread claimed it releases immediately and never runs — `asyncio.to_thread` gives no handle to tell those apart, so the CPU-bound phases submit to a pool sized from the same width table the semaphore uses.

**Event-loop responsiveness.** Parsing, admission and rewriting are CPU-bound and run before any guard that bounds execution — row limit, byte caps, deadline all apply after the backend is reached. Run on the loop, the whole phase is one uninterrupted block and every concurrent request waits it out. Both phases run in threads, which buys interleaving rather than isolation: the work is pure Python, so the GIL still admits spikes. Measured at the input cap, four concurrent admissions give a p95 loop gap of 22 ms threaded against 30 ms inline, with the median moving from 30 ms to 0.03 ms. The input cap drops from 1 MiB to 2 KiB, which is what bounds how much of this work a single call can buy; the largest realistic analytics query on hand is 1358 B, and the cap is stated in the tool description.

Also: a caller's own error reported as a timeout, `USING` keys resolved against only the first left relation, and timestamp conversion missed when the comparison ran through parentheses or an aggregate.

## Tests

**Compile every admitted statement.** Each corpus statement is rewritten and handed to a real engine to prepare. Preparing rather than executing needs no fixtures, so a case added for its admission behaviour is covered here the day it is written. Four of the fixes above were defects this would have caught.

**Assert elapsed time by value.** These paths were covered by checking the result was non-zero, which every failure mode above also satisfies. The seeded spans imply exact answers, so those are asserted, including predicate forms where imprecision drops the row entirely and returns empty.

Every guard added here was checked by reverting its fix and confirming the test fails.

## Upstream

Twelve sites exist only to compensate for sqlglot, all greppable as `Workaround for`. Eleven carry the issue URL and its disposition, because the disposition decides whether the site is ever removable:

- **Open:** [#8251](https://github.com/tobymao/sqlglot/issues/8251) (JSON path key holding `'` emitted unescaped), [#8279](https://github.com/tobymao/sqlglot/issues/8279) (`GROUPING SETS`/`ROLLUP`/`CUBE` followed by `LIMIT` fails to parse, in every dialect), [#8280](https://github.com/tobymao/sqlglot/issues/8280) (`CAST(x AS "char")` parsed as `CHAR`, so PostgreSQL's one-byte type becomes bpchar).
- **Fixed upstream, unreleased at the 30.17.0 pin:** [#8152](https://github.com/tobymao/sqlglot/issues/8152), [#8211](https://github.com/tobymao/sqlglot/issues/8211), [#8232](https://github.com/tobymao/sqlglot/issues/8232). These become removable at the next bump.
- **Closed `not planned`:** [#8074](https://github.com/tobymao/sqlglot/issues/8074), [#8075](https://github.com/tobymao/sqlglot/issues/8075), [#8077](https://github.com/tobymao/sqlglot/issues/8077), [#8079](https://github.com/tobymao/sqlglot/issues/8079). Permanent; nothing to wait for.

The twelfth compensates for PostgreSQL's niladic session keywords parsing as a bare column, for which a search of the sqlglot repository found no issue.

Every defect above was reproduced against the pinned 30.17.0, so none of the workarounds is removable today.

## Verification

`2014 passed` on SQLite, `2216 passed` on PostgreSQL 14.19 -- the same major version CI runs -- rebased onto current `main`. ruff, ruff format, and mypy clean across 1073 files.
