### PR TITLE
chore: fix Codex local environment setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -5,9 +5,7 @@ name = "phoenix"
 [setup]
 script = '''
 uv sync --python 3.10
-cd app
-pnpm install
-WORKTREE_PATH="$(dirname "$(pwd)")"
+WORKTREE_PATH="$(pwd)"
 WORKTREE_ID="$(basename "$(dirname "${WORKTREE_PATH}")")"
 PORT_OFFSET="$(printf '%s' "${WORKTREE_PATH}" | cksum | awk '{print $1 % 1000}')"
 PHOENIX_PORT="$((6006 + PORT_OFFSET))"
@@ -16,6 +14,11 @@ VITE_PORT="$((5173 + PORT_OFFSET))"
 DEBUGPY_PORT="$((5678 + PORT_OFFSET))"
 
 mkdir -p "${PHOENIX_WORKING_DIR}"
+
+cd js
+pnpm install
+cd app
+pnpm run build:deps
 
 touch .env
 
@@ -26,13 +29,13 @@ export VITE_PORT=${VITE_PORT}
 export DEBUGPY_PORT=${DEBUGPY_PORT}
 EOF
 
-cd ..
+cd ../..
 '''
 
 [[actions]]
 name = "run"
 icon = "tool"
 command = '''
-cd app
+cd js/app
 pnpm dev
 '''


### PR DESCRIPTION
## Summary

- update the Codex environment setup for the app move from `app/` to `js/app/`
- install from the unified `js/` pnpm workspace and build the app workspace dependencies
- preserve worktree-specific ports and run the app from its new location

## Verification

- `uv sync --python 3.10`
- `pnpm install` from `js/`
- `pnpm run build:deps` from `js/app/`
- validated TOML and embedded shell syntax
- confirmed Python import and generated worktree environment values