### PR TITLE
feat(js): add px prompt set for creating and updating prompts

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -403,8 +403,8 @@ px experiment list --dataset <name> --format raw --no-progress | jq '.[] | {id, 
 px experiment get <id> --format raw --no-progress | jq '.[] | select(.error != null) | {input, error}'
 px prompt list --format raw --no-progress | jq '.[].name'
 px prompt get <name> --format text --no-progress   # plain text, ideal for piping to AI
-px prompt set <name> --template "Hello {{name}}" --model gpt-4o --format raw --no-progress
-px prompt set <name> --file prompt.json --tag production --format raw --no-progress
+px prompt set <name> --template "Hello {{name}}" --model gpt-4o --model-provider OPENAI --format raw --no-progress
+px prompt set <name> --json prompt.json --tag production --format raw --no-progress
 ```
 
 ## Annotation Configs

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.
 metadata:
   author: arize-ai
-  version: "3.3.0"
+  version: "3.4.0"
 ---
 
 # Phoenix CLI
@@ -45,6 +45,7 @@ px experiment get <id>
 px experiment delete <experiment-id>
 px prompt list
 px prompt get <prompt-identifier>
+px prompt set <prompt-identifier>
 px prompt delete <prompt-identifier>
 px project list
 px project get <name>
@@ -402,6 +403,8 @@ px experiment list --dataset <name> --format raw --no-progress | jq '.[] | {id, 
 px experiment get <id> --format raw --no-progress | jq '.[] | select(.error != null) | {input, error}'
 px prompt list --format raw --no-progress | jq '.[].name'
 px prompt get <name> --format text --no-progress   # plain text, ideal for piping to AI
+px prompt set <name> --template "Hello {{name}}" --model gpt-4o --format raw --no-progress
+px prompt set <name> --file prompt.json --tag production --format raw --no-progress
 ```
 
 ## Annotation Configs

--- a/js/.changeset/px-prompt-set.md
+++ b/js/.changeset/px-prompt-set.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `px prompt set` to create a prompt or append a new version. Pass `--template`, repeatable `--message role:content`, or `--file` (JSON, or `-` for stdin). Omitted fields are copied from the latest version.

--- a/js/.changeset/px-prompt-set.md
+++ b/js/.changeset/px-prompt-set.md
@@ -2,4 +2,4 @@
 "@arizeai/phoenix-cli": minor
 ---
 
-Add `px prompt set` to create a prompt or append a new version. Pass `--template`, repeatable `--message role:content`, or `--file` (JSON, or `-` for stdin). Omitted fields are copied from the latest version.
+Add `px prompt set` to create a prompt or append a new version. Pass `--template`, repeatable `--message role:content`, or `--json` (path to a JSON prompt body, or `-` for stdin). Creating a prompt requires both `--model` and `--model-provider`; on update, omitted fields are copied from the latest version.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -496,6 +496,46 @@ px prompt get my-evaluator --tag production --format json | jq '.template'
 
 ---
 
+### `px prompt set <prompt-identifier>`
+
+Create a prompt, or append a new version if one with that name already exists. Omitted fields are copied from the latest version.
+
+```bash
+# Create from a template string
+px prompt set greeting --template "Hello {{name}}" --model gpt-4o
+
+# Chat prompt with system + user messages
+px prompt set greeting --message "system:You are a helpful assistant" --message "user:Hello {{name}}" --model gpt-4o
+
+# Update only the template; model and other fields stay as they are
+px prompt set greeting --template "Hi {{name}}"
+
+# Create from a JSON file (POST /v1/prompts body or `px prompt get --format raw`)
+px prompt set greeting --file prompt.json --tag production --format raw --no-progress
+
+# Round-trip the latest version
+px prompt get greeting --format raw --no-progress | px prompt set greeting --file -
+```
+
+| Option                         | Description                                                                 | Default            |
+| ------------------------------ | --------------------------------------------------------------------------- | ------------------ |
+| `--template <text>`            | Prompt body as a single user message                                        | —                  |
+| `--message <role:content>`     | Chat message, repeatable (`user`, `system`, `assistant`, …)                 | —                  |
+| `--file <path>`                | JSON prompt body. Use `-` for stdin                                         | —                  |
+| `--model <name>`               | Model name. Required on create unless `--file` includes `model_name`        | —                  |
+| `--model-provider <provider>`  | Model provider                                                              | `OPENAI` on create |
+| `--template-format <format>`   | `MUSTACHE`, `F_STRING`, or `NONE`                                           | `MUSTACHE`         |
+| `--description <text>`         | Prompt description (applied when creating the prompt)                       | —                  |
+| `--version-description <text>` | Description of this version                                                 | —                  |
+| `--invocation-parameters <json>` | Provider parameters, e.g. `{"temperature":0.2}`                           | —                  |
+| `--metadata <json>`            | Prompt metadata (applied when creating the prompt)                          | —                  |
+| `--tag <name>`                 | Tag the newly written version                                               | —                  |
+| `--format <format>`            | `pretty`, `json`, `raw`, or `text`                                          | `pretty`           |
+
+The command prints the saved prompt version (same shape as `px prompt get`). Names must be lowercase letters, digits, hyphens, and underscores.
+
+---
+
 ### `px project list`
 
 List all available Phoenix projects.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -502,35 +502,35 @@ Create a prompt, or append a new version if one with that name already exists. O
 
 ```bash
 # Create from a template string
-px prompt set greeting --template "Hello {{name}}" --model gpt-4o
+px prompt set greeting --template "Hello {{name}}" --model gpt-4o --model-provider OPENAI
 
 # Chat prompt with system + user messages
-px prompt set greeting --message "system:You are a helpful assistant" --message "user:Hello {{name}}" --model gpt-4o
+px prompt set greeting --message "system:You are a helpful assistant" --message "user:Hello {{name}}" --model gpt-4o --model-provider OPENAI
 
 # Update only the template; model and other fields stay as they are
 px prompt set greeting --template "Hi {{name}}"
 
 # Create from a JSON file (POST /v1/prompts body or `px prompt get --format raw`)
-px prompt set greeting --file prompt.json --tag production --format raw --no-progress
+px prompt set greeting --json prompt.json --tag production --format raw --no-progress
 
 # Round-trip the latest version
-px prompt get greeting --format raw --no-progress | px prompt set greeting --file -
+px prompt get greeting --format raw --no-progress | px prompt set greeting --json -
 ```
 
-| Option                         | Description                                                                 | Default            |
-| ------------------------------ | --------------------------------------------------------------------------- | ------------------ |
-| `--template <text>`            | Prompt body as a single user message                                        | —                  |
-| `--message <role:content>`     | Chat message, repeatable (`user`, `system`, `assistant`, …)                 | —                  |
-| `--file <path>`                | JSON prompt body. Use `-` for stdin                                         | —                  |
-| `--model <name>`               | Model name. Required on create unless `--file` includes `model_name`        | —                  |
-| `--model-provider <provider>`  | Model provider                                                              | `OPENAI` on create |
-| `--template-format <format>`   | `MUSTACHE`, `F_STRING`, or `NONE`                                           | `MUSTACHE`         |
-| `--description <text>`         | Prompt description (applied when creating the prompt)                       | —                  |
-| `--version-description <text>` | Description of this version                                                 | —                  |
-| `--invocation-parameters <json>` | Provider parameters, e.g. `{"temperature":0.2}`                           | —                  |
-| `--metadata <json>`            | Prompt metadata (applied when creating the prompt)                          | —                  |
-| `--tag <name>`                 | Tag the newly written version                                               | —                  |
-| `--format <format>`            | `pretty`, `json`, `raw`, or `text`                                          | `pretty`           |
+| Option                           | Description                                                                  | Default    |
+| -------------------------------- | ---------------------------------------------------------------------------- | ---------- |
+| `--template <text>`              | Prompt body as a single user message                                         | —          |
+| `--message <role:content>`       | Chat message, repeatable (`user`, `system`, `assistant`, …)                  | —          |
+| `--json <path>`                  | JSON prompt body. Use `-` for stdin                                          | —          |
+| `--model <name>`                 | Model name. Required on create unless `--json` includes `model_name`         | —          |
+| `--model-provider <provider>`    | Model provider. Required on create unless `--json` includes `model_provider` | —          |
+| `--template-format <format>`     | `MUSTACHE`, `F_STRING`, or `NONE`                                            | `MUSTACHE` |
+| `--description <text>`           | Prompt description (applied when creating the prompt)                        | —          |
+| `--version-description <text>`   | Description of this version                                                  | —          |
+| `--invocation-parameters <json>` | Provider parameters, e.g. `{"temperature":0.2}`                              | —          |
+| `--metadata <json>`              | Prompt metadata (applied when creating the prompt)                           | —          |
+| `--tag <name>`                   | Tag the newly written version                                                | —          |
+| `--format <format>`              | `pretty`, `json`, `raw`, or `text`                                           | `pretty`   |
 
 The command prints the saved prompt version (same shape as `px prompt get`). Names must be lowercase letters, digits, hyphens, and underscores.
 

--- a/js/packages/phoenix-cli/src/commands/prompt.ts
+++ b/js/packages/phoenix-cli/src/commands/prompt.ts
@@ -1,4 +1,9 @@
-import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+import { readFileSync } from "node:fs";
+import {
+  HttpError,
+  type componentsV1,
+  type PhoenixClient,
+} from "@arizeai/phoenix-client";
 import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
@@ -8,11 +13,26 @@ import {
   validateConfig,
 } from "../config";
 import { assertDeletesEnabled, confirmOrExit } from "../confirm";
-import { ExitCode, getExitCodeForError } from "../exitCodes";
+import {
+  ExitCode,
+  getExitCodeForError,
+  InvalidArgumentError,
+} from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
+import { collectString } from "../optionParsers";
+import { writeStructuredError } from "../structuredError";
 import { formatPromptOutput, type OutputFormat } from "./formatPrompt";
 import { formatPromptsOutput } from "./formatPrompts";
 import type { CommonOptions, DeleteOptions } from "./options";
+import {
+  assertPromptIdentifier,
+  buildPromptSetRequest,
+  hasPromptVersionInput,
+  parsePromptSetFile,
+  parsePromptSetFlags,
+  PROMPT_SET_USAGE_HINT,
+  type PromptSetFileContents,
+} from "./promptSet";
 
 type Prompt = componentsV1["schemas"]["Prompt"];
 type PromptVersion = componentsV1["schemas"]["PromptVersion"];
@@ -47,6 +67,90 @@ interface PromptListOptions extends CommonOptions {
    * @example 50
    */
   limit?: number;
+}
+
+/**
+ * Options for `px prompt set <prompt-identifier>`. Creates the prompt when
+ * it does not exist; otherwise appends a new version. Fields omitted on an
+ * update are copied from the latest version.
+ */
+interface PromptSetOptions extends CommonOptions<OutputFormat> {
+  /**
+   * `--template <text>`: Prompt body as a single user message. Mutually
+   * exclusive with `--message`.
+   *
+   * @example "Hello {{name}}"
+   */
+  template?: string;
+  /**
+   * `--message <role:content>`: Chat message, repeatable. Role is one of
+   * `user`, `assistant`, `system`, `developer`, `model`, `ai`, `tool`.
+   *
+   * @example ["system:You are helpful", "user:Hello {{name}}"]
+   */
+  message?: string[];
+  /**
+   * `--file <path>`: JSON prompt body. Accepts the POST /v1/prompts payload,
+   * a `PromptVersion` (`px prompt get --format raw`), or `{messages: [...]}`.
+   * Use `-` to read stdin.
+   *
+   * @example "prompt.json"
+   */
+  file?: string;
+  /**
+   * `--model <name>`: Model name for the new version. Required when creating
+   * a prompt unless `--file` already has `model_name`.
+   *
+   * @example "gpt-4o"
+   */
+  model?: string;
+  /**
+   * `--model-provider <provider>`: Model provider. Case-insensitive.
+   * Defaults to `OPENAI` on create; copied from the latest version on update.
+   *
+   * @example "OPENAI"
+   */
+  modelProvider?: string;
+  /**
+   * `--template-format <format>`: `MUSTACHE`, `F_STRING`, or `NONE`.
+   * Defaults to `MUSTACHE` on create.
+   *
+   * @example "MUSTACHE"
+   */
+  templateFormat?: string;
+  /**
+   * `--description <text>`: Prompt description. Applied when creating a
+   * prompt; the API does not update it on an existing prompt.
+   *
+   * @example "Greets the user by name"
+   */
+  description?: string;
+  /**
+   * `--version-description <text>`: Description of this prompt version.
+   *
+   * @example "Rewrote the greeting"
+   */
+  versionDescription?: string;
+  /**
+   * `--invocation-parameters <json>`: Provider invocation parameters as a
+   * JSON object, e.g. `{"temperature":0.2}`. Anthropic requires `max_tokens`.
+   *
+   * @example '{"temperature":0.2}'
+   */
+  invocationParameters?: string;
+  /**
+   * `--metadata <json>`: Prompt metadata as a JSON object. Applied when
+   * creating a prompt.
+   *
+   * @example '{"team":"evals"}'
+   */
+  metadata?: string;
+  /**
+   * `--tag <name>`: Tag the newly written version (e.g. `production`).
+   *
+   * @example "production"
+   */
+  tag?: string;
 }
 
 /**
@@ -310,6 +414,193 @@ async function promptDeleteHandler(
   }
 }
 
+/**
+ * Handler for `prompt set`
+ */
+async function promptSetHandler(
+  promptIdentifier: string,
+  options: PromptSetOptions
+): Promise<void> {
+  const format = structuredErrorFormat(options.format);
+  if (!hasPromptVersionInput(options)) {
+    writeStructuredError({
+      format,
+      message:
+        "Provide a template (--template, --message, or --file) or a version field to change (--model, --model-provider, --template-format, --invocation-parameters, --version-description)",
+      code: "INVALID_ARGUMENT",
+      hint: PROMPT_SET_USAGE_HINT,
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+
+  let name: string;
+  let flags: ReturnType<typeof parsePromptSetFlags>;
+  let file: PromptSetFileContents | undefined;
+  try {
+    name = assertPromptIdentifier(promptIdentifier, "Prompt name");
+    flags = parsePromptSetFlags(options);
+    if (options.file !== undefined) {
+      file = parsePromptSetFile(await readPromptSetFile(options.file));
+    }
+  } catch (error) {
+    if (error instanceof InvalidArgumentError) {
+      writeStructuredError({
+        format,
+        message: error.message,
+        code: "INVALID_ARGUMENT",
+        hint: PROMPT_SET_USAGE_HINT,
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+    throw error;
+  }
+
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const client = createPhoenixClient({ config });
+
+    const existing = await fetchLatestPromptVersionOrUndefined(
+      client,
+      promptIdentifier
+    );
+
+    const body = buildPromptSetRequest({
+      name,
+      flags,
+      file,
+      existing,
+    });
+
+    writeProgress({
+      message: `Saving prompt "${name}"...`,
+      noProgress: !options.progress,
+    });
+
+    const response = await client.POST("/v1/prompts", {
+      body,
+    });
+
+    if (response.error || !response.data) {
+      throw new Error(
+        `Failed to save prompt: ${response.error || "Unknown error"}`
+      );
+    }
+
+    const promptVersion = response.data.data;
+
+    if (flags.tag !== undefined) {
+      const tagResponse = await client.POST(
+        "/v1/prompt_versions/{prompt_version_id}/tags",
+        {
+          params: {
+            path: { prompt_version_id: promptVersion.id },
+          },
+          body: { name: flags.tag },
+        }
+      );
+      if (tagResponse.error) {
+        throw new Error(
+          `Saved prompt version ${promptVersion.id} but failed to tag it '${flags.tag}': ${tagResponse.error}`
+        );
+      }
+    }
+
+    writeProgress({
+      message:
+        flags.tag !== undefined
+          ? `Saved prompt version ${promptVersion.id} (tag: ${flags.tag})`
+          : `Saved prompt version ${promptVersion.id}`,
+      noProgress: !options.progress,
+    });
+
+    writeOutput({
+      message: formatPromptOutput({
+        promptVersion,
+        format: options.format,
+      }),
+    });
+  } catch (error) {
+    if (error instanceof InvalidArgumentError) {
+      writeStructuredError({
+        format,
+        message: error.message,
+        code: "INVALID_ARGUMENT",
+        hint: PROMPT_SET_USAGE_HINT,
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+    writeError({
+      message: `Error saving prompt: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+async function fetchLatestPromptVersionOrUndefined(
+  client: PhoenixClient,
+  promptIdentifier: string
+): Promise<PromptVersion | undefined> {
+  try {
+    return await fetchPromptVersion(client, promptIdentifier);
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 404) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function readPromptSetFile(filePath: string): Promise<string> {
+  if (filePath === "-") {
+    if (process.stdin.isTTY) {
+      throw new InvalidArgumentError(
+        "No prompt JSON on stdin. Pipe a file or pass --file <path>"
+      );
+    }
+    return readStdin();
+  }
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch (error) {
+    throw new InvalidArgumentError(
+      `Failed to read --file '${filePath}': ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    process.stdin.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+function structuredErrorFormat(
+  format: OutputFormat | undefined
+): "pretty" | "json" | "raw" {
+  return format === "json" || format === "raw" ? format : "pretty";
+}
+
 export function createPromptGetCommand(): Command {
   return new Command("get")
     .description("Show a Phoenix prompt")
@@ -353,6 +644,68 @@ export function createPromptDeleteCommand(): Command {
     .action(promptDeleteHandler);
 }
 
+export function createPromptSetCommand(): Command {
+  return new Command("set")
+    .description("Create a prompt or append a new version")
+    .argument("<prompt-identifier>", "Prompt name")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--template <text>", "Prompt body as a single user message")
+    .option(
+      "--message <role:content>",
+      "Chat message, e.g. user:Hello (repeatable)",
+      collectString,
+      []
+    )
+    .option(
+      "--file <path>",
+      "JSON prompt body (POST /v1/prompts or px prompt get --format raw). Use - for stdin"
+    )
+    .option("--model <name>", "Model name, e.g. gpt-4o")
+    .option(
+      "--model-provider <provider>",
+      "Model provider (default: OPENAI on create)"
+    )
+    .option(
+      "--template-format <format>",
+      "MUSTACHE, F_STRING, or NONE (default: MUSTACHE on create)"
+    )
+    .option(
+      "--description <text>",
+      "Prompt description (applied when creating the prompt)"
+    )
+    .option("--version-description <text>", "Description of this version")
+    .option(
+      "--invocation-parameters <json>",
+      "Provider invocation parameters, e.g. '{\"temperature\":0.2}'"
+    )
+    .option("--metadata <json>", "Prompt metadata as a JSON object")
+    .option("--tag <name>", "Tag the newly written version, e.g. production")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, raw, or text",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText(
+      "after",
+      "\nCreates the named prompt, or appends a new version if it already exists. " +
+        "Omitted fields are copied from the latest version.\n" +
+        "\nExamples:\n" +
+        "  # Create a prompt from a template string\n" +
+        '  px prompt set greeting --template "Hello {{name}}" --model gpt-4o\n\n' +
+        "  # Chat prompt with a system and user message\n" +
+        '  px prompt set greeting --message "system:You are a helpful assistant" --message "user:Hello {{name}}" --model gpt-4o\n\n' +
+        "  # Update only the template; model and other fields stay as they are\n" +
+        '  px prompt set greeting --template "Hi {{name}}"\n\n' +
+        "  # Create from a JSON file and tag the version (agent-friendly)\n" +
+        "  px prompt set greeting --file prompt.json --tag production --format raw --no-progress\n\n" +
+        "  # Round-trip the latest version through a file\n" +
+        "  px prompt get greeting --format raw --no-progress | px prompt set greeting --file -\n"
+    )
+    .action(promptSetHandler);
+}
+
 /**
  * Create the `prompt` command with subcommands
  */
@@ -361,6 +714,7 @@ export function createPromptCommand(): Command {
   command.description("Manage Phoenix prompts");
   command.addCommand(createPromptListCommand());
   command.addCommand(createPromptGetCommand());
+  command.addCommand(createPromptSetCommand());
   command.addCommand(createPromptDeleteCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/prompt.ts
+++ b/js/packages/phoenix-cli/src/commands/prompt.ts
@@ -28,10 +28,11 @@ import {
   assertPromptIdentifier,
   buildPromptSetRequest,
   hasPromptVersionInput,
-  parsePromptSetFile,
+  MODEL_PROVIDERS,
   parsePromptSetFlags,
+  parsePromptSetJson,
   PROMPT_SET_USAGE_HINT,
-  type PromptSetFileContents,
+  type PromptSetJsonContents,
 } from "./promptSet";
 
 type Prompt = componentsV1["schemas"]["Prompt"];
@@ -90,23 +91,24 @@ interface PromptSetOptions extends CommonOptions<OutputFormat> {
    */
   message?: string[];
   /**
-   * `--file <path>`: JSON prompt body. Accepts the POST /v1/prompts payload,
+   * `--json <path>`: JSON prompt body. Accepts the POST /v1/prompts payload,
    * a `PromptVersion` (`px prompt get --format raw`), or `{messages: [...]}`.
    * Use `-` to read stdin.
    *
    * @example "prompt.json"
    */
-  file?: string;
+  json?: string;
   /**
    * `--model <name>`: Model name for the new version. Required when creating
-   * a prompt unless `--file` already has `model_name`.
+   * a prompt unless `--json` already has `model_name`.
    *
    * @example "gpt-4o"
    */
   model?: string;
   /**
-   * `--model-provider <provider>`: Model provider. Case-insensitive.
-   * Defaults to `OPENAI` on create; copied from the latest version on update.
+   * `--model-provider <provider>`: Model provider. Case-insensitive. Required
+   * when creating a prompt unless `--json` already has `model_provider`;
+   * copied from the latest version on update.
    *
    * @example "OPENAI"
    */
@@ -426,7 +428,7 @@ async function promptSetHandler(
     writeStructuredError({
       format,
       message:
-        "Provide a template (--template, --message, or --file) or a version field to change (--model, --model-provider, --template-format, --invocation-parameters, --version-description)",
+        "Provide a template (--template, --message, or --json) or a version field to change (--model, --model-provider, --template-format, --invocation-parameters, --version-description)",
       code: "INVALID_ARGUMENT",
       hint: PROMPT_SET_USAGE_HINT,
     });
@@ -435,12 +437,12 @@ async function promptSetHandler(
 
   let name: string;
   let flags: ReturnType<typeof parsePromptSetFlags>;
-  let file: PromptSetFileContents | undefined;
+  let json: PromptSetJsonContents | undefined;
   try {
     name = assertPromptIdentifier(promptIdentifier, "Prompt name");
     flags = parsePromptSetFlags(options);
-    if (options.file !== undefined) {
-      file = parsePromptSetFile(await readPromptSetFile(options.file));
+    if (options.json !== undefined) {
+      json = parsePromptSetJson(await readPromptSetJson(options.json));
     }
   } catch (error) {
     if (error instanceof InvalidArgumentError) {
@@ -481,7 +483,7 @@ async function promptSetHandler(
     const body = buildPromptSetRequest({
       name,
       flags,
-      file,
+      json,
       existing,
     });
 
@@ -564,11 +566,11 @@ async function fetchLatestPromptVersionOrUndefined(
   }
 }
 
-async function readPromptSetFile(filePath: string): Promise<string> {
+async function readPromptSetJson(filePath: string): Promise<string> {
   if (filePath === "-") {
     if (process.stdin.isTTY) {
       throw new InvalidArgumentError(
-        "No prompt JSON on stdin. Pipe a file or pass --file <path>"
+        "No prompt JSON on stdin. Pipe a file or pass --json <path>"
       );
     }
     return readStdin();
@@ -577,7 +579,7 @@ async function readPromptSetFile(filePath: string): Promise<string> {
     return readFileSync(filePath, "utf8");
   } catch (error) {
     throw new InvalidArgumentError(
-      `Failed to read --file '${filePath}': ${error instanceof Error ? error.message : String(error)}`
+      `Failed to read --json '${filePath}': ${error instanceof Error ? error.message : String(error)}`
     );
   }
 }
@@ -658,13 +660,13 @@ export function createPromptSetCommand(): Command {
       []
     )
     .option(
-      "--file <path>",
+      "--json <path>",
       "JSON prompt body (POST /v1/prompts or px prompt get --format raw). Use - for stdin"
     )
-    .option("--model <name>", "Model name, e.g. gpt-4o")
+    .option("--model <name>", "Model name, e.g. gpt-4o. Required on create")
     .option(
       "--model-provider <provider>",
-      "Model provider (default: OPENAI on create)"
+      `Model provider, e.g. OPENAI. Required on create. One of: ${MODEL_PROVIDERS.join(", ")}`
     )
     .option(
       "--template-format <format>",
@@ -693,15 +695,15 @@ export function createPromptSetCommand(): Command {
         "Omitted fields are copied from the latest version.\n" +
         "\nExamples:\n" +
         "  # Create a prompt from a template string\n" +
-        '  px prompt set greeting --template "Hello {{name}}" --model gpt-4o\n\n' +
+        '  px prompt set greeting --template "Hello {{name}}" --model gpt-4o --model-provider OPENAI\n\n' +
         "  # Chat prompt with a system and user message\n" +
-        '  px prompt set greeting --message "system:You are a helpful assistant" --message "user:Hello {{name}}" --model gpt-4o\n\n' +
+        '  px prompt set greeting --message "system:You are a helpful assistant" --message "user:Hello {{name}}" --model gpt-4o --model-provider OPENAI\n\n' +
         "  # Update only the template; model and other fields stay as they are\n" +
         '  px prompt set greeting --template "Hi {{name}}"\n\n' +
         "  # Create from a JSON file and tag the version (agent-friendly)\n" +
-        "  px prompt set greeting --file prompt.json --tag production --format raw --no-progress\n\n" +
+        "  px prompt set greeting --json prompt.json --tag production --format raw --no-progress\n\n" +
         "  # Round-trip the latest version through a file\n" +
-        "  px prompt get greeting --format raw --no-progress | px prompt set greeting --file -\n"
+        "  px prompt get greeting --format raw --no-progress | px prompt set greeting --json -\n"
     )
     .action(promptSetHandler);
 }

--- a/js/packages/phoenix-cli/src/commands/promptSet.ts
+++ b/js/packages/phoenix-cli/src/commands/promptSet.ts
@@ -52,17 +52,16 @@ export const PROMPT_MESSAGE_ROLES: readonly PromptMessage["role"][] = [
  */
 export const PROMPT_IDENTIFIER_PATTERN = /^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$/;
 
-const DEFAULT_MODEL_PROVIDER: ModelProvider = "OPENAI";
 const DEFAULT_TEMPLATE_FORMAT: PromptTemplateFormat = "MUSTACHE";
 
 export const PROMPT_SET_USAGE_HINT =
-  'px prompt set <name> --template "..." --model gpt-4o';
+  'px prompt set <name> --template "..." --model gpt-4o --model-provider OPENAI';
 
 /**
- * Fields parsed from `--file` (or stdin). Flags overlay these; a latest
+ * Fields parsed from `--json` (or stdin). Flags overlay these; a latest
  * version, when one exists, fills anything still missing.
  */
-export interface PromptSetFileContents {
+export interface PromptSetJsonContents {
   promptDescription?: string | null;
   promptMetadata?: Record<string, unknown> | null;
   version?: Partial<PromptVersionData>;
@@ -93,7 +92,7 @@ export interface BuildPromptSetRequestInput {
    */
   name: string;
   flags: PromptSetParsedFlags;
-  file?: PromptSetFileContents;
+  json?: PromptSetJsonContents;
   /**
    * Latest version of an existing prompt, used so `set` can change one field
    * without respecifying the rest.
@@ -110,7 +109,7 @@ export interface BuildPromptSetRequestInput {
 export function hasPromptVersionInput(options: {
   template?: string;
   message?: string[];
-  file?: string;
+  json?: string;
   model?: string;
   modelProvider?: string;
   templateFormat?: string;
@@ -120,7 +119,7 @@ export function hasPromptVersionInput(options: {
   return (
     options.template !== undefined ||
     (options.message !== undefined && options.message.length > 0) ||
-    options.file !== undefined ||
+    options.json !== undefined ||
     options.model !== undefined ||
     options.modelProvider !== undefined ||
     options.templateFormat !== undefined ||
@@ -248,16 +247,16 @@ export function parsePromptSetFlags(options: {
 }
 
 /**
- * Parse a `--file` payload. Accepts the POST /v1/prompts body, a
+ * Parse a `--json` payload. Accepts the POST /v1/prompts body, a
  * `PromptVersion` (including `px prompt get --format raw` output), a
  * `{ data: PromptVersion }` wrapper, a `{ messages: [...] }` chat template,
  * or a JSON string treated as a user-message template.
  */
-export function parsePromptSetFile(contents: string): PromptSetFileContents {
+export function parsePromptSetJson(contents: string): PromptSetJsonContents {
   const trimmed = contents.trim();
   if (trimmed === "") {
     throw new InvalidArgumentError(
-      "--file is empty. Pass a JSON prompt body or the output of px prompt get --format raw"
+      "--json is empty. Pass a JSON prompt body or the output of px prompt get --format raw"
     );
   }
 
@@ -266,32 +265,34 @@ export function parsePromptSetFile(contents: string): PromptSetFileContents {
     parsed = JSON.parse(trimmed);
   } catch {
     throw new InvalidArgumentError(
-      "--file must be valid JSON. Use --template for a plain-text prompt"
+      "--json must be valid JSON. Use --template for a plain-text prompt"
     );
   }
 
   if (typeof parsed === "string") {
     if (parsed.trim() === "") {
-      throw new InvalidArgumentError("--file JSON string must not be empty");
+      throw new InvalidArgumentError(
+        "--json string template must not be empty"
+      );
     }
     return { templateText: parsed };
   }
 
   if (!isRecord(parsed)) {
     throw new InvalidArgumentError(
-      "--file must be a JSON object (prompt version, {prompt, version}, or {messages})"
+      "--json must be a JSON object (prompt version, {prompt, version}, or {messages})"
     );
   }
 
   const unwrapped = unwrapPromptVersionRecord(parsed);
-  const file: PromptSetFileContents = {};
+  const json: PromptSetJsonContents = {};
 
   if (isRecord(unwrapped.prompt)) {
     if (typeof unwrapped.prompt.description === "string") {
-      file.promptDescription = unwrapped.prompt.description;
+      json.promptDescription = unwrapped.prompt.description;
     }
     if (isRecord(unwrapped.prompt.metadata)) {
-      file.promptMetadata = unwrapped.prompt.metadata;
+      json.promptMetadata = unwrapped.prompt.metadata;
     }
   }
 
@@ -302,75 +303,75 @@ export function parsePromptSetFile(contents: string): PromptSetFileContents {
       : undefined;
 
   if (versionRecord !== undefined) {
-    file.version = promptVersionDataFromRecord(versionRecord);
+    json.version = promptVersionDataFromRecord(versionRecord);
     if (
       typeof versionRecord.template === "string" &&
       versionRecord.template.trim() !== ""
     ) {
-      file.templateText = versionRecord.template;
+      json.templateText = versionRecord.template;
     }
   }
 
   if (
     Array.isArray(unwrapped.messages) &&
-    file.version?.template === undefined
+    json.version?.template === undefined
   ) {
-    file.messages = parseFileMessages(unwrapped.messages);
+    json.messages = parseJsonMessages(unwrapped.messages);
   }
 
   const hasContent =
-    file.version !== undefined ||
-    file.templateText !== undefined ||
-    file.messages !== undefined ||
-    file.promptDescription !== undefined ||
-    file.promptMetadata !== undefined;
+    json.version !== undefined ||
+    json.templateText !== undefined ||
+    json.messages !== undefined ||
+    json.promptDescription !== undefined ||
+    json.promptMetadata !== undefined;
   if (!hasContent) {
     throw new InvalidArgumentError(
-      "--file JSON must include a prompt version (template / messages) or {prompt, version}"
+      "--json must include a prompt version (template / messages) or {prompt, version}"
     );
   }
 
-  return file;
+  return json;
 }
 
 export function buildPromptSetRequest({
   name,
   flags,
-  file,
+  json,
   existing,
 }: BuildPromptSetRequestInput): {
   prompt: PromptData;
   version: PromptVersionData;
 } {
-  const template = resolveChatTemplate({ flags, file, existing });
-  const modelName = resolveModelName({ flags, file, existing });
-  const modelProvider = resolveModelProvider({ flags, file, existing });
+  const template = resolveChatTemplate({ flags, json, existing });
+  const modelName = resolveModelName({ flags, json, existing });
+  const modelProvider = resolveModelProvider({ flags, json, existing });
   const templateFormat =
     flags.templateFormat ??
-    file?.version?.template_format ??
+    json?.version?.template_format ??
     existing?.template_format ??
     DEFAULT_TEMPLATE_FORMAT;
   const versionDescription =
     flags.versionDescription ??
-    file?.version?.description ??
+    json?.version?.description ??
     existing?.description ??
     undefined;
   const invocationParameters = resolveInvocationParameters({
     flags,
-    file,
+    json,
     existing,
     modelProvider,
   });
-  const tools = file?.version?.tools ?? existing?.tools ?? undefined;
+  const tools = json?.version?.tools ?? existing?.tools ?? undefined;
   const responseFormat =
-    file?.version?.response_format ?? existing?.response_format ?? undefined;
+    json?.version?.response_format ?? existing?.response_format ?? undefined;
 
   const prompt: PromptData = { name };
-  const description = flags.description ?? file?.promptDescription;
+  const description = flags.description ?? json?.promptDescription;
   if (description !== undefined && description !== null) {
     prompt.description = description;
   }
-  const metadata = flags.metadata ?? file?.promptMetadata;
+  const metadata = flags.metadata ?? json?.promptMetadata;
   if (metadata !== undefined && metadata !== null) {
     prompt.metadata = metadata;
   }
@@ -398,11 +399,11 @@ export function buildPromptSetRequest({
 
 function resolveChatTemplate({
   flags,
-  file,
+  json,
   existing,
 }: {
   flags: PromptSetParsedFlags;
-  file?: PromptSetFileContents;
+  json?: PromptSetJsonContents;
   existing?: PromptVersion;
 }): PromptChatTemplate {
   if (flags.messages !== undefined) {
@@ -411,34 +412,34 @@ function resolveChatTemplate({
   if (flags.template !== undefined) {
     return userMessageTemplate(flags.template);
   }
-  if (file?.messages !== undefined) {
-    return { type: "chat", messages: file.messages };
+  if (json?.messages !== undefined) {
+    return { type: "chat", messages: json.messages };
   }
-  if (file?.templateText !== undefined) {
-    return userMessageTemplate(file.templateText);
+  if (json?.templateText !== undefined) {
+    return userMessageTemplate(json.templateText);
   }
-  if (file?.version?.template !== undefined) {
-    return toChatTemplate(file.version.template);
+  if (json?.version?.template !== undefined) {
+    return toChatTemplate(json.version.template);
   }
   if (existing?.template !== undefined) {
     return toChatTemplate(existing.template);
   }
   throw new InvalidArgumentError(
-    "Missing prompt template. Pass --template, --message, or --file"
+    "Missing prompt template. Pass --template, --message, or --json"
   );
 }
 
 function resolveModelName({
   flags,
-  file,
+  json,
   existing,
 }: {
   flags: PromptSetParsedFlags;
-  file?: PromptSetFileContents;
+  json?: PromptSetJsonContents;
   existing?: PromptVersion;
 }): string {
   const modelName =
-    flags.model ?? file?.version?.model_name ?? existing?.model_name;
+    flags.model ?? json?.version?.model_name ?? existing?.model_name;
   if (modelName === undefined || modelName.trim() === "") {
     throw new InvalidArgumentError("Missing required flag --model");
   }
@@ -447,29 +448,33 @@ function resolveModelName({
 
 function resolveModelProvider({
   flags,
-  file,
+  json,
   existing,
 }: {
   flags: PromptSetParsedFlags;
-  file?: PromptSetFileContents;
+  json?: PromptSetJsonContents;
   existing?: PromptVersion;
 }): ModelProvider {
-  return (
+  const modelProvider =
     flags.modelProvider ??
-    file?.version?.model_provider ??
-    existing?.model_provider ??
-    DEFAULT_MODEL_PROVIDER
-  );
+    json?.version?.model_provider ??
+    existing?.model_provider;
+  if (modelProvider === undefined) {
+    throw new InvalidArgumentError(
+      `Missing required flag --model-provider. Must be one of: ${MODEL_PROVIDERS.join(", ")}`
+    );
+  }
+  return modelProvider;
 }
 
 function resolveInvocationParameters({
   flags,
-  file,
+  json,
   existing,
   modelProvider,
 }: {
   flags: PromptSetParsedFlags;
-  file?: PromptSetFileContents;
+  json?: PromptSetJsonContents;
   existing?: PromptVersion;
   modelProvider: ModelProvider;
 }): InvocationParameters {
@@ -477,13 +482,13 @@ function resolveInvocationParameters({
     return buildInvocationParameters(modelProvider, flags.invocationParameters);
   }
   if (
-    file?.version?.invocation_parameters !== undefined &&
+    json?.version?.invocation_parameters !== undefined &&
     invocationParametersMatchProvider(
-      file.version.invocation_parameters,
+      json.version.invocation_parameters,
       modelProvider
     )
   ) {
-    return file.version.invocation_parameters;
+    return json.version.invocation_parameters;
   }
   if (
     existing?.invocation_parameters !== undefined &&
@@ -629,23 +634,23 @@ function isPromptTemplate(
   return false;
 }
 
-function parseFileMessages(values: unknown[]): PromptMessage[] {
+function parseJsonMessages(values: unknown[]): PromptMessage[] {
   const messages: PromptMessage[] = [];
   for (const value of values) {
     if (!isRecord(value) || typeof value.role !== "string") {
       throw new InvalidArgumentError(
-        "--file messages must be objects with a role and content"
+        "--json messages must be objects with a role and content"
       );
     }
     const role = value.role.toLowerCase();
     if (!isPromptMessageRole(role)) {
       throw new InvalidArgumentError(
-        `Invalid message role '${value.role}' in --file. Must be one of: ${PROMPT_MESSAGE_ROLES.join(", ")}`
+        `Invalid message role '${value.role}' in --json. Must be one of: ${PROMPT_MESSAGE_ROLES.join(", ")}`
       );
     }
     if (typeof value.content !== "string" && !Array.isArray(value.content)) {
       throw new InvalidArgumentError(
-        "--file messages must include string or content-part content"
+        "--json messages must include string or content-part content"
       );
     }
     messages.push({
@@ -654,7 +659,7 @@ function parseFileMessages(values: unknown[]): PromptMessage[] {
     });
   }
   if (messages.length === 0) {
-    throw new InvalidArgumentError("--file messages must not be empty");
+    throw new InvalidArgumentError("--json messages must not be empty");
   }
   return messages;
 }

--- a/js/packages/phoenix-cli/src/commands/promptSet.ts
+++ b/js/packages/phoenix-cli/src/commands/promptSet.ts
@@ -1,0 +1,668 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+
+import { InvalidArgumentError } from "../exitCodes";
+
+type PromptData = componentsV1["schemas"]["PromptData"];
+type PromptVersion = componentsV1["schemas"]["PromptVersion"];
+type PromptVersionData = componentsV1["schemas"]["PromptVersionData"];
+type PromptMessage = componentsV1["schemas"]["PromptMessage"];
+type PromptChatTemplate = componentsV1["schemas"]["PromptChatTemplate"];
+type PromptStringTemplate = componentsV1["schemas"]["PromptStringTemplate"];
+type ModelProvider = componentsV1["schemas"]["ModelProvider"];
+type PromptTemplateFormat = componentsV1["schemas"]["PromptTemplateFormat"];
+type InvocationParameters = PromptVersionData["invocation_parameters"];
+
+export const MODEL_PROVIDERS: readonly ModelProvider[] = [
+  "OPENAI",
+  "AZURE_OPENAI",
+  "ANTHROPIC",
+  "GOOGLE",
+  "DEEPSEEK",
+  "XAI",
+  "OLLAMA",
+  "AWS",
+  "CEREBRAS",
+  "FIREWORKS",
+  "GROQ",
+  "MOONSHOT",
+  "PERPLEXITY",
+  "TOGETHER",
+];
+
+export const TEMPLATE_FORMATS: readonly PromptTemplateFormat[] = [
+  "MUSTACHE",
+  "F_STRING",
+  "NONE",
+];
+
+export const PROMPT_MESSAGE_ROLES: readonly PromptMessage["role"][] = [
+  "user",
+  "assistant",
+  "model",
+  "ai",
+  "tool",
+  "system",
+  "developer",
+];
+
+/**
+ * Prompt names (and version tags) must match the server Identifier pattern:
+ * lowercase letters, digits, hyphens, and underscores, starting and ending
+ * with an alphanumeric character.
+ */
+export const PROMPT_IDENTIFIER_PATTERN = /^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$/;
+
+const DEFAULT_MODEL_PROVIDER: ModelProvider = "OPENAI";
+const DEFAULT_TEMPLATE_FORMAT: PromptTemplateFormat = "MUSTACHE";
+
+export const PROMPT_SET_USAGE_HINT =
+  'px prompt set <name> --template "..." --model gpt-4o';
+
+/**
+ * Fields parsed from `--file` (or stdin). Flags overlay these; a latest
+ * version, when one exists, fills anything still missing.
+ */
+export interface PromptSetFileContents {
+  promptDescription?: string | null;
+  promptMetadata?: Record<string, unknown> | null;
+  version?: Partial<PromptVersionData>;
+  templateText?: string;
+  messages?: PromptMessage[];
+}
+
+/**
+ * Flag-level inputs after JSON / enum / `--message` parsing. Undefined means
+ * the user did not pass that flag.
+ */
+export interface PromptSetParsedFlags {
+  template?: string;
+  messages?: PromptMessage[];
+  model?: string;
+  modelProvider?: ModelProvider;
+  templateFormat?: PromptTemplateFormat;
+  description?: string;
+  versionDescription?: string;
+  invocationParameters?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  tag?: string;
+}
+
+export interface BuildPromptSetRequestInput {
+  /**
+   * Prompt name written to `prompt.name`. Must already be a valid Identifier.
+   */
+  name: string;
+  flags: PromptSetParsedFlags;
+  file?: PromptSetFileContents;
+  /**
+   * Latest version of an existing prompt, used so `set` can change one field
+   * without respecifying the rest.
+   */
+  existing?: PromptVersion;
+}
+
+/**
+ * True when the user supplied at least one field that belongs on a new
+ * prompt version. `--description`, `--metadata`, and `--tag` alone do not
+ * qualify — description/metadata only apply when creating the prompt, and
+ * `--tag` labels the version that `set` writes, it does not retag latest.
+ */
+export function hasPromptVersionInput(options: {
+  template?: string;
+  message?: string[];
+  file?: string;
+  model?: string;
+  modelProvider?: string;
+  templateFormat?: string;
+  versionDescription?: string;
+  invocationParameters?: string;
+}): boolean {
+  return (
+    options.template !== undefined ||
+    (options.message !== undefined && options.message.length > 0) ||
+    options.file !== undefined ||
+    options.model !== undefined ||
+    options.modelProvider !== undefined ||
+    options.templateFormat !== undefined ||
+    options.versionDescription !== undefined ||
+    options.invocationParameters !== undefined
+  );
+}
+
+export function assertPromptIdentifier(value: string, flag: string): string {
+  if (!PROMPT_IDENTIFIER_PATTERN.test(value)) {
+    throw new InvalidArgumentError(
+      `${flag} '${value}' is not a valid prompt identifier. Use lowercase letters, digits, hyphens, and underscores (e.g. my-prompt)`
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse repeatable `--message <role:content>` values. Split is on the first
+ * colon so the content may contain more colons.
+ */
+export function parsePromptMessages(values: string[]): PromptMessage[] {
+  return values.map((value) => {
+    const separatorIndex = value.indexOf(":");
+    if (separatorIndex === -1) {
+      throw new InvalidArgumentError(
+        `Invalid --message '${value}'. Expected role:content, e.g. user:Hello`
+      );
+    }
+    const role = value.slice(0, separatorIndex).trim().toLowerCase();
+    const content = value.slice(separatorIndex + 1);
+    if (!isPromptMessageRole(role)) {
+      throw new InvalidArgumentError(
+        `Invalid --message role '${role}'. Must be one of: ${PROMPT_MESSAGE_ROLES.join(", ")}`
+      );
+    }
+    return { role, content };
+  });
+}
+
+export function parseModelProvider(value: string): ModelProvider {
+  const provider = value.toUpperCase() as ModelProvider;
+  if (!MODEL_PROVIDERS.includes(provider)) {
+    throw new InvalidArgumentError(
+      `Invalid --model-provider '${value}'. Must be one of: ${MODEL_PROVIDERS.join(", ")}`
+    );
+  }
+  return provider;
+}
+
+export function parseTemplateFormat(value: string): PromptTemplateFormat {
+  const format = value.toUpperCase() as PromptTemplateFormat;
+  if (!TEMPLATE_FORMATS.includes(format)) {
+    throw new InvalidArgumentError(
+      `Invalid --template-format '${value}'. Must be one of: ${TEMPLATE_FORMATS.join(", ")}`
+    );
+  }
+  return format;
+}
+
+/**
+ * Parse the CLI flags that can fail without talking to the server.
+ */
+export function parsePromptSetFlags(options: {
+  template?: string;
+  message?: string[];
+  model?: string;
+  modelProvider?: string;
+  templateFormat?: string;
+  description?: string;
+  versionDescription?: string;
+  invocationParameters?: string;
+  metadata?: string;
+  tag?: string;
+}): PromptSetParsedFlags {
+  if (options.template !== undefined && options.template.trim() === "") {
+    throw new InvalidArgumentError("--template must not be empty");
+  }
+  const hasMessages =
+    options.message !== undefined && options.message.length > 0;
+  if (options.template !== undefined && hasMessages) {
+    throw new InvalidArgumentError(
+      "--template and --message cannot be used together. Pass a string template or chat messages, not both"
+    );
+  }
+
+  const flags: PromptSetParsedFlags = {};
+  if (options.template !== undefined) {
+    flags.template = options.template;
+  }
+  if (hasMessages) {
+    flags.messages = parsePromptMessages(options.message ?? []);
+  }
+  if (options.model !== undefined) {
+    if (options.model.trim() === "") {
+      throw new InvalidArgumentError("--model must not be empty");
+    }
+    flags.model = options.model;
+  }
+  if (options.modelProvider !== undefined) {
+    flags.modelProvider = parseModelProvider(options.modelProvider);
+  }
+  if (options.templateFormat !== undefined) {
+    flags.templateFormat = parseTemplateFormat(options.templateFormat);
+  }
+  if (options.description !== undefined) {
+    flags.description = options.description;
+  }
+  if (options.versionDescription !== undefined) {
+    flags.versionDescription = options.versionDescription;
+  }
+  if (options.invocationParameters !== undefined) {
+    flags.invocationParameters = parseObjectFlag(
+      "--invocation-parameters",
+      options.invocationParameters
+    );
+  }
+  if (options.metadata !== undefined) {
+    flags.metadata = parseObjectFlag("--metadata", options.metadata);
+  }
+  if (options.tag !== undefined) {
+    flags.tag = assertPromptIdentifier(options.tag, "--tag");
+  }
+  return flags;
+}
+
+/**
+ * Parse a `--file` payload. Accepts the POST /v1/prompts body, a
+ * `PromptVersion` (including `px prompt get --format raw` output), a
+ * `{ data: PromptVersion }` wrapper, a `{ messages: [...] }` chat template,
+ * or a JSON string treated as a user-message template.
+ */
+export function parsePromptSetFile(contents: string): PromptSetFileContents {
+  const trimmed = contents.trim();
+  if (trimmed === "") {
+    throw new InvalidArgumentError(
+      "--file is empty. Pass a JSON prompt body or the output of px prompt get --format raw"
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new InvalidArgumentError(
+      "--file must be valid JSON. Use --template for a plain-text prompt"
+    );
+  }
+
+  if (typeof parsed === "string") {
+    if (parsed.trim() === "") {
+      throw new InvalidArgumentError("--file JSON string must not be empty");
+    }
+    return { templateText: parsed };
+  }
+
+  if (!isRecord(parsed)) {
+    throw new InvalidArgumentError(
+      "--file must be a JSON object (prompt version, {prompt, version}, or {messages})"
+    );
+  }
+
+  const unwrapped = unwrapPromptVersionRecord(parsed);
+  const file: PromptSetFileContents = {};
+
+  if (isRecord(unwrapped.prompt)) {
+    if (typeof unwrapped.prompt.description === "string") {
+      file.promptDescription = unwrapped.prompt.description;
+    }
+    if (isRecord(unwrapped.prompt.metadata)) {
+      file.promptMetadata = unwrapped.prompt.metadata;
+    }
+  }
+
+  const versionRecord = isRecord(unwrapped.version)
+    ? unwrapped.version
+    : hasVersionShape(unwrapped)
+      ? unwrapped
+      : undefined;
+
+  if (versionRecord !== undefined) {
+    file.version = promptVersionDataFromRecord(versionRecord);
+    if (
+      typeof versionRecord.template === "string" &&
+      versionRecord.template.trim() !== ""
+    ) {
+      file.templateText = versionRecord.template;
+    }
+  }
+
+  if (
+    Array.isArray(unwrapped.messages) &&
+    file.version?.template === undefined
+  ) {
+    file.messages = parseFileMessages(unwrapped.messages);
+  }
+
+  const hasContent =
+    file.version !== undefined ||
+    file.templateText !== undefined ||
+    file.messages !== undefined ||
+    file.promptDescription !== undefined ||
+    file.promptMetadata !== undefined;
+  if (!hasContent) {
+    throw new InvalidArgumentError(
+      "--file JSON must include a prompt version (template / messages) or {prompt, version}"
+    );
+  }
+
+  return file;
+}
+
+export function buildPromptSetRequest({
+  name,
+  flags,
+  file,
+  existing,
+}: BuildPromptSetRequestInput): {
+  prompt: PromptData;
+  version: PromptVersionData;
+} {
+  const template = resolveChatTemplate({ flags, file, existing });
+  const modelName = resolveModelName({ flags, file, existing });
+  const modelProvider = resolveModelProvider({ flags, file, existing });
+  const templateFormat =
+    flags.templateFormat ??
+    file?.version?.template_format ??
+    existing?.template_format ??
+    DEFAULT_TEMPLATE_FORMAT;
+  const versionDescription =
+    flags.versionDescription ??
+    file?.version?.description ??
+    existing?.description ??
+    undefined;
+  const invocationParameters = resolveInvocationParameters({
+    flags,
+    file,
+    existing,
+    modelProvider,
+  });
+  const tools = file?.version?.tools ?? existing?.tools ?? undefined;
+  const responseFormat =
+    file?.version?.response_format ?? existing?.response_format ?? undefined;
+
+  const prompt: PromptData = { name };
+  const description = flags.description ?? file?.promptDescription;
+  if (description !== undefined && description !== null) {
+    prompt.description = description;
+  }
+  const metadata = flags.metadata ?? file?.promptMetadata;
+  if (metadata !== undefined && metadata !== null) {
+    prompt.metadata = metadata;
+  }
+
+  const version: PromptVersionData = {
+    model_provider: modelProvider,
+    model_name: modelName,
+    template,
+    template_type: "CHAT",
+    template_format: templateFormat,
+    invocation_parameters: invocationParameters,
+  };
+  if (versionDescription !== undefined && versionDescription !== null) {
+    version.description = versionDescription;
+  }
+  if (tools !== undefined && tools !== null) {
+    version.tools = tools;
+  }
+  if (responseFormat !== undefined && responseFormat !== null) {
+    version.response_format = responseFormat;
+  }
+
+  return { prompt, version };
+}
+
+function resolveChatTemplate({
+  flags,
+  file,
+  existing,
+}: {
+  flags: PromptSetParsedFlags;
+  file?: PromptSetFileContents;
+  existing?: PromptVersion;
+}): PromptChatTemplate {
+  if (flags.messages !== undefined) {
+    return { type: "chat", messages: flags.messages };
+  }
+  if (flags.template !== undefined) {
+    return userMessageTemplate(flags.template);
+  }
+  if (file?.messages !== undefined) {
+    return { type: "chat", messages: file.messages };
+  }
+  if (file?.templateText !== undefined) {
+    return userMessageTemplate(file.templateText);
+  }
+  if (file?.version?.template !== undefined) {
+    return toChatTemplate(file.version.template);
+  }
+  if (existing?.template !== undefined) {
+    return toChatTemplate(existing.template);
+  }
+  throw new InvalidArgumentError(
+    "Missing prompt template. Pass --template, --message, or --file"
+  );
+}
+
+function resolveModelName({
+  flags,
+  file,
+  existing,
+}: {
+  flags: PromptSetParsedFlags;
+  file?: PromptSetFileContents;
+  existing?: PromptVersion;
+}): string {
+  const modelName =
+    flags.model ?? file?.version?.model_name ?? existing?.model_name;
+  if (modelName === undefined || modelName.trim() === "") {
+    throw new InvalidArgumentError("Missing required flag --model");
+  }
+  return modelName;
+}
+
+function resolveModelProvider({
+  flags,
+  file,
+  existing,
+}: {
+  flags: PromptSetParsedFlags;
+  file?: PromptSetFileContents;
+  existing?: PromptVersion;
+}): ModelProvider {
+  return (
+    flags.modelProvider ??
+    file?.version?.model_provider ??
+    existing?.model_provider ??
+    DEFAULT_MODEL_PROVIDER
+  );
+}
+
+function resolveInvocationParameters({
+  flags,
+  file,
+  existing,
+  modelProvider,
+}: {
+  flags: PromptSetParsedFlags;
+  file?: PromptSetFileContents;
+  existing?: PromptVersion;
+  modelProvider: ModelProvider;
+}): InvocationParameters {
+  if (flags.invocationParameters !== undefined) {
+    return buildInvocationParameters(modelProvider, flags.invocationParameters);
+  }
+  if (
+    file?.version?.invocation_parameters !== undefined &&
+    invocationParametersMatchProvider(
+      file.version.invocation_parameters,
+      modelProvider
+    )
+  ) {
+    return file.version.invocation_parameters;
+  }
+  if (
+    existing?.invocation_parameters !== undefined &&
+    existing.model_provider === modelProvider
+  ) {
+    return existing.invocation_parameters;
+  }
+  return buildInvocationParameters(modelProvider, {});
+}
+
+function userMessageTemplate(template: string): PromptChatTemplate {
+  return { type: "chat", messages: [{ role: "user", content: template }] };
+}
+
+function toChatTemplate(
+  template: PromptChatTemplate | PromptStringTemplate
+): PromptChatTemplate {
+  if (template.type === "string") {
+    return userMessageTemplate(template.template);
+  }
+  return template;
+}
+
+/**
+ * Build the provider-discriminated invocation-parameters object. Anthropic
+ * requires `max_tokens`; every other provider accepts an empty object.
+ */
+export function buildInvocationParameters(
+  provider: ModelProvider,
+  content: Record<string, unknown>
+): InvocationParameters {
+  const unwrapped = unwrapInvocationContent(content, provider);
+  if (provider === "ANTHROPIC" && typeof unwrapped.max_tokens !== "number") {
+    throw new InvalidArgumentError(
+      "ANTHROPIC prompts require max_tokens in --invocation-parameters, e.g. '{\"max_tokens\":1024}'"
+    );
+  }
+  const key = provider.toLowerCase();
+  return {
+    type: key,
+    [key]: unwrapped,
+  } as InvocationParameters;
+}
+
+function unwrapInvocationContent(
+  content: Record<string, unknown>,
+  provider: ModelProvider
+): Record<string, unknown> {
+  const key = provider.toLowerCase();
+  if (content.type === key && isRecord(content[key])) {
+    return content[key];
+  }
+  return content;
+}
+
+function invocationParametersMatchProvider(
+  parameters: InvocationParameters,
+  provider: ModelProvider
+): boolean {
+  return parameters.type === provider.toLowerCase();
+}
+
+function parseObjectFlag(flag: string, raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new InvalidArgumentError(`${flag} must be valid JSON`);
+  }
+  if (!isRecord(parsed)) {
+    throw new InvalidArgumentError(`${flag} must be a JSON object`);
+  }
+  return parsed;
+}
+
+function unwrapPromptVersionRecord(
+  parsed: Record<string, unknown>
+): Record<string, unknown> {
+  if (isRecord(parsed.data) && !isRecord(parsed.version)) {
+    return parsed.data;
+  }
+  return parsed;
+}
+
+function hasVersionShape(value: Record<string, unknown>): boolean {
+  return (
+    value.template !== undefined ||
+    value.model_name !== undefined ||
+    value.model_provider !== undefined ||
+    value.template_type !== undefined ||
+    value.invocation_parameters !== undefined
+  );
+}
+
+function promptVersionDataFromRecord(
+  record: Record<string, unknown>
+): Partial<PromptVersionData> {
+  const version: Partial<PromptVersionData> = {};
+  if (typeof record.description === "string") {
+    version.description = record.description;
+  }
+  if (typeof record.model_name === "string") {
+    version.model_name = record.model_name;
+  }
+  if (typeof record.model_provider === "string") {
+    version.model_provider = parseModelProvider(record.model_provider);
+  }
+  if (typeof record.template_format === "string") {
+    version.template_format = parseTemplateFormat(record.template_format);
+  }
+  if (isPromptTemplate(record.template)) {
+    version.template = record.template;
+  }
+  if (
+    isRecord(record.invocation_parameters) &&
+    record.invocation_parameters.type
+  ) {
+    version.invocation_parameters =
+      record.invocation_parameters as InvocationParameters;
+  }
+  if (record.tools !== undefined) {
+    version.tools = record.tools as PromptVersionData["tools"];
+  }
+  if (record.response_format !== undefined) {
+    version.response_format =
+      record.response_format as PromptVersionData["response_format"];
+  }
+  return version;
+}
+
+function isPromptTemplate(
+  value: unknown
+): value is PromptChatTemplate | PromptStringTemplate {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return false;
+  }
+  if (value.type === "string") {
+    return typeof value.template === "string";
+  }
+  if (value.type === "chat") {
+    return Array.isArray(value.messages);
+  }
+  return false;
+}
+
+function parseFileMessages(values: unknown[]): PromptMessage[] {
+  const messages: PromptMessage[] = [];
+  for (const value of values) {
+    if (!isRecord(value) || typeof value.role !== "string") {
+      throw new InvalidArgumentError(
+        "--file messages must be objects with a role and content"
+      );
+    }
+    const role = value.role.toLowerCase();
+    if (!isPromptMessageRole(role)) {
+      throw new InvalidArgumentError(
+        `Invalid message role '${value.role}' in --file. Must be one of: ${PROMPT_MESSAGE_ROLES.join(", ")}`
+      );
+    }
+    if (typeof value.content !== "string" && !Array.isArray(value.content)) {
+      throw new InvalidArgumentError(
+        "--file messages must include string or content-part content"
+      );
+    }
+    messages.push({
+      role,
+      content: value.content as PromptMessage["content"],
+    });
+  }
+  if (messages.length === 0) {
+    throw new InvalidArgumentError("--file messages must not be empty");
+  }
+  return messages;
+}
+
+function isPromptMessageRole(value: string): value is PromptMessage["role"] {
+  return (PROMPT_MESSAGE_ROLES as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/js/packages/phoenix-cli/test/promptCommand.test.ts
+++ b/js/packages/phoenix-cli/test/promptCommand.test.ts
@@ -177,7 +177,7 @@ describe("prompt get", () => {
 });
 
 describe("prompt set", () => {
-  it("POSTs a new prompt from --template and --model when latest is missing", async () => {
+  it("POSTs a new prompt from --template, --model, and --model-provider when latest is missing", async () => {
     const captured: { body?: Record<string, unknown>; count: number } = {
       count: 0,
     };
@@ -204,6 +204,8 @@ describe("prompt set", () => {
         "Hello {{name}}",
         "--model",
         "gpt-4o",
+        "--model-provider",
+        "OPENAI",
         "--format",
         "raw",
         ...BASE_ARGS,
@@ -308,7 +310,7 @@ describe("prompt set", () => {
         [
           "set",
           "greeting",
-          "--file",
+          "--json",
           filePath,
           "--tag",
           "production",
@@ -347,6 +349,8 @@ describe("prompt set", () => {
           "greeting",
           "--template",
           "Hello",
+          "--model-provider",
+          "OPENAI",
           "--format",
           "raw",
           ...BASE_ARGS,
@@ -358,6 +362,38 @@ describe("prompt set", () => {
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining("Missing required flag --model")
+    );
+  });
+
+  it("exits INVALID_ARGUMENT when creating without --model-provider", async () => {
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      )
+    );
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createPromptCommand().parseAsync(
+        [
+          "set",
+          "greeting",
+          "--template",
+          "Hello",
+          "--model",
+          "gpt-4o",
+          "--format",
+          "raw",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Missing required flag --model-provider")
     );
   });
 
@@ -418,6 +454,8 @@ describe("prompt set", () => {
         "Hello {{name}}",
         "--model",
         "gpt-4o",
+        "--model-provider",
+        "OPENAI",
         "--format",
         "raw",
         ...BASE_ARGS,

--- a/js/packages/phoenix-cli/test/promptCommand.test.ts
+++ b/js/packages/phoenix-cli/test/promptCommand.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import type { componentsV1 } from "@arizeai/phoenix-testing";
 import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -170,5 +173,260 @@ describe("prompt get", () => {
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining("Error fetching prompt")
     );
+  });
+});
+
+describe("prompt set", () => {
+  it("POSTs a new prompt from --template and --model when latest is missing", async () => {
+    const captured: { body?: Record<string, unknown>; count: number } = {
+      count: 0,
+    };
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      ),
+      http.post("/v1/prompts", async ({ request, response }) => {
+        captured.count += 1;
+        captured.body = (await request.clone().json()) as Record<
+          string,
+          unknown
+        >;
+        return response(200).json({ data: PROMPT_VERSION });
+      })
+    );
+    const io = captureCliOutput();
+
+    await createPromptCommand().parseAsync(
+      [
+        "set",
+        "greeting",
+        "--template",
+        "Hello {{name}}",
+        "--model",
+        "gpt-4o",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    expect(captured.body).toEqual({
+      prompt: { name: "greeting" },
+      version: {
+        model_provider: "OPENAI",
+        model_name: "gpt-4o",
+        template: {
+          type: "chat",
+          messages: [{ role: "user", content: "Hello {{name}}" }],
+        },
+        template_type: "CHAT",
+        template_format: "MUSTACHE",
+        invocation_parameters: { type: "openai", openai: {} },
+      },
+    });
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
+    expect(parsed).toEqual(PROMPT_VERSION);
+  });
+
+  it("inherits model from the latest version when only --template is passed", async () => {
+    const captured: { body?: Record<string, unknown>; count: number } = {
+      count: 0,
+    };
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", ({ response }) =>
+        response(200).json({ data: PROMPT_VERSION })
+      ),
+      http.post("/v1/prompts", async ({ request, response }) => {
+        captured.count += 1;
+        captured.body = (await request.clone().json()) as Record<
+          string,
+          unknown
+        >;
+        return response(200).json({ data: PROMPT_VERSION });
+      })
+    );
+    captureCliOutput();
+
+    await createPromptCommand().parseAsync(
+      [
+        "set",
+        "greeting",
+        "--template",
+        "Hi {{name}}",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    const version = captured.body?.version as {
+      model_name?: string;
+      template?: { messages?: Array<{ content?: string }> };
+    };
+    expect(version.model_name).toBe("gpt-4o");
+    expect(version.template?.messages?.[0]?.content).toBe("Hi {{name}}");
+  });
+
+  it("reads a PromptVersion JSON file and tags the new version", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "px-prompt-set-"));
+    const filePath = path.join(tmpDir, "prompt.json");
+    fs.writeFileSync(filePath, JSON.stringify(PROMPT_VERSION));
+    const captured: {
+      body?: Record<string, unknown>;
+      tagName?: string;
+      tagCount: number;
+    } = { tagCount: 0 };
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      ),
+      http.post("/v1/prompts", async ({ request, response }) => {
+        captured.body = (await request.clone().json()) as Record<
+          string,
+          unknown
+        >;
+        return response(200).json({ data: PROMPT_VERSION });
+      }),
+      http.post(
+        "/v1/prompt_versions/{prompt_version_id}/tags",
+        async ({ request, response }) => {
+          captured.tagCount += 1;
+          const tagBody = (await request.clone().json()) as { name?: string };
+          captured.tagName = tagBody.name;
+          return response(204).empty();
+        }
+      )
+    );
+    const io = captureCliOutput();
+
+    try {
+      await createPromptCommand().parseAsync(
+        [
+          "set",
+          "greeting",
+          "--file",
+          filePath,
+          "--tag",
+          "production",
+          "--format",
+          "raw",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    expect(captured.tagCount).toBe(1);
+    expect(captured.tagName).toBe("production");
+    const version = captured.body?.version as { model_name?: string };
+    expect(version.model_name).toBe("gpt-4o");
+    expect(JSON.parse(String(io.stdout.mock.calls[0]?.[0]))).toEqual(
+      PROMPT_VERSION
+    );
+  });
+
+  it("exits INVALID_ARGUMENT when creating without --model", async () => {
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      )
+    );
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createPromptCommand().parseAsync(
+        [
+          "set",
+          "greeting",
+          "--template",
+          "Hello",
+          "--format",
+          "raw",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Missing required flag --model")
+    );
+  });
+
+  it("exits INVALID_ARGUMENT when no template or version field is given", async () => {
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createPromptCommand().parseAsync(
+        ["set", "greeting", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Provide a template")
+    );
+  });
+
+  it("exits NETWORK_ERROR when the connection fails", async () => {
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", () =>
+        HttpResponse.error()
+      )
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createPromptCommand().parseAsync(
+        [
+          "set",
+          "greeting",
+          "--template",
+          "Hello",
+          "--model",
+          "gpt-4o",
+          "--format",
+          "raw",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+  });
+
+  it("succeeds end-to-end against the generated OpenAPI handlers", async () => {
+    const io = captureCliOutput();
+
+    await createPromptCommand().parseAsync(
+      [
+        "set",
+        "greeting",
+        "--template",
+        "Hello {{name}}",
+        "--model",
+        "gpt-4o",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
+    expect(typeof parsed.id).toBe("string");
+    expect(parsed.template).toBeDefined();
   });
 });

--- a/js/packages/phoenix-cli/test/promptSet.test.ts
+++ b/js/packages/phoenix-cli/test/promptSet.test.ts
@@ -7,8 +7,8 @@ import {
   buildPromptSetRequest,
   hasPromptVersionInput,
   parsePromptMessages,
-  parsePromptSetFile,
   parsePromptSetFlags,
+  parsePromptSetJson,
 } from "../src/commands/promptSet";
 import { InvalidArgumentError } from "../src/exitCodes";
 
@@ -29,10 +29,10 @@ describe("hasPromptVersionInput", () => {
     expect(hasPromptVersionInput({ message: [] })).toBe(false);
   });
 
-  it("is true for a template, messages, file, or version field", () => {
+  it("is true for a template, messages, json, or version field", () => {
     expect(hasPromptVersionInput({ template: "Hi" })).toBe(true);
     expect(hasPromptVersionInput({ message: ["user:Hi"] })).toBe(true);
-    expect(hasPromptVersionInput({ file: "p.json" })).toBe(true);
+    expect(hasPromptVersionInput({ json: "p.json" })).toBe(true);
     expect(hasPromptVersionInput({ model: "gpt-4o" })).toBe(true);
   });
 });
@@ -102,18 +102,18 @@ describe("parsePromptSetFlags", () => {
   });
 });
 
-describe("parsePromptSetFile", () => {
+describe("parsePromptSetJson", () => {
   it("accepts a PromptVersion from px prompt get --format raw", () => {
-    const file = parsePromptSetFile(JSON.stringify(EXISTING));
-    expect(file.version?.model_name).toBe("gpt-4o");
-    expect(file.version?.template).toEqual({
+    const parsed = parsePromptSetJson(JSON.stringify(EXISTING));
+    expect(parsed.version?.model_name).toBe("gpt-4o");
+    expect(parsed.version?.template).toEqual({
       type: "string",
       template: "Hello {{name}}",
     });
   });
 
   it("accepts a {prompt, version} POST body", () => {
-    const file = parsePromptSetFile(
+    const parsed = parsePromptSetJson(
       JSON.stringify({
         prompt: { name: "greeting", description: "says hello" },
         version: {
@@ -129,8 +129,8 @@ describe("parsePromptSetFile", () => {
         },
       })
     );
-    expect(file.promptDescription).toBe("says hello");
-    expect(file.version?.template).toEqual({
+    expect(parsed.promptDescription).toBe("says hello");
+    expect(parsed.version?.template).toEqual({
       type: "chat",
       messages: [{ role: "user", content: "Hi" }],
     });
@@ -138,19 +138,19 @@ describe("parsePromptSetFile", () => {
 
   it("accepts {messages: [...]} and a JSON string template", () => {
     expect(
-      parsePromptSetFile(
+      parsePromptSetJson(
         JSON.stringify({ messages: [{ role: "user", content: "Hi" }] })
       ).messages
     ).toEqual([{ role: "user", content: "Hi" }]);
-    expect(parsePromptSetFile(JSON.stringify("Hello"))).toEqual({
+    expect(parsePromptSetJson(JSON.stringify("Hello"))).toEqual({
       templateText: "Hello",
     });
   });
 
   it("rejects empty or non-object JSON", () => {
-    expect(() => parsePromptSetFile("")).toThrow(InvalidArgumentError);
-    expect(() => parsePromptSetFile("[]")).toThrow(InvalidArgumentError);
-    expect(() => parsePromptSetFile("not json")).toThrow(InvalidArgumentError);
+    expect(() => parsePromptSetJson("")).toThrow(InvalidArgumentError);
+    expect(() => parsePromptSetJson("[]")).toThrow(InvalidArgumentError);
+    expect(() => parsePromptSetJson("not json")).toThrow(InvalidArgumentError);
   });
 });
 
@@ -185,10 +185,14 @@ describe("buildInvocationParameters", () => {
 });
 
 describe("buildPromptSetRequest", () => {
-  it("creates a chat version from --template and --model", () => {
+  it("creates a chat version from --template, --model, and --model-provider", () => {
     const { prompt, version } = buildPromptSetRequest({
       name: "greeting",
-      flags: { template: "Hello {{name}}", model: "gpt-4o" },
+      flags: {
+        template: "Hello {{name}}",
+        model: "gpt-4o",
+        modelProvider: "OPENAI",
+      },
     });
     expect(prompt).toEqual({ name: "greeting" });
     expect(version.model_provider).toBe("OPENAI");
@@ -242,11 +246,11 @@ describe("buildPromptSetRequest", () => {
     });
   });
 
-  it("overlays --file onto flags", () => {
+  it("overlays --json onto flags", () => {
     const { prompt, version } = buildPromptSetRequest({
       name: "greeting",
       flags: { model: "gpt-4.1", description: "from flags" },
-      file: parsePromptSetFile(JSON.stringify(EXISTING)),
+      json: parsePromptSetJson(JSON.stringify(EXISTING)),
     });
     expect(prompt.description).toBe("from flags");
     expect(version.model_name).toBe("gpt-4.1");
@@ -256,12 +260,30 @@ describe("buildPromptSetRequest", () => {
     });
   });
 
-  it("requires --model when creating without a file", () => {
+  it("requires --model when creating without JSON input", () => {
     expect(() =>
       buildPromptSetRequest({
         name: "greeting",
-        flags: { template: "Hello" },
+        flags: { template: "Hello", modelProvider: "OPENAI" },
       })
     ).toThrow(InvalidArgumentError);
+  });
+
+  it("requires --model-provider when creating without JSON input", () => {
+    expect(() =>
+      buildPromptSetRequest({
+        name: "greeting",
+        flags: { template: "Hello", model: "gpt-4o" },
+      })
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it("inherits the provider from --json when the flag is omitted", () => {
+    const { version } = buildPromptSetRequest({
+      name: "greeting",
+      flags: { template: "Hello" },
+      json: parsePromptSetJson(JSON.stringify(EXISTING)),
+    });
+    expect(version.model_provider).toBe("OPENAI");
   });
 });

--- a/js/packages/phoenix-cli/test/promptSet.test.ts
+++ b/js/packages/phoenix-cli/test/promptSet.test.ts
@@ -1,0 +1,267 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertPromptIdentifier,
+  buildInvocationParameters,
+  buildPromptSetRequest,
+  hasPromptVersionInput,
+  parsePromptMessages,
+  parsePromptSetFile,
+  parsePromptSetFlags,
+} from "../src/commands/promptSet";
+import { InvalidArgumentError } from "../src/exitCodes";
+
+const EXISTING: componentsV1["schemas"]["PromptVersion"] = {
+  id: "pv-001",
+  description: "first version",
+  model_provider: "OPENAI",
+  model_name: "gpt-4o",
+  template: { type: "string", template: "Hello {{name}}" },
+  template_type: "STR",
+  template_format: "MUSTACHE",
+  invocation_parameters: { type: "openai", openai: { temperature: 0.5 } },
+};
+
+describe("hasPromptVersionInput", () => {
+  it("is false when only description or tag would change", () => {
+    expect(hasPromptVersionInput({ tag: "production" })).toBe(false);
+    expect(hasPromptVersionInput({ message: [] })).toBe(false);
+  });
+
+  it("is true for a template, messages, file, or version field", () => {
+    expect(hasPromptVersionInput({ template: "Hi" })).toBe(true);
+    expect(hasPromptVersionInput({ message: ["user:Hi"] })).toBe(true);
+    expect(hasPromptVersionInput({ file: "p.json" })).toBe(true);
+    expect(hasPromptVersionInput({ model: "gpt-4o" })).toBe(true);
+  });
+});
+
+describe("assertPromptIdentifier", () => {
+  it("accepts lowercase identifier names", () => {
+    expect(assertPromptIdentifier("greeting", "Prompt name")).toBe("greeting");
+    expect(assertPromptIdentifier("my-prompt_1", "Prompt name")).toBe(
+      "my-prompt_1"
+    );
+  });
+
+  it("rejects uppercase names and IDs", () => {
+    expect(() => assertPromptIdentifier("Greeting", "Prompt name")).toThrow(
+      InvalidArgumentError
+    );
+    expect(() => assertPromptIdentifier("UHJvbXB0OjE=", "Prompt name")).toThrow(
+      InvalidArgumentError
+    );
+  });
+});
+
+describe("parsePromptMessages", () => {
+  it("splits on the first colon and lowercases the role", () => {
+    expect(
+      parsePromptMessages(["SYSTEM:Be nice", "user:Hello: world"])
+    ).toEqual([
+      { role: "system", content: "Be nice" },
+      { role: "user", content: "Hello: world" },
+    ]);
+  });
+
+  it("rejects a missing colon or unknown role", () => {
+    expect(() => parsePromptMessages(["hello"])).toThrow(InvalidArgumentError);
+    expect(() => parsePromptMessages(["narrator:hi"])).toThrow(
+      InvalidArgumentError
+    );
+  });
+});
+
+describe("parsePromptSetFlags", () => {
+  it("rejects --template together with --message", () => {
+    expect(() =>
+      parsePromptSetFlags({
+        template: "Hi",
+        message: ["user:Hi"],
+      })
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it("parses invocation-parameters and metadata JSON objects", () => {
+    const flags = parsePromptSetFlags({
+      invocationParameters: '{"temperature":0.2}',
+      metadata: '{"team":"evals"}',
+    });
+    expect(flags.invocationParameters).toEqual({ temperature: 0.2 });
+    expect(flags.metadata).toEqual({ team: "evals" });
+  });
+
+  it("rejects invalid JSON flags", () => {
+    expect(() =>
+      parsePromptSetFlags({ invocationParameters: "not-json" })
+    ).toThrow(InvalidArgumentError);
+    expect(() => parsePromptSetFlags({ metadata: "[1]" })).toThrow(
+      InvalidArgumentError
+    );
+  });
+});
+
+describe("parsePromptSetFile", () => {
+  it("accepts a PromptVersion from px prompt get --format raw", () => {
+    const file = parsePromptSetFile(JSON.stringify(EXISTING));
+    expect(file.version?.model_name).toBe("gpt-4o");
+    expect(file.version?.template).toEqual({
+      type: "string",
+      template: "Hello {{name}}",
+    });
+  });
+
+  it("accepts a {prompt, version} POST body", () => {
+    const file = parsePromptSetFile(
+      JSON.stringify({
+        prompt: { name: "greeting", description: "says hello" },
+        version: {
+          model_provider: "OPENAI",
+          model_name: "gpt-4o",
+          template: {
+            type: "chat",
+            messages: [{ role: "user", content: "Hi" }],
+          },
+          template_type: "CHAT",
+          template_format: "MUSTACHE",
+          invocation_parameters: { type: "openai", openai: {} },
+        },
+      })
+    );
+    expect(file.promptDescription).toBe("says hello");
+    expect(file.version?.template).toEqual({
+      type: "chat",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+  });
+
+  it("accepts {messages: [...]} and a JSON string template", () => {
+    expect(
+      parsePromptSetFile(
+        JSON.stringify({ messages: [{ role: "user", content: "Hi" }] })
+      ).messages
+    ).toEqual([{ role: "user", content: "Hi" }]);
+    expect(parsePromptSetFile(JSON.stringify("Hello"))).toEqual({
+      templateText: "Hello",
+    });
+  });
+
+  it("rejects empty or non-object JSON", () => {
+    expect(() => parsePromptSetFile("")).toThrow(InvalidArgumentError);
+    expect(() => parsePromptSetFile("[]")).toThrow(InvalidArgumentError);
+    expect(() => parsePromptSetFile("not json")).toThrow(InvalidArgumentError);
+  });
+});
+
+describe("buildInvocationParameters", () => {
+  it("wraps a bare object in the provider discriminator", () => {
+    expect(buildInvocationParameters("OPENAI", { temperature: 0.2 })).toEqual({
+      type: "openai",
+      openai: { temperature: 0.2 },
+    });
+  });
+
+  it("unwraps an already-wrapped object", () => {
+    expect(
+      buildInvocationParameters("OPENAI", {
+        type: "openai",
+        openai: { temperature: 0.1 },
+      })
+    ).toEqual({ type: "openai", openai: { temperature: 0.1 } });
+  });
+
+  it("requires max_tokens for Anthropic", () => {
+    expect(() => buildInvocationParameters("ANTHROPIC", {})).toThrow(
+      InvalidArgumentError
+    );
+    expect(
+      buildInvocationParameters("ANTHROPIC", { max_tokens: 1024 })
+    ).toEqual({
+      type: "anthropic",
+      anthropic: { max_tokens: 1024 },
+    });
+  });
+});
+
+describe("buildPromptSetRequest", () => {
+  it("creates a chat version from --template and --model", () => {
+    const { prompt, version } = buildPromptSetRequest({
+      name: "greeting",
+      flags: { template: "Hello {{name}}", model: "gpt-4o" },
+    });
+    expect(prompt).toEqual({ name: "greeting" });
+    expect(version.model_provider).toBe("OPENAI");
+    expect(version.model_name).toBe("gpt-4o");
+    expect(version.template_type).toBe("CHAT");
+    expect(version.template).toEqual({
+      type: "chat",
+      messages: [{ role: "user", content: "Hello {{name}}" }],
+    });
+    expect(version.invocation_parameters).toEqual({
+      type: "openai",
+      openai: {},
+    });
+  });
+
+  it("inherits model and converts a string template when updating", () => {
+    const { version } = buildPromptSetRequest({
+      name: "greeting",
+      flags: { template: "Hi {{name}}" },
+      existing: EXISTING,
+    });
+    expect(version.model_name).toBe("gpt-4o");
+    expect(version.model_provider).toBe("OPENAI");
+    expect(version.template).toEqual({
+      type: "chat",
+      messages: [{ role: "user", content: "Hi {{name}}" }],
+    });
+    expect(version.invocation_parameters).toEqual({
+      type: "openai",
+      openai: { temperature: 0.5 },
+    });
+  });
+
+  it("rebuilds invocation parameters when the provider changes", () => {
+    const { version } = buildPromptSetRequest({
+      name: "greeting",
+      flags: {
+        modelProvider: "GOOGLE",
+        model: "gemini-2.0-flash",
+      },
+      existing: EXISTING,
+    });
+    expect(version.model_provider).toBe("GOOGLE");
+    expect(version.invocation_parameters).toEqual({
+      type: "google",
+      google: {},
+    });
+    expect(version.template).toEqual({
+      type: "chat",
+      messages: [{ role: "user", content: "Hello {{name}}" }],
+    });
+  });
+
+  it("overlays --file onto flags", () => {
+    const { prompt, version } = buildPromptSetRequest({
+      name: "greeting",
+      flags: { model: "gpt-4.1", description: "from flags" },
+      file: parsePromptSetFile(JSON.stringify(EXISTING)),
+    });
+    expect(prompt.description).toBe("from flags");
+    expect(version.model_name).toBe("gpt-4.1");
+    expect(version.template).toEqual({
+      type: "chat",
+      messages: [{ role: "user", content: "Hello {{name}}" }],
+    });
+  });
+
+  it("requires --model when creating without a file", () => {
+    expect(() =>
+      buildPromptSetRequest({
+        name: "greeting",
+        flags: { template: "Hello" },
+      })
+    ).toThrow(InvalidArgumentError);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `px prompt set <name>` so the CLI can create a prompt or append a new version (the existing `POST /v1/prompts` upsert).
- Accept a string `--template`, repeatable `--message role:content`, or `--file` JSON (including `px prompt get --format raw` and stdin via `-`). Omitted fields are copied from the latest version.
- Document the command in the CLI README and Phoenix CLI skill, and cover create, update, file/tag, and error paths in tests.

## Test plan

- [ ] `cd js/packages/phoenix-cli && pnpm test -- test/promptSet.test.ts test/promptCommand.test.ts`
- [ ] `px prompt set greeting --template "Hello {{name}}" --model gpt-4o --format raw --no-progress` creates a prompt
- [ ] Re-run with a new `--template` only and confirm the model is inherited on the new version
- [ ] `px prompt get greeting --format raw --no-progress | px prompt set greeting --file -` round-trips
- [ ] `px prompt set greeting --file prompt.json --tag production` tags the written version
- [ ] Missing `--model` on create and a bare `px prompt set greeting` both exit `3` (`INVALID_ARGUMENT`)