### PR TITLE
fix: round-trip annotation names in table sort column ids

### DIFF
--- a/js/app/src/pages/project/__tests__/tableUtils.test.ts
+++ b/js/app/src/pages/project/__tests__/tableUtils.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ANNOTATIONS_COLUMN_PREFIX,
+  ANNOTATIONS_KEY_SEPARATOR,
   getGqlSessionSort,
   getGqlSort,
   makeFlatAnnotationColumnId,
   normalizeAnnotationColumnOrder,
 } from "../tableUtils";
 
+const ANNOTATION_NAMES_WITH_SPECIAL_CHARS = [
+  ["spaces", "my annotation"],
+  ["dashes", "hallucination-check"],
+  ["underscores", "qa_score"],
+  ["punctuation", "Q&A"],
+  ["percent signs", "top 10%"],
+  ["unicode", "质量"],
+] as const;
+
 describe("tableUtils", () => {
+  describe("makeFlatAnnotationColumnId", () => {
+    it("keeps alphanumeric names as a stable persisted column id", () => {
+      expect(makeFlatAnnotationColumnId("quality")).toEqual(
+        "annotations-score-quality"
+      );
+    });
+  });
+
   describe("getGqlSort", () => {
     it("extracts the score attribute from a flat annotation column id", () => {
       expect(
@@ -22,6 +41,42 @@ describe("tableUtils", () => {
       });
     });
 
+    it.each(ANNOTATION_NAMES_WITH_SPECIAL_CHARS)(
+      "round-trips score sorts for annotation names with %s",
+      (_label, name) => {
+        expect(
+          getGqlSort({
+            id: makeFlatAnnotationColumnId(name),
+            desc: true,
+          })
+        ).toEqual({
+          col: null,
+          evalResultKey: { attr: "score", name },
+          dir: "desc",
+        });
+      }
+    );
+
+    it.each(ANNOTATION_NAMES_WITH_SPECIAL_CHARS)(
+      "round-trips label sorts for annotation names with %s",
+      (_label, name) => {
+        expect(
+          getGqlSort({
+            id: [
+              ANNOTATIONS_COLUMN_PREFIX,
+              "label",
+              encodeURIComponent(name),
+            ].join(ANNOTATIONS_KEY_SEPARATOR),
+            desc: false,
+          })
+        ).toEqual({
+          col: null,
+          evalResultKey: { attr: "label", name },
+          dir: "asc",
+        });
+      }
+    );
+
     it("does not sort trace annotation columns", () => {
       expect(
         getGqlSort({
@@ -29,6 +84,15 @@ describe("tableUtils", () => {
           desc: false,
         })
       ).toEqual({ col: null, evalResultKey: null, dir: "asc" });
+    });
+
+    it("does not sort trace annotation columns whose names contain spaces", () => {
+      expect(
+        getGqlSort({
+          id: makeFlatAnnotationColumnId("my annotation", "trace"),
+          desc: true,
+        })
+      ).toEqual({ col: null, evalResultKey: null, dir: "desc" });
     });
   });
 
@@ -45,6 +109,42 @@ describe("tableUtils", () => {
         dir: "asc",
       });
     });
+
+    it.each(ANNOTATION_NAMES_WITH_SPECIAL_CHARS)(
+      "round-trips score sorts for annotation names with %s",
+      (_label, name) => {
+        expect(
+          getGqlSessionSort({
+            id: makeFlatAnnotationColumnId(name),
+            desc: false,
+          })
+        ).toEqual({
+          col: null,
+          annoResultKey: { attr: "score", name },
+          dir: "asc",
+        });
+      }
+    );
+
+    it.each(ANNOTATION_NAMES_WITH_SPECIAL_CHARS)(
+      "round-trips label sorts for annotation names with %s",
+      (_label, name) => {
+        expect(
+          getGqlSessionSort({
+            id: [
+              ANNOTATIONS_COLUMN_PREFIX,
+              "label",
+              encodeURIComponent(name),
+            ].join(ANNOTATIONS_KEY_SEPARATOR),
+            desc: true,
+          })
+        ).toEqual({
+          col: null,
+          annoResultKey: { attr: "label", name },
+          dir: "desc",
+        });
+      }
+    );
 
     it("does not sort trace annotation columns", () => {
       expect(

--- a/js/app/src/pages/project/tableUtils.ts
+++ b/js/app/src/pages/project/tableUtils.ts
@@ -29,6 +29,19 @@ export const DEFAULT_SESSION_SORT: ProjectSessionSort = {
   dir: "desc",
 };
 
+function parseAnnotationColumnSortKey(columnId: string): {
+  attr: string;
+  name: string;
+} {
+  const [, attr, ...encodedNameParts] = columnId.split(
+    ANNOTATIONS_KEY_SEPARATOR
+  );
+  return {
+    attr,
+    name: decodeURIComponent(encodedNameParts.join(ANNOTATIONS_KEY_SEPARATOR)),
+  };
+}
+
 export function getGqlSort(
   sort: ColumnSort
 ): TracesTableQuery$variables["sort"] {
@@ -44,7 +57,7 @@ export function getGqlSort(
     };
   }
   if (sort.id && sort.id.startsWith(ANNOTATIONS_COLUMN_PREFIX)) {
-    const [, attr, name] = sort.id.split(ANNOTATIONS_KEY_SEPARATOR);
+    const { attr, name } = parseAnnotationColumnSortKey(sort.id);
     evalResultKey = {
       attr,
       name,
@@ -74,7 +87,7 @@ export function getGqlSessionSort(
     };
   }
   if (sort.id && sort.id.startsWith(ANNOTATIONS_COLUMN_PREFIX)) {
-    const [, attr, name] = sort.id.split(ANNOTATIONS_KEY_SEPARATOR);
+    const { attr, name } = parseAnnotationColumnSortKey(sort.id);
     annoResultKey = {
       attr,
       name,
@@ -100,12 +113,10 @@ export function makeFlatAnnotationColumnId(
       ? TRACE_ANNOTATIONS_COLUMN_PREFIX
       : ANNOTATIONS_COLUMN_PREFIX;
   // The "score" segment survives from the grouped-column era so persisted
-  // sort, order, and visibility ids stay valid.
-  return (
-    `${prefix}${ANNOTATIONS_KEY_SEPARATOR}score${ANNOTATIONS_KEY_SEPARATOR}${name}`
-      // replace anything that's not alphanumeric with a dash
-      .replace(/[^a-zA-Z0-9]/g, "-")
-  );
+  // sort, order, and visibility ids stay valid. Encode only the name suffix
+  // so ids remain reversible for names with spaces or punctuation, while
+  // alphanumeric names keep the same persisted ids.
+  return `${prefix}${ANNOTATIONS_KEY_SEPARATOR}score${ANNOTATIONS_KEY_SEPARATOR}${encodeURIComponent(name)}`;
 }
 
 /** A kind of flat annotation columns: names plus the column id each maps to. */


### PR DESCRIPTION
Sorting by an annotation label or score column returned an empty table when the annotation name contained spaces, dashes, or punctuation.

`makeFlatAnnotationColumnId` replaced every non-alphanumeric character with `-`. `getGqlSort` and `getGqlSessionSort` then split the id on `-` and kept only the third segment, so `"my annotation"` became `"my"` and `"Q&A"` became `"Q"`. The backend joined on a name that did not exist and returned zero rows.

This encodes only the name suffix with `encodeURIComponent` and decodes the remaining segments, so alphanumeric ids stay `annotations-score-quality` while names with punctuation round-trip. Trace-annotation columns stay non-sortable.

Fixes #14748