### PR TITLE
chore: release arize-phoenix-client 3.4.0

### DIFF
--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -35,7 +35,7 @@ Phoenix Client provides an interface for interacting with the Phoenix platform v
 
 ## Installation
 
-Install the Phoenix Client using pip:
+Install the Phoenix Client with pip:
 
 ```bash
 pip install arize-phoenix-client


### PR DESCRIPTION
## Summary

Forces release-please to propose `3.4.0` instead of the incorrect `4.0.0` major bump currently shown in #15599. The breaking-change marker describes a change to an unreleased endpoint, so no published client contract was broken.

Includes a one-line README cleanup so release-please counts the commit within the `arize-phoenix-client` package path. After this merges, release-please will refresh its release PR as a normal minor release.

Release-As: 3.4.0