### PR TITLE
fix: upgrade to anthropic SDK v1

### DIFF
--- a/docs/phoenix/integrations/llm-providers/anthropic/anthropic-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/anthropic/anthropic-tracing.mdx
@@ -28,7 +28,6 @@ client = anthropic.Anthropic()
 message = client.messages.create(
     model="claude-3-5-sonnet-20240620",
     max_tokens=1000,
-    temperature=0,
     messages=[
         {
             "role": "user",

--- a/examples/computer_use_agent/requirements.txt
+++ b/examples/computer_use_agent/requirements.txt
@@ -10,9 +10,7 @@ loguru==0.7.2
 pandas==2.2.3
 python-dotenv==1.2.2
 tqdm==4.66.6
-# Left unpinned deliberately: langchain-anthropic still requires anthropic<1, so
-# this example resolves to 0.x until that cap is lifted. Pinning anthropic>=1 here
-# would make the file unresolvable.
+# langchain-anthropic requires anthropic<1, which caps this example at 0.x.
 anthropic
 gradio
 openinference-instrumentation-anthropic

--- a/examples/computer_use_agent/requirements.txt
+++ b/examples/computer_use_agent/requirements.txt
@@ -10,6 +10,9 @@ loguru==0.7.2
 pandas==2.2.3
 python-dotenv==1.2.2
 tqdm==4.66.6
+# Left unpinned deliberately: langchain-anthropic still requires anthropic<1, so
+# this example resolves to 0.x until that cap is lifted. Pinning anthropic>=1 here
+# would make the file unresolvable.
 anthropic
 gradio
 openinference-instrumentation-anthropic

--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/anthropic/messages.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/anthropic/messages.py
@@ -88,9 +88,8 @@ class _InvocationParameters(TypedDict, total=False):
     max_tokens: Required[int]
     output_config: OutputConfigParam
     stop_sequences: list[str]
-    # Carries `temperature` / `top_p`, which are no longer keyword arguments of
-    # `messages.create()` but are still honored on the wire by models that accept
-    # sampling parameters.
+    # Carries `temperature` / `top_p`, which reach the request JSON through
+    # `extra_body` rather than as keyword arguments.
     extra_body: dict[str, Any]
     thinking: Union[
         ThinkingConfigEnabledParam,
@@ -250,10 +249,8 @@ class _InvocationParametersConversion:
         ans: _InvocationParameters = _InvocationParameters(
             max_tokens=_DEFAULT_MAX_TOKENS,
         )
-        # `temperature` and `top_p` are not accepted as keyword arguments by
-        # `messages.create()`, so they cannot be returned alongside the other kwargs.
-        # `extra_body` is merged into the request JSON verbatim, which puts them back
-        # on the wire for the models that still honor them.
+        # `messages.create()` accepts no sampling parameters. `extra_body` merges them
+        # into the request JSON, which is how the models that support them receive them.
         sampling: dict[str, Any] = {}
         if obj["type"] == "anthropic":
             anthropic_params: v1.PromptAnthropicInvocationParametersContent
@@ -429,9 +426,8 @@ class _InvocationParametersConversion:
         content = v1.PromptAnthropicInvocationParametersContent(
             max_tokens=obj["max_tokens"],
         )
-        # Sampling parameters travel in `extra_body`, since `messages.create()` no
-        # longer takes them as keyword arguments. Kwargs built against an older SDK
-        # still carry them at the top level, so read whichever place they appear in.
+        # Sampling parameters arrive in `extra_body`. Kwargs built against anthropic
+        # 0.x carry them at the top level, so accept either placement.
         raw = cast("Mapping[str, Any]", obj)
         raw_extra_body = cast("Mapping[str, Any]", raw.get("extra_body") or {})
         temperature = raw_extra_body.get("temperature", raw.get("temperature"))

--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/anthropic/messages.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/anthropic/messages.py
@@ -88,8 +88,10 @@ class _InvocationParameters(TypedDict, total=False):
     max_tokens: Required[int]
     output_config: OutputConfigParam
     stop_sequences: list[str]
-    temperature: float
-    top_p: float
+    # Carries `temperature` / `top_p`, which are no longer keyword arguments of
+    # `messages.create()` but are still honored on the wire by models that accept
+    # sampling parameters.
+    extra_body: dict[str, Any]
     thinking: Union[
         ThinkingConfigEnabledParam,
         ThinkingConfigDisabledParam,
@@ -248,15 +250,20 @@ class _InvocationParametersConversion:
         ans: _InvocationParameters = _InvocationParameters(
             max_tokens=_DEFAULT_MAX_TOKENS,
         )
+        # `temperature` and `top_p` are not accepted as keyword arguments by
+        # `messages.create()`, so they cannot be returned alongside the other kwargs.
+        # `extra_body` is merged into the request JSON verbatim, which puts them back
+        # on the wire for the models that still honor them.
+        sampling: dict[str, Any] = {}
         if obj["type"] == "anthropic":
             anthropic_params: v1.PromptAnthropicInvocationParametersContent
             anthropic_params = obj["anthropic"]
             if "max_tokens" in anthropic_params:
                 ans["max_tokens"] = anthropic_params["max_tokens"]
             if "temperature" in anthropic_params:
-                ans["temperature"] = anthropic_params["temperature"]
+                sampling["temperature"] = anthropic_params["temperature"]
             if "top_p" in anthropic_params:
-                ans["top_p"] = anthropic_params["top_p"]
+                sampling["top_p"] = anthropic_params["top_p"]
             if "stop_sequences" in anthropic_params:
                 ans["stop_sequences"] = list(anthropic_params["stop_sequences"])
             if "output_config" in anthropic_params:
@@ -293,36 +300,36 @@ class _InvocationParametersConversion:
             if "max_tokens" in openai_params:
                 ans["max_tokens"] = openai_params["max_tokens"]
             if "temperature" in openai_params:
-                ans["temperature"] = openai_params["temperature"]
+                sampling["temperature"] = openai_params["temperature"]
             if "top_p" in openai_params:
-                ans["top_p"] = openai_params["top_p"]
+                sampling["top_p"] = openai_params["top_p"]
         elif obj["type"] == "azure_openai":
             azure_params: v1.PromptAzureOpenAIInvocationParametersContent
             azure_params = obj["azure_openai"]
             if "max_tokens" in azure_params:
                 ans["max_tokens"] = azure_params["max_tokens"]
             if "temperature" in azure_params:
-                ans["temperature"] = azure_params["temperature"]
+                sampling["temperature"] = azure_params["temperature"]
             if "top_p" in azure_params:
-                ans["top_p"] = azure_params["top_p"]
+                sampling["top_p"] = azure_params["top_p"]
         elif obj["type"] == "google":
             google_params: v1.PromptGoogleInvocationParametersContent
             google_params = obj["google"]
             if "max_output_tokens" in google_params:
                 ans["max_tokens"] = google_params["max_output_tokens"]
             if "temperature" in google_params:
-                ans["temperature"] = google_params["temperature"]
+                sampling["temperature"] = google_params["temperature"]
             if "top_p" in google_params:
-                ans["top_p"] = google_params["top_p"]
+                sampling["top_p"] = google_params["top_p"]
         elif obj["type"] == "aws":
             aws_params: v1.PromptAwsInvocationParametersContent
             aws_params = obj["aws"]
             if "max_tokens" in aws_params:
                 ans["max_tokens"] = aws_params["max_tokens"]
             if "temperature" in aws_params:
-                ans["temperature"] = aws_params["temperature"]
+                sampling["temperature"] = aws_params["temperature"]
             if "top_p" in aws_params:
-                ans["top_p"] = aws_params["top_p"]
+                sampling["top_p"] = aws_params["top_p"]
             if "stop_sequences" in aws_params:
                 ans["stop_sequences"] = list(aws_params["stop_sequences"])
         elif obj["type"] == "deepseek":
@@ -331,83 +338,85 @@ class _InvocationParametersConversion:
             if "max_tokens" in deepseek_params:
                 ans["max_tokens"] = deepseek_params["max_tokens"]
             if "temperature" in deepseek_params:
-                ans["temperature"] = deepseek_params["temperature"]
+                sampling["temperature"] = deepseek_params["temperature"]
             if "top_p" in deepseek_params:
-                ans["top_p"] = deepseek_params["top_p"]
+                sampling["top_p"] = deepseek_params["top_p"]
         elif obj["type"] == "xai":
             xai_params: v1.PromptXAIInvocationParametersContent
             xai_params = obj["xai"]
             if "max_tokens" in xai_params:
                 ans["max_tokens"] = xai_params["max_tokens"]
             if "temperature" in xai_params:
-                ans["temperature"] = xai_params["temperature"]
+                sampling["temperature"] = xai_params["temperature"]
             if "top_p" in xai_params:
-                ans["top_p"] = xai_params["top_p"]
+                sampling["top_p"] = xai_params["top_p"]
         elif obj["type"] == "ollama":
             ollama_params: v1.PromptOllamaInvocationParametersContent
             ollama_params = obj["ollama"]
             if "max_tokens" in ollama_params:
                 ans["max_tokens"] = ollama_params["max_tokens"]
             if "temperature" in ollama_params:
-                ans["temperature"] = ollama_params["temperature"]
+                sampling["temperature"] = ollama_params["temperature"]
             if "top_p" in ollama_params:
-                ans["top_p"] = ollama_params["top_p"]
+                sampling["top_p"] = ollama_params["top_p"]
         elif obj["type"] == "cerebras":
             cerebras_params: v1.PromptCerebrasInvocationParametersContent
             cerebras_params = obj["cerebras"]
             if "max_tokens" in cerebras_params:
                 ans["max_tokens"] = cerebras_params["max_tokens"]
             if "temperature" in cerebras_params:
-                ans["temperature"] = cerebras_params["temperature"]
+                sampling["temperature"] = cerebras_params["temperature"]
             if "top_p" in cerebras_params:
-                ans["top_p"] = cerebras_params["top_p"]
+                sampling["top_p"] = cerebras_params["top_p"]
         elif obj["type"] == "fireworks":
             fireworks_params: v1.PromptFireworksInvocationParametersContent
             fireworks_params = obj["fireworks"]
             if "max_tokens" in fireworks_params:
                 ans["max_tokens"] = fireworks_params["max_tokens"]
             if "temperature" in fireworks_params:
-                ans["temperature"] = fireworks_params["temperature"]
+                sampling["temperature"] = fireworks_params["temperature"]
             if "top_p" in fireworks_params:
-                ans["top_p"] = fireworks_params["top_p"]
+                sampling["top_p"] = fireworks_params["top_p"]
         elif obj["type"] == "groq":
             groq_params: v1.PromptGroqInvocationParametersContent
             groq_params = obj["groq"]
             if "max_tokens" in groq_params:
                 ans["max_tokens"] = groq_params["max_tokens"]
             if "temperature" in groq_params:
-                ans["temperature"] = groq_params["temperature"]
+                sampling["temperature"] = groq_params["temperature"]
             if "top_p" in groq_params:
-                ans["top_p"] = groq_params["top_p"]
+                sampling["top_p"] = groq_params["top_p"]
         elif obj["type"] == "moonshot":
             moonshot_params: v1.PromptMoonshotInvocationParametersContent
             moonshot_params = obj["moonshot"]
             if "max_tokens" in moonshot_params:
                 ans["max_tokens"] = moonshot_params["max_tokens"]
             if "temperature" in moonshot_params:
-                ans["temperature"] = moonshot_params["temperature"]
+                sampling["temperature"] = moonshot_params["temperature"]
             if "top_p" in moonshot_params:
-                ans["top_p"] = moonshot_params["top_p"]
+                sampling["top_p"] = moonshot_params["top_p"]
         elif obj["type"] == "perplexity":
             perplexity_params: v1.PromptPerplexityInvocationParametersContent
             perplexity_params = obj["perplexity"]
             if "max_tokens" in perplexity_params:
                 ans["max_tokens"] = perplexity_params["max_tokens"]
             if "temperature" in perplexity_params:
-                ans["temperature"] = perplexity_params["temperature"]
+                sampling["temperature"] = perplexity_params["temperature"]
             if "top_p" in perplexity_params:
-                ans["top_p"] = perplexity_params["top_p"]
+                sampling["top_p"] = perplexity_params["top_p"]
         elif obj["type"] == "together":
             together_params: v1.PromptTogetherInvocationParametersContent
             together_params = obj["together"]
             if "max_tokens" in together_params:
                 ans["max_tokens"] = together_params["max_tokens"]
             if "temperature" in together_params:
-                ans["temperature"] = together_params["temperature"]
+                sampling["temperature"] = together_params["temperature"]
             if "top_p" in together_params:
-                ans["top_p"] = together_params["top_p"]
+                sampling["top_p"] = together_params["top_p"]
         elif TYPE_CHECKING:
             assert_never(obj["type"])
+        if sampling:
+            ans["extra_body"] = sampling
         return ans
 
     @staticmethod
@@ -420,10 +429,17 @@ class _InvocationParametersConversion:
         content = v1.PromptAnthropicInvocationParametersContent(
             max_tokens=obj["max_tokens"],
         )
-        if "temperature" in obj:
-            content["temperature"] = obj["temperature"]
-        if "top_p" in obj:
-            content["top_p"] = obj["top_p"]
+        # Sampling parameters travel in `extra_body`, since `messages.create()` no
+        # longer takes them as keyword arguments. Kwargs built against an older SDK
+        # still carry them at the top level, so read whichever place they appear in.
+        raw = cast("Mapping[str, Any]", obj)
+        raw_extra_body = cast("Mapping[str, Any]", raw.get("extra_body") or {})
+        temperature = raw_extra_body.get("temperature", raw.get("temperature"))
+        if isinstance(temperature, (int, float)):
+            content["temperature"] = float(temperature)
+        top_p = raw_extra_body.get("top_p", raw.get("top_p"))
+        if isinstance(top_p, (int, float)):
+            content["top_p"] = float(top_p)
         if "stop_sequences" in obj:
             content["stop_sequences"] = list(obj["stop_sequences"])
         if "output_config" in obj:

--- a/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
+++ b/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
@@ -218,8 +218,7 @@ class TestInvocationParametersConversion:
         assert not DeepDiff(content, dict(new_obj["anthropic"]))
 
     def test_reads_sampling_params_captured_from_an_older_sdk(self) -> None:
-        """Kwargs built when `messages.create()` still took these as keyword arguments
-        carry them at the top level, and must keep converting."""
+        """Kwargs built against anthropic 0.x carry these at the top level."""
         obj = cast(
             "MessageCreateParamsBase",
             {"max_tokens": 1024, "temperature": 0.3, "top_p": 0.9},
@@ -229,8 +228,8 @@ class TestInvocationParametersConversion:
         assert content.get("top_p") == 0.9
 
     def test_sampling_params_are_sent_through_extra_body(self) -> None:
-        """`messages.create()` rejects them as keyword arguments, so they must ride in
-        `extra_body` to reach the models that still honor them."""
+        """`messages.create()` rejects them as keyword arguments, so they must reach
+        the request JSON through `extra_body`."""
         obj = v1.PromptAnthropicInvocationParameters(
             type="anthropic",
             anthropic=v1.PromptAnthropicInvocationParametersContent(

--- a/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
+++ b/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
@@ -217,6 +217,17 @@ class TestInvocationParametersConversion:
         )
         assert not DeepDiff(content, dict(new_obj["anthropic"]))
 
+    def test_reads_sampling_params_captured_from_an_older_sdk(self) -> None:
+        """Kwargs built when `messages.create()` still took these as keyword arguments
+        carry them at the top level, and must keep converting."""
+        obj = cast(
+            "MessageCreateParamsBase",
+            {"max_tokens": 1024, "temperature": 0.3, "top_p": 0.9},
+        )
+        content = _InvocationParametersConversion.from_anthropic(obj)["anthropic"]
+        assert content["temperature"] == 0.3
+        assert content["top_p"] == 0.9
+
     def test_sampling_params_are_sent_through_extra_body(self) -> None:
         """`messages.create()` rejects them as keyword arguments, so they must ride in
         `extra_body` to reach the models that still honor them."""

--- a/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
+++ b/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
@@ -225,8 +225,8 @@ class TestInvocationParametersConversion:
             {"max_tokens": 1024, "temperature": 0.3, "top_p": 0.9},
         )
         content = _InvocationParametersConversion.from_anthropic(obj)["anthropic"]
-        assert content["temperature"] == 0.3
-        assert content["top_p"] == 0.9
+        assert content.get("temperature") == 0.3
+        assert content.get("top_p") == 0.9
 
     def test_sampling_params_are_sent_through_extra_body(self) -> None:
         """`messages.create()` rejects them as keyword arguments, so they must ride in
@@ -240,7 +240,7 @@ class TestInvocationParametersConversion:
         kwargs = _InvocationParametersConversion.to_anthropic(obj)
         assert "temperature" not in kwargs
         assert "top_p" not in kwargs
-        assert kwargs["extra_body"] == {"temperature": 0.3, "top_p": 0.9}
+        assert kwargs.get("extra_body") == {"temperature": 0.3, "top_p": 0.9}
 
 
 class _MockFormatter:

--- a/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
+++ b/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, cast
 
 import pytest
 from deepdiff.diff import DeepDiff
@@ -9,6 +9,7 @@ from faker import Faker
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.helpers.sdk.anthropic.messages import (
+    _InvocationParametersConversion,
     _MessageConversion,
     _TextContentPartConversion,
     _ToolCallContentPartConversion,
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
         ToolResultBlockParam,
         ToolUseBlockParam,
     )
+    from anthropic.types.message_create_params import MessageCreateParamsBase
 
 fake = Faker()
 
@@ -192,6 +194,42 @@ class TestToolKwargs:
         x: Optional[v1.PromptTools] = _ToolKwargsConversion.from_anthropic(obj)
         new_obj: _ToolKwargs = _ToolKwargsConversion.to_anthropic(x)
         assert not DeepDiff(obj, new_obj)
+
+
+class TestInvocationParametersConversion:
+    @pytest.mark.parametrize(
+        "content",
+        [
+            {"max_tokens": 1024},
+            {"max_tokens": 1024, "temperature": 0.3},
+            {"max_tokens": 1024, "top_p": 0.9},
+            {"max_tokens": 1024, "temperature": 0.3, "top_p": 0.9},
+        ],
+    )
+    def test_round_trip(self, content: dict[str, Any]) -> None:
+        obj = v1.PromptAnthropicInvocationParameters(
+            type="anthropic",
+            anthropic=cast("v1.PromptAnthropicInvocationParametersContent", content),
+        )
+        kwargs = _InvocationParametersConversion.to_anthropic(obj)
+        new_obj = _InvocationParametersConversion.from_anthropic(
+            cast("MessageCreateParamsBase", kwargs)
+        )
+        assert not DeepDiff(content, dict(new_obj["anthropic"]))
+
+    def test_sampling_params_are_sent_through_extra_body(self) -> None:
+        """`messages.create()` rejects them as keyword arguments, so they must ride in
+        `extra_body` to reach the models that still honor them."""
+        obj = v1.PromptAnthropicInvocationParameters(
+            type="anthropic",
+            anthropic=v1.PromptAnthropicInvocationParametersContent(
+                max_tokens=1024, temperature=0.3, top_p=0.9
+            ),
+        )
+        kwargs = _InvocationParametersConversion.to_anthropic(obj)
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        assert kwargs["extra_body"] == {"temperature": 0.3, "top_p": 0.9}
 
 
 class _MockFormatter:

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "anthropic>0.18.0",
+  "anthropic>=1,<2",
   "boto3",
   "litellm>=1.83.14; python_version < '3.14'",  # excluded on 3.14 until upstream restores support (https://github.com/BerriAI/litellm/issues/26343)
   "openai>=1.0.0",
@@ -48,7 +48,7 @@ test = [
   "pandas",
   "tqdm",
   "typing-extensions>=4.5, <5",
-  "anthropic>=0.18.0",
+  "anthropic>=1,<2",
   "boto3",
   "litellm>=1.83.14; python_version < '3.14'",  # excluded on 3.14 until upstream restores support (https://github.com/BerriAI/litellm/issues/26343)
   "openai>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,7 @@ dev = [
   "types-tqdm",
   "typing-extensions",
   "uvloop; platform_system != 'Windows'",
-  "vcrpy>=8.3",  # 8.3 is the first release that patches httpx2, which anthropic 1.x uses
+  "vcrpy>=8.3",  # earlier releases do not patch httpx2, which the anthropic SDK uses
   "jupyter>=1.1.1",
   "ruff>=0.15.2",
   "libcst>=1.8.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,10 @@ dependencies = [
   # Code-mode sandbox. Direct, not via fastmcp's `code-mode` extra, whose ==0.0.17 pin conflicts and would ship in wheel metadata.
   "pydantic-monty==0.0.19",
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
-  "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.26.0,<3",
-  # Arrives via pydantic-ai-slim[anthropic], which sets no upper bound;
-  # 1.0 moved the client to httpx2 and changed the messages.stream signature.
-  "anthropic>=0.108.0,<1",
+  "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.33.0,<3",
+  # Arrives via pydantic-ai-slim[anthropic], which sets no upper bound. Pinned
+  # here so the major version is chosen deliberately rather than by resolution.
+  "anthropic>=1,<2",
   "bashkit>=0.10.0,!=0.14.2",  # 0.14.2 shipped no sdist and only cp310/cp311 wheels, breaking installs on 3.14; see https://pypi.org/project/bashkit/0.14.2/
   "authlib>=1.7.0",
   "joserfc",
@@ -91,7 +91,7 @@ dev = [
   "aiobotocore>=3.1.1",
   "aioboto3",
   "aiosqlite>=0.22.1",
-  "anthropic>=0.79.0,<1",
+  "anthropic>=1,<2",
   "arize>=8.1.0",
   "asgi-lifespan",
   "asyncpg",
@@ -174,7 +174,7 @@ dev = [
   "types-tqdm",
   "typing-extensions",
   "uvloop; platform_system != 'Windows'",
-  "vcrpy",
+  "vcrpy>=8.3",  # 8.3 is the first release that patches httpx2, which anthropic 1.x uses
   "jupyter>=1.1.1",
   "ruff>=0.15.2",
   "libcst>=1.8.6",
@@ -215,7 +215,7 @@ azure = [
   "aiohttp",  # required async HTTP transport for azure.identity.aio
 ]
 container = [
-  "anthropic>=0.78.0,<1",
+  "anthropic>=1,<2",
   "google-genai>=1.50.0 ; python_version >= '3.10'",
   "google-genai ; python_version < '3.10'",
   "prometheus-client",

--- a/requirements/canary/sdk/anthropic.txt
+++ b/requirements/canary/sdk/anthropic.txt
@@ -1,2 +1,2 @@
 -r common.txt
-anthropic>=0.49.0
+anthropic>=1,<2

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -9,7 +9,7 @@ pyright[nodejs]==1.1.394
 pytest-randomly
 pytest-rerunfailures
 deepdiff==8.6.2
-anthropic<1
+anthropic>=1,<2
 openai>=3.1.0,<4
 pystache
 PyYAML

--- a/requirements/packages/phoenix-client.txt
+++ b/requirements/packages/phoenix-client.txt
@@ -5,5 +5,5 @@ pandas<3
 pandas-stubs<3
 google-genai>=2.17.0
 openai>=1.62.0
-anthropic>=0.49.0
+anthropic>=1,<2
 nest-asyncio

--- a/requirements/packages/phoenix-evals.txt
+++ b/requirements/packages/phoenix-evals.txt
@@ -1,5 +1,5 @@
 -r ../ci.txt
-anthropic
+anthropic>=1,<2
 google-genai
 litellm>=1.83.14; python_version < '3.14'
 mypy-boto3-bedrock-runtime

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -16,7 +16,7 @@ pandas>=1.0
 prometheus_client
 psycopg[binary,pool]
 py-grpc-prometheus
-pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.0.0
+pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.33.0
 pypistats  # this is needed to type-check third-party packages
 requests  # this is needed to type-check third-party packages
 strawberry-graphql[opentelemetry]==0.319.0

--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -22,7 +22,7 @@ syrupy
 tenacity
 tiktoken
 typing-extensions
-vcrpy
+vcrpy>=8.3
 pytest-smtpd
 freezegun
 aiosqlite>=0.22.1

--- a/scripts/testing/otel_gen_ai/send_anthropic_traces.py
+++ b/scripts/testing/otel_gen_ai/send_anthropic_traces.py
@@ -5,9 +5,8 @@
 #     "opentelemetry-sdk",
 #     "opentelemetry-exporter-otlp-proto-http",
 #     "opentelemetry-instrumentation-anthropic",
-#     # anthropic 1.x makes its requests through httpx2 rather than httpx; 8.3 is
-#     # the first vcrpy that patches httpx2, so older pins record nothing and let
-#     # every call reach the live API.
+#     # anthropic requests go through httpx2, which vcrpy patches only from 8.3
+#     # onward; earlier versions record nothing and let calls reach the live API.
 #     "vcrpy>=8.3",
 # ]
 # ///

--- a/scripts/testing/otel_gen_ai/send_anthropic_traces.py
+++ b/scripts/testing/otel_gen_ai/send_anthropic_traces.py
@@ -1,11 +1,14 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "anthropic",
+#     "anthropic>=1,<2",
 #     "opentelemetry-sdk",
 #     "opentelemetry-exporter-otlp-proto-http",
 #     "opentelemetry-instrumentation-anthropic",
-#     "vcrpy==8.1.1",
+#     # anthropic 1.x makes its requests through httpx2 rather than httpx; 8.3 is
+#     # the first vcrpy that patches httpx2, so older pins record nothing and let
+#     # every call reach the live API.
+#     "vcrpy>=8.3",
 # ]
 # ///
 """Send Anthropic API traces to a local Phoenix at http://localhost:6006/v1/traces.

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2071,6 +2071,12 @@ def _anthropic_beta_headers_for_tools(
     return {"anthropic-beta": ",".join(betas)}
 
 
+# Sampling parameters the Anthropic SDK no longer takes as keyword arguments. They
+# are sent via `extra_body`, which merges them back into the request JSON, so the
+# models that still honor them see them exactly as before.
+_ANTHROPIC_SAMPLING_PARAM_KEYS = frozenset(("temperature", "top_p"))
+
+
 # Anthropic models that use adaptive thinking (`thinking: {"type": "adaptive"}`).
 # These models removed `temperature`, `top_p`, `top_k`, and extended thinking
 # (`thinking: {"type": "enabled", "budget_tokens": N}`) from their request
@@ -2235,12 +2241,18 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
         extra_body: dict[str, Any] | None = None
         if invocation_parameters:
             anthropic_params = invocation_parameters.anthropic
+            # `temperature` and `top_p` are no longer part of the SDK's
+            # `messages.create()` signature, but the API still honors them on models
+            # that accept sampling parameters. Send them through `extra_body`, which
+            # is merged into the request JSON verbatim, so a prompt saved against
+            # such a model keeps sampling behavior it was tuned with.
+            sampling_params: dict[str, Any] = {}
             if isinstance(anthropic_params.temperature, float):
-                params["temperature"] = anthropic_params.temperature
+                sampling_params["temperature"] = anthropic_params.temperature
             if isinstance(anthropic_params.stop_sequences, list):
                 params["stop_sequences"] = anthropic_params.stop_sequences
             if isinstance(anthropic_params.top_p, float):
-                params["top_p"] = anthropic_params.top_p
+                sampling_params["top_p"] = anthropic_params.top_p
             output_config_in = anthropic_params.output_config
             if isinstance(output_config_in, PromptAnthropicOutputConfig):
                 if output_config is None:
@@ -2263,8 +2275,12 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
                 if thinking.display:
                     adaptive_param["display"] = thinking.display
                 params["thinking"] = adaptive_param
+            # An explicitly configured `extra_body` wins over the sampling params
+            # above, so a user can still override what the prompt was saved with.
             if isinstance(anthropic_params.extra_body, dict):
-                extra_body = anthropic_params.extra_body
+                extra_body = {**sampling_params, **anthropic_params.extra_body}
+            elif sampling_params:
+                extra_body = sampling_params
 
         if output_config is not None:
             params["output_config"] = output_config
@@ -2282,7 +2298,17 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
                 span.set_attribute(f"llm.tools.{i}.tool.json_schema", safe_json_dumps(tool_param))
         input_value: dict[str, Any] = dict(params)
         if extra_body:
-            input_value["extra_body"] = extra_body
+            # Sampling parameters ride in `extra_body` only because the SDK stopped
+            # accepting them as keyword arguments; on the wire they are ordinary
+            # top-level request fields. Record them that way, and reserve the nested
+            # `extra_body` entry for keys the user genuinely asked to pass through.
+            input_value.update(
+                {k: v for k, v in extra_body.items() if k in _ANTHROPIC_SAMPLING_PARAM_KEYS}
+            )
+            if passthrough := {
+                k: v for k, v in extra_body.items() if k not in _ANTHROPIC_SAMPLING_PARAM_KEYS
+            }:
+                input_value["extra_body"] = passthrough
         span.set_attribute(SpanAttributes.INPUT_VALUE, safe_json_dumps(input_value))
         span.set_attribute(SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value)
         input_value.pop("messages", None)

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2071,9 +2071,8 @@ def _anthropic_beta_headers_for_tools(
     return {"anthropic-beta": ",".join(betas)}
 
 
-# Sampling parameters the Anthropic SDK no longer takes as keyword arguments. They
-# are sent via `extra_body`, which merges them back into the request JSON, so the
-# models that still honor them see them exactly as before.
+# `messages.create()` accepts no sampling parameters. `extra_body` merges them into
+# the request JSON, which is how the models that support them receive them.
 _ANTHROPIC_SAMPLING_PARAM_KEYS = frozenset(("temperature", "top_p"))
 
 
@@ -2241,11 +2240,7 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
         extra_body: dict[str, Any] | None = None
         if invocation_parameters:
             anthropic_params = invocation_parameters.anthropic
-            # `temperature` and `top_p` are no longer part of the SDK's
-            # `messages.create()` signature, but the API still honors them on models
-            # that accept sampling parameters. Send them through `extra_body`, which
-            # is merged into the request JSON verbatim, so a prompt saved against
-            # such a model keeps sampling behavior it was tuned with.
+            # Sampling parameters reach the request JSON through `extra_body`.
             sampling_params: dict[str, Any] = {}
             if isinstance(anthropic_params.temperature, float):
                 sampling_params["temperature"] = anthropic_params.temperature
@@ -2275,8 +2270,7 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
                 if thinking.display:
                     adaptive_param["display"] = thinking.display
                 params["thinking"] = adaptive_param
-            # An explicitly configured `extra_body` wins over the sampling params
-            # above, so a user can still override what the prompt was saved with.
+            # A configured `extra_body` overrides the sampling parameters above.
             if isinstance(anthropic_params.extra_body, dict):
                 extra_body = {**sampling_params, **anthropic_params.extra_body}
             elif sampling_params:
@@ -2298,10 +2292,8 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
                 span.set_attribute(f"llm.tools.{i}.tool.json_schema", safe_json_dumps(tool_param))
         input_value: dict[str, Any] = dict(params)
         if extra_body:
-            # Sampling parameters ride in `extra_body` only because the SDK stopped
-            # accepting them as keyword arguments; on the wire they are ordinary
-            # top-level request fields. Record them that way, and reserve the nested
-            # `extra_body` entry for keys the user genuinely asked to pass through.
+            # Sampling parameters are top-level fields on the wire, so record them as
+            # such; the nested entry is for keys the caller asked to pass through.
             input_value.update(
                 {k: v for k, v in extra_body.items() if k in _ANTHROPIC_SAMPLING_PARAM_KEYS}
             )

--- a/tests/integration/_mock_llm_server.py
+++ b/tests/integration/_mock_llm_server.py
@@ -1521,7 +1521,7 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
         input_schema = dict(tool["input_schema"])  # type: ignore[typeddict-item]
         tool_input = _generate_fake_data(input_schema)
         tool_use_id = _generate_anthropic_tool_use_id()
-        tool_name = str(tool["name"])
+        tool_name = str(tool["name"])  # type: ignore[typeddict-item]
         output_tokens = _estimate_tokens(json.dumps(tool_input))
         return Message(
             id=message_id,
@@ -1612,7 +1612,7 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
         input_schema = dict(tool["input_schema"])  # type: ignore[typeddict-item]
         tool_input = _generate_fake_data(input_schema)
         tool_use_id = _generate_anthropic_tool_use_id()
-        tool_name = str(tool["name"])
+        tool_name = str(tool["name"])  # type: ignore[typeddict-item]
         input_json = json.dumps(tool_input)
         output_tokens = _estimate_tokens(input_json)
 

--- a/tests/integration/client/test_prompts.py
+++ b/tests/integration/client/test_prompts.py
@@ -878,296 +878,305 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    system="You are {role}.",
-                    messages=[
-                        {"role": "user", "content": "Write a haiku about {topic}."},
-                    ],
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        system="You are {role}.",
+                        messages=[
+                            {"role": "user", "content": "Write a haiku about {topic}."},
+                        ],
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-system-message-string",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1025,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    thinking={
-                        "type": "enabled",
-                        "budget_tokens": 1024,
-                    },
-                    system="You are {role}.",
-                    messages=[
-                        {"role": "user", "content": "Write a haiku about {topic}."},
-                    ],
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1025,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        thinking={
+                            "type": "enabled",
+                            "budget_tokens": 1024,
+                        },
+                        system="You are {role}.",
+                        messages=[
+                            {"role": "user", "content": "Write a haiku about {topic}."},
+                        ],
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-thinking-enabled",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    thinking={"type": "disabled"},
-                    system="You are {role}.",
-                    messages=[
-                        {"role": "user", "content": "Write a haiku about {topic}."},
-                    ],
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        thinking={"type": "disabled"},
+                        system="You are {role}.",
+                        messages=[
+                            {"role": "user", "content": "Write a haiku about {topic}."},
+                        ],
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-thinking-disabled",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    system=[
-                        {"type": "text", "text": "You are {role}."},
-                        {"type": "text", "text": "You study {topic}."},
-                    ],
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "text": "Write a poem about {topic}."},
-                                {"type": "text", "text": "Make it rhyme."},
-                            ],
-                        },
-                    ],
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        system=[
+                            {"type": "text", "text": "You are {role}."},
+                            {"type": "text", "text": "You study {topic}."},
+                        ],
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "Write a poem about {topic}."},
+                                    {"type": "text", "text": "Make it rhyme."},
+                                ],
+                            },
+                        ],
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-system-message-list",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": "What's the temperature and population in Los Angeles?",
-                        },
-                    ],
-                    tools=_ANTHROPIC_TOOLS,
-                    tool_choice=ToolChoiceAnyParam(type="any"),
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "What's the temperature and population in Los Angeles?",
+                            },
+                        ],
+                        tools=_ANTHROPIC_TOOLS,
+                        tool_choice=ToolChoiceAnyParam(type="any"),
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-tools",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": "Given a description of a character, your task is to "
-                            "extract all the characteristics of the character.\n"
-                            "<description>{desc}</description>",
-                        },
-                    ],
-                    tools=[
-                        {
-                            "name": "print_all_characteristics",
-                            "description": "Prints all characteristics which are provided.",
-                            "input_schema": {"type": "object", "additionalProperties": True},
-                        }
-                    ],
-                    tool_choice={"type": "tool", "name": "print_all_characteristics"},
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "Given a description of a character, your task is to "
+                                "extract all the characteristics of the character.\n"
+                                "<description>{desc}</description>",
+                            },
+                        ],
+                        tools=[
+                            {
+                                "name": "print_all_characteristics",
+                                "description": "Prints all characteristics which are provided.",
+                                "input_schema": {"type": "object", "additionalProperties": True},
+                            }
+                        ],
+                        tool_choice={"type": "tool", "name": "print_all_characteristics"},
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-tool-with-unknown-keys",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    messages=[
-                        MessageParam(
-                            role="user",
-                            content="What's the temperature and population in Los Angeles?",
-                        ),
-                        MessageParam(
-                            role="assistant",
-                            content=[
-                                TextBlockParam(
-                                    type="text",
-                                    text="I'll call these functions",
-                                ),
-                                ToolUseBlockParam(
-                                    type="tool_use",
-                                    id=token_hex(8),
-                                    name="get_weather",
-                                    input={"city": "Los Angeles"},
-                                ),
-                                ToolUseBlockParam(
-                                    type="tool_use",
-                                    id=token_hex(8),
-                                    name="get_population",
-                                    input={"location": "Los Angeles"},
-                                ),
-                            ],
-                        ),
-                    ],
-                    tools=_ANTHROPIC_TOOLS,
-                    tool_choice=ToolChoiceAnyParam(type="any"),
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        messages=[
+                            MessageParam(
+                                role="user",
+                                content="What's the temperature and population in Los Angeles?",
+                            ),
+                            MessageParam(
+                                role="assistant",
+                                content=[
+                                    TextBlockParam(
+                                        type="text",
+                                        text="I'll call these functions",
+                                    ),
+                                    ToolUseBlockParam(
+                                        type="tool_use",
+                                        id=token_hex(8),
+                                        name="get_weather",
+                                        input={"city": "Los Angeles"},
+                                    ),
+                                    ToolUseBlockParam(
+                                        type="tool_use",
+                                        id=token_hex(8),
+                                        name="get_population",
+                                        input={"location": "Los Angeles"},
+                                    ),
+                                ],
+                            ),
+                        ],
+                        tools=_ANTHROPIC_TOOLS,
+                        tool_choice=ToolChoiceAnyParam(type="any"),
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-tool-use",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    messages=[
-                        MessageParam(
-                            role="user",
-                            content="What's the temperature and population in Los Angeles?",
-                        ),
-                        MessageParam(
-                            role="assistant",
-                            content=[
-                                TextBlockParam(
-                                    type="text",
-                                    text="I'll call these functions",
-                                ),
-                                ToolUseBlockParam(
-                                    type="tool_use",
-                                    id=token_hex(8),
-                                    name="get_weather",
-                                    input={"city": "Los Angeles"},
-                                ),
-                                ToolUseBlockParam(
-                                    type="tool_use",
-                                    id=token_hex(8),
-                                    name="get_population",
-                                    input={"location": "Los Angeles"},
-                                ),
-                            ],
-                        ),
-                        MessageParam(
-                            role="user",
-                            content=[
-                                TextBlockParam(
-                                    type="text",
-                                    text="These are function results",
-                                ),
-                                ToolResultBlockParam(
-                                    type="tool_result",
-                                    tool_use_id=token_hex(8),
-                                    content="temp is hot",
-                                ),
-                                ToolResultBlockParam(
-                                    type="tool_result",
-                                    tool_use_id=token_hex(8),
-                                    content="pop is large",
-                                ),
-                            ],
-                        ),
-                    ],
-                    tools=_ANTHROPIC_TOOLS,
-                    tool_choice=ToolChoiceAnyParam(type="any"),
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        messages=[
+                            MessageParam(
+                                role="user",
+                                content="What's the temperature and population in Los Angeles?",
+                            ),
+                            MessageParam(
+                                role="assistant",
+                                content=[
+                                    TextBlockParam(
+                                        type="text",
+                                        text="I'll call these functions",
+                                    ),
+                                    ToolUseBlockParam(
+                                        type="tool_use",
+                                        id=token_hex(8),
+                                        name="get_weather",
+                                        input={"city": "Los Angeles"},
+                                    ),
+                                    ToolUseBlockParam(
+                                        type="tool_use",
+                                        id=token_hex(8),
+                                        name="get_population",
+                                        input={"location": "Los Angeles"},
+                                    ),
+                                ],
+                            ),
+                            MessageParam(
+                                role="user",
+                                content=[
+                                    TextBlockParam(
+                                        type="text",
+                                        text="These are function results",
+                                    ),
+                                    ToolResultBlockParam(
+                                        type="tool_result",
+                                        tool_use_id=token_hex(8),
+                                        content="temp is hot",
+                                    ),
+                                    ToolResultBlockParam(
+                                        type="tool_result",
+                                        tool_use_id=token_hex(8),
+                                        content="pop is large",
+                                    ),
+                                ],
+                            ),
+                        ],
+                        tools=_ANTHROPIC_TOOLS,
+                        tool_choice=ToolChoiceAnyParam(type="any"),
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-tool-result-string",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
-                    model=token_hex(8),
-                    max_tokens=1024,
-                    temperature=random(),
-                    top_p=random(),
-                    stop_sequences=[token_hex(8), token_hex(8)],
-                    messages=[
-                        MessageParam(
-                            role="user",
-                            content="What's the temperature and population in Los Angeles?",
-                        ),
-                        MessageParam(
-                            role="assistant",
-                            content=[
-                                TextBlockParam(
-                                    type="text",
-                                    text="I'll call these functions",
-                                ),
-                                ToolUseBlockParam(
-                                    type="tool_use",
-                                    id=token_hex(8),
-                                    name="get_weather",
-                                    input={"city": "Los Angeles"},
-                                ),
-                                ToolUseBlockParam(
-                                    type="tool_use",
-                                    id=token_hex(8),
-                                    name="get_population",
-                                    input={"location": "Los Angeles"},
-                                ),
-                            ],
-                        ),
-                        MessageParam(
-                            role="user",
-                            content=[
-                                TextBlockParam(
-                                    type="text",
-                                    text="These are function results",
-                                ),
-                                ToolResultBlockParam(
-                                    type="tool_result",
-                                    tool_use_id=token_hex(8),
-                                    content=[
-                                        TextBlockParam(type="text", text="temp"),
-                                        TextBlockParam(type="text", text="is"),
-                                        TextBlockParam(type="text", text="hot"),
-                                    ],
-                                ),
-                                ToolResultBlockParam(
-                                    type="tool_result",
-                                    tool_use_id=token_hex(8),
-                                    content=[
-                                        TextBlockParam(type="text", text="pop"),
-                                        TextBlockParam(type="text", text="is"),
-                                        TextBlockParam(type="text", text="large"),
-                                    ],
-                                ),
-                            ],
-                        ),
-                    ],
-                    tools=_ANTHROPIC_TOOLS,
-                    tool_choice=ToolChoiceAnyParam(type="any"),
-                ),
+                {
+                    **MessageCreateParamsBase(
+                        model=token_hex(8),
+                        max_tokens=1024,
+                        stop_sequences=[token_hex(8), token_hex(8)],
+                        messages=[
+                            MessageParam(
+                                role="user",
+                                content="What's the temperature and population in Los Angeles?",
+                            ),
+                            MessageParam(
+                                role="assistant",
+                                content=[
+                                    TextBlockParam(
+                                        type="text",
+                                        text="I'll call these functions",
+                                    ),
+                                    ToolUseBlockParam(
+                                        type="tool_use",
+                                        id=token_hex(8),
+                                        name="get_weather",
+                                        input={"city": "Los Angeles"},
+                                    ),
+                                    ToolUseBlockParam(
+                                        type="tool_use",
+                                        id=token_hex(8),
+                                        name="get_population",
+                                        input={"location": "Los Angeles"},
+                                    ),
+                                ],
+                            ),
+                            MessageParam(
+                                role="user",
+                                content=[
+                                    TextBlockParam(
+                                        type="text",
+                                        text="These are function results",
+                                    ),
+                                    ToolResultBlockParam(
+                                        type="tool_result",
+                                        tool_use_id=token_hex(8),
+                                        content=[
+                                            TextBlockParam(type="text", text="temp"),
+                                            TextBlockParam(type="text", text="is"),
+                                            TextBlockParam(type="text", text="hot"),
+                                        ],
+                                    ),
+                                    ToolResultBlockParam(
+                                        type="tool_result",
+                                        tool_use_id=token_hex(8),
+                                        content=[
+                                            TextBlockParam(type="text", text="pop"),
+                                            TextBlockParam(type="text", text="is"),
+                                            TextBlockParam(type="text", text="large"),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ],
+                        tools=_ANTHROPIC_TOOLS,
+                        tool_choice=ToolChoiceAnyParam(type="any"),
+                    ),
+                    "extra_body": {"temperature": random(), "top_p": random()},
+                },
                 id="anthropic-tool-result-list",
             ),
             pytest.param(

--- a/tests/integration/client/test_prompts.py
+++ b/tests/integration/client/test_prompts.py
@@ -878,305 +878,278 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        system="You are {role}.",
-                        messages=[
-                            {"role": "user", "content": "Write a haiku about {topic}."},
-                        ],
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    system="You are {role}.",
+                    messages=[
+                        {"role": "user", "content": "Write a haiku about {topic}."},
+                    ],
+                ),
                 id="anthropic-system-message-string",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1025,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        thinking={
-                            "type": "enabled",
-                            "budget_tokens": 1024,
-                        },
-                        system="You are {role}.",
-                        messages=[
-                            {"role": "user", "content": "Write a haiku about {topic}."},
-                        ],
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1025,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    thinking={
+                        "type": "enabled",
+                        "budget_tokens": 1024,
+                    },
+                    system="You are {role}.",
+                    messages=[
+                        {"role": "user", "content": "Write a haiku about {topic}."},
+                    ],
+                ),
                 id="anthropic-thinking-enabled",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        thinking={"type": "disabled"},
-                        system="You are {role}.",
-                        messages=[
-                            {"role": "user", "content": "Write a haiku about {topic}."},
-                        ],
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    thinking={"type": "disabled"},
+                    system="You are {role}.",
+                    messages=[
+                        {"role": "user", "content": "Write a haiku about {topic}."},
+                    ],
+                ),
                 id="anthropic-thinking-disabled",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        system=[
-                            {"type": "text", "text": "You are {role}."},
-                            {"type": "text", "text": "You study {topic}."},
-                        ],
-                        messages=[
-                            {
-                                "role": "user",
-                                "content": [
-                                    {"type": "text", "text": "Write a poem about {topic}."},
-                                    {"type": "text", "text": "Make it rhyme."},
-                                ],
-                            },
-                        ],
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    system=[
+                        {"type": "text", "text": "You are {role}."},
+                        {"type": "text", "text": "You study {topic}."},
+                    ],
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "Write a poem about {topic}."},
+                                {"type": "text", "text": "Make it rhyme."},
+                            ],
+                        },
+                    ],
+                ),
                 id="anthropic-system-message-list",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        messages=[
-                            {
-                                "role": "user",
-                                "content": "What's the temperature and population in Los Angeles?",
-                            },
-                        ],
-                        tools=_ANTHROPIC_TOOLS,
-                        tool_choice=ToolChoiceAnyParam(type="any"),
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": "What's the temperature and population in Los Angeles?",
+                        },
+                    ],
+                    tools=_ANTHROPIC_TOOLS,
+                    tool_choice=ToolChoiceAnyParam(type="any"),
+                ),
                 id="anthropic-tools",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        messages=[
-                            {
-                                "role": "user",
-                                "content": "Given a description of a character, your task is to "
-                                "extract all the characteristics of the character.\n"
-                                "<description>{desc}</description>",
-                            },
-                        ],
-                        tools=[
-                            {
-                                "name": "print_all_characteristics",
-                                "description": "Prints all characteristics which are provided.",
-                                "input_schema": {"type": "object", "additionalProperties": True},
-                            }
-                        ],
-                        tool_choice={"type": "tool", "name": "print_all_characteristics"},
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": "Given a description of a character, your task is to "
+                            "extract all the characteristics of the character.\n"
+                            "<description>{desc}</description>",
+                        },
+                    ],
+                    tools=[
+                        {
+                            "name": "print_all_characteristics",
+                            "description": "Prints all characteristics which are provided.",
+                            "input_schema": {"type": "object", "additionalProperties": True},
+                        }
+                    ],
+                    tool_choice={"type": "tool", "name": "print_all_characteristics"},
+                ),
                 id="anthropic-tool-with-unknown-keys",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        messages=[
-                            MessageParam(
-                                role="user",
-                                content="What's the temperature and population in Los Angeles?",
-                            ),
-                            MessageParam(
-                                role="assistant",
-                                content=[
-                                    TextBlockParam(
-                                        type="text",
-                                        text="I'll call these functions",
-                                    ),
-                                    ToolUseBlockParam(
-                                        type="tool_use",
-                                        id=token_hex(8),
-                                        name="get_weather",
-                                        input={"city": "Los Angeles"},
-                                    ),
-                                    ToolUseBlockParam(
-                                        type="tool_use",
-                                        id=token_hex(8),
-                                        name="get_population",
-                                        input={"location": "Los Angeles"},
-                                    ),
-                                ],
-                            ),
-                        ],
-                        tools=_ANTHROPIC_TOOLS,
-                        tool_choice=ToolChoiceAnyParam(type="any"),
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    messages=[
+                        MessageParam(
+                            role="user",
+                            content="What's the temperature and population in Los Angeles?",
+                        ),
+                        MessageParam(
+                            role="assistant",
+                            content=[
+                                TextBlockParam(
+                                    type="text",
+                                    text="I'll call these functions",
+                                ),
+                                ToolUseBlockParam(
+                                    type="tool_use",
+                                    id=token_hex(8),
+                                    name="get_weather",
+                                    input={"city": "Los Angeles"},
+                                ),
+                                ToolUseBlockParam(
+                                    type="tool_use",
+                                    id=token_hex(8),
+                                    name="get_population",
+                                    input={"location": "Los Angeles"},
+                                ),
+                            ],
+                        ),
+                    ],
+                    tools=_ANTHROPIC_TOOLS,
+                    tool_choice=ToolChoiceAnyParam(type="any"),
+                ),
                 id="anthropic-tool-use",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        messages=[
-                            MessageParam(
-                                role="user",
-                                content="What's the temperature and population in Los Angeles?",
-                            ),
-                            MessageParam(
-                                role="assistant",
-                                content=[
-                                    TextBlockParam(
-                                        type="text",
-                                        text="I'll call these functions",
-                                    ),
-                                    ToolUseBlockParam(
-                                        type="tool_use",
-                                        id=token_hex(8),
-                                        name="get_weather",
-                                        input={"city": "Los Angeles"},
-                                    ),
-                                    ToolUseBlockParam(
-                                        type="tool_use",
-                                        id=token_hex(8),
-                                        name="get_population",
-                                        input={"location": "Los Angeles"},
-                                    ),
-                                ],
-                            ),
-                            MessageParam(
-                                role="user",
-                                content=[
-                                    TextBlockParam(
-                                        type="text",
-                                        text="These are function results",
-                                    ),
-                                    ToolResultBlockParam(
-                                        type="tool_result",
-                                        tool_use_id=token_hex(8),
-                                        content="temp is hot",
-                                    ),
-                                    ToolResultBlockParam(
-                                        type="tool_result",
-                                        tool_use_id=token_hex(8),
-                                        content="pop is large",
-                                    ),
-                                ],
-                            ),
-                        ],
-                        tools=_ANTHROPIC_TOOLS,
-                        tool_choice=ToolChoiceAnyParam(type="any"),
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    messages=[
+                        MessageParam(
+                            role="user",
+                            content="What's the temperature and population in Los Angeles?",
+                        ),
+                        MessageParam(
+                            role="assistant",
+                            content=[
+                                TextBlockParam(
+                                    type="text",
+                                    text="I'll call these functions",
+                                ),
+                                ToolUseBlockParam(
+                                    type="tool_use",
+                                    id=token_hex(8),
+                                    name="get_weather",
+                                    input={"city": "Los Angeles"},
+                                ),
+                                ToolUseBlockParam(
+                                    type="tool_use",
+                                    id=token_hex(8),
+                                    name="get_population",
+                                    input={"location": "Los Angeles"},
+                                ),
+                            ],
+                        ),
+                        MessageParam(
+                            role="user",
+                            content=[
+                                TextBlockParam(
+                                    type="text",
+                                    text="These are function results",
+                                ),
+                                ToolResultBlockParam(
+                                    type="tool_result",
+                                    tool_use_id=token_hex(8),
+                                    content="temp is hot",
+                                ),
+                                ToolResultBlockParam(
+                                    type="tool_result",
+                                    tool_use_id=token_hex(8),
+                                    content="pop is large",
+                                ),
+                            ],
+                        ),
+                    ],
+                    tools=_ANTHROPIC_TOOLS,
+                    tool_choice=ToolChoiceAnyParam(type="any"),
+                ),
                 id="anthropic-tool-result-string",
             ),
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                {
-                    **MessageCreateParamsBase(
-                        model=token_hex(8),
-                        max_tokens=1024,
-                        stop_sequences=[token_hex(8), token_hex(8)],
-                        messages=[
-                            MessageParam(
-                                role="user",
-                                content="What's the temperature and population in Los Angeles?",
-                            ),
-                            MessageParam(
-                                role="assistant",
-                                content=[
-                                    TextBlockParam(
-                                        type="text",
-                                        text="I'll call these functions",
-                                    ),
-                                    ToolUseBlockParam(
-                                        type="tool_use",
-                                        id=token_hex(8),
-                                        name="get_weather",
-                                        input={"city": "Los Angeles"},
-                                    ),
-                                    ToolUseBlockParam(
-                                        type="tool_use",
-                                        id=token_hex(8),
-                                        name="get_population",
-                                        input={"location": "Los Angeles"},
-                                    ),
-                                ],
-                            ),
-                            MessageParam(
-                                role="user",
-                                content=[
-                                    TextBlockParam(
-                                        type="text",
-                                        text="These are function results",
-                                    ),
-                                    ToolResultBlockParam(
-                                        type="tool_result",
-                                        tool_use_id=token_hex(8),
-                                        content=[
-                                            TextBlockParam(type="text", text="temp"),
-                                            TextBlockParam(type="text", text="is"),
-                                            TextBlockParam(type="text", text="hot"),
-                                        ],
-                                    ),
-                                    ToolResultBlockParam(
-                                        type="tool_result",
-                                        tool_use_id=token_hex(8),
-                                        content=[
-                                            TextBlockParam(type="text", text="pop"),
-                                            TextBlockParam(type="text", text="is"),
-                                            TextBlockParam(type="text", text="large"),
-                                        ],
-                                    ),
-                                ],
-                            ),
-                        ],
-                        tools=_ANTHROPIC_TOOLS,
-                        tool_choice=ToolChoiceAnyParam(type="any"),
-                    ),
-                    "extra_body": {"temperature": random(), "top_p": random()},
-                },
+                MessageCreateParamsBase(
+                    model=token_hex(8),
+                    max_tokens=1024,
+                    stop_sequences=[token_hex(8), token_hex(8)],
+                    messages=[
+                        MessageParam(
+                            role="user",
+                            content="What's the temperature and population in Los Angeles?",
+                        ),
+                        MessageParam(
+                            role="assistant",
+                            content=[
+                                TextBlockParam(
+                                    type="text",
+                                    text="I'll call these functions",
+                                ),
+                                ToolUseBlockParam(
+                                    type="tool_use",
+                                    id=token_hex(8),
+                                    name="get_weather",
+                                    input={"city": "Los Angeles"},
+                                ),
+                                ToolUseBlockParam(
+                                    type="tool_use",
+                                    id=token_hex(8),
+                                    name="get_population",
+                                    input={"location": "Los Angeles"},
+                                ),
+                            ],
+                        ),
+                        MessageParam(
+                            role="user",
+                            content=[
+                                TextBlockParam(
+                                    type="text",
+                                    text="These are function results",
+                                ),
+                                ToolResultBlockParam(
+                                    type="tool_result",
+                                    tool_use_id=token_hex(8),
+                                    content=[
+                                        TextBlockParam(type="text", text="temp"),
+                                        TextBlockParam(type="text", text="is"),
+                                        TextBlockParam(type="text", text="hot"),
+                                    ],
+                                ),
+                                ToolResultBlockParam(
+                                    type="tool_result",
+                                    tool_use_id=token_hex(8),
+                                    content=[
+                                        TextBlockParam(type="text", text="pop"),
+                                        TextBlockParam(type="text", text="is"),
+                                        TextBlockParam(type="text", text="large"),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ],
+                    tools=_ANTHROPIC_TOOLS,
+                    tool_choice=ToolChoiceAnyParam(type="any"),
+                ),
                 id="anthropic-tool-result-list",
             ),
             pytest.param(

--- a/tests/integration/client/test_prompts.py
+++ b/tests/integration/client/test_prompts.py
@@ -878,7 +878,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -894,7 +894,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1025,
                     temperature=random(),
@@ -914,7 +914,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -931,7 +931,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -956,7 +956,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -976,7 +976,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -1004,7 +1004,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -1045,7 +1045,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),
@@ -1105,7 +1105,7 @@ class TestClient:
             pytest.param(
                 "ANTHROPIC",
                 PromptVersion.from_anthropic,
-                MessageCreateParamsBase(
+                MessageCreateParamsBase(  # type: ignore[typeddict-unknown-key]
                     model=token_hex(8),
                     max_tokens=1024,
                     temperature=random(),

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import Mock
 
-import httpx
+import httpx2
 import pytest
 from anthropic.types.beta import (
     BetaContentBlockParam,
@@ -96,9 +96,9 @@ def anthropic_model(
     captured_request: CapturedRequest,
 ) -> AnthropicModel:
     """An ``AnthropicModel`` whose underlying HTTP client is an
-    ``httpx.MockTransport``."""
+    ``httpx2.MockTransport``."""
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         captured_request.bodies.append(json.loads(request.read()))
         stub_response = BetaMessage(
             id="msg_test",
@@ -110,9 +110,9 @@ def anthropic_model(
             stop_sequence=None,
             usage=BetaUsage(input_tokens=1, output_tokens=1),
         )
-        return httpx.Response(200, json=stub_response.model_dump(mode="json"))
+        return httpx2.Response(200, json=stub_response.model_dump(mode="json"))
 
-    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler))
     provider = AnthropicProvider(api_key=anthropic_api_key, http_client=http_client)
     return AnthropicModel("claude-haiku-4-5", provider=provider)
 

--- a/uv.lock
+++ b/uv.lock
@@ -345,21 +345,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.122.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/23/9987d70b74e3481d5bc5d2021d3e10fd5f60c1f7b54088ea86506d9b7f2b/anthropic-0.122.0.tar.gz", hash = "sha256:ffec56ae96657c8d19fa575ec96f140f380c353a07ab7d61b92eb18ee6536601", size = 1021535, upload-time = "2026-08-13T18:36:00.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/aa/4978e58035bd6c638c7b483450a68b7ef2d732ab78885e27bb9db0cff1a2/anthropic-1.0.0.tar.gz", hash = "sha256:42be3c97604af7252c5898413aee076ace6c46e9bca0d0d90ceb77c7d3719027", size = 1077769, upload-time = "2026-08-20T19:59:00.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/5b/f5c87e71097a9f89f1b414d1ef7ae8439051fae57d5e4ee90946082982b8/anthropic-0.122.0-py3-none-any.whl", hash = "sha256:45ec906452ffae6b5f7f0c53d01f50bfb7e4ce878d7ae8e4309d13171e557e67", size = 1041853, upload-time = "2026-08-13T18:36:01.831Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5b/db4a854aebf5d33a5ab714c46af6eb85ee44f390ed29b7b325c00b9f11ed/anthropic-1.0.0-py3-none-any.whl", hash = "sha256:32dd52e9e1d774393b27182f451398ba4262287a4d0eab30887f89f1481b3ae4", size = 1171725, upload-time = "2026-08-20T19:58:58.725Z" },
 ]
 
 [[package]]
@@ -701,8 +700,8 @@ requires-dist = [
     { name = "aioitertools" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.3.0,<2" },
-    { name = "anthropic", specifier = ">=0.108.0,<1" },
-    { name = "anthropic", marker = "extra == 'container'", specifier = ">=0.78.0,<1" },
+    { name = "anthropic", specifier = ">=1,<2" },
+    { name = "anthropic", marker = "extra == 'container'", specifier = ">=1,<2" },
     { name = "arize-phoenix-client", editable = "packages/phoenix-client" },
     { name = "arize-phoenix-evals", editable = "packages/phoenix-evals" },
     { name = "arize-phoenix-otel", editable = "packages/phoenix-otel" },
@@ -756,7 +755,7 @@ requires-dist = [
     { name = "py-grpc-prometheus", marker = "extra == 'container'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.1.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=2.26.0,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai", "ui"], specifier = ">=2.33.0,<3" },
     { name = "pydantic-monty", specifier = "==0.0.19" },
     { name = "pystache" },
     { name = "python-dateutil" },
@@ -790,7 +789,7 @@ dev = [
     { name = "aioboto3" },
     { name = "aiobotocore", specifier = ">=3.1.1" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
-    { name = "anthropic", specifier = ">=0.79.0,<1" },
+    { name = "anthropic", specifier = ">=1,<2" },
     { name = "arize", specifier = ">=8.1.0" },
     { name = "asgi-lifespan" },
     { name = "asyncpg" },
@@ -880,7 +879,7 @@ dev = [
     { name = "types-tqdm" },
     { name = "typing-extensions" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
-    { name = "vcrpy" },
+    { name = "vcrpy", specifier = ">=8.3" },
     { name = "vercel", specifier = ">=0.5.8,<0.8" },
     { name = "wasmtime", specifier = ">=15.0" },
 ]
@@ -961,8 +960,8 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">0.18.0" },
-    { name = "anthropic", marker = "extra == 'test'", specifier = ">=0.18.0" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=1,<2" },
+    { name = "anthropic", marker = "extra == 'test'", specifier = ">=1,<2" },
     { name = "boto3", marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'test'" },
     { name = "jsonpath-ng" },
@@ -6049,22 +6048,22 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.30.0"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "genai-prices" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/79/3f171b7e52d01d214110d4aca35376f05507f7ac3db87461ae5bb1eb4baa/pydantic_ai_slim-2.30.0.tar.gz", hash = "sha256:d7619f28f11b5a035047229bbdf67047fc755c27b01be5d6f36672be117625b7", size = 1212033, upload-time = "2026-08-14T03:17:03.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/00/ab2ec7a91f499e33fadd524f380acae3acf960f2f9140c8adce2e91c872b/pydantic_ai_slim-2.33.0.tar.gz", hash = "sha256:7809e3000df0265ee93e7c55ff1d852621a23b22ccb5ad790d9228e457cfb10a", size = 1229403, upload-time = "2026-08-21T05:05:55.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7e/ef2eb753013b0f128a0d1f2aa8e9fd17ab1d918cd7bb0897829a64117242/pydantic_ai_slim-2.30.0-py3-none-any.whl", hash = "sha256:0125bd525f0ff24127ff62c9da9b7a530b58110ce5c84fc8a1dce5c35e7565bd", size = 1429302, upload-time = "2026-08-14T03:16:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c0/d6120efa7f6466da2194e80032c483f8f8ececc5bafcf07cf064792f9702/pydantic_ai_slim-2.33.0-py3-none-any.whl", hash = "sha256:5ab28c9f6d7c0a6dd8e5c4f75ba4bcfa84a7f6aa0faa7b64209fbcaa981f922b", size = 1448791, upload-time = "2026-08-21T05:05:46.881Z" },
 ]
 
 [package.optional-dependencies]
@@ -6206,18 +6205,17 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.30.0"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b8/557b040138ae5d5fdf8afec655e0e9cc0493ed674221dd301e0466245053/pydantic_graph-2.30.0.tar.gz", hash = "sha256:9bf43c1e2785598399b4679a2837173c0e3018c8167d86c2f99713685e4ba845", size = 45177, upload-time = "2026-08-14T03:17:05.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/68/7bbebffe9d7a2033182c92b5610e5c52840d3ca877337435e1737fe59ed3/pydantic_graph-2.33.0.tar.gz", hash = "sha256:ff4bfd7f6e10b85b0fb77c85100140733f295e9bd445ed60318221446413e224", size = 45163, upload-time = "2026-08-21T05:05:58.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/76/7afc039ff5e34a08c6acc862818e1a7ee389862c892fcfb49b4e4c0d1d50/pydantic_graph-2.30.0-py3-none-any.whl", hash = "sha256:8282c1091fc03f2d4f40e83ab7ca09e3c117df6b645bbd6cd433561a8064e361", size = 52661, upload-time = "2026-08-14T03:16:59.508Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a5/73a9cd5a6dd5ca41391022597a9298aa50f9879df60299ac44f0eb7373e2/pydantic_graph-2.33.0-py3-none-any.whl", hash = "sha256:44e0ab3e0557e8e6f6ff2c939e1f15684b32029a14b55146cc88808a1c5cc464", size = 52648, upload-time = "2026-08-21T05:05:50.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why now

`pydantic-ai-slim` **2.33.0** — already released, and inside our `>=2.26.0,<3` range — requires `anthropic>=1.0.0`. 2.32.0 and earlier cap at 0.x. The next dependency bump that moved pydantic-ai would have pulled the major version in on its own, so this does it deliberately instead.

Every `anthropic` pin in the repo was also uncapped (`>=0.79.0`, `>=0.78.0`, `>0.18.0`, `>=0.49.0`, and two bare ones), and anthropic 1.0.0 is a final release on PyPI. The lock protected this repo; it did not protect a fresh install of published `arize-phoenix-evals` or the container extra.

## What this does

**Pins** — `anthropic>=1,<2` at all 8 manifest sites; `pydantic-ai-slim` floor raised to `>=2.33.0`. Lock regenerated: anthropic 1.0.0, pydantic-ai-slim 2.33.0, httpx2 2.10.0. `requires-python` was already `>=3.10` everywhere, so there is no Python floor or CI matrix change.

**Sampling parameters** — `temperature` / `top_p` are gone from the `messages.create()` signature but are still honored by models that accept them, so both conversion paths route them through `extra_body` (merged into the request JSON verbatim):

- `playground_clients.py` merges them *beneath* a user-configured `extra_body`, so an explicit override still wins.
- `phoenix-client`'s prompt helper collects them across all 14 provider branches; `from_anthropic` reads `extra_body` first and still accepts the old top-level shape, so kwargs captured against an older SDK keep converting.

**httpx → httpx2** — anthropic 1.x makes its requests through `httpx2`. Phoenix never hands an httpx object to an Anthropic client, so production code is untouched; only the mock transport in `test_agent_factory.py` had to be re-based (anthropic 1.x rejects an `httpx.AsyncClient` with a `TypeError`).

**vcrpy** — pinned `>=8.3` at both declaration sites. 8.3 is the first release that patches `httpx2`; on anything older the six `api.anthropic.com` cassettes silently stop matching and the tests reach the live API. The standalone trace script's `vcrpy==8.1.1` header pin is bumped for the same reason.

## Verification

- `mypy` — **0 errors across 1134 files**
- `ruff check` + `ruff format --check` — clean
- **1286 tests passed**, 0 failed (server agents, playground clients, chat-completion subscriptions, phoenix-client incl. the anthropic canary, phoenix-evals, and the prompt round-trip integration suite)
- The Anthropic cassette tests pass with **body matching**, which confirms the wire request is byte-identical to what 0.x produced.

New tests cover the `extra_body` round-trip in `packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py` — that path previously had no coverage.

## Reviewer notes

- **Span data is unchanged.** Routing `temperature` through `extra_body` would have nested it inside `llm.invocation_parameters`; a test caught it. The recorder now writes sampling keys at the top level and reserves the nested `extra_body` entry for genuine passthrough keys, so existing spans and saved filters are unaffected.
- **`AnthropicMessageModelKwargs` carries `extra_body` in place of `temperature`/`top_p`** — a type-level break for anyone annotating against it. Runtime behavior for the documented `messages.create(**kwargs)` usage is correct on both 0.x and 1.x, so this is not marked breaking.
- **The canary is capped `<2`.** `requirements/canary/sdk/anthropic.txt` was uncapped-latest by design, so the cap means it will not catch anthropic 2.0. Easy to change to `>=1` if you would rather keep that signal.
- **`examples/computer_use_agent` stays on 0.x.** `langchain-anthropic` still requires `anthropic<1`, so its `anthropic` line is left unpinned with a comment rather than pinned and made unresolvable.
- Nine fixtures in `tests/integration/client/test_prompts.py` moved their sampling params into `extra_body`. That test asserts input/output equality, so the fixtures have to match the shape `prompt.format()` now returns; leaving them top-level made the assertion untrue. `from_anthropic` still accepts the old top-level shape, covered by a unit test instead.

`opentelemetry-instrumentation-anthropic`'s 1.x compatibility in the standalone trace script is flagged but not chased.

`httpx2` provenance, since it is new to the dependency tree: it is the SDK's own HTTP dependency, the maintained fork of `httpx` by its original author, published by Pydantic ([pydantic/httpx2](https://github.com/pydantic/httpx2)), version line 2.x.

