### PR TITLE
fix(ui): submit login form on Enter keypress instead of navigating to forgot-password (#15617)

### DIFF
--- a/js/app/src/pages/auth/LoginForm.tsx
+++ b/js/app/src/pages/auth/LoginForm.tsx
@@ -144,6 +144,12 @@ export function LoginForm(props: LoginFormProps) {
                     onChange={onChange}
                     value={value}
                     autoComplete="current-password"
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        void handleSubmit(onSubmit)();
+                      }
+                    }}
                   >
                     <Label>Password</Label>
                     <Input placeholder="your password" />


### PR DESCRIPTION
Fixes #15617

### Summary
When focused on the password field in the login form (`/auth/login`) and pressing `Enter`, the browser was inadvertently activating the `#forgot-password-link` element positioned inside the password input container.

### Fix
- Added `onKeyDown` event handler to the password `TextField` component in `LoginForm.tsx` 