### PR TITLE
fix(docs): label name in datasets and experiments get started doc

### DIFF
--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -150,7 +150,7 @@ To follow along, you should already have:
     - New application runs as a results of our task
     - Evaluation results for each version
 
-    In this example, we should see more traces receiving a **correct** label, indicating that the changes improved performance.
+    In this example, we should see more traces receiving a **complete** label, indicating that the changes improved performance.
 
     <Frame caption="View Experiment Results">
       <video


### PR DESCRIPTION
The video in the example below the changed line in the doc shows "complete" label instead of "correct".

resolves #<issue-number>


