### PR TITLE
ci: run the platform matrix only for version-* branches with an open PR

### DIFF
--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -15,10 +15,13 @@ jobs:
   discover-branches:
     name: Discover Branches
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       branches: ${{ steps.branches.outputs.branches }}
     steps:
-      - name: Discover main and version-* branches
+      - name: Discover main and version-* branches with open non-draft PRs
         id: branches
         env:
           GH_TOKEN: ${{ github.token }}
@@ -29,7 +32,24 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$REF_NAME" != "main" ]; then
             branches=$(jq -cn --arg b "$REF_NAME" '[$b]')
           else
-            branches=$(gh api "repos/$REPO/branches" --paginate | jq -c -s '[.[][] | select(.name == "main" or (.name | startswith("version-"))) | .name]')
+            # A version-* branch is in the matrix only while it heads an open
+            # non-draft PR. associatedPullRequests is head-only, and the names
+            # come from this repository's own refs, so forks cannot enter the
+            # matrix. `query` matches substrings, hence the startswith filter.
+            # workflow_dispatch runs any branch on demand.
+            #
+            # Assign before filtering; a pipe into jq would mask a failed request.
+            refs=$(gh api graphql --paginate -F owner="${REPO%/*}" -F name="${REPO#*/}" -f query='
+              query($owner: String!, $name: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  refs(refPrefix: "refs/heads/", query: "version-", first: 100, after: $endCursor) {
+                    nodes { name associatedPullRequests(states: OPEN, first: 10) { nodes { isDraft } } }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }')
+            version_branches=$(printf '%s' "$refs" | jq -c -s '[.[].data.repository.refs.nodes[] | select(.name | startswith("version-")) | select(any(.associatedPullRequests.nodes[]; .isDraft | not)) | .name]')
+            branches=$(jq -cn --argjson v "$version_branches" '["main"] + $v')
           fi
           echo "branches=$branches" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
`Python All Platforms` sweeps every `version-*` branch each weekday, and each branch in the matrix costs ~26 jobs. A branch that is dormant but undeleted — today `version-rbac` — keeps buying a full platform sweep with nothing waiting on the result.

Discovery now asks for the `version-*` refs and their open PRs directly:

- `main` always runs.
- A `version-*` branch runs while it heads an open non-draft PR. `associatedPullRequests` is head-only, so a branch that merely receives PRs does not qualify; the names come from this repository's own refs, so forks cannot enter the matrix.
- `workflow_dispatch` on a branch still runs it on demand, PR or not.
- Push-triggered `python-CI.yml` continues to cover `version-*` branches on every push.

Reading pull requests needs the `pull-requests` scope, granted on the discovery job alone rather than workflow-wide.

Against the repo as of today the step emits `["main","version-online-evals"]` in 0.9 s, reading 4 KB in one request. Dropping `version-rbac` removes ~26 jobs per run.
