### PR TITLE
chore: release arize-phoenix 20.4.0

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1800,7 +1800,7 @@ class OAuth2ClientConfig:
         if self.client_assertion_file and not os.path.isabs(self.client_assertion_file):
             # Enforced here so the rule holds however the path arrived. A relative path would
             # resolve against the working directory, which nothing about this deployment
-            # pins — and requiring it now is only possible now, since tightening the contract
+            # pins — and requiring it is only possible now, since tightening the contract
             # after a release would break anyone who had relied on the looser one.
             source = (
                 f"named by {self.client_assertion_file_env_var}"


### PR DESCRIPTION
## Summary

Forces release-please to propose `20.4.0` instead of the incorrect `21.0.0` major bump currently shown in #15487. The breaking-change marker describes a change to an unreleased endpoint, so no published Phoenix contract was broken.

Includes a one-line comment cleanup under `src/phoenix/` so release-please counts the commit within the root `arize-phoenix` package. After this merges, release-please will refresh its release PR as a normal minor release.

Release-As: 20.4.0