### PR TITLE
fix: improve long filters and share tooltips

### DIFF
--- a/js/app/src/components/ShareLinkButton.tsx
+++ b/js/app/src/components/ShareLinkButton.tsx
@@ -1,7 +1,12 @@
-import { Tooltip, TooltipTrigger } from "react-aria-components";
 import { useLocation } from "react-router";
 
-import { Button, Icon, Icons, Text, View } from "@phoenix/components";
+import {
+  Button,
+  Icon,
+  Icons,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
@@ -40,16 +45,7 @@ export const ShareLinkButton = ({
       >
         {buttonText}
       </Button>
-      <Tooltip offset={10}>
-        <View
-          padding="size-100"
-          borderColor="default"
-          borderWidth="thin"
-          borderRadius="small"
-        >
-          <Text>{tooltipText}</Text>
-        </View>
-      </Tooltip>
+      <Tooltip offset={10}>{tooltipText}</Tooltip>
     </TooltipTrigger>
   );
 };

--- a/js/app/src/components/filter/styles.ts
+++ b/js/app/src/components/filter/styles.ts
@@ -20,6 +20,18 @@ export const dslFilterCodeMirrorCSS = css`
      controls out of view — without this the flex item's auto minimum is
      the full content width */
   min-width: 0;
+  .cm-scroller {
+    /* This is a single-line input, so keep long conditions horizontally
+       scrollable without letting scrollbar chrome consume vertical space and
+       create a second, unintended scroll axis. Caret movement, keyboard, and
+       trackpad scrolling still move the horizontal scrollport. */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
   .cm-content {
     padding: var(--global-dimension-size-100) 0;
   }

--- a/js/app/stories/DSLFilterConditionField.stories.tsx
+++ b/js/app/stories/DSLFilterConditionField.stories.tsx
@@ -73,6 +73,11 @@ const snippets: DSLFilterSnippet[] = [
   },
 ];
 
+const longCondition =
+  "parent_id is None and annotations['category'].label == 'alpha' and " +
+  "annotations['quality'].score >= 0.8 and latency_ms >= 10_000 and " +
+  "metadata['environment'] == 'production'";
+
 /**
  * Simulates fetching completions for values that actually exist in the
  * user's data (e.g. annotation names)
@@ -130,15 +135,17 @@ export default meta;
  * "Applied condition" readout below it. Each template supplies the field.
  */
 function FilterFieldHarness({
+  initialValue = "",
   renderField,
 }: {
+  initialValue?: string;
   renderField: (fieldProps: {
     value: string;
     onChange: (value: string) => void;
     onApplied: (condition: string) => void;
   }) => ReactNode;
 }) {
-  const [value, setValue] = useState<string>("");
+  const [value, setValue] = useState<string>(initialValue);
   const [validCondition, setValidCondition] = useState<string>("");
   return (
     <View width="600px" padding="size-400">
@@ -158,24 +165,37 @@ function FilterFieldHarness({
   );
 }
 
+function DSLFilterFieldStory({
+  args,
+  initialValue,
+}: {
+  args: DSLFilterConditionFieldProps;
+  initialValue?: string;
+}) {
+  return (
+    <FilterFieldHarness
+      initialValue={initialValue}
+      renderField={({ value, onChange, onApplied }) => (
+        <DSLFilterConditionField
+          {...args}
+          value={value}
+          onChange={onChange}
+          completions={completions}
+          snippets={snippets}
+          loadCompletions={loadCompletions}
+          validateCondition={validateCondition}
+          onValidCondition={(validCondition) => {
+            onApplied(validCondition.condition);
+            args.onValidCondition(validCondition);
+          }}
+        />
+      )}
+    />
+  );
+}
+
 const Template: StoryFn<DSLFilterConditionFieldProps> = (args) => (
-  <FilterFieldHarness
-    renderField={({ value, onChange, onApplied }) => (
-      <DSLFilterConditionField
-        {...args}
-        value={value}
-        onChange={onChange}
-        completions={completions}
-        snippets={snippets}
-        loadCompletions={loadCompletions}
-        validateCondition={validateCondition}
-        onValidCondition={(validCondition) => {
-          onApplied(validCondition.condition);
-          args.onValidCondition(validCondition);
-        }}
-      />
-    )}
-  />
+  <DSLFilterFieldStory args={args} />
 );
 
 /**
@@ -187,6 +207,15 @@ const Template: StoryFn<DSLFilterConditionFieldProps> = (args) => (
 export const Default = {
   render: Template,
 };
+
+/**
+ * A single-line condition that exceeds the field width. The editor keeps the
+ * caret reachable through horizontal scrolling without adding vertical scroll
+ * or moving the surrounding controls.
+ */
+export const LongCondition: StoryFn<DSLFilterConditionFieldProps> = (args) => (
+  <DSLFilterFieldStory args={args} initialValue={longCondition} />
+);
 
 function AIQueryTemplate(args: DSLFilterConditionFieldProps) {
   return (


### PR DESCRIPTION
## Summary

- Keep long span and trace filter conditions within the single-line editor without introducing vertical scrolling
- Preserve horizontal scrolling through caret movement, keyboard navigation, and trackpad gestures
- Use the shared Phoenix tooltip component for Share buttons so detail-drawer tooltips have the standard opaque background, border, and shadow
- Add a Storybook state covering an overflowing filter condition

## Screenshots

### Long filter

| Before | After |
| --- | --- |
| ![Long filter with scrollbar chrome](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15591-filter-before.png) | ![Long filter remains single-line without scrollbar chrome](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15591-filter-after.png) |

### Share tooltip

![Opaque Share tooltip in the trace drawer](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15591-share-tooltip.png)

## Testing

- `make format-frontend`
- `make lint-frontend`
- `make typecheck-frontend`
- `make build-ts`
- Focused filter tests: 19 passed
- Browser-verified a long filter in the seeded project UI, including Home/End navigation
- Browser-verified the Share tooltip in a trace drawer against the adjacent Copy ID tooltip
