### PR TITLE
fix(playground): preserve tool choice and strict setting for Anthropic and Bedrock

### DIFF
--- a/js/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/js/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -31,6 +31,7 @@ import {
   getToolsFromAttributes,
   getResponseFormatFromAttributes,
   getToolChoiceFromAttributes,
+  getToolDefinitionDisplay,
   getToolName,
   getVariablesMapFromInstances,
   inferOpenAIApiTypeFromRawToolDefinitions,
@@ -38,6 +39,7 @@ import {
   isOpenAIResponsesSpan,
   processAttributeToolCalls,
   promptToolFromGraphQL,
+  toCanonicalToolDefinition,
   toolFromEditorJSON,
   toolToPromptToolInput,
   transformSpanAttributesToPlaygroundInstance,
@@ -2214,6 +2216,62 @@ describe("toolFromEditorJSON", () => {
       })
     ).toBeNull();
   });
+
+  it("should convert Anthropic-shaped editor JSON with strict into a function tool", () => {
+    const value = {
+      name: "get_weather",
+      description: "Get weather",
+      input_schema: {
+        type: "object",
+        properties: { location: { type: "string" } },
+        required: ["location"],
+      },
+      strict: true,
+    };
+
+    expect(toolFromEditorJSON({ value, id: 1, editorType: "json" })).toEqual({
+      kind: "function",
+      id: 1,
+      editorType: "json",
+      definition: {
+        name: "get_weather",
+        description: "Get weather",
+        parameters: {
+          type: "object",
+          properties: { location: { type: "string" } },
+          required: ["location"],
+        },
+        strict: true,
+      },
+    });
+  });
+});
+
+describe("tool definition strict round-trip", () => {
+  const buildCanonicalTool = (strict: boolean): CanonicalToolDefinition => ({
+    name: "get_weather",
+    description: "Get weather",
+    parameters: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+    strict,
+  });
+
+  it.each([
+    ["ANTHROPIC", true],
+    ["ANTHROPIC", false],
+    ["AWS", true],
+    ["AWS", false],
+  ] as const)(
+    "should preserve strict through the %s editor display and back (strict: %s)",
+    (provider, strict) => {
+      const canonicalTool = buildCanonicalTool(strict);
+      const display = getToolDefinitionDisplay(canonicalTool, provider);
+      expect(toCanonicalToolDefinition(display)).toEqual(canonicalTool);
+    }
+  );
 });
 
 describe("getPromptTemplateVariablesFromAttributes", () => {

--- a/js/app/src/pages/playground/playgroundUtils.ts
+++ b/js/app/src/pages/playground/playgroundUtils.ts
@@ -1730,14 +1730,11 @@ export function toCanonicalToolDefinition(
   // OpenAI Chat Completions: { type: "function", function: { name, description?, parameters, strict? } }
   const openai = openAIChatCompletionsToolDefinitionSchema.safeParse(raw);
   if (openai.success) {
-    const fn = openai.data.function as Record<string, unknown>;
     return {
       name: openai.data.function.name,
       description: openai.data.function.description ?? null,
       parameters: canonicalParameters(openai.data.function.parameters),
-      // strict lives at the function level in the actual API but isn't in
-      // our looseObject schema — extract safely.
-      strict: typeof fn.strict === "boolean" ? fn.strict : null,
+      strict: openai.data.function.strict ?? null,
     };
   }
   // OpenAI Responses API: flat { type: "function", name, parameters, strict, description? }
@@ -1757,7 +1754,7 @@ export function toCanonicalToolDefinition(
       name: anthropic.data.name,
       description: anthropic.data.description ?? null,
       parameters: canonicalParameters(anthropic.data.input_schema),
-      strict: null,
+      strict: anthropic.data.strict ?? null,
     };
   }
   // AWS: { toolSpec: { name, description, inputSchema: { json } } }
@@ -1769,7 +1766,7 @@ export function toCanonicalToolDefinition(
       name: spec.name,
       description: spec.description ?? null,
       parameters: canonicalParameters(spec.inputSchema.json),
-      strict: null,
+      strict: spec.strict ?? null,
     };
   }
   // Gemini: { name, description?, parameters? | parameters_json_schema? }
@@ -1825,6 +1822,7 @@ export function getToolDefinitionDisplay(
         description: toolDefinition.description,
       }),
       input_schema: parametersSchemaWithObjectType(toolDefinition.parameters),
+      ...(toolDefinition.strict != null && { strict: toolDefinition.strict }),
     };
   }
   if (provider === "AWS") {
@@ -1837,6 +1835,7 @@ export function getToolDefinitionDisplay(
         inputSchema: {
           json: parametersSchemaWithObjectType(toolDefinition.parameters),
         },
+        ...(toolDefinition.strict != null && { strict: toolDefinition.strict }),
       },
     };
   }

--- a/js/app/src/schemas/__tests__/toolSchemas.test.ts
+++ b/js/app/src/schemas/__tests__/toolSchemas.test.ts
@@ -137,6 +137,24 @@ describe("toolSchemas", () => {
       };
       expect(anthropicToolDefinitionSchema.safeParse(tool).success).toBe(false);
     });
+
+    it("should parse an Anthropic tool with strict", () => {
+      const tool = {
+        name: "get_weather",
+        description: "Get weather",
+        input_schema: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
+        },
+        strict: true,
+      };
+      const result = anthropicToolDefinitionSchema.safeParse(tool);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.strict).toBe(true);
+      }
+    });
   });
 
   describe("geminiToolDefinitionSchema", () => {
@@ -192,6 +210,28 @@ describe("toolSchemas", () => {
         expect(result.data.toolSpec.inputSchema.json).toEqual({
           type: "object",
         });
+      }
+    });
+
+    it("should parse an AWS tool with strict", () => {
+      const tool = {
+        toolSpec: {
+          name: "get_weather",
+          description: "Get weather",
+          inputSchema: {
+            json: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+          },
+          strict: true,
+        },
+      };
+      const result = awsToolDefinitionSchema.safeParse(tool);
+      expect(result.success).toBe(true);
+      if (result.success && "toolSpec" in result.data) {
+        expect(result.data.toolSpec.strict).toBe(true);
       }
     });
 

--- a/js/app/src/schemas/toolSchemas.ts
+++ b/js/app/src/schemas/toolSchemas.ts
@@ -201,6 +201,10 @@ export const anthropicToolDefinitionSchema = z.strictObject({
   name: z.string(),
   description: z.string().optional(),
   input_schema: requiredToolParametersJsonSchema,
+  strict: z
+    .boolean()
+    .optional()
+    .describe("Whether the tool input must exactly match the input schema"),
 });
 
 /**
@@ -223,6 +227,10 @@ const awsToolSpecSchema = z.strictObject({
   inputSchema: z.strictObject({
     json: parametersSchemaWithDefaultObjectType,
   }),
+  strict: z
+    .boolean()
+    .optional()
+    .describe("Whether the tool input must exactly match the input schema"),
 });
 
 /**

--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/anthropic/messages.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/anthropic/messages.py
@@ -608,6 +608,8 @@ class _ToolConversion:
                 }
                 if "description" in function:
                     param["description"] = function["description"]
+                if "strict" in function and isinstance(function["strict"], bool):
+                    param["strict"] = function["strict"]
                 yield param
             elif tool["type"] == "raw":
                 # Vendor passthrough: forward the raw dict as a ToolUnionParam
@@ -634,6 +636,8 @@ class _ToolConversion:
                 if "description" in tool_param:
                     function["description"] = tool_param["description"]
                 function["parameters"] = tool_param["input_schema"]
+                if "strict" in tool_param and isinstance(tool_param["strict"], bool):
+                    function["strict"] = tool_param["strict"]
                 yield v1.PromptToolFunction(type="function", function=function)
             else:
                 yield v1.PromptToolRaw(type="raw", raw=dict(cast(Mapping[str, Any], tool)))

--- a/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
+++ b/packages/phoenix-client/tests/canary/sdk/anthropic/test_messages.py
@@ -65,8 +65,8 @@ def _tool_result() -> ToolResultBlockParam:
     }
 
 
-def _tool(name: Optional[str] = None) -> ToolParam:
-    return {
+def _tool(name: Optional[str] = None, strict: Optional[bool] = None) -> ToolParam:
+    tool: ToolParam = {
         "name": name or _str(),
         "description": _str(),
         "input_schema": {
@@ -79,6 +79,9 @@ def _tool(name: Optional[str] = None) -> ToolParam:
             "additionalProperties": False,
         },
     }
+    if strict is not None:
+        tool["strict"] = strict
+    return tool
 
 
 class TestMessageConversion:
@@ -102,7 +105,7 @@ class TestMessageConversion:
 class TestToolConversion:
     @pytest.mark.parametrize(
         "tools",
-        [[_tool() for _ in range(3)]],
+        [[_tool(), _tool(strict=True), _tool(strict=False)]],
     )
     def test_round_trip(self, tools: Iterable[ToolParam]) -> None:
         new_tools = list(_ToolConversion.to_anthropic(_ToolConversion.from_anthropic(tools)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ phoenix = "phoenix.server.main:main"
 dev = [
   "check-wheel-contents",
   "twine",
-  "aiobotocore>=3.1.1",
+  "aiobotocore>=3.2.0",  # first release whose botocore floor includes Converse ToolSpecification "strict"; older botocore rejects it client-side
   "aioboto3",
   "aiosqlite>=0.22.1",
   "anthropic>=1,<2",
@@ -208,6 +208,7 @@ pg = [
 ]
 aws = [
   "aioboto3",
+  "aiobotocore>=3.2.0",  # first release whose botocore floor includes Converse ToolSpecification "strict"; older botocore rejects it client-side
   "types-aiobotocore-bedrock-runtime>=3.6.0",
 ]
 azure = [
@@ -235,6 +236,7 @@ container = [
   "strawberry-graphql[opentelemetry]==0.320.4",
   "uvloop; platform_system != 'Windows'",
   "aioboto3",
+  "aiobotocore>=3.2.0",  # first release whose botocore floor includes Converse ToolSpecification "strict"; older botocore rejects it client-side
   "types-aiobotocore-bedrock-runtime>=3.6.0",
   # Sandbox provider SDKs — bundled so the shipped container can use any
   # configured provider without a rebuild. Each pin matches the matching

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1616,6 +1616,8 @@ class BedrockClient(PlaygroundClient["BedrockRuntimeClient"]):
                 )
                 if fn.description:
                     tool_spec["description"] = fn.description
+                if isinstance(fn.strict, bool):
+                    tool_spec["strict"] = fn.strict
                 tool_list.append(ToolTypeDef(toolSpec=tool_spec))
 
             tool_config = ToolConfigurationTypeDef(tools=tool_list)
@@ -2212,7 +2214,7 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
                     params["tool_choice"] = choice_tool
                 else:
                     assert_never(tc.type)
-            if tools.disable_parallel_tool_calls:
+            elif tools.disable_parallel_tool_calls:
                 params["tool_choice"] = ToolChoiceAutoParam(
                     type="auto", disable_parallel_tool_use=True
                 )
@@ -2230,6 +2232,8 @@ class AnthropicClient(PlaygroundClient["AsyncAnthropic"]):
                     )
                     if f.description:
                         t["description"] = f.description
+                    if isinstance(f.strict, bool):
+                        t["strict"] = f.strict
                     tool_list.append(t)
                 params["tools"] = tool_list
                 extra_headers = _anthropic_beta_headers_for_tools(tool_list)

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1622,9 +1622,14 @@ class BedrockClient(PlaygroundClient["BedrockRuntimeClient"]):
 
             tool_config = ToolConfigurationTypeDef(tools=tool_list)
 
+            # The Converse API has no disable-parallel-tool-use setting, so
+            # tools.disable_parallel_tool_calls cannot be honored here.
+            send_tools = True
             if tc := tools.tool_choice:
                 if tc.type == "none":
-                    pass
+                    # Converse has no "none" tool choice; withholding the
+                    # tools entirely is the only way to prevent tool calls.
+                    send_tools = False
                 elif tc.type == "zero_or_more":
                     tool_config["toolChoice"] = ToolChoiceTypeDef(auto={})
                 elif tc.type == "one_or_more":
@@ -1636,7 +1641,8 @@ class BedrockClient(PlaygroundClient["BedrockRuntimeClient"]):
                 elif TYPE_CHECKING:
                     assert_never(tc.type)
 
-            request["toolConfig"] = tool_config
+            if send_tools:
+                request["toolConfig"] = tool_config
 
         if response_format:
             json_schema = JsonSchemaDefinitionTypeDef(

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -25,8 +25,11 @@ from phoenix.db.types.model_provider import LLMClientFactory, ModelProvider
 from phoenix.db.types.prompts import (
     PromptAnthropicInvocationParameters,
     PromptAnthropicInvocationParametersContent,
+    PromptAwsInvocationParameters,
+    PromptAwsInvocationParametersContent,
     PromptOpenAIInvocationParameters,
     PromptOpenAIInvocationParametersContent,
+    PromptToolChoiceNone,
     PromptToolChoiceSpecificFunctionTool,
     PromptToolChoiceZeroOrMore,
     PromptToolFunction,
@@ -42,6 +45,7 @@ from phoenix.server.api.helpers.playground_clients import (
     AnthropicClient,
     AzureOpenAIChatCompletionsClient,
     AzureOpenAIResponsesClient,
+    BedrockClient,
     GoogleClient,
     OpenAIChatCompletionsClient,
     OpenAICompatibleClient,
@@ -561,6 +565,95 @@ class TestAnthropicStreamingClient:
         ]
         assert extra_headers is None
 
+    def _anthropic_client(self) -> Any:
+        @asynccontextmanager
+        async def create_client() -> AsyncIterator[Any]:
+            yield None
+
+        return AnthropicClient(
+            client_factory=LLMClientFactory(create_client, ("anthropic", "test")),
+            model_name="claude-3-5-sonnet-latest",
+            provider="anthropic",
+        )
+
+    def _anthropic_params(self, tools: PromptTools) -> dict[str, Any]:
+        params, _, _ = self._anthropic_client()._anthropic_message_params(
+            messages=[
+                create_playground_message(ChatCompletionMessageRole.USER, "Evaluate this answer.")
+            ],
+            tools=tools,
+            response_format=None,
+            invocation_parameters=PromptAnthropicInvocationParameters(
+                type="anthropic",
+                anthropic=PromptAnthropicInvocationParametersContent(max_tokens=1024),
+            ),
+        )
+        return dict(params)
+
+    @staticmethod
+    def _function_tool(strict: Any = None) -> PromptToolFunction:
+        kwargs: dict[str, Any] = {
+            "name": "correctness",
+            "description": "Evaluate correctness",
+            "parameters": {"type": "object", "properties": {"label": {"type": "string"}}},
+        }
+        if strict is not None:
+            kwargs["strict"] = strict
+        return PromptToolFunction(type="function", function=PromptToolFunctionDefinition(**kwargs))
+
+    def test_specific_tool_choice_survives_disable_parallel_tool_calls(self) -> None:
+        """Disabling parallel tool use must not downgrade a specific tool choice to `auto`."""
+        params = self._anthropic_params(
+            PromptTools(
+                type="tools",
+                tool_choice=PromptToolChoiceSpecificFunctionTool(
+                    type="specific_function", function_name="correctness"
+                ),
+                disable_parallel_tool_calls=True,
+                tools=[self._function_tool()],
+            )
+        )
+        assert params["tool_choice"] == {
+            "type": "tool",
+            "name": "correctness",
+            "disable_parallel_tool_use": True,
+        }
+
+    def test_tool_choice_none_survives_disable_parallel_tool_calls(self) -> None:
+        """`none` means "do not call tools" and must not be turned into `auto`."""
+        params = self._anthropic_params(
+            PromptTools(
+                type="tools",
+                tool_choice=PromptToolChoiceNone(type="none"),
+                disable_parallel_tool_calls=True,
+                tools=[self._function_tool()],
+            )
+        )
+        assert params["tool_choice"] == {"type": "none"}
+
+    def test_disable_parallel_tool_calls_without_explicit_choice_falls_back_to_auto(self) -> None:
+        """With no explicit choice, the flag still yields `auto` + `disable_parallel_tool_use`."""
+        params = self._anthropic_params(
+            PromptTools(
+                type="tools",
+                disable_parallel_tool_calls=True,
+                tools=[self._function_tool()],
+            )
+        )
+        assert params["tool_choice"] == {"type": "auto", "disable_parallel_tool_use": True}
+
+    def test_function_tool_strict_is_forwarded(self) -> None:
+        """The stored prompt tool's `strict` setting must reach the Anthropic request."""
+        params = self._anthropic_params(
+            PromptTools(type="tools", tools=[self._function_tool(strict=True)])
+        )
+        assert params["tools"][0]["strict"] is True
+
+    def test_function_tool_omits_strict_when_unset(self) -> None:
+        """`strict` is optional; an unset value must not be sent."""
+        params = self._anthropic_params(PromptTools(type="tools", tools=[self._function_tool()]))
+        assert "strict" not in params["tools"][0]
+
     def test_raw_computer_tools_add_anthropic_beta_header(self) -> None:
         @asynccontextmanager
         async def create_client() -> AsyncIterator[Any]:
@@ -656,6 +749,57 @@ TOOL_CALL_FUNCTION_ARGUMENTS_JSON = ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUME
 
 # tool attributes
 TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
+
+
+class TestBedrockClient:
+    def _converse_request(self, tools: PromptTools) -> dict[str, Any]:
+        @asynccontextmanager
+        async def create_client() -> AsyncIterator[Any]:
+            yield None
+
+        client: Any = BedrockClient(
+            client_factory=LLMClientFactory(create_client, ("aws", "test")),
+            model_name="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            provider="aws",
+        )
+        request = client._converse_build_request(
+            messages=[
+                create_playground_message(ChatCompletionMessageRole.USER, "Evaluate this answer.")
+            ],
+            tools=tools,
+            response_format=None,
+            invocation_parameters=PromptAwsInvocationParameters(
+                type="aws",
+                aws=PromptAwsInvocationParametersContent(max_tokens=1024),
+            ),
+            span=INVALID_SPAN,
+        )
+        return dict(request)
+
+    @staticmethod
+    def _function_tool(strict: Any = None) -> PromptToolFunction:
+        kwargs: dict[str, Any] = {
+            "name": "correctness",
+            "description": "Evaluate correctness",
+            "parameters": {"type": "object", "properties": {"label": {"type": "string"}}},
+        }
+        if strict is not None:
+            kwargs["strict"] = strict
+        return PromptToolFunction(type="function", function=PromptToolFunctionDefinition(**kwargs))
+
+    def test_function_tool_strict_is_forwarded(self) -> None:
+        """The stored prompt tool's `strict` setting must reach the Bedrock toolSpec."""
+        request = self._converse_request(
+            PromptTools(type="tools", tools=[self._function_tool(strict=True)])
+        )
+        tool_spec = request["toolConfig"]["tools"][0]["toolSpec"]
+        assert tool_spec["strict"] is True
+
+    def test_function_tool_omits_strict_when_unset(self) -> None:
+        """`strict` is optional; an unset value must not be sent."""
+        request = self._converse_request(PromptTools(type="tools", tools=[self._function_tool()]))
+        tool_spec = request["toolConfig"]["tools"][0]["toolSpec"]
+        assert "strict" not in tool_spec
 
 
 class TestGetOpenAIClientClass:

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -31,6 +31,7 @@ from phoenix.db.types.prompts import (
     PromptOpenAIInvocationParameters,
     PromptOpenAIInvocationParametersContent,
     PromptToolChoiceNone,
+    PromptToolChoiceOneOrMore,
     PromptToolChoiceSpecificFunctionTool,
     PromptToolChoiceZeroOrMore,
     PromptToolFunction,
@@ -621,6 +622,18 @@ class TestAnthropicStreamingClient:
             "disable_parallel_tool_use": True,
         }
 
+    def test_one_or_more_tool_choice_survives_disable_parallel_tool_calls(self) -> None:
+        """Disabling parallel tool use must not downgrade a required tool choice to `auto`."""
+        params = self._anthropic_params(
+            PromptTools(
+                type="tools",
+                tool_choice=PromptToolChoiceOneOrMore(type="one_or_more"),
+                disable_parallel_tool_calls=True,
+                tools=[_function_tool()],
+            )
+        )
+        assert params["tool_choice"] == {"type": "any", "disable_parallel_tool_use": True}
+
     def test_tool_choice_none_survives_disable_parallel_tool_calls(self) -> None:
         """`none` means "do not call tools" and must not be turned into `auto`."""
         params = self._anthropic_params(
@@ -776,6 +789,17 @@ class TestBedrockClient:
             span=INVALID_SPAN,
         )
         return dict(request)
+
+    def test_one_or_more_tool_choice_maps_to_any(self) -> None:
+        """A required tool choice must reach Converse as `toolChoice: {any: {}}`."""
+        request = self._converse_request(
+            PromptTools(
+                type="tools",
+                tool_choice=PromptToolChoiceOneOrMore(type="one_or_more"),
+                tools=[_function_tool()],
+            )
+        )
+        assert request["toolConfig"]["toolChoice"] == {"any": {}}
 
     def test_tool_choice_none_withholds_tool_config(self) -> None:
         """Converse has no `none` tool choice; the tools must be withheld entirely."""

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -20,6 +20,7 @@ from opentelemetry.trace import INVALID_SPAN, StatusCode, Tracer
 from pydantic import SecretStr
 
 from phoenix.db import models
+from phoenix.db.types.db_helper_types import UNDEFINED
 from phoenix.db.types.experiment_config import OpenAIConnectionConfig
 from phoenix.db.types.model_provider import LLMClientFactory, ModelProvider
 from phoenix.db.types.prompts import (
@@ -66,6 +67,26 @@ from phoenix.server.api.types.ChatCompletionSubscriptionPayload import TextChunk
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 from phoenix.server.types import DbSessionFactory
 from tests.unit.vcr import CustomVCR
+
+
+def _null_client_factory(provider: str) -> LLMClientFactory[Any]:
+    @asynccontextmanager
+    async def create_client() -> AsyncIterator[Any]:
+        yield None
+
+    return LLMClientFactory(create_client, (provider, "test"))
+
+
+def _function_tool(strict: bool = UNDEFINED) -> PromptToolFunction:
+    return PromptToolFunction(
+        type="function",
+        function=PromptToolFunctionDefinition(
+            name="correctness",
+            description="Evaluate correctness",
+            parameters={"type": "object", "properties": {"label": {"type": "string"}}},
+            strict=strict,
+        ),
+    )
 
 
 class TestGoogleStreamingClient:
@@ -497,12 +518,8 @@ class TestOpenAIBaseStreamingClient:
 
 class TestAnthropicStreamingClient:
     def test_specific_tool_choice_includes_tool_definitions(self) -> None:
-        @asynccontextmanager
-        async def create_client() -> AsyncIterator[Any]:
-            yield None
-
         client: Any = AnthropicClient(
-            client_factory=LLMClientFactory(create_client, ("anthropic", "test")),
+            client_factory=_null_client_factory("anthropic"),
             model_name="claude-3-5-sonnet-latest",
             provider="anthropic",
         )
@@ -566,12 +583,8 @@ class TestAnthropicStreamingClient:
         assert extra_headers is None
 
     def _anthropic_client(self) -> Any:
-        @asynccontextmanager
-        async def create_client() -> AsyncIterator[Any]:
-            yield None
-
         return AnthropicClient(
-            client_factory=LLMClientFactory(create_client, ("anthropic", "test")),
+            client_factory=_null_client_factory("anthropic"),
             model_name="claude-3-5-sonnet-latest",
             provider="anthropic",
         )
@@ -590,17 +603,6 @@ class TestAnthropicStreamingClient:
         )
         return dict(params)
 
-    @staticmethod
-    def _function_tool(strict: Any = None) -> PromptToolFunction:
-        kwargs: dict[str, Any] = {
-            "name": "correctness",
-            "description": "Evaluate correctness",
-            "parameters": {"type": "object", "properties": {"label": {"type": "string"}}},
-        }
-        if strict is not None:
-            kwargs["strict"] = strict
-        return PromptToolFunction(type="function", function=PromptToolFunctionDefinition(**kwargs))
-
     def test_specific_tool_choice_survives_disable_parallel_tool_calls(self) -> None:
         """Disabling parallel tool use must not downgrade a specific tool choice to `auto`."""
         params = self._anthropic_params(
@@ -610,7 +612,7 @@ class TestAnthropicStreamingClient:
                     type="specific_function", function_name="correctness"
                 ),
                 disable_parallel_tool_calls=True,
-                tools=[self._function_tool()],
+                tools=[_function_tool()],
             )
         )
         assert params["tool_choice"] == {
@@ -626,7 +628,7 @@ class TestAnthropicStreamingClient:
                 type="tools",
                 tool_choice=PromptToolChoiceNone(type="none"),
                 disable_parallel_tool_calls=True,
-                tools=[self._function_tool()],
+                tools=[_function_tool()],
             )
         )
         assert params["tool_choice"] == {"type": "none"}
@@ -637,7 +639,7 @@ class TestAnthropicStreamingClient:
             PromptTools(
                 type="tools",
                 disable_parallel_tool_calls=True,
-                tools=[self._function_tool()],
+                tools=[_function_tool()],
             )
         )
         assert params["tool_choice"] == {"type": "auto", "disable_parallel_tool_use": True}
@@ -645,22 +647,25 @@ class TestAnthropicStreamingClient:
     def test_function_tool_strict_is_forwarded(self) -> None:
         """The stored prompt tool's `strict` setting must reach the Anthropic request."""
         params = self._anthropic_params(
-            PromptTools(type="tools", tools=[self._function_tool(strict=True)])
+            PromptTools(type="tools", tools=[_function_tool(strict=True)])
         )
         assert params["tools"][0]["strict"] is True
 
+    def test_function_tool_strict_false_is_forwarded(self) -> None:
+        """An explicit `strict=False` must be sent, not treated as unset."""
+        params = self._anthropic_params(
+            PromptTools(type="tools", tools=[_function_tool(strict=False)])
+        )
+        assert params["tools"][0]["strict"] is False
+
     def test_function_tool_omits_strict_when_unset(self) -> None:
         """`strict` is optional; an unset value must not be sent."""
-        params = self._anthropic_params(PromptTools(type="tools", tools=[self._function_tool()]))
+        params = self._anthropic_params(PromptTools(type="tools", tools=[_function_tool()]))
         assert "strict" not in params["tools"][0]
 
     def test_raw_computer_tools_add_anthropic_beta_header(self) -> None:
-        @asynccontextmanager
-        async def create_client() -> AsyncIterator[Any]:
-            yield None
-
         client: Any = AnthropicClient(
-            client_factory=LLMClientFactory(create_client, ("anthropic", "test")),
+            client_factory=_null_client_factory("anthropic"),
             model_name="claude-3-5-sonnet-latest",
             provider="anthropic",
         )
@@ -753,12 +758,8 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
 
 class TestBedrockClient:
     def _converse_request(self, tools: PromptTools) -> dict[str, Any]:
-        @asynccontextmanager
-        async def create_client() -> AsyncIterator[Any]:
-            yield None
-
         client: Any = BedrockClient(
-            client_factory=LLMClientFactory(create_client, ("aws", "test")),
+            client_factory=_null_client_factory("aws"),
             model_name="anthropic.claude-3-5-sonnet-20240620-v1:0",
             provider="aws",
         )
@@ -776,28 +777,36 @@ class TestBedrockClient:
         )
         return dict(request)
 
-    @staticmethod
-    def _function_tool(strict: Any = None) -> PromptToolFunction:
-        kwargs: dict[str, Any] = {
-            "name": "correctness",
-            "description": "Evaluate correctness",
-            "parameters": {"type": "object", "properties": {"label": {"type": "string"}}},
-        }
-        if strict is not None:
-            kwargs["strict"] = strict
-        return PromptToolFunction(type="function", function=PromptToolFunctionDefinition(**kwargs))
+    def test_tool_choice_none_withholds_tool_config(self) -> None:
+        """Converse has no `none` tool choice; the tools must be withheld entirely."""
+        request = self._converse_request(
+            PromptTools(
+                type="tools",
+                tool_choice=PromptToolChoiceNone(type="none"),
+                tools=[_function_tool()],
+            )
+        )
+        assert "toolConfig" not in request
 
     def test_function_tool_strict_is_forwarded(self) -> None:
         """The stored prompt tool's `strict` setting must reach the Bedrock toolSpec."""
         request = self._converse_request(
-            PromptTools(type="tools", tools=[self._function_tool(strict=True)])
+            PromptTools(type="tools", tools=[_function_tool(strict=True)])
         )
         tool_spec = request["toolConfig"]["tools"][0]["toolSpec"]
         assert tool_spec["strict"] is True
 
+    def test_function_tool_strict_false_is_forwarded(self) -> None:
+        """An explicit `strict=False` must be sent, not treated as unset."""
+        request = self._converse_request(
+            PromptTools(type="tools", tools=[_function_tool(strict=False)])
+        )
+        tool_spec = request["toolConfig"]["tools"][0]["toolSpec"]
+        assert tool_spec["strict"] is False
+
     def test_function_tool_omits_strict_when_unset(self) -> None:
         """`strict` is optional; an unset value must not be sent."""
-        request = self._converse_request(PromptTools(type="tools", tools=[self._function_tool()]))
+        request = self._converse_request(PromptTools(type="tools", tools=[_function_tool()]))
         tool_spec = request["toolConfig"]["tools"][0]["toolSpec"]
         assert "strict" not in tool_spec
 

--- a/uv.lock
+++ b/uv.lock
@@ -542,6 +542,7 @@ dependencies = [
 [package.optional-dependencies]
 aws = [
     { name = "aioboto3" },
+    { name = "aiobotocore" },
     { name = "types-aiobotocore-bedrock-runtime" },
 ]
 azure = [
@@ -550,6 +551,7 @@ azure = [
 ]
 container = [
     { name = "aioboto3" },
+    { name = "aiobotocore" },
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "azure-identity" },
@@ -702,6 +704,8 @@ dev = [
 requires-dist = [
     { name = "aioboto3", marker = "extra == 'aws'" },
     { name = "aioboto3", marker = "extra == 'container'" },
+    { name = "aiobotocore", marker = "extra == 'aws'", specifier = ">=3.2.0" },
+    { name = "aiobotocore", marker = "extra == 'container'", specifier = ">=3.2.0" },
     { name = "aiohttp", marker = "extra == 'azure'" },
     { name = "aiohttp", marker = "extra == 'container'" },
     { name = "aioitertools" },
@@ -794,7 +798,7 @@ provides-extras = ["aws", "azure", "container", "daytona", "e2b", "evals", "expe
 [package.metadata.requires-dev]
 dev = [
     { name = "aioboto3" },
-    { name = "aiobotocore", specifier = ">=3.1.1" },
+    { name = "aiobotocore", specifier = ">=3.2.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "anthropic", specifier = ">=1,<2" },
     { name = "arize", specifier = ">=8.1.0" },


### PR DESCRIPTION
Fixes #15644

The server provider clients drop parts of the tool contract before the request goes out. Because playground calls, evaluator previews, and online evaluator execution all share these clients, the same loss shows up in each.

## 1. Anthropic tool choice is overwritten

`_anthropic_message_params` builds `tool_choice` from `tools.tool_choice`, then immediately discards it:

```python
                else:
                    assert_never(tc.type)
            if tools.disable_parallel_tool_calls:          # ← runs after, unconditionally
                params["tool_choice"] = ToolChoiceAutoParam(
                    type="auto", disable_parallel_tool_use=True
                )
```

Every branch of the block above **already** applies `disable_parallel_tool_use`, so this overwrite was only ever needed as the fallback for when no explicit choice was given. As written it fires whenever the flag is set, regardless:

| `tool_choice` | `disable_parallel_tool_calls` | Sent before this PR |
|---|---|---|
| `specific_function` | `True` | `{"type": "auto", ...}` — named tool lost |
| `one_or_more` | `True` | `{"type": "auto", ...}` — "must call a tool" lost |
| `none` | `True` | `{"type": "auto", ...}` — **tool use enabled when it was turned off** |

The `none` case is worth calling out separately: it isn't in the issue description, but it inverts the user's intent rather than merely relaxing it — "do not call tools" becomes "call tools freely".

Fix: make the fallback an `elif`, so an explicit choice wins and the `auto` default still applies when there is none.

## 2. Anthropic and Bedrock drop the tool's `strict` setting

Both function-tool builders pass only name / schema / description, so `PromptToolFunctionDefinition.strict` never reaches the provider. The OpenAI builder already forwards it:

```python
# OpenAI, existing
strict=f.strict if isinstance(f.strict, bool) else None,
```

Both target types accept the field, so this is a straightforward omission rather than an unsupported capability:

- `anthropic.types.ToolParam` → `strict`
- Bedrock `ToolSpecificationTypeDef` → `strict: NotRequired[bool]`

Fix: forward it when it is a bool, matching the adjacent `description` handling so an unset value is still omitted.

## Acceptance criteria

- [x] Anthropic keeps a specific tool choice when parallel tool use is disabled
- [x] Anthropic sends the supported strict tool field from the stored prompt tool
- [x] Bedrock sends the supported strict tool field from the stored prompt tool
- [x] Request-shape tests cover the cases above

## Tests

Seven tests added to `tests/unit/server/api/helpers/test_playground_clients.py`, split intentionally:

**Four fail without the source change** — the corrected behaviour:
- `test_specific_tool_choice_survives_disable_parallel_tool_calls`
- `test_tool_choice_none_survives_disable_parallel_tool_calls`
- `TestAnthropicStreamingClient::test_function_tool_strict_is_forwarded`
- `TestBedrockClient::test_function_tool_strict_is_forwarded`

**Three pass with and without it** — guards that this PR does *not* change behaviour it shouldn't:
- `test_disable_parallel_tool_calls_without_explicit_choice_falls_back_to_auto` — the `auto` fallback still works when no explicit choice is given
- `test_function_tool_omits_strict_when_unset` (Anthropic and Bedrock) — an unset `strict` is still omitted, not sent as `None`

Verified by stashing only the source change and re-running: 4 failed, 3 passed.

## Verification

- `pytest tests/unit/server/api/helpers/` → **505 passed, 113 skipped**
- `ruff check` and `ruff format --check` clean on both changed files (both confirmed clean at `main` first, so no unrelated reformatting is mixed in)
- Source diff is **+5 / −1**

## Note on the local environment

I could not reproduce the CI dependency set exactly, so CI is the real check on this:

- `requirements/unit-tests.txt` did not resolve for me — `litellm>=1.83.14` requires `openai>=2.20.0,<3.0.0`, while another pinned dependency requires `openai>=3.1.0`. `requirements/type-check.txt` hits a related `openai` conflict.
- I ran the suite with `ci.txt` plus the test dependencies, excluding `litellm` and `type-check.txt`. Nothing in the changed code paths touches litellm.

Happy to adjust if there is a lockfile or resolver setting I missed.

---

## Review follow-ups (`04b1c47`)

An adversarial review of the first commit surfaced gaps in the same tool contract; a second commit closes them.

### Dependency floor for Bedrock `strict`

The `aws`/`container` extras declared `aioboto3` with no floor, and botocore only gained `ToolSpecification.strict` in **1.42.42** — older botocore fails the whole request client-side (`ParamValidationError: Unknown parameter … "strict"`) before it leaves the process. The extras and dev group now floor `aiobotocore>=3.2.0`, the first release whose botocore range (`>=1.42.53`) guarantees the member. Anthropic needs no analogous floor: `anthropic>=1` already types `strict` on `ToolParam`, and that SDK passes unrecognized request keys through rather than validating client-side.

### Bedrock `tool_choice: "none"`

The Converse API has no `none` tool choice, so the first commit's `pass` branch still attached the full tool list with default `auto` — the model could call tools the user had turned off. `none` now withholds `toolConfig` entirely.

**Known tradeoff, kept deliberately:** if the conversation history already contains `toolUse`/`toolResult` blocks, Converse rejects a request without `toolConfig` (`ValidationException`). That corner previously "worked" by silently calling tools against the user's intent; a loud provider error was chosen over silent inversion. Also documented in-code that Converse has no `disable_parallel_tool_use` equivalent, so that flag cannot be honored on Bedrock.

### The frontend no longer erases `strict`

Two frontend gaps silently negated the server-side fix for Anthropic/AWS:

- The editor's zod schemas are `strictObject`s and had no `strict` key, so a tool JSON containing it failed canonicalization and was demoted to a raw passthrough. They now accept an optional boolean `strict`.
- `toCanonicalToolDefinition` hard-coded `strict: null` on the Anthropic/AWS branches and `getToolDefinitionDisplay` never emitted it, so one edit in the tool editor erased a saved `strict` with no UI signal. Both directions now preserve it, including explicit `false`.

### phoenix-client parity

The Anthropic helper's `_ToolConversion` dropped `strict` in both directions while its OpenAI sibling forwarded it, so the same stored prompt enforced strict in the playground but not through the client SDK. It now forwards `strict` both ways.

### Tests

Explicit `strict=False` cases per provider pin the `isinstance(…, bool)` gate (unset omitted, explicit `False` sent); Bedrock `none` withholding is covered; the `_function_tool` and null-client-factory helpers are deduplicated to module level. A later commit (`9379bf1`) adds the required (`one_or_more`) tool choice request-shape tests for both providers, completing the issue's test coverage criterion.

### Behavior change worth a release note

Stored prompts have been able to carry `strict: true` all along — Phoenix stored it but silently dropped it for Anthropic/Bedrock. It now reaches the provider, so such prompts begin enforcing schema validation and may receive provider-side 400s where they previously succeeded (e.g. a schema that doesn't meet strict-mode requirements, or a Bedrock model without `strict` support). Removing `strict` from the tool definition restores the old behavior. Bedrock deployments need `aiobotocore>=3.2.0`, now enforced by the extras.

### Verification (follow-up commit)

- `mypy` clean (1,077 files); `pytest tests/unit/server/api` → 2,278 passed (one pre-existing failure in `test_sandbox_queries.py`, reproduced on a clean `main`)
- Full `js/app` vitest → 2,317 passed across 231 files; `tsc` errors limited to pre-existing ones in `evals/aiQuery/` (reproduced with these changes stashed)
- `ruff` / `oxfmt` / `oxlint` clean; `uv.lock` regenerated (metadata-only diff, resolution unchanged)
