### PR TITLE
fix(agents): hold the send after a stop until the interrupted turn persists

### DIFF
--- a/js/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
+++ b/js/app/src/agent/chat/__tests__/createAgentSessionChat.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createClientToolTimingRecorder } from "@phoenix/agent/chat/clientToolTimings";
 import {
+  INTERRUPTED_TURN_POLL_INTERVAL_MS,
   applyClientToolTimingMetadata,
   createAgentSessionChat,
   getTurnClientState,
@@ -125,6 +126,146 @@ describe("applyClientToolTimingMetadata", () => {
         toolTimings,
       })
     ).toBe(messages);
+  });
+});
+
+type UIMessageStreamChunk = Record<string, unknown>;
+
+/**
+ * A UI message stream response that emits `chunks` and then stays open until
+ * the request is aborted (mirroring a real fetch, whose body read rejects on
+ * abort) or `shouldClose` is set.
+ */
+function createUIMessageStreamResponse({
+  chunks,
+  signal,
+  shouldClose = false,
+}: {
+  chunks: UIMessageStreamChunk[];
+  signal: AbortSignal | null | undefined;
+  shouldClose?: boolean;
+}) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)
+        );
+      }
+      if (shouldClose) {
+        controller.close();
+        return;
+      }
+      signal?.addEventListener(
+        "abort",
+        () => controller.error(new DOMException("Aborted", "AbortError")),
+        { once: true }
+      );
+    },
+  });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function createRelayEnvironmentWithSyncState(
+  getSyncState: () => { isActive: boolean; lastMessageId: string | null }
+) {
+  return new Environment({
+    network: Network.create((operation) => {
+      if (operation.name !== "agentSessionRelaySessionSyncStateQuery") {
+        return Promise.resolve({ data: {} });
+      }
+      const syncState = getSyncState();
+      return Promise.resolve({
+        data: {
+          agentSession: {
+            __typename: "AgentSession",
+            id: "session-1",
+            isActive: syncState.isActive,
+            updatedAt: "2026-08-25T00:00:00Z",
+            lastMessageId: syncState.lastMessageId,
+          },
+        },
+      });
+    }),
+    store: new Store(new RecordSource()),
+  });
+}
+
+describe("createAgentSessionChat stop", () => {
+  it("holds the next send after a stop until the server releases the turn lock", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      let isTurnLockHeld = true;
+      const getSyncState = vi.fn(() => ({
+        isActive: isTurnLockHeld,
+        lastMessageId: isTurnLockHeld ? "user-1" : "assistant-1",
+      }));
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) =>
+          fetchMock.mock.calls.length === 1
+            ? createUIMessageStreamResponse({
+                chunks: [
+                  { type: "start", messageId: "assistant-1" },
+                  { type: "text-start", id: "text-1" },
+                  { type: "text-delta", id: "text-1", delta: "Partial" },
+                ],
+                signal: init?.signal,
+              })
+            : createUIMessageStreamResponse({
+                chunks: [
+                  { type: "start", messageId: "assistant-2" },
+                  { type: "finish" },
+                ],
+                signal: init?.signal,
+                shouldClose: true,
+              })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const chat = createAgentSessionChat({
+        sessionId: "session-1",
+        seedMessages: [],
+        store: createAgentStore(),
+        relayEnvironment: createRelayEnvironmentWithSyncState(getSyncState),
+        onTranscriptSynced: () => undefined,
+      });
+
+      void chat.sendMessage({ text: "hello" });
+      await vi.waitFor(() => {
+        expect(chat.messages.at(-1)).toMatchObject({
+          id: "assistant-1",
+          role: "assistant",
+        });
+      });
+      await chat.stop();
+      // The stop starts probing for the lock release right away.
+      await vi.waitFor(() => {
+        expect(getSyncState).toHaveBeenCalledTimes(1);
+      });
+
+      // The follow-up is held while the server still holds the lock (it
+      // persists the interrupted turn before releasing it).
+      void chat.sendMessage({ text: "again" });
+      await vi.advanceTimersByTimeAsync(INTERRUPTED_TURN_POLL_INTERVAL_MS);
+      await flushMicrotasks();
+      expect(getSyncState).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      isTurnLockHeld = false;
+      await vi.advanceTimersByTimeAsync(INTERRUPTED_TURN_POLL_INTERVAL_MS);
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+      expect(getSyncState).toHaveBeenCalledTimes(3);
+      const secondRequestBody = JSON.parse(
+        String(fetchMock.mock.calls[1]?.[1]?.body)
+      ) as { lastMessageId: string | null };
+      expect(secondRequestBody.lastMessageId).toBe("assistant-1");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/js/app/src/agent/chat/createAgentSessionChat.ts
+++ b/js/app/src/agent/chat/createAgentSessionChat.ts
@@ -39,6 +39,7 @@ import {
   toAgentModelSelection,
 } from "@phoenix/components/agent/agentSessionModel";
 import {
+  fetchAgentSessionSyncState,
   refetchAgentSession,
   type AgentSessionSyncState,
   type RelayEnvironment,
@@ -55,6 +56,14 @@ import {
   parseAgentSessionConflictCode,
 } from "./agentChatApi";
 import { getRemovedUserMessageText } from "./removedUserMessageText";
+
+/**
+ * Cadence and cap for confirming the server released the turn lock after a
+ * stop. The server persists the interrupted turn before releasing the lock,
+ * so a released lock means the next send's `lastMessageId` check sees it.
+ */
+export const INTERRUPTED_TURN_POLL_INTERVAL_MS = 500;
+const INTERRUPTED_TURN_POLL_MAX_ATTEMPTS = 10;
 
 export type TurnClientState = {
   toolTimings: ReturnType<typeof createClientToolTimingRecorder>;
@@ -118,6 +127,36 @@ export function createAgentSessionChat({
   // racing its own in-flight change.
   let lastAssertedModelSelection: AgentModelSelection | null = null;
   const transcriptPersistence = createTranscriptPersistenceCoordinator();
+  /**
+   * Confirmation that the server finished persisting the turn this client
+   * stopped. The next send awaits it so its `lastMessageId` check cannot race
+   * the server's write of the interrupted message.
+   */
+  let interruptedTurnSettled: Promise<void> | null = null;
+  const waitForInterruptedTurnSettled = async () => {
+    for (
+      let attempt = 0;
+      attempt < INTERRUPTED_TURN_POLL_MAX_ATTEMPTS;
+      attempt += 1
+    ) {
+      if (attempt > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, INTERRUPTED_TURN_POLL_INTERVAL_MS)
+        );
+      }
+      try {
+        const syncState = await fetchAgentSessionSyncState({
+          environment: relayEnvironment,
+          sessionId,
+        });
+        if (syncState === null || !syncState.isActive) {
+          return;
+        }
+      } catch {
+        // Transient failure: try again on the next tick.
+      }
+    }
+  };
   const turnCompletionGate = createTurnCompletionGate({
     getShouldSendAutomatically: (messages) =>
       shouldSendAutomaticallyAfterToolOutput({
@@ -205,7 +244,8 @@ export function createAgentSessionChat({
     transport: new DefaultChatTransport({
       api: chatApiUrl,
       fetch: authFetch,
-      prepareSendMessagesRequest: ({ body, id, messages }) => {
+      prepareSendMessagesRequest: async ({ body, id, messages }) => {
+        await interruptedTurnSettled;
         turnCompletionGate.beginTurn();
         store.getState().setSessionResponsePending(sessionId, true);
         store.getState().setSessionNotice(sessionId, null);
@@ -354,7 +394,15 @@ export function createAgentSessionChat({
       }
       store.getState().setSessionBusyElsewhere(sessionId, true);
     },
-    onFinish: ({ messages: finalMessages, message }) => {
+    onFinish: ({ messages: finalMessages, message, isAbort }) => {
+      if (isAbort) {
+        const settled = waitForInterruptedTurnSettled().finally(() => {
+          if (interruptedTurnSettled === settled) {
+            interruptedTurnSettled = null;
+          }
+        });
+        interruptedTurnSettled = settled;
+      }
       turnCompletionGate.handleFinish({ finalMessages, message });
     },
   });


### PR DESCRIPTION
## What

Stopping a PXI response in the browser and sending a follow-up right away could be rejected as `agent_session_messages_stale`, withdrawing the message to the composer and showing "messages added elsewhere" although no other client touched the session.

The new request asserts the stopped assistant message as `lastMessageId`. The server persists that message inside the stream's shielded cleanup after it notices the disconnect, so a fast follow-up can land before the write commits.

## Fix

The chat runtime notes an aborted turn in `onFinish` (`isAbort`), polls the session's cheap sync probe until the turn lock is released — the server releases it only after persisting the interrupted turn — and `prepareSendMessagesRequest` awaits that confirmation before building the next request. Polling is 500 ms with a 10-attempt cap, so a persist failure delays the send by at most ~5 s and then falls through to the existing stale handling.

Companion CLI fix: #15455 (same race in `pxi`).

## Tested

- New test drives a real `Chat` through a stubbed UI message stream, calls `stop()`, and asserts the next send is held while the lock is reported held and goes out (with `lastMessageId` = the stopped message) once it is released.
- `vitest run src/agent/chat`: 79 passed. `tsc --noEmit` and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
