### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -12,7 +12,6 @@
 
 ## Quick Start
 
-- [Agent-Assisted Setup](https://arize.com/docs/phoenix/agent-assisted-setup): Add Phoenix tracing with one command — px setup hands instrumentation to your coding agent and verifies a real trace arrives
 - [Tracing Quickstart](https://arize.com/docs/phoenix/get-started/get-started-tracing): Instrument an app and send your first traces to Phoenix
 - [Evaluations Quickstart](https://arize.com/docs/phoenix/get-started/get-started-evaluations): Run your first LLM evaluator and view results
 - [Playground Quickstart](https://arize.com/docs/phoenix/get-started/get-started-prompt-playground): Test prompt variations against real examples in the Playground
@@ -133,6 +132,7 @@
 - [Matches Regex](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/matches-regex): Evaluate if output matches a regular expression pattern
 - [Precision / Recall / F-Score](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/precision-recall-fscore): Compute precision, recall, and F-beta scores for classification tasks
 - [Refusal](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/refusal): Detect when an LLM refuses or declines to answer a user query
+- [Retrieval Relevance](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/retrieval-relevance): Score whether retrieved context — RAG, tool, MCP, or web search — is relevant to the request
 - [Tool Invocation](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-invocation): Evaluate whether LLM tool calls have correct arguments and formatting
 - [Tool Response Handling](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-response-handling): Evaluate how agents process tool results — error handling, data extraction, and recovery
 - [Tool Selection](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-selection): Evaluate whether LLMs select the correct tools for given tasks
@@ -450,7 +450,6 @@
 ### Evaluation
 
 - [LLM as a Judge](https://arize.com/docs/phoenix/evaluation/concepts-evals/llm-as-a-judge): LLM-based evaluation best practices
-- [Evaluator Input Mapping](https://arize.com/docs/phoenix/evaluation/concepts-evals/input-mapping): Reshape nested payloads to an evaluator's expected fields with `input_mapping` and `bind_evaluator`
 
 ## Resources
 
@@ -837,6 +836,7 @@
 - [08.04.2026: Chat Completions Proxy, AI Query, and Annotation Charts](https://arize.com/docs/phoenix/release-notes/08-2026/08-04-2026-chat-completions-proxy-ai-query-and-annotation-charts): Proxy OpenAI-compatible chat completions with server-held credentials, write filters in plain English, chart every annotation, and judge hallucination against the conversation
 - [08.11.2026: Persistent Agent Sessions](https://arize.com/docs/phoenix/release-notes/08-2026/08-11-2026-persistent-agent-sessions): Agent conversations persist server-side — browse, restore, rewind, branch, and compact them from the browser or the pxi terminal client
 - [08.12.2026: Session Filter Expressions, REST API Expansion, and Endpoint Configuration](https://arize.com/docs/phoenix/release-notes/08-2026/08-12-2026-session-filters-rest-api-and-endpoint-config): Filter sessions with a full expression language, manage dataset splits and experiment tags over REST, transfer traces between projects, and point every SDK at PHOENIX_ENDPOINT
+- [08.17.2026: Trace Filter Expressions and Analytics SQL](https://arize.com/docs/phoenix/release-notes/08-2026/08-17-2026-trace-filters-and-analytics-sql): Filter the traces table with a full expression language and query Phoenix with read-only SQL over MCP
 
 ### 2025
 


### PR DESCRIPTION
## Summary

Audited `docs/phoenix/llms.txt` against the docs tree (`docs.json` navigation ∩ `docs/phoenix/**/*.mdx`, cross-checked with `docs/phoenix/sitemap.xml`) and reconciled the index.

Net: **+2 entries, −2 entries** (702 entries total).

## Added

| Entry | Why |
| --- | --- |
| `evaluation/pre-built-metrics/retrieval-relevance` | Published nav page with no index entry. Slots into the alphabetized **Pre-Built Metrics — Individual Pages** list so agents can find the metric by name. |
| `release-notes/08-2026/08-17-2026-trace-filters-and-analytics-sql` | Newest release note (arize-phoenix 20.3.0) was missing from the **Release Notes → 2026** subsection. |

## Removed

| Entry | Why |
| --- | --- |
| `evaluation/concepts-evals/input-mapping` | **Stale.** This path is a *redirect source* in `docs.json` (→ `/docs/phoenix/evaluation/how-to-evals`) and is absent from the sitemap. Server-side input mapping is still covered by the `evaluation/server-evals/input-mapping` entry. |
| `agent-assisted-setup` | Excluded per the llms.txt coverage rules — the page targets AI coding agents performing setup, not LLM documentation consumers. |

## Coverage

- Sitemap pages: **707**
- Indexed in `llms.txt`: **698** → **98.7%** (AFDocs Agent Score flags < 80%, target ≥ 90%)

The 9 unindexed sitemap pages are all deliberate exclusions:

- `documentation/jp`, `documentation/zh` — translated pages
- `end-to-end-features-notebook` — Colab notebook link
- `phoenix-demo` — interactive demo, not fetchable content
- `agent-assisted-setup` — see above
- `resources/github`, `resources/openinference`, `resources/python-api`, `resources/typescript-api` — frontmatter-only stubs (`url:` redirects) with no page body; two point at external GitHub repos, two duplicate SDK reference pages already indexed under **SDK & API Reference**

## Verified, no change needed

- No duplicate titles and no duplicate URLs across the file.
- All 702 entry lines parse as `- [Title](url): description`.
- No filler descriptions ("comprehensive", "learn more about", "overview of").
- `get-started` is indexed but not in the sitemap — intentional. `docs/phoenix/get-started.mdx` exists, is a redirect destination from `/docs/phoenix/quickstart`, and is linked from four other docs pages; it is served, just not in the sidebar nav.
- The OpenAPI spec URL remains present in the **SDK & API Reference** section.

## Test plan

- `pnpm --dir js/packages/phoenix-cli test -- --grep "docs"` — the CLI docs parser tests exercise this file. Not run locally (sandbox blocked the command); CI covers it.
