### PR TITLE
test(dsl): normalize the session filter's NUL message on Python >= 3.11

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -927,9 +927,19 @@ def _compile_condition(
             validated = ast.parse(source, mode="eval")
         except ValueError:
             # A NUL in the source, which CPython 3.10 reports as `ValueError`
-            # rather than `SyntaxError` (3.11+ raises the latter, normalized by
-            # `_format_syntax_error` at the boundary).
+            # rather than `SyntaxError`.
             raise SyntaxError("condition cannot contain a NUL character") from None
+        except SyntaxError as error:
+            # From 3.11 on the same NUL arrives as a `SyntaxError` carrying the
+            # tokenizer's wording ("source code string cannot contain null
+            # bytes"), which describes source code the user never wrote. The
+            # rewrite has to happen here rather than at a caller's boundary:
+            # `SessionFilter` raises out of this function directly, so nothing
+            # downstream would reword it. Every other syntax error is the
+            # parser describing the user's own text and passes through raw.
+            if "null bytes" in (error.msg or ""):
+                raise SyntaxError("condition cannot contain a NUL character") from None
+            raise
         _validate_expression(validated, source, bindings, valid_eval_names=valid_annotation_names)
         _validate_semantics(validated, source, bindings)
         source, aliased_annotation_relations = _apply_eval_aliasing(source, bindings)
@@ -1089,9 +1099,11 @@ class SpanFilter:
         try:
             root = ast.parse(source, mode="eval")
         except ValueError as error:
-            # A NUL anywhere in the source, which `ast.parse` reports as a
+            # A NUL anywhere in the source, which CPython 3.10 reports as a
             # `ValueError` rather than a `SyntaxError`. Callers catch only the
-            # latter, so it would escape as a server error.
+            # latter, so it would escape as a server error. From 3.11 on the
+            # same NUL is already a `SyntaxError`, reworded by the
+            # `_format_syntax_error` boundary in `__post_init__`.
             raise SyntaxError("condition cannot contain a NUL character") from error
         _validate_expression(root, source)
         # Derived from the tree parsed just above rather than from the source


### PR DESCRIPTION
Follow-up to #14963, which normalized the NUL message at the two parse boundaries that existed then — `_format_syntax_error` (covering `SpanFilter`) and the experiment-run filter compiler. Both still hold.

The session filter DSL (#14101) added a third boundary five days later, `_compile_condition`, and reintroduced the same bug there. It copied the 3.10-only `except ValueError` shape from `SpanFilter._initialize` without the thing that makes that shape correct on newer interpreters — and said so in the comment it shipped with:

```python
except ValueError:
    # A NUL in the source, which CPython 3.10 reports as `ValueError`
    # rather than `SyntaxError` (3.11+ raises the latter, normalized by
    # `_format_syntax_error` at the boundary).
```

That parenthetical is true for `SpanFilter`, whose `__post_init__` wraps `_initialize` and reformats. It is false for `SessionFilter`, which calls `_compile_condition` directly and lets the `SyntaxError` out raw. So from 3.11 on, the tokenizer's `source code string cannot contain null bytes` — source code the user never wrote — reached the caller, and through `session_filters.py` reached a `BadRequest`.

The rewrite now happens at the parse site rather than at a caller's boundary, so a future caller of `_compile_condition` inherits it instead of having to remember it. Every other syntax error is the parser describing the user's own text and still passes through raw. The stale 3.10-only comment at the `SpanFilter` parse site is corrected too — behavior there was already right, the comment just carried the claim that misled here.

## Guard

The real-NUL row already in `test_session_filter_semantics.py` pins it. Which branch it exercises depends on the interpreter, which is the point: on a >= 3.11 leg it is the real end-to-end check and fails loudly if CPython changes the exception's type or wording again.

It has been failing on **every** >= 3.11 leg of the scheduled all-platforms run since #14101 merged on 2026-08-05 — spot-checked the 2026-08-05, 2026-08-07 and 2026-08-24 runs, where ubuntu/macos/windows x 3.13/3.14 all fail on this test id and every 3.10 leg passes. PR CI runs the unit suites on 3.10 only (`python-CI.yml` Unit Tests matrix), so this PR's own gate cannot prove the fix; the scheduled leg remains the honest guard, as noted in #14963.

## Verification

A/B on a throwaway 3.14 env, `tests/unit/trace/dsl/test_session_filter_semantics.py::test_session_filter_rejects_undesigned_forms`:

| | 3.10 | 3.14 |
|---|---|---|
| without fix | 95 passed | **1 failed** (`session_id == 'a\x00b'`), 94 passed — reproduces the CI assertion verbatim |
| with fix | 95 passed | 95 passed |

Full `tests/unit/trace/dsl/` green on both (815 passed, 218 skipped), plus `test_experiment_run_filters.py` on 3.14 to confirm #14963's other boundary is untouched.