### PR TITLE
fix(filters): keep DSL overlays visible in clipped layouts

### DIFF
--- a/js/app/src/components/ai/AIOutline.tsx
+++ b/js/app/src/components/ai/AIOutline.tsx
@@ -6,7 +6,6 @@ import {
   aiConicBandCSS,
   aiConicSpin,
   aiGlowBreatheContained,
-  aiGlowBreathe,
   aiGlowFlashOpacity,
   aiGlowWipe,
   aiGlowWipeContinuousCSS,
@@ -17,15 +16,12 @@ import { classNames } from "@phoenix/utils/classNames";
 
 export type AIOutlineState = "idle" | "eligible" | "active";
 export type AIOutlineRadius = "small" | "medium";
-export type AIOutlineGlowMode = "outer" | "contained";
 
 export interface AIOutlineProps extends StylableProps {
   children: ReactNode;
   className?: string;
   /** Expands to the available width instead of shrink-wrapping its child. */
   isFullWidth?: boolean;
-  /** Keeps the glow within the target bounds for clipped or tightly packed rows. */
-  glowMode?: AIOutlineGlowMode;
   radius?: AIOutlineRadius;
   /** Runs one attention flash when an eligible outline changes to true. */
   shouldFlash?: boolean;
@@ -34,7 +30,6 @@ export interface AIOutlineProps extends StylableProps {
 
 const outlineCSS = css`
   --ai-conic-band-stroke-width: 1.5px;
-  --ai-outline-gap: var(--global-dimension-static-size-25);
   --ai-outline-target-radius: var(--global-rounding-small);
   position: relative;
   display: inline-grid;
@@ -54,47 +49,39 @@ const outlineCSS = css`
     --ai-outline-target-radius: var(--global-rounding-medium);
   }
 
+  /* Both decoration layers draw within the target's own bounds — the ring
+     rides the border and the glow blooms inward — so an ancestor may clip
+     right at the target's edge (dense toolbars, forms, dialogs) without
+     cutting the treatment. */
   .ai-outline__stroke,
   .ai-outline__glow {
     position: absolute;
+    inset: 0;
+    border-radius: var(--ai-outline-target-radius);
     pointer-events: none;
   }
 
   .ai-outline__stroke {
     ${aiConicBandCSS};
-    inset: calc(
-      -1 * (var(--ai-outline-gap) + var(--ai-conic-band-stroke-width))
-    );
     z-index: 2;
-    border-radius: calc(
-      var(--ai-outline-target-radius) + var(--ai-outline-gap) +
-        var(--ai-conic-band-stroke-width)
-    );
     opacity: 0.3;
     animation: ${aiConicSpin} var(--ai-conic-spin-duration) linear infinite
       paused;
   }
 
+  /* Above the child (which may be opaque) so the inward glow stays visible,
+     below the stroke so the band keeps its crisp edge */
   .ai-outline__glow {
     ${aiGlowWipeMaskCSS};
-    inset: calc(
-      -1 *
-        (var(--ai-outline-gap) + var(--ai-conic-band-stroke-width) +
-          var(--ai-glow-bleed))
-    );
-    z-index: 0;
-    border-radius: calc(
-      var(--ai-outline-target-radius) + var(--ai-outline-gap) +
-        var(--ai-conic-band-stroke-width)
-    );
+    z-index: 1;
   }
 
   .ai-outline__glow::before {
     content: "";
     position: absolute;
-    inset: var(--ai-glow-bleed);
+    inset: 0;
     border-radius: inherit;
-    box-shadow: var(--ai-glow-box-shadow-rest);
+    box-shadow: var(--ai-glow-box-shadow-contained-rest);
     opacity: 0;
   }
 
@@ -119,8 +106,8 @@ const outlineCSS = css`
 
   &[data-state="active"] .ai-outline__glow::before {
     opacity: 0.72;
-    animation: ${aiGlowBreathe} var(--ai-glow-wipe-duration) ease-in-out
-      infinite;
+    animation: ${aiGlowBreatheContained} var(--ai-glow-wipe-duration)
+      ease-in-out infinite;
   }
 
   &[data-state="eligible"][data-should-flash="true"] .ai-outline__glow {
@@ -130,34 +117,8 @@ const outlineCSS = css`
 
   &[data-state="eligible"][data-should-flash="true"] .ai-outline__glow::before {
     animation:
-      ${aiGlowBreathe} var(--ai-glow-wipe-duration) ease-in-out 1,
+      ${aiGlowBreatheContained} var(--ai-glow-wipe-duration) ease-in-out 1,
       ${aiGlowFlashOpacity} var(--ai-glow-wipe-duration) linear 1;
-  }
-
-  &[data-glow-mode="contained"] {
-    .ai-outline__stroke {
-      inset: 0;
-      border-radius: var(--ai-outline-target-radius);
-    }
-
-    .ai-outline__glow {
-      inset: 0;
-      border-radius: var(--ai-outline-target-radius);
-    }
-
-    .ai-outline__glow::before {
-      inset: 0;
-      box-shadow: var(--ai-glow-box-shadow-contained-rest);
-    }
-
-    &[data-state="active"] .ai-outline__glow::before {
-      animation-name: ${aiGlowBreatheContained};
-    }
-
-    &[data-state="eligible"][data-should-flash="true"]
-      .ai-outline__glow::before {
-      animation-name: ${aiGlowBreatheContained}, ${aiGlowFlashOpacity};
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -177,7 +138,6 @@ export function AIOutline({
   className,
   css: propCSS,
   isFullWidth = false,
-  glowMode = "outer",
   radius = "small",
   shouldFlash = false,
   state = "idle",
@@ -191,7 +151,6 @@ export function AIOutline({
       className={classNames("ai-outline", className)}
       css={composedCSS}
       data-full-width={isFullWidth ? "true" : undefined}
-      data-glow-mode={glowMode}
       data-radius={radius}
       data-should-flash={canFlash ? "true" : undefined}
       data-state={state}

--- a/js/app/src/components/core/overlay/Modal.tsx
+++ b/js/app/src/components/core/overlay/Modal.tsx
@@ -155,6 +155,7 @@ function ModalOverlay({
   return (
     <AriaModalOverlay
       {...props}
+      data-overlay-container="modal"
       data-testid="modal-overlay"
       css={modalBackdropCSS}
       // default to true, but allow for override

--- a/js/app/src/components/core/overlay/ViewportModal.tsx
+++ b/js/app/src/components/core/overlay/ViewportModal.tsx
@@ -208,6 +208,7 @@ function ViewportModalOverlayInner({
 
   const overlay = (
     <div
+      data-overlay-container="modal"
       data-testid="viewport-modal-overlay"
       className={typeof className === "string" ? className : undefined}
       css={viewportModalOverlayCSS}

--- a/js/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/js/app/src/components/filter/DSLFilterConditionField.tsx
@@ -16,13 +16,14 @@ import {
   StateEffect,
   StateField,
 } from "@codemirror/state";
-import { css } from "@emotion/react";
+import { css, Global } from "@emotion/react";
 import CodeMirror, {
   type BasicSetupOptions,
   Decoration,
   type DecorationSet,
   EditorView,
   keymap,
+  tooltips,
 } from "@uiw/react-codemirror";
 import type { ReactNode, Ref } from "react";
 import {
@@ -59,6 +60,7 @@ import {
   dslFilterCodeMirrorCSS,
   dslFilterErrorTooltipCSS,
   dslFilterFieldCSS,
+  portaledTypeaheadMenuCSS,
 } from "./styles";
 
 /**
@@ -827,6 +829,7 @@ export function DSLFilterConditionField<
       className={classNames("dsl-filter-condition-field", className)}
       css={dslFilterFieldCSS}
     >
+      <Global styles={portaledTypeaheadMenuCSS} />
       <Flex direction="row" alignItems="center">
         {leadingVisual ?? (
           <Icon svg={<Icons.ListFilter />} className="filter-icon" />
@@ -838,6 +841,22 @@ export function DSLFilterConditionField<
           readOnly={isReadOnly}
           onCreateEditor={(editorView) => {
             editorViewRef.current = editorView;
+            // A centered modal transforms and overflow-clips its dialog. That
+            // makes CodeMirror's fixed tooltip relative to the dialog and
+            // hides the completion menu outside the input's row. Reparent all
+            // editor tooltips to the modal overlay: they stay in the modal's
+            // interaction subtree while escaping the dialog's clip.
+            const tooltipParent = editorView.dom.closest<HTMLElement>(
+              '[data-overlay-container="modal"]'
+            );
+            if (tooltipParent) {
+              tooltipParent.classList.add("dsl-filter-tooltip-root");
+              editorView.dispatch({
+                effects: StateEffect.appendConfig.of(
+                  tooltips({ parent: tooltipParent })
+                ),
+              });
+            }
           }}
           onFocus={() => {
             // Refresh the loaded completions each time the user returns to

--- a/js/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/js/app/src/components/filter/DSLFilterConditionField.tsx
@@ -570,6 +570,16 @@ export function DSLFilterConditionField<
     [ariaLabel]
   );
 
+  // A centered modal transforms and overflow-clips its dialog. That makes
+  // CodeMirror's fixed tooltip relative to the dialog and hides the
+  // completion menu outside the input's row. Reparent all editor tooltips to
+  // the modal overlay: they stay in the modal's interaction subtree while
+  // escaping the dialog's clip. The parent is discovered once the editor
+  // mounts (see onCreateEditor) and lives in the extensions array — an
+  // appended config would be silently dropped by the root reconfigure that
+  // any extensions change dispatches.
+  const [tooltipParent, setTooltipParent] = useState<HTMLElement | null>(null);
+
   // The extensions must be referentially stable across renders — a new
   // array causes a CodeMirror reconfigure, which resets the in-flight
   // completion state (e.g. the dropdown opened by focusing the field).
@@ -579,8 +589,16 @@ export function DSLFilterConditionField<
   // while the variant is on (a variant flip reconfigures the editor either
   // way).
   const extensions = useMemo(() => {
+    const tooltipReparent = tooltipParent
+      ? [tooltips({ parent: tooltipParent })]
+      : [];
     if (variant === "prose") {
-      return [...composedExtensions, singleLineKeymap, contentAttributes];
+      return [
+        ...composedExtensions,
+        singleLineKeymap,
+        contentAttributes,
+        ...tooltipReparent,
+      ];
     }
     // Fetch loaded completions at most once per focus, retrying on failure
     // the next time the dropdown opens
@@ -640,6 +658,7 @@ export function DSLFilterConditionField<
         }
       }),
       contentAttributes,
+      ...tooltipReparent,
       autocompletion({
         override: [
           ...completionSources,
@@ -668,6 +687,7 @@ export function DSLFilterConditionField<
     completionSources,
     getContextualCompletions,
     contentAttributes,
+    tooltipParent,
   ]);
 
   // Anchor the error to the sub-expression it came from once validation has
@@ -841,21 +861,12 @@ export function DSLFilterConditionField<
           readOnly={isReadOnly}
           onCreateEditor={(editorView) => {
             editorViewRef.current = editorView;
-            // A centered modal transforms and overflow-clips its dialog. That
-            // makes CodeMirror's fixed tooltip relative to the dialog and
-            // hides the completion menu outside the input's row. Reparent all
-            // editor tooltips to the modal overlay: they stay in the modal's
-            // interaction subtree while escaping the dialog's clip.
-            const tooltipParent = editorView.dom.closest<HTMLElement>(
+            const overlay = editorView.dom.closest<HTMLElement>(
               '[data-overlay-container="modal"]'
             );
-            if (tooltipParent) {
-              tooltipParent.classList.add("dsl-filter-tooltip-root");
-              editorView.dispatch({
-                effects: StateEffect.appendConfig.of(
-                  tooltips({ parent: tooltipParent })
-                ),
-              });
+            if (overlay) {
+              overlay.classList.add("dsl-filter-tooltip-root");
+              setTooltipParent(overlay);
             }
           }}
           onFocus={() => {

--- a/js/app/src/components/filter/ai/AIQueryDSLFilterField.tsx
+++ b/js/app/src/components/filter/ai/AIQueryDSLFilterField.tsx
@@ -458,7 +458,6 @@ export function AIQueryDSLFilterField<
 
   return (
     <AIOutline
-      glowMode="contained"
       isFullWidth
       state={aiOutlineState}
       shouldFlash

--- a/js/app/src/components/filter/ai/AIQueryDSLFilterField.tsx
+++ b/js/app/src/components/filter/ai/AIQueryDSLFilterField.tsx
@@ -458,6 +458,7 @@ export function AIQueryDSLFilterField<
 
   return (
     <AIOutline
+      glowMode="contained"
       isFullWidth
       state={aiOutlineState}
       shouldFlash

--- a/js/app/src/components/filter/ai/styles.ts
+++ b/js/app/src/components/filter/ai/styles.ts
@@ -42,7 +42,7 @@ export const aiQueryFilterFieldCSS = css`
   .dsl-filter-condition-field[data-variant="prose"] {
     border-color: transparent;
     &:has(.cm-content:focus-visible) {
-      outline: none;
+      outline-color: transparent;
     }
   }
   /* The converting glyph keeps the resting glyph's footprint (no layout

--- a/js/app/src/components/filter/ai/styles.ts
+++ b/js/app/src/components/filter/ai/styles.ts
@@ -15,9 +15,6 @@ import { dslFilterBadgeGrowIn } from "../styles";
 export const aiQueryFilterFieldCSS = css`
   flex: 1 1 auto;
   min-width: 0;
-  /* The gradient hugs the field's border — the outline's default standoff
-     gap reads as a detached double border on an input */
-  --ai-outline-gap: 0px;
   &[data-state="idle"] .ai-outline__stroke {
     opacity: 0;
   }

--- a/js/app/src/components/filter/styles.ts
+++ b/js/app/src/components/filter/styles.ts
@@ -223,6 +223,12 @@ export const dslFilterFieldCSS = css`
   background-color: var(--global-input-field-background-color);
   transition: all 0.2s ease-in-out;
   overflow-x: hidden;
+  /* Carry the focus ring's geometry at rest and reveal it with color alone,
+     the way the text inputs do. Leaving the outline unset means focus has to
+     transition off the initial medium-width outline, which animates a thicker
+     ring inward from outside the border. */
+  outline: var(--focus-ring-thickness) solid transparent;
+  outline-offset: calc(-1 * var(--focus-ring-thickness));
   &:hover {
     border-color: var(--global-input-field-border-color-active);
   }
@@ -230,8 +236,7 @@ export const dslFilterFieldCSS = css`
     border-color: var(--global-input-field-border-color-active);
   }
   &:has(.cm-content:focus-visible) {
-    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
-    outline-offset: calc(-1 * var(--focus-ring-thickness));
+    outline-color: var(--focus-ring-color);
   }
   /* Flag invalidity only once the user has left the field — a red border
      while they're still typing/fixing the expression is too alarming */

--- a/js/app/src/components/filter/styles.ts
+++ b/js/app/src/components/filter/styles.ts
@@ -1,54 +1,25 @@
 import { css, keyframes } from "@emotion/react";
 
-import { APP_FLOATING_Z_INDEX } from "@phoenix/components/core/zIndex";
+import { APP_PORTALED_OVERLAY_Z_INDEX } from "@phoenix/components/core/zIndex";
 
 /**
  * The popover surface shared by every floating element the filter field
  * shows — the typeahead menu, its info panel, and the error popover — so
  * they all read as the same surface
  */
-const popoverSurfaceCSS = css`
+export const popoverSurfaceCSS = css`
   background-color: var(--global-popover-background-color);
   border: 1px solid var(--global-popover-border-color);
   border-radius: var(--global-rounding-small);
   box-shadow: 0 8px 16px var(--global-overlay-shadow-color);
 `;
 
-export const dslFilterCodeMirrorCSS = css`
-  flex: 1 1 auto;
-  /* A long expression must scroll inside the editor, not push the field's
-     controls out of view — without this the flex item's auto minimum is
-     the full content width */
-  min-width: 0;
-  .cm-scroller {
-    /* This is a single-line input, so keep long conditions horizontally
-       scrollable without letting scrollbar chrome consume vertical space and
-       create a second, unintended scroll axis. Caret movement, keyboard, and
-       trackpad scrolling still move the horizontal scrollport. */
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none;
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-  .cm-content {
-    padding: var(--global-dimension-size-100) 0;
-  }
-  .cm-editor {
-    background-color: transparent !important;
-  }
-  .cm-focused {
-    outline: none;
-  }
-  .cm-selectionLayer .cm-selectionBackground {
-    background: var(--global-color-cyan-400) !important;
-  }
-  /* Restyle the autocomplete tooltip as a design-system menu */
+/** Shared CodeMirror autocomplete menu and info-panel chrome. */
+export const typeaheadMenuCSS = css`
   .cm-tooltip.cm-tooltip-autocomplete.dsl-filter-typeahead {
     ${popoverSurfaceCSS}
     padding: var(--global-dimension-size-50);
-    z-index: ${APP_FLOATING_Z_INDEX};
+    z-index: ${APP_PORTALED_OVERLAY_Z_INDEX};
     /* CodeMirror anchors the tooltip to the text line inside the field, so
        the offset must clear the field's inner padding and border before it
        reads as a gap below the input itself. A transform (rather than
@@ -62,7 +33,11 @@ export const dslFilterCodeMirrorCSS = css`
       font-family: var(--global-font-family-sans);
       font-size: var(--global-font-size-s);
       line-height: var(--global-line-height-s);
-      max-height: 400px;
+      /* Keep the menu short enough to fit on either side of a field in a
+         centered dialog. CodeMirror chooses above/below from the measured
+         height, so a viewport-relative cap prevents an unnecessary flip into
+         the viewport edge on compact screens. */
+      max-height: min(400px, 40vh);
       min-width: 280px;
       /* Wide enough that the longest shipped suggestion snippet (~77 mono
          chars) fits its own stacked line — see li.dsl-filter-suggestion */
@@ -149,6 +124,50 @@ export const dslFilterCodeMirrorCSS = css`
     color: var(--global-text-color-700);
     max-width: 300px;
   }
+`;
+
+/**
+ * CodeMirror tooltips normally inherit the field's scoped Emotion styles.
+ * Inside a modal they are reparented to the overlay container to escape the
+ * dialog's transformed overflow clip, so repeat that scope at the portal root.
+ */
+export const portaledTypeaheadMenuCSS = css`
+  .dsl-filter-tooltip-root {
+    ${typeaheadMenuCSS}
+  }
+`;
+
+export const dslFilterCodeMirrorCSS = css`
+  flex: 1 1 auto;
+  /* A long expression must scroll inside the editor, not push the field's
+     controls out of view — without this the flex item's auto minimum is
+     the full content width */
+  min-width: 0;
+  .cm-scroller {
+    /* This is a single-line input, so keep long conditions horizontally
+       scrollable without letting scrollbar chrome consume vertical space and
+       create a second, unintended scroll axis. Caret movement, keyboard, and
+       trackpad scrolling still move the horizontal scrollport. */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+  .cm-content {
+    padding: var(--global-dimension-size-100) 0;
+  }
+  .cm-editor {
+    background-color: transparent !important;
+  }
+  .cm-focused {
+    outline: none;
+  }
+  .cm-selectionLayer .cm-selectionBackground {
+    background: var(--global-color-cyan-400) !important;
+  }
+  ${typeaheadMenuCSS}
   /* The tab-through blanks an inserted snippet leaves behind — CodeMirror's
      default marking is a near-invisible gray, so tint them with the primary
      color to read as "fill me in": the active one is selected for overtyping,

--- a/js/app/stories/AIOutline.stories.tsx
+++ b/js/app/stories/AIOutline.stories.tsx
@@ -35,17 +35,12 @@ const meta = {
   },
   args: {
     children: <Button size="S">Hallucination evaluator</Button>,
-    glowMode: "outer",
     isFullWidth: false,
     radius: "small",
     shouldFlash: false,
     state: "idle",
   },
   argTypes: {
-    glowMode: {
-      control: "inline-radio",
-      options: ["outer", "contained"],
-    },
     radius: {
       control: "inline-radio",
       options: ["small", "medium"],
@@ -187,27 +182,21 @@ function ClippedRowExample() {
       <Flex key={flashKey} direction="column" gap="size-300">
         <Flex direction="column" gap="size-100">
           <Text size="XS" color="text-500">
-            Glow modes inside overflow: hidden
+            Inside overflow: hidden
           </Text>
           <div css={clippedRowCSS}>
-            <AIOutline glowMode="outer" state="eligible" shouldFlash>
-              <Button size="S">Outer glow</Button>
-            </AIOutline>
-            <AIOutline glowMode="contained" state="eligible" shouldFlash>
-              <Button size="S">Contained glow</Button>
+            <AIOutline state="eligible" shouldFlash>
+              <Button size="S">Hallucination evaluator</Button>
             </AIOutline>
           </div>
         </Flex>
         <Flex direction="column" gap="size-100">
           <Text size="XS" color="text-500">
-            Glow modes with overflow visible
+            With overflow visible
           </Text>
           <Flex gap="size-200">
-            <AIOutline glowMode="outer" state="eligible" shouldFlash>
-              <Button size="S">Outer glow</Button>
-            </AIOutline>
-            <AIOutline glowMode="contained" state="eligible" shouldFlash>
-              <Button size="S">Contained glow</Button>
+            <AIOutline state="eligible" shouldFlash>
+              <Button size="S">Hallucination evaluator</Button>
             </AIOutline>
           </Flex>
         </Flex>

--- a/js/app/stories/DSLFilterConditionField.stories.tsx
+++ b/js/app/stories/DSLFilterConditionField.stories.tsx
@@ -350,8 +350,18 @@ export const WithAIQueryInClippedLayout = {
     await userEvent.click(
       await body.findByRole("button", { name: "Plain-English query" })
     );
+    // The treatment draws within the field's own bounds, so the clipping
+    // ancestor cannot cut it — assert the ring never extends past the field
     const outline = document.querySelector(".ai-outline");
-    await expect(outline).toHaveAttribute("data-glow-mode", "contained");
+    const stroke = outline?.querySelector(".ai-outline__stroke");
+    await expect(outline).not.toBeNull();
+    await expect(stroke).not.toBeNull();
+    const outlineRect = outline!.getBoundingClientRect();
+    const strokeRect = stroke!.getBoundingClientRect();
+    await expect(strokeRect.left).toBeGreaterThanOrEqual(outlineRect.left);
+    await expect(strokeRect.top).toBeGreaterThanOrEqual(outlineRect.top);
+    await expect(strokeRect.right).toBeLessThanOrEqual(outlineRect.right);
+    await expect(strokeRect.bottom).toBeLessThanOrEqual(outlineRect.bottom);
   },
 };
 

--- a/js/app/stories/DSLFilterConditionField.stories.tsx
+++ b/js/app/stories/DSLFilterConditionField.stories.tsx
@@ -1,10 +1,23 @@
 import type { Completion } from "@codemirror/autocomplete";
+import { css } from "@emotion/react";
 import type { Meta, StoryFn } from "@storybook/react";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
-import { Flex, Text, View } from "@phoenix/components";
+import {
+  Dialog,
+  Flex,
+  Text,
+  View,
+  ViewportModal,
+  ViewportModalOverlay,
+} from "@phoenix/components";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@phoenix/components/core/dialog";
 import {
   type DSLFilterSnippet,
   AIQueryDSLFilterField,
@@ -217,6 +230,46 @@ export const LongCondition: StoryFn<DSLFilterConditionFieldProps> = (args) => (
   <DSLFilterFieldStory args={args} initialValue={longCondition} />
 );
 
+/**
+ * The evaluator form renders the field inside a modal whose transformed,
+ * overflow-clipped dialog would trap CodeMirror's fixed typeahead. This story
+ * keeps that production geometry in the regression harness and opens the
+ * suggestions as a user would.
+ */
+export const InModal = {
+  render: (args: DSLFilterConditionFieldProps) => (
+    <ViewportModalOverlay defaultOpen isDismissable={false}>
+      <ViewportModal size="fullscreen">
+        <Dialog>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Evaluator Scope</DialogTitle>
+            </DialogHeader>
+            <DSLFilterFieldStory args={args} />
+          </DialogContent>
+        </Dialog>
+      </ViewportModal>
+    </ViewportModalOverlay>
+  ),
+  play: async () => {
+    const body = within(document.body);
+    const field = await body.findByRole("textbox", {
+      name: "filter condition",
+    });
+    await userEvent.click(field);
+    const listbox = await body.findByRole("listbox", {
+      name: "Completions",
+    });
+    await expect(listbox).toBeVisible();
+    await userEvent.keyboard("{ArrowDown}");
+    await expect(
+      within(listbox).getByRole("option", {
+        name: /filter by fast responses/i,
+      })
+    ).toHaveAttribute("aria-selected", "true");
+  },
+};
+
 function AIQueryTemplate(args: DSLFilterConditionFieldProps) {
   return (
     <CredentialsProvider>
@@ -272,6 +325,35 @@ export const WithAIQueryEnabled: StoryFn<DSLFilterConditionFieldProps> = (
     <AIQueryTemplate {...args} />
   </PreferencesProvider>
 );
+
+const clippedLayoutCSS = css`
+  width: 600px;
+  overflow: hidden;
+  border: 1px dashed var(--global-border-color-default);
+`;
+
+/**
+ * Dense form and table layouts often clip overflow at their bounds. The AI
+ * treatment must keep its complete animated border visible in that geometry
+ * rather than bleeding outside the field and losing its outer edges.
+ */
+export const WithAIQueryInClippedLayout = {
+  render: (args: DSLFilterConditionFieldProps) => (
+    <div css={clippedLayoutCSS}>
+      <PreferencesProvider isAIQueryEnabled>
+        <AIQueryTemplate {...args} />
+      </PreferencesProvider>
+    </div>
+  ),
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.click(
+      await body.findByRole("button", { name: "Plain-English query" })
+    );
+    const outline = document.querySelector(".ai-outline");
+    await expect(outline).toHaveAttribute("data-glow-mode", "contained");
+  },
+};
 
 /**
  * Without `snippets` or `loadCompletions`, the typeahead surfaces only the


### PR DESCRIPTION
Closes #15615. Supersedes #15618, rebased onto `main` so it stands alone (its base branch is unmerged).

## Summary
- reparent CodeMirror filter tooltips to modal overlay roots so the typeahead escapes transformed, overflow-clipped dialogs — the `tooltips({parent})` extension lives in the editor's extensions array so it survives root reconfigures (variant flips, completion refreshes)
- extract the typeahead menu styles into a shared `typeaheadMenuCSS` so the reparented tooltips keep their styling at the portal root; use the portaled-overlay stacking band and a viewport-relative menu height for reliable modal placement
- give `AIOutline` a single clip-proof geometry: the ring rides the target's border and the glow blooms inward, so clipped form and table layouts keep the complete treatment with no per-caller `glowMode`
- layer the glow above the (opaque) child so the active "thinking" pulse is actually visible
- settle the DSL field's focus ring like a text input (transparent outline at rest, color-only reveal)
- add interactive Storybook regressions for modal keyboard completion and the clipped AI Query treatment

## Test plan
- [x] `make format-frontend`
- [x] `make lint-frontend`
- [x] `make typecheck-frontend`
- [x] `make test-frontend` (231 files; 2,310 passed, 12 skipped)
- [x] verify the modal typeahead, clipped AI Query, and AIOutline stories in Storybook against this rebase

## Screenshots
The viewport-modal story keeps the typeahead visible beyond the dialog's clipped content and selects its first option through keyboard navigation.

![DSL filter typeahead visible in modal](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15618-modal-dsl-typeahead.png)

The clipped-layout story shows the complete AI Query gradient border inside an `overflow: hidden` container.

![AI Query glow whole in clipped layout](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15618-contained-ai-query-glow.png)
