### PR TITLE
feat(evaluators): extend project empty state

### DIFF
--- a/js/app/src/GlobalStyles.tsx
+++ b/js/app/src/GlobalStyles.tsx
@@ -88,6 +88,9 @@ const staticCSS = css`
     --global-button-height-s: var(--global-input-height-s);
     --global-button-height-m: var(--global-input-height-m);
     --global-button-height-l: var(--global-input-height-l);
+
+    // layout sizing
+    --global-text-content-max-width: 800px;
   }
 `;
 

--- a/js/app/src/Routes.tsx
+++ b/js/app/src/Routes.tsx
@@ -500,7 +500,7 @@ export const appRouteObjects = createRoutesFromElements(
                   agentRoute: {
                     label: "Project Evaluators",
                     description:
-                      "Create and manage project evaluators — online evals that automatically run against live spans.",
+                      "Browse templates, create, and manage project evaluators — online evals that automatically run against live spans.",
                   },
                 }}
               >

--- a/js/app/src/constants/searchParams.ts
+++ b/js/app/src/constants/searchParams.ts
@@ -60,3 +60,14 @@ export const LABEL_ID_PARAM = "labelId";
 export const CREATE_CODE_EVALUATOR_PARAM = "createCodeEvaluator";
 
 export const CREATE_LLM_EVALUATOR_PARAM = "createLlmEvaluator";
+
+/**
+ * The evaluator template category selected in the project evaluator gallery.
+ * Uses the stable GraphQL enum value rather than the display label.
+ */
+export const PROJECT_EVALUATOR_CATEGORY_PARAM = "category";
+
+/**
+ * The evaluator template selected in the project evaluator gallery.
+ */
+export const PROJECT_EVALUATOR_TEMPLATE_PARAM = "template";

--- a/js/app/src/pages/project/ProjectConfigPage.tsx
+++ b/js/app/src/pages/project/ProjectConfigPage.tsx
@@ -53,7 +53,7 @@ const projectConfigPageCSS = css`
 
 const projectConfigPageInnerCSS = css`
   padding: var(--global-dimension-size-400);
-  max-width: 800px;
+  max-width: var(--global-text-content-max-width);
   min-width: 500px;
   box-sizing: border-box;
   width: 100%;

--- a/js/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
+++ b/js/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
@@ -20,6 +20,7 @@ import {
   MenuSectionTitle,
   MenuTrigger,
 } from "@phoenix/components/core/menu";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { View } from "@phoenix/components/core/view";
 import type { projectEvaluatorOptionsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptionsQuery.graphql";
 import { projectEvaluatorOptionsQuery as projectEvaluatorOptionsQueryNode } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
@@ -28,30 +29,81 @@ import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/proj
 export const AddProjectEvaluatorMenu = ({
   size,
   ...props
-}: {
+}: ProjectEvaluatorMenuTriggerProps) => {
+  return (
+    <ProjectEvaluatorMenu
+      size={size}
+      buttonLabel="Add evaluator"
+      buttonVariant="primary"
+      buttonLeadingVisual={<Icon svg={<Icons.Plus />} />}
+      shouldShowGalleryLink
+      {...props}
+    />
+  );
+};
+
+export const BuildProjectEvaluatorMenu = ({
+  size,
+  ...props
+}: ProjectEvaluatorMenuTriggerProps) => {
+  return (
+    <ProjectEvaluatorMenu
+      size={size}
+      buttonLabel="Build from scratch"
+      buttonVariant="default"
+      shouldShowGalleryLink={false}
+      {...props}
+    />
+  );
+};
+
+type ProjectEvaluatorMenuTriggerProps = {
   size: ButtonProps["size"];
-} & Omit<MenuTriggerProps, "children">) => {
+} & Omit<MenuTriggerProps, "children">;
+
+function ProjectEvaluatorMenu({
+  size,
+  buttonLabel,
+  buttonVariant,
+  buttonLeadingVisual,
+  shouldShowGalleryLink,
+  ...props
+}: ProjectEvaluatorMenuTriggerProps & {
+  buttonLabel: string;
+  buttonVariant: ButtonProps["variant"];
+  buttonLeadingVisual?: ButtonProps["leadingVisual"];
+  shouldShowGalleryLink: boolean;
+}) {
   return (
     <MenuTrigger {...props}>
       <Button
-        variant="primary"
+        variant={buttonVariant}
         size={size}
-        leadingVisual={<Icon svg={<Icons.Plus />} />}
+        leadingVisual={buttonLeadingVisual}
       >
-        Add evaluator
+        {buttonLabel}
       </Button>
       {/* Keep the query inside the popover so the evaluator list is fetched
           only when the menu opens. */}
       <MenuContainer minHeight="auto">
         <Suspense fallback={<Loading />}>
-          <AddProjectEvaluatorMenuItems />
+          <ProjectEvaluatorMenuItems
+            menuLabel={buttonLabel}
+            shouldShowGalleryLink={shouldShowGalleryLink}
+          />
         </Suspense>
       </MenuContainer>
     </MenuTrigger>
   );
-};
+}
 
-function AddProjectEvaluatorMenuItems() {
+function ProjectEvaluatorMenuItems({
+  menuLabel,
+  shouldShowGalleryLink,
+}: {
+  menuLabel: string;
+  shouldShowGalleryLink: boolean;
+}) {
   const navigate = useNavigate();
   const paths = useProjectEvaluatorPaths();
   const galleryHref = useHref(paths.gallery);
@@ -71,7 +123,7 @@ function AddProjectEvaluatorMenuItems() {
   return (
     <>
       <Menu
-        aria-label="Add evaluator"
+        aria-label={menuLabel}
         onAction={(action) => {
           if (action === "createEvaluator") {
             navigate(paths.newLlm);
@@ -80,15 +132,17 @@ function AddProjectEvaluatorMenuItems() {
           }
         }}
       >
-        <MenuSection>
-          <MenuItem
-            leadingContent={<Icon svg={<Icons.Grid />} />}
-            id="browseGallery"
-            href={galleryHref}
-          >
-            Browse the whole library
-          </MenuItem>
-        </MenuSection>
+        {shouldShowGalleryLink ? (
+          <MenuSection>
+            <MenuItem
+              leadingContent={<Icon svg={<Icons.Grid />} />}
+              id="browseGallery"
+              href={galleryHref}
+            >
+              Browse the whole library
+            </MenuItem>
+          </MenuSection>
+        ) : null}
         <MenuSection>
           <MenuSectionTitle title="LLM evaluator" />
           <MenuItem
@@ -167,10 +221,16 @@ function EvaluatorSubmenu({
               <Flex direction="column" gap="size-50">
                 <Text weight="heavy">{evaluator.name}</Text>
                 {evaluator.description ? (
-                  <Text size="S" color="text-700">
-                    {evaluator.description}
+                  <Truncate maxLines={3} title={evaluator.description}>
+                    <Text size="S" color="text-700">
+                      {evaluator.description}
+                    </Text>
+                  </Truncate>
+                ) : (
+                  <Text size="S" color="text-500" fontStyle="italic">
+                    No description
                   </Text>
-                ) : null}
+                )}
               </Flex>
             </MenuItem>
           )}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import { Header, ListBoxSection } from "react-aria-components";
 import { useLazyLoadQuery } from "react-relay";
-import { Outlet, useNavigate } from "react-router";
+import { Outlet, useNavigate, useSearchParams } from "react-router";
 
 import {
   Badge,
@@ -28,7 +28,14 @@ import {
 } from "@phoenix/components/annotation/optimizationUtils";
 import { LineClamp } from "@phoenix/components/core/utility/LineClamp";
 import { ErrorBoundary } from "@phoenix/components/exception";
-import type { projectEvaluatorTemplatesQuery as ProjectEvaluatorTemplatesQueryType } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
+import {
+  PROJECT_EVALUATOR_CATEGORY_PARAM,
+  PROJECT_EVALUATOR_TEMPLATE_PARAM,
+} from "@phoenix/constants/searchParams";
+import type {
+  EvaluatorCategory,
+  projectEvaluatorTemplatesQuery as ProjectEvaluatorTemplatesQueryType,
+} from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import {
   getProjectEvaluatorTemplateCategoryLabel,
@@ -37,11 +44,24 @@ import {
   projectEvaluatorTemplatesQuery,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTemplates";
 
-const ALL_EVALUATORS_CATEGORY = "All evaluators";
-const RECOMMENDED_CATEGORY = "Recommended";
+const ALL_EVALUATORS_CATEGORY = "all" as const;
+const RECOMMENDED_CATEGORY = "recommended" as const;
+const OTHER_CATEGORY = "other" as const;
 const GALLERY_SKELETON_HEIGHT = 440;
 /** The combined minimum width of the category, template, and details columns. */
 const GALLERY_EXPANDED_MIN_WIDTH = 960;
+
+type TemplateCategory = EvaluatorCategory | typeof OTHER_CATEGORY;
+type GalleryCategory =
+  | TemplateCategory
+  | typeof ALL_EVALUATORS_CATEGORY
+  | typeof RECOMMENDED_CATEGORY;
+
+function getGalleryCategory(
+  category: EvaluatorCategory | null
+): TemplateCategory {
+  return category ?? OTHER_CATEGORY;
+}
 
 export function ProjectEvaluatorGalleryPage() {
   return (
@@ -61,11 +81,7 @@ export function ProjectEvaluatorGalleryPage() {
 function EvaluatorGallery() {
   const navigate = useNavigate();
   const paths = useProjectEvaluatorPaths();
-  const [selectedCategory, setSelectedCategory] =
-    useState(RECOMMENDED_CATEGORY);
-  const [selectedTemplateName, setSelectedTemplateName] = useState<
-    string | null
-  >(null);
+  const [searchParams, setSearchParams] = useSearchParams();
   const data = useLazyLoadQuery<ProjectEvaluatorTemplatesQueryType>(
     projectEvaluatorTemplatesQuery,
     {},
@@ -73,38 +89,42 @@ function EvaluatorGallery() {
   );
   const templates = data.evaluatorGalleryConfigs;
   const categories = Array.from(
-    new Set(
-      templates.map(({ category }) =>
-        getProjectEvaluatorTemplateCategoryLabel(category)
-      )
-    )
+    new Set(templates.map(({ category }) => getGalleryCategory(category)))
   );
   const recommendedTemplateCount = templates.filter(
     ({ recommended }) => recommended
   ).length;
   const quickStartItems = [
     {
-      name: ALL_EVALUATORS_CATEGORY,
+      id: ALL_EVALUATORS_CATEGORY,
+      name: "All evaluators",
       count: templates.length,
     },
     {
-      name: RECOMMENDED_CATEGORY,
+      id: RECOMMENDED_CATEGORY,
+      name: "Recommended",
       count: recommendedTemplateCount,
     },
   ];
   const useCaseItems = categories.map((category) => ({
-    name: category,
+    id: category,
+    name:
+      category === OTHER_CATEGORY
+        ? "Other"
+        : getProjectEvaluatorTemplateCategoryLabel(category),
     count: templates.filter(
       ({ category: templateCategory }) =>
-        getProjectEvaluatorTemplateCategoryLabel(templateCategory) === category
+        getGalleryCategory(templateCategory) === category
     ).length,
   }));
   const categoryItems = [...quickStartItems, ...useCaseItems];
-  const activeCategory = categoryItems.some(
-    ({ name }) => name === selectedCategory
-  )
-    ? selectedCategory
-    : ALL_EVALUATORS_CATEGORY;
+  const requestedCategory = searchParams.get(PROJECT_EVALUATOR_CATEGORY_PARAM);
+  const activeCategoryItem = categoryItems.find(
+    ({ id }) => id === requestedCategory
+  );
+  const activeCategory: GalleryCategory =
+    activeCategoryItem?.id ?? RECOMMENDED_CATEGORY;
+  const activeCategoryLabel = activeCategoryItem?.name ?? "Recommended";
   const visibleTemplates = templates.filter(({ recommended, category }) => {
     if (activeCategory === ALL_EVALUATORS_CATEGORY) {
       return true;
@@ -112,25 +132,40 @@ function EvaluatorGallery() {
     if (activeCategory === RECOMMENDED_CATEGORY) {
       return recommended;
     }
-    return (
-      getProjectEvaluatorTemplateCategoryLabel(category) === activeCategory
-    );
+    return getGalleryCategory(category) === activeCategory;
   });
+  const requestedTemplateName = searchParams.get(
+    PROJECT_EVALUATOR_TEMPLATE_PARAM
+  );
   const selectedTemplate =
-    visibleTemplates.find(({ name }) => name === selectedTemplateName) ??
+    visibleTemplates.find(({ name }) => name === requestedTemplateName) ??
     visibleTemplates[0];
   const renderCategoryItem = ({
+    id,
     name,
     count,
   }: {
+    id: GalleryCategory;
     name: string;
     count: number;
   }) => (
-    <ListBoxItem key={name} id={name} textValue={name}>
+    <ListBoxItem key={id} id={id} textValue={name}>
       <Text size="S">{name}</Text>
       <Counter variant="quiet">{count}</Counter>
     </ListBoxItem>
   );
+  const setSelectedCategory = (category: string) => {
+    setSearchParams((currentSearchParams) => {
+      const nextSearchParams = new URLSearchParams(currentSearchParams);
+      if (category === RECOMMENDED_CATEGORY) {
+        nextSearchParams.delete(PROJECT_EVALUATOR_CATEGORY_PARAM);
+      } else {
+        nextSearchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);
+      }
+      nextSearchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
+      return nextSearchParams;
+    });
+  };
 
   return (
     <div css={galleryCSS} className="project-evaluator-gallery">
@@ -233,7 +268,7 @@ function EvaluatorGallery() {
           size="S"
           weight="heavy"
         >
-          {activeCategory}
+          {activeCategoryLabel}
         </Text>
         <ListBox
           aria-labelledby="evaluator-template-list-title"
@@ -248,7 +283,16 @@ function EvaluatorGallery() {
             if (selection === "all") return;
             const templateName = selection.keys().next().value;
             if (typeof templateName === "string") {
-              setSelectedTemplateName(templateName);
+              setSearchParams((currentSearchParams) => {
+                const nextSearchParams = new URLSearchParams(
+                  currentSearchParams
+                );
+                nextSearchParams.set(
+                  PROJECT_EVALUATOR_TEMPLATE_PARAM,
+                  templateName
+                );
+                return nextSearchParams;
+              });
             }
           }}
         >

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -119,6 +119,8 @@ function EvaluatorGallery() {
   }));
   const categoryItems = [...quickStartItems, ...useCaseItems];
   const requestedCategory = searchParams.get(PROJECT_EVALUATOR_CATEGORY_PARAM);
+  // Shared or stale URLs can contain an unknown category; Recommended is the
+  // gallery's stable fallback.
   const activeCategoryItem = categoryItems.find(
     ({ id }) => id === requestedCategory
   );
@@ -137,6 +139,8 @@ function EvaluatorGallery() {
   const requestedTemplateName = searchParams.get(
     PROJECT_EVALUATOR_TEMPLATE_PARAM
   );
+  // Fall back to the first visible template if a saved selection is no longer
+  // part of the active category.
   const selectedTemplate =
     visibleTemplates.find(({ name }) => name === requestedTemplateName) ??
     visibleTemplates[0];
@@ -163,6 +167,13 @@ function EvaluatorGallery() {
         nextSearchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);
       }
       nextSearchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
+      return nextSearchParams;
+    });
+  };
+  const setSelectedTemplate = (templateName: string) => {
+    setSearchParams((currentSearchParams) => {
+      const nextSearchParams = new URLSearchParams(currentSearchParams);
+      nextSearchParams.set(PROJECT_EVALUATOR_TEMPLATE_PARAM, templateName);
       return nextSearchParams;
     });
   };
@@ -283,16 +294,7 @@ function EvaluatorGallery() {
             if (selection === "all") return;
             const templateName = selection.keys().next().value;
             if (typeof templateName === "string") {
-              setSearchParams((currentSearchParams) => {
-                const nextSearchParams = new URLSearchParams(
-                  currentSearchParams
-                );
-                nextSearchParams.set(
-                  PROJECT_EVALUATOR_TEMPLATE_PARAM,
-                  templateName
-                );
-                return nextSearchParams;
-              });
+              setSelectedTemplate(templateName);
             }
           }}
         >

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -42,6 +42,13 @@ function useCloseSlideover(to?: string) {
   };
 }
 
+function useCloseGallerySlideover() {
+  // Gallery slideovers close over the selected category and template rather
+  // than resetting the gallery to its default view.
+  const { galleryReturn } = useProjectEvaluatorPaths();
+  return useCloseSlideover(galleryReturn);
+}
+
 function useRouteProjectId() {
   const { projectId } = useParams();
   invariant(projectId, "projectId is required");
@@ -79,8 +86,7 @@ export function NewLlmProjectEvaluatorPage() {
 
 export function NewGalleryLlmProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
-  const { gallery } = useProjectEvaluatorPaths();
-  const onOpenChange = useCloseSlideover(gallery);
+  const onOpenChange = useCloseGallerySlideover();
   return (
     <CreateProjectEvaluatorSlideover
       isOpen
@@ -106,8 +112,7 @@ export function NewCodeProjectEvaluatorPage() {
 
 export function NewGalleryCodeProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
-  const { gallery } = useProjectEvaluatorPaths();
-  const onOpenChange = useCloseSlideover(gallery);
+  const onOpenChange = useCloseGallerySlideover();
   return (
     <CreateProjectEvaluatorSlideover
       isOpen
@@ -122,8 +127,7 @@ export function NewGalleryLlmFromTemplateProjectEvaluatorPage() {
   const projectId = useRouteProjectId();
   const { templateName } = useParams();
   invariant(templateName, "templateName is required");
-  const { gallery } = useProjectEvaluatorPaths();
-  const onOpenChange = useCloseSlideover(gallery);
+  const onOpenChange = useCloseGallerySlideover();
   const data = useLazyLoadQuery<ProjectEvaluatorTemplatesQueryType>(
     projectEvaluatorTemplatesQuery,
     {},

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyState.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyState.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Suspense, useState } from "react";
+import { Suspense, useRef, useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
 
 import {
@@ -23,7 +23,7 @@ import {
 
 const MAX_CATEGORY_TEMPLATES = 3;
 const CATEGORY_CARDS_PER_VIEW = 3;
-const CATEGORY_CARD_SKELETON_HEIGHT = 250;
+const CATEGORY_CARD_MIN_HEIGHT = 250;
 const CATEGORY_CAROUSEL_ID = "project-evaluator-category-carousel";
 
 export function ProjectEvaluatorsEmptyState() {
@@ -31,21 +31,20 @@ export function ProjectEvaluatorsEmptyState() {
   return (
     <Flex
       direction="column"
+      gap="size-200"
       width="100%"
       maxWidth="var(--global-text-content-max-width)"
       css={emptyStateContentCSS}
     >
-      <Flex direction="column" gap="size-200" width="100%">
-        <ErrorBoundary fallback={EvaluatorCategoryCardsError}>
-          <Suspense fallback={<EvaluatorCategoryCardsSkeleton />}>
-            <EvaluatorCategoryCards />
-          </Suspense>
-        </ErrorBoundary>
-        <Flex justifyContent="start">
-          <LinkButton size="S" variant="primary" to={paths.gallery}>
-            Browse the library
-          </LinkButton>
-        </Flex>
+      <ErrorBoundary fallback={EvaluatorCategoryCardsError}>
+        <Suspense fallback={<EvaluatorCategoryCardsSkeleton />}>
+          <EvaluatorCategoryCards />
+        </Suspense>
+      </ErrorBoundary>
+      <Flex justifyContent="start">
+        <LinkButton size="S" variant="primary" to={paths.gallery}>
+          Browse the library
+        </LinkButton>
       </Flex>
     </Flex>
   );
@@ -66,27 +65,42 @@ function CategoryCards({
   templates: readonly ProjectEvaluatorTemplate[];
 }) {
   const paths = useProjectEvaluatorPaths();
+  // Keep the full track mounted so native scrolling can animate continuously
+  // between neighboring groups of cards.
+  const categoryCardListRef = useRef<HTMLUListElement>(null);
   const [firstVisibleCategoryIndex, setFirstVisibleCategoryIndex] = useState(0);
   const lastFirstVisibleCategoryIndex = Math.max(
     PROJECT_EVALUATOR_CATEGORIES.length - CATEGORY_CARDS_PER_VIEW,
     0
   );
-  const visibleCategories = PROJECT_EVALUATOR_CATEGORIES.slice(
-    firstVisibleCategoryIndex,
-    firstVisibleCategoryIndex + CATEGORY_CARDS_PER_VIEW
-  );
   const hasPreviousCategories = firstVisibleCategoryIndex > 0;
   const hasNextCategories =
     firstVisibleCategoryIndex < lastFirstVisibleCategoryIndex;
 
+  const showCategoryAtIndex = (categoryIndex: number) => {
+    const categoryCardList = categoryCardListRef.current;
+    const firstCategoryCard = categoryCardList?.children.item(0);
+    const targetCategoryCard = categoryCardList?.children.item(categoryIndex);
+    if (
+      categoryCardList &&
+      firstCategoryCard instanceof HTMLElement &&
+      targetCategoryCard instanceof HTMLElement
+    ) {
+      // Measure actual offsets so the scroll target stays aligned if card or
+      // gap tokens change.
+      categoryCardList.scrollTo({
+        left: targetCategoryCard.offsetLeft - firstCategoryCard.offsetLeft,
+      });
+    }
+    setFirstVisibleCategoryIndex(categoryIndex);
+  };
+
   const showPreviousCategories = () => {
-    setFirstVisibleCategoryIndex((currentIndex) =>
-      Math.max(currentIndex - 1, 0)
-    );
+    showCategoryAtIndex(Math.max(firstVisibleCategoryIndex - 1, 0));
   };
   const showNextCategories = () => {
-    setFirstVisibleCategoryIndex((currentIndex) =>
-      Math.min(currentIndex + 1, lastFirstVisibleCategoryIndex)
+    showCategoryAtIndex(
+      Math.min(firstVisibleCategoryIndex + 1, lastFirstVisibleCategoryIndex)
     );
   };
 
@@ -104,49 +118,63 @@ function CategoryCards({
           onNext={showNextCategories}
         />
         <ul
+          ref={categoryCardListRef}
           id={CATEGORY_CAROUSEL_ID}
           css={categoryCardListCSS}
           aria-live="polite"
         >
-          {visibleCategories.map(({ value, label, description }) => {
-            const categoryTemplates = templates
-              .filter(({ category }) => category === value)
-              .slice(0, MAX_CATEGORY_TEMPLATES);
-            return (
-              <li key={value} css={categoryCardCSS}>
-                <Link
-                  to={paths.galleryCategory(value)}
-                  css={categorySummaryLinkCSS}
+          {PROJECT_EVALUATOR_CATEGORIES.map(
+            ({ value, label, description }, categoryIndex) => {
+              const categoryTemplates = templates
+                .filter(({ category }) => category === value)
+                .slice(0, MAX_CATEGORY_TEMPLATES);
+              const isCategoryVisible =
+                categoryIndex >= firstVisibleCategoryIndex &&
+                categoryIndex <
+                  firstVisibleCategoryIndex + CATEGORY_CARDS_PER_VIEW;
+              return (
+                <li
+                  key={value}
+                  css={categoryCardCSS}
+                  // Offscreen cards remain mounted for motion, so exclude
+                  // their links from the accessibility tree and tab order.
+                  aria-hidden={isCategoryVisible ? undefined : true}
+                  inert={isCategoryVisible ? undefined : true}
                 >
-                  <Text weight="heavy" color="inherit">
-                    {label}
-                  </Text>
-                  <Text size="S" color="text-700">
-                    {description}
-                  </Text>
-                </Link>
-                {categoryTemplates.length > 0 ? (
-                  <ul css={templateLinkListCSS}>
-                    {categoryTemplates.map((template) => (
-                      <li key={template.name}>
-                        <Link
-                          to={paths.galleryTemplate({
-                            category: value,
-                            templateName: template.name,
-                          })}
-                          css={templateLinkCSS}
-                        >
-                          <Text size="XS" color="inherit">
-                            {template.name}
-                          </Text>
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-              </li>
-            );
-          })}
+                  <Link
+                    to={paths.galleryCategory(value)}
+                    css={categorySummaryLinkCSS}
+                  >
+                    <Text weight="heavy" color="inherit">
+                      {label}
+                    </Text>
+                    <Text size="S" color="text-700">
+                      {description}
+                    </Text>
+                  </Link>
+                  {categoryTemplates.length > 0 ? (
+                    <ul css={templateLinkListCSS}>
+                      {categoryTemplates.map((template) => (
+                        <li key={template.name}>
+                          <Link
+                            to={paths.galleryTemplate({
+                              category: value,
+                              templateName: template.name,
+                            })}
+                            css={templateLinkCSS}
+                          >
+                            <Text size="XS" color="inherit">
+                              {template.name}
+                            </Text>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              );
+            }
+          )}
         </ul>
       </Flex>
     </section>
@@ -161,7 +189,7 @@ function EvaluatorCategoryCardsSkeleton() {
         {PROJECT_EVALUATOR_CATEGORIES.slice(0, CATEGORY_CARDS_PER_VIEW).map(
           ({ value }) => (
             <li key={value}>
-              <Skeleton height={CATEGORY_CARD_SKELETON_HEIGHT} />
+              <Skeleton height={CATEGORY_CARD_MIN_HEIGHT} />
             </li>
           )
         )}
@@ -233,22 +261,34 @@ const emptyStateContentCSS = css`
 `;
 
 const categoryCardListCSS = css`
-  display: grid;
-  grid-template-columns: repeat(${CATEGORY_CARDS_PER_VIEW}, minmax(0, 1fr));
-  gap: var(--global-dimension-size-125);
+  --category-card-gap: var(--global-dimension-size-125);
+
+  display: flex;
+  gap: var(--category-card-gap);
+  overflow: hidden;
   margin: 0;
   padding: 0;
   list-style: none;
+  scroll-behavior: smooth;
 
   > li {
     display: flex;
+    flex: 0 0
+      calc(
+        (100% - var(--category-card-gap) - var(--category-card-gap)) /
+          ${CATEGORY_CARDS_PER_VIEW}
+      );
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
   }
 `;
 
 const categoryCardCSS = css`
   box-sizing: border-box;
   flex-direction: column;
-  min-height: ${CATEGORY_CARD_SKELETON_HEIGHT}px;
+  min-height: ${CATEGORY_CARD_MIN_HEIGHT}px;
   min-width: 0;
   border: var(--global-border-size-thin) solid
     var(--global-border-color-default);

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyState.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyState.tsx
@@ -1,186 +1,329 @@
 import { css } from "@emotion/react";
-import type { ReactNode } from "react";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
-import { useNavigate } from "react-router";
 
-import { Flex, Icon, Icons, Skeleton, Text } from "@phoenix/components";
 import {
-  EmptyState,
-  EmptyStateArea,
-  EmptyStateGraphic,
-} from "@phoenix/components/core/empty";
-import { LineClamp } from "@phoenix/components/core/utility/LineClamp";
+  Flex,
+  Icon,
+  IconButton,
+  Icons,
+  Link,
+  LinkButton,
+  Skeleton,
+  Text,
+} from "@phoenix/components";
 import { ErrorBoundary } from "@phoenix/components/exception";
-import type { projectEvaluatorOptionsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptionsQuery.graphql";
-import { projectEvaluatorOptionsQuery as projectEvaluatorOptionsQueryNode } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+import type { projectEvaluatorTemplatesQuery as ProjectEvaluatorTemplatesQueryType } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
+import {
+  PROJECT_EVALUATOR_CATEGORIES,
+  type ProjectEvaluatorTemplate,
+  projectEvaluatorTemplatesQuery,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTemplates";
 
-const MAX_COPY_CARDS = 4;
-const MAX_ATTACH_CARDS = 3;
-const EVALUATOR_CARD_HEIGHT = 90;
+const MAX_CATEGORY_TEMPLATES = 3;
+const CATEGORY_CARDS_PER_VIEW = 3;
+const CATEGORY_CARD_SKELETON_HEIGHT = 250;
+const CATEGORY_CAROUSEL_ID = "project-evaluator-category-carousel";
 
 export function ProjectEvaluatorsEmptyState() {
   const paths = useProjectEvaluatorPaths();
   return (
-    <EmptyStateArea>
-      <Flex
-        direction="column"
-        gap="size-300"
-        width="100%"
-        maxWidth="700px"
-        marginTop="var(--global-dimension-size-300)"
-      >
-        <EmptyState
-          graphic={<EmptyStateGraphic variant="evaluator" />}
-          title="No evaluators for this project"
-          description="Add an evaluator to score spans, traces, or sessions automatically as they arrive."
-          action={{
-            type: "strip",
-            items: [
-              {
-                kind: "internal-link",
-                variant: "primary",
-                children: "Browse the whole library",
-                to: paths.gallery,
-              },
-            ],
-          }}
-        />
-        <ErrorBoundary fallback={EvaluatorOptionsError}>
-          <Suspense fallback={<EvaluatorOptionsSkeleton />}>
-            <EvaluatorOptions />
+    <Flex
+      direction="column"
+      width="100%"
+      maxWidth="var(--global-text-content-max-width)"
+      css={emptyStateContentCSS}
+    >
+      <Flex direction="column" gap="size-200" width="100%">
+        <ErrorBoundary fallback={EvaluatorCategoryCardsError}>
+          <Suspense fallback={<EvaluatorCategoryCardsSkeleton />}>
+            <EvaluatorCategoryCards />
           </Suspense>
         </ErrorBoundary>
+        <Flex justifyContent="start">
+          <LinkButton size="S" variant="primary" to={paths.gallery}>
+            Browse the library
+          </LinkButton>
+        </Flex>
       </Flex>
-    </EmptyStateArea>
+    </Flex>
   );
 }
 
-function EvaluatorOptions() {
-  const navigate = useNavigate();
-  const paths = useProjectEvaluatorPaths();
-  const data = useLazyLoadQuery<projectEvaluatorOptionsQuery>(
-    projectEvaluatorOptionsQueryNode,
+function EvaluatorCategoryCards() {
+  const data = useLazyLoadQuery<ProjectEvaluatorTemplatesQueryType>(
+    projectEvaluatorTemplatesQuery,
     {},
     { fetchPolicy: "store-and-network" }
   );
-  const evaluators = data.evaluators.edges.map(({ evaluator }) => evaluator);
-  const copyEvaluators = evaluators
-    .filter((evaluator) => evaluator.__typename === "LLMEvaluator")
-    .slice(0, MAX_COPY_CARDS);
-  const attachEvaluators = evaluators
-    .filter((evaluator) => evaluator.__typename === "CodeEvaluator")
-    .slice(0, MAX_ATTACH_CARDS);
+  return <CategoryCards templates={data.evaluatorGalleryConfigs} />;
+}
+
+function CategoryCards({
+  templates,
+}: {
+  templates: readonly ProjectEvaluatorTemplate[];
+}) {
+  const paths = useProjectEvaluatorPaths();
+  const [firstVisibleCategoryIndex, setFirstVisibleCategoryIndex] = useState(0);
+  const lastFirstVisibleCategoryIndex = Math.max(
+    PROJECT_EVALUATOR_CATEGORIES.length - CATEGORY_CARDS_PER_VIEW,
+    0
+  );
+  const visibleCategories = PROJECT_EVALUATOR_CATEGORIES.slice(
+    firstVisibleCategoryIndex,
+    firstVisibleCategoryIndex + CATEGORY_CARDS_PER_VIEW
+  );
+  const hasPreviousCategories = firstVisibleCategoryIndex > 0;
+  const hasNextCategories =
+    firstVisibleCategoryIndex < lastFirstVisibleCategoryIndex;
+
+  const showPreviousCategories = () => {
+    setFirstVisibleCategoryIndex((currentIndex) =>
+      Math.max(currentIndex - 1, 0)
+    );
+  };
+  const showNextCategories = () => {
+    setFirstVisibleCategoryIndex((currentIndex) =>
+      Math.min(currentIndex + 1, lastFirstVisibleCategoryIndex)
+    );
+  };
+
   return (
-    <Flex direction="row" gap="size-125" width="100%">
-      <div css={evaluatorColumnCSS}>
-        <EvaluatorCard
-          icon={<Icon svg={<Icons.Plus />} />}
-          title="Create new LLM evaluator"
-          description="Author an LLM-as-a-judge evaluator from scratch."
-          onPress={() => navigate(paths.newLlm)}
+    <section
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Evaluator categories"
+    >
+      <Flex direction="column" gap="size-200">
+        <CategoryCarouselHeader
+          hasPreviousCategories={hasPreviousCategories}
+          hasNextCategories={hasNextCategories}
+          onPrevious={showPreviousCategories}
+          onNext={showNextCategories}
         />
-        {copyEvaluators.map((evaluator) => (
-          <EvaluatorCard
-            key={evaluator.id}
-            title={`Copy ${evaluator.name}`}
-            description={evaluator.description}
-            onPress={() => navigate(paths.copyLlm(evaluator.id))}
-          />
-        ))}
-      </div>
-      <div css={evaluatorColumnCSS}>
-        <EvaluatorCard
-          icon={<Icon svg={<Icons.Code />} />}
-          title="Create new code evaluator"
-          description="Author a Python or TypeScript evaluator from scratch."
-          onPress={() => navigate(paths.newCode)}
-        />
-        {attachEvaluators.map((evaluator) => (
-          <EvaluatorCard
-            key={evaluator.id}
-            title={`Attach ${evaluator.name}`}
-            description={evaluator.description}
-            onPress={() => navigate(paths.attachCode(evaluator.id))}
-          />
-        ))}
-      </div>
+        <ul
+          id={CATEGORY_CAROUSEL_ID}
+          css={categoryCardListCSS}
+          aria-live="polite"
+        >
+          {visibleCategories.map(({ value, label, description }) => {
+            const categoryTemplates = templates
+              .filter(({ category }) => category === value)
+              .slice(0, MAX_CATEGORY_TEMPLATES);
+            return (
+              <li key={value} css={categoryCardCSS}>
+                <Link
+                  to={paths.galleryCategory(value)}
+                  css={categorySummaryLinkCSS}
+                >
+                  <Text weight="heavy" color="inherit">
+                    {label}
+                  </Text>
+                  <Text size="S" color="text-700">
+                    {description}
+                  </Text>
+                </Link>
+                {categoryTemplates.length > 0 ? (
+                  <ul css={templateLinkListCSS}>
+                    {categoryTemplates.map((template) => (
+                      <li key={template.name}>
+                        <Link
+                          to={paths.galleryTemplate({
+                            category: value,
+                            templateName: template.name,
+                          })}
+                          css={templateLinkCSS}
+                        >
+                          <Text size="XS" color="inherit">
+                            {template.name}
+                          </Text>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      </Flex>
+    </section>
+  );
+}
+
+function EvaluatorCategoryCardsSkeleton() {
+  return (
+    <Flex direction="column" gap="size-200" aria-hidden="true">
+      <CategoryCarouselHeader />
+      <ul css={categoryCardListCSS}>
+        {PROJECT_EVALUATOR_CATEGORIES.slice(0, CATEGORY_CARDS_PER_VIEW).map(
+          ({ value }) => (
+            <li key={value}>
+              <Skeleton height={CATEGORY_CARD_SKELETON_HEIGHT} />
+            </li>
+          )
+        )}
+      </ul>
     </Flex>
   );
 }
 
-function EvaluatorCard({
-  icon,
-  title,
-  description,
-  onPress,
+function EvaluatorCategoryCardsError() {
+  return <CategoryCards templates={[]} />;
+}
+
+function CategoryCarouselHeader({
+  hasPreviousCategories = false,
+  hasNextCategories = false,
+  onPrevious,
+  onNext,
 }: {
-  icon?: ReactNode;
-  title: string;
-  description: ReactNode;
-  onPress: () => void;
+  hasPreviousCategories?: boolean;
+  hasNextCategories?: boolean;
+  onPrevious?: () => void;
+  onNext?: () => void;
 }) {
   return (
-    <button css={evaluatorItemButtonCSS} onClick={onPress}>
-      <Flex direction="row" alignItems="center" gap="size-50">
-        {icon}
-        <Text size="S" weight="heavy">
-          {title}
+    <Flex
+      direction="row"
+      gap="size-100"
+      wrap="wrap"
+      alignItems="center"
+      justifyContent="space-between"
+    >
+      <Flex direction="row" gap="size-100" wrap="wrap" alignItems="baseline">
+        <Text elementType="h2" size="S" weight="heavy">
+          Browse by category
+        </Text>
+        <Text size="S" color="text-700">
+          Pick an area to start browsing.
         </Text>
       </Flex>
-      <LineClamp lines={2}>
-        <Text size="XS" color="text-700">
-          {description}
-        </Text>
-      </LineClamp>
-    </button>
-  );
-}
-
-function EvaluatorOptionsSkeleton() {
-  const column = (
-    <div css={evaluatorColumnCSS}>
-      <Skeleton height={EVALUATOR_CARD_HEIGHT} />
-      <Skeleton height={EVALUATOR_CARD_HEIGHT} />
-    </div>
-  );
-  return (
-    <Flex direction="row" gap="size-125" width="100%" aria-hidden="true">
-      {column}
-      {column}
+      <Flex direction="row" gap="size-50">
+        <IconButton
+          size="S"
+          isDisabled={!hasPreviousCategories}
+          onPress={onPrevious}
+          aria-label="Previous evaluator categories"
+          aria-controls={CATEGORY_CAROUSEL_ID}
+        >
+          <Icon svg={<Icons.ChevronLeftSmall />} />
+        </IconButton>
+        <IconButton
+          size="S"
+          isDisabled={!hasNextCategories}
+          onPress={onNext}
+          aria-label="Next evaluator categories"
+          aria-controls={CATEGORY_CAROUSEL_ID}
+        >
+          <Icon svg={<Icons.ChevronRightSmall />} />
+        </IconButton>
+      </Flex>
     </Flex>
   );
 }
 
-function EvaluatorOptionsError() {
-  return (
-    <Text size="S" color="text-500">
-      Existing evaluators could not be loaded.
-    </Text>
-  );
-}
+const emptyStateContentCSS = css`
+  box-sizing: border-box;
+  margin-inline: auto;
+  padding: var(--global-dimension-size-400) var(--global-dimension-size-300)
+    var(--global-dimension-size-600);
+`;
 
-const evaluatorItemButtonCSS = css`
-  display: flex;
-  flex-direction: column;
-  gap: var(--global-dimension-size-50);
-  height: ${EVALUATOR_CARD_HEIGHT}px;
-  padding: var(--global-dimension-size-200);
-  border-radius: var(--global-rounding-small);
-  border: 1px solid var(--global-border-color-default);
-  background-color: transparent;
-  cursor: pointer;
-  text-align: left;
-  transition: background-color 0.2s ease;
-  &:hover {
-    background-color: var(--global-color-gray-200);
+const categoryCardListCSS = css`
+  display: grid;
+  grid-template-columns: repeat(${CATEGORY_CARDS_PER_VIEW}, minmax(0, 1fr));
+  gap: var(--global-dimension-size-125);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  > li {
+    display: flex;
   }
 `;
 
-const evaluatorColumnCSS = css`
-  display: flex;
+const categoryCardCSS = css`
+  box-sizing: border-box;
   flex-direction: column;
-  gap: var(--global-dimension-size-125);
+  min-height: ${CATEGORY_CARD_SKELETON_HEIGHT}px;
+  min-width: 0;
+  border: var(--global-border-size-thin) solid
+    var(--global-border-color-default);
+  border-radius: var(--global-rounding-small);
+
+  > .link-container {
+    display: flex;
+    flex: 1;
+    width: 100%;
+    max-width: none;
+    min-height: 0;
+  }
+`;
+
+const categorySummaryLinkCSS = css`
+  box-sizing: border-box;
+  display: flex;
   flex: 1;
+  flex-direction: column;
+  gap: var(--global-dimension-size-100);
+  width: 100%;
+  padding: var(--global-dimension-size-200) var(--global-dimension-size-200)
+    var(--global-dimension-size-100);
+  border-radius: var(--global-rounding-small) var(--global-rounding-small) 0 0;
+  color: var(--global-text-color-900);
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--global-card-header-background-color-hover);
+    text-decoration: none;
+  }
+`;
+
+const templateLinkListCSS = css`
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  gap: var(--global-dimension-size-100);
+  width: 100%;
+  height: var(--global-dimension-size-1700);
+  margin: 0;
+  padding: var(--global-dimension-size-100) var(--global-dimension-size-200);
+  list-style: none;
+
+  li {
+    min-width: 0;
+  }
+
+  .link-container {
+    display: flex;
+    width: 100%;
+    max-width: none;
+  }
+`;
+
+const templateLinkCSS = css`
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: none;
+  padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
+  border: var(--global-border-size-thin) solid
+    var(--global-border-color-default);
+  border-radius: var(--global-rounding-small);
+  background-color: var(--global-card-header-background-color);
+  color: var(--global-text-color-900);
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--global-card-header-background-color-hover);
+    border-color: var(--global-color-gray-400);
+    text-decoration: none;
+  }
 `;

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyState.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsEmptyState.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Suspense, useRef, useState } from "react";
+import { type ReactNode, Suspense, useRef, useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
 
 import {
@@ -14,6 +14,7 @@ import {
 } from "@phoenix/components";
 import { ErrorBoundary } from "@phoenix/components/exception";
 import type { projectEvaluatorTemplatesQuery as ProjectEvaluatorTemplatesQueryType } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
+import { BuildProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import {
   PROJECT_EVALUATOR_CATEGORIES,
@@ -41,7 +42,8 @@ export function ProjectEvaluatorsEmptyState() {
           <EvaluatorCategoryCards />
         </Suspense>
       </ErrorBoundary>
-      <Flex justifyContent="start">
+      <Flex direction="row" gap="size-100" wrap="wrap" justifyContent="center">
+        <BuildProjectEvaluatorMenu size="S" />
         <LinkButton size="S" variant="primary" to={paths.gallery}>
           Browse the library
         </LinkButton>
@@ -79,17 +81,12 @@ function CategoryCards({
 
   const showCategoryAtIndex = (categoryIndex: number) => {
     const categoryCardList = categoryCardListRef.current;
-    const firstCategoryCard = categoryCardList?.children.item(0);
     const targetCategoryCard = categoryCardList?.children.item(categoryIndex);
-    if (
-      categoryCardList &&
-      firstCategoryCard instanceof HTMLElement &&
-      targetCategoryCard instanceof HTMLElement
-    ) {
-      // Measure actual offsets so the scroll target stays aligned if card or
-      // gap tokens change.
-      categoryCardList.scrollTo({
-        left: targetCategoryCard.offsetLeft - firstCategoryCard.offsetLeft,
+    if (targetCategoryCard instanceof HTMLElement) {
+      // The scroll port's padding keeps adjacent cards peeking at the edges.
+      targetCategoryCard.scrollIntoView({
+        block: "nearest",
+        inline: "start",
       });
     }
     setFirstVisibleCategoryIndex(categoryIndex);
@@ -110,18 +107,19 @@ function CategoryCards({
       aria-roledescription="carousel"
       aria-label="Evaluator categories"
     >
-      <Flex direction="column" gap="size-200">
-        <CategoryCarouselHeader
-          hasPreviousCategories={hasPreviousCategories}
-          hasNextCategories={hasNextCategories}
-          onPrevious={showPreviousCategories}
-          onNext={showNextCategories}
-        />
+      <CategoryCarouselControls
+        hasPreviousCategories={hasPreviousCategories}
+        hasNextCategories={hasNextCategories}
+        onPrevious={showPreviousCategories}
+        onNext={showNextCategories}
+      >
         <ul
           ref={categoryCardListRef}
           id={CATEGORY_CAROUSEL_ID}
           css={categoryCardListCSS}
           aria-live="polite"
+          data-overflow-start={hasPreviousCategories}
+          data-overflow-end={hasNextCategories}
         >
           {PROJECT_EVALUATOR_CATEGORIES.map(
             ({ value, label, description }, categoryIndex) => {
@@ -176,25 +174,33 @@ function CategoryCards({
             }
           )}
         </ul>
-      </Flex>
+      </CategoryCarouselControls>
     </section>
   );
 }
 
 function EvaluatorCategoryCardsSkeleton() {
+  const hasCategoryOverflow =
+    PROJECT_EVALUATOR_CATEGORIES.length > CATEGORY_CARDS_PER_VIEW;
   return (
-    <Flex direction="column" gap="size-200" aria-hidden="true">
-      <CategoryCarouselHeader />
-      <ul css={categoryCardListCSS}>
-        {PROJECT_EVALUATOR_CATEGORIES.slice(0, CATEGORY_CARDS_PER_VIEW).map(
-          ({ value }) => (
+    <div aria-hidden="true">
+      <CategoryCarouselControls>
+        <ul
+          id={CATEGORY_CAROUSEL_ID}
+          css={categoryCardListCSS}
+          data-overflow-end={hasCategoryOverflow}
+        >
+          {PROJECT_EVALUATOR_CATEGORIES.slice(
+            0,
+            CATEGORY_CARDS_PER_VIEW + 1
+          ).map(({ value }) => (
             <li key={value}>
               <Skeleton height={CATEGORY_CARD_MIN_HEIGHT} />
             </li>
-          )
-        )}
-      </ul>
-    </Flex>
+          ))}
+        </ul>
+      </CategoryCarouselControls>
+    </div>
   );
 }
 
@@ -202,34 +208,22 @@ function EvaluatorCategoryCardsError() {
   return <CategoryCards templates={[]} />;
 }
 
-function CategoryCarouselHeader({
+function CategoryCarouselControls({
+  children,
   hasPreviousCategories = false,
   hasNextCategories = false,
   onPrevious,
   onNext,
 }: {
+  children: ReactNode;
   hasPreviousCategories?: boolean;
   hasNextCategories?: boolean;
   onPrevious?: () => void;
   onNext?: () => void;
 }) {
   return (
-    <Flex
-      direction="row"
-      gap="size-100"
-      wrap="wrap"
-      alignItems="center"
-      justifyContent="space-between"
-    >
-      <Flex direction="row" gap="size-100" wrap="wrap" alignItems="baseline">
-        <Text elementType="h2" size="S" weight="heavy">
-          Browse by category
-        </Text>
-        <Text size="S" color="text-700">
-          Pick an area to start browsing.
-        </Text>
-      </Flex>
-      <Flex direction="row" gap="size-50">
+    <Flex direction="row" gap="size-100" alignItems="center" width="100%">
+      <Flex alignItems="center" css={categoryCarouselControlCSS}>
         <IconButton
           size="S"
           isDisabled={!hasPreviousCategories}
@@ -239,6 +233,9 @@ function CategoryCarouselHeader({
         >
           <Icon svg={<Icons.ChevronLeftSmall />} />
         </IconButton>
+      </Flex>
+      {children}
+      <Flex alignItems="center" css={categoryCarouselControlCSS}>
         <IconButton
           size="S"
           isDisabled={!hasNextCategories}
@@ -256,19 +253,42 @@ function CategoryCarouselHeader({
 const emptyStateContentCSS = css`
   box-sizing: border-box;
   margin-inline: auto;
-  padding: var(--global-dimension-size-400) var(--global-dimension-size-300)
-    var(--global-dimension-size-600);
+  padding: var(--global-dimension-size-400) 0 var(--global-dimension-size-600);
+`;
+
+const categoryCarouselControlCSS = css`
+  position: relative;
+  align-self: stretch;
+
+  > button {
+    position: static;
+
+    /* Extend the real button's hit target without enlarging its visual state. */
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
+  }
 `;
 
 const categoryCardListCSS = css`
   --category-card-gap: var(--global-dimension-size-125);
+  --category-carousel-peek: var(--global-dimension-size-250);
+  --category-carousel-fade-start: 0px;
+  --category-carousel-fade-end: 0px;
 
+  box-sizing: border-box;
   display: flex;
+  flex: 1;
   gap: var(--category-card-gap);
+  min-width: 0;
   overflow: hidden;
   margin: 0;
-  padding: 0;
+  /* Reserve the same edge slot whether it holds empty space or a card peek. */
+  padding: 0 var(--category-carousel-peek);
   list-style: none;
+  scroll-padding-inline: var(--category-carousel-peek);
   scroll-behavior: smooth;
 
   > li {
@@ -280,6 +300,32 @@ const categoryCardListCSS = css`
       );
   }
 
+  &[data-overflow-start="true"] {
+    --category-carousel-fade-start: var(--category-carousel-peek);
+  }
+
+  &[data-overflow-end="true"] {
+    --category-carousel-fade-end: var(--category-carousel-peek);
+  }
+
+  /* Match the directional overflow treatment used by horizontal tabs. */
+  &:is([data-overflow-start="true"], [data-overflow-end="true"]) {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent,
+      black var(--category-carousel-fade-start),
+      black calc(100% - var(--category-carousel-fade-end)),
+      transparent
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      black var(--category-carousel-fade-start),
+      black calc(100% - var(--category-carousel-fade-end)),
+      transparent
+    );
+  }
+
   @media (prefers-reduced-motion: reduce) {
     scroll-behavior: auto;
   }
@@ -287,12 +333,19 @@ const categoryCardListCSS = css`
 
 const categoryCardCSS = css`
   box-sizing: border-box;
+  position: relative;
+  isolation: isolate;
   flex-direction: column;
   min-height: ${CATEGORY_CARD_MIN_HEIGHT}px;
   min-width: 0;
   border: var(--global-border-size-thin) solid
     var(--global-border-color-default);
   border-radius: var(--global-rounding-small);
+  transition: background-color 0.15s ease;
+
+  &:has(> .link-container > a:hover) {
+    background-color: var(--global-card-header-background-color-hover);
+  }
 
   > .link-container {
     display: flex;
@@ -314,34 +367,71 @@ const categorySummaryLinkCSS = css`
     var(--global-dimension-size-100);
   border-radius: var(--global-rounding-small) var(--global-rounding-small) 0 0;
   color: var(--global-text-color-900);
-  transition: background-color 0.15s ease;
+
+  /* Stretch this anchor without wrapping the sibling template links. */
+  &::after {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    border-radius: var(--global-rounding-small);
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+
+  &:focus-visible::after {
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
+  }
 
   &:hover {
-    background-color: var(--global-card-header-background-color-hover);
     text-decoration: none;
   }
 `;
 
 const templateLinkListCSS = css`
+  --template-link-gap: var(--global-dimension-size-100);
+
   box-sizing: border-box;
+  position: relative;
+  z-index: 1;
   display: flex;
   flex: none;
   flex-direction: column;
-  gap: var(--global-dimension-size-100);
+  gap: var(--template-link-gap);
   width: 100%;
   height: var(--global-dimension-size-1700);
   margin: 0;
   padding: var(--global-dimension-size-100) var(--global-dimension-size-200);
   list-style: none;
+  /* Padding falls through to the category link; rows and gaps opt back in. */
+  pointer-events: none;
 
   li {
     min-width: 0;
+  }
+
+  li + li {
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: calc(-1 * var(--template-link-gap));
+      right: 0;
+      left: 0;
+      height: var(--template-link-gap);
+      pointer-events: auto;
+    }
   }
 
   .link-container {
     display: flex;
     width: 100%;
     max-width: none;
+    pointer-events: auto;
   }
 `;
 

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -4,9 +4,10 @@ import { graphql, useLazyLoadQuery } from "react-relay";
 import { Outlet, useParams } from "react-router";
 import invariant from "tiny-invariant";
 
-import { Skeleton, View } from "@phoenix/components";
+import { Flex, PageHeader, Skeleton, View } from "@phoenix/components";
 import { useTimeRange } from "@phoenix/components/datetime";
 import type { ProjectEvaluatorsPageQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql";
+import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
 import { ProjectEvaluatorsTable } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsTable";
 import { ProjectEvaluatorsToolbar } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsToolbar";
 
@@ -23,9 +24,12 @@ export function ProjectEvaluatorsPage() {
         min-height: 0;
       `}
     >
-      <ProjectEvaluatorsToolbar filter={filter} onFilterChange={setFilter} />
       <Suspense fallback={<ProjectEvaluatorsPageSkeleton />}>
-        <ProjectEvaluatorsPageContent projectId={projectId} filter={filter} />
+        <ProjectEvaluatorsPageContent
+          projectId={projectId}
+          filter={filter}
+          onFilterChange={setFilter}
+        />
       </Suspense>
       {/* The create and edit slideovers, each on its own nested route. The
           copy and attach routes suspend while loading the evaluator they are
@@ -40,9 +44,11 @@ export function ProjectEvaluatorsPage() {
 function ProjectEvaluatorsPageContent({
   projectId,
   filter,
+  onFilterChange,
 }: {
   projectId: string;
   filter: string;
+  onFilterChange: (filter: string) => void;
 }) {
   const { timeRangeISOStrings } = useTimeRange();
   // The owner query supplies the initial filter and range. Subsequent toolbar,
@@ -59,6 +65,7 @@ function ProjectEvaluatorsPageContent({
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            evaluatorCount
             ...ProjectEvaluatorsTable_project
               @arguments(filter: $filter, timeRange: $timeRange)
           }
@@ -73,21 +80,49 @@ function ProjectEvaluatorsPageContent({
     { fetchPolicy: "store-and-network" }
   );
   invariant(data.project, "project is required");
+  const isEmptyState =
+    (data.project.evaluatorCount ?? 0) === 0 && filter.trim().length === 0;
   return (
-    <ProjectEvaluatorsTable
-      project={data.project}
-      projectId={projectId}
-      filter={filter}
-      timeRange={timeRangeISOStrings}
-      initialFilter={initialFilter}
-      initialTimeRange={initialTimeRange}
-    />
+    <>
+      {isEmptyState ? (
+        <View borderBottomWidth="thin" borderBottomColor="default" flex="none">
+          <PageHeader
+            title="Evaluators"
+            subTitle="Evaluators read span inputs, outputs, retrieved documents, and tool calls, then return labels or scores you can filter, chart, and alert on."
+            extra={<AddProjectEvaluatorMenu size="M" />}
+          />
+        </View>
+      ) : (
+        <ProjectEvaluatorsToolbar
+          filter={filter}
+          onFilterChange={onFilterChange}
+        />
+      )}
+      <ProjectEvaluatorsTable
+        project={data.project}
+        projectId={projectId}
+        filter={filter}
+        timeRange={timeRangeISOStrings}
+        initialFilter={initialFilter}
+        initialTimeRange={initialTimeRange}
+      />
+    </>
   );
 }
 
 function ProjectEvaluatorsPageSkeleton() {
   return (
     <>
+      <View
+        padding="size-100"
+        borderBottomWidth="thin"
+        borderBottomColor="default"
+        flex="none"
+      >
+        <Flex justifyContent="end">
+          <Skeleton width={140} height={40} animation="wave" />
+        </Flex>
+      </View>
       <View padding="size-100">
         <Skeleton width="100%" height={180} animation="wave" />
       </View>

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1ce7546d28cd6b451c9aef8750a8c5d8>>
+ * @generated SignedSource<<9805c63fa714557fa01430c48490bdc4>>
  * @lightSyntaxTransform
  */
 
@@ -25,6 +25,7 @@ export type ProjectEvaluatorsPageQuery$variables = {
 };
 export type ProjectEvaluatorsPageQuery$data = {
   readonly project: {
+    readonly evaluatorCount?: number;
     readonly " $fragmentSpreads": FragmentRefs<"ProjectEvaluatorsTable_project">;
   };
 };
@@ -57,48 +58,55 @@ v3 = [
   }
 ],
 v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "evaluatorCount",
+  "storageKey": null
+},
+v5 = {
   "kind": "Variable",
   "name": "filter",
   "variableName": "filter"
 },
-v5 = {
+v6 = {
   "kind": "Variable",
   "name": "timeRange",
   "variableName": "timeRange"
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = [
-  (v4/*:: as any*/),
+v9 = [
+  (v5/*:: as any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   }
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = [
-  (v5/*:: as any*/)
-],
 v11 = [
+  (v6/*:: as any*/)
+],
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -129,10 +137,11 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
+              (v4/*:: as any*/),
               {
                 "args": [
-                  (v4/*:: as any*/),
-                  (v5/*:: as any*/)
+                  (v5/*:: as any*/),
+                  (v6/*:: as any*/)
                 ],
                 "kind": "FragmentSpread",
                 "name": "ProjectEvaluatorsTable_project"
@@ -166,14 +175,15 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*:: as any*/),
           (v7/*:: as any*/),
+          (v8/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
+              (v4/*:: as any*/),
               {
                 "alias": null,
-                "args": (v8/*:: as any*/),
+                "args": (v9/*:: as any*/),
                 "concreteType": "ProjectEvaluatorConnection",
                 "kind": "LinkedField",
                 "name": "evaluators",
@@ -195,8 +205,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v7/*:: as any*/),
-                          (v9/*:: as any*/),
+                          (v8/*:: as any*/),
+                          (v10/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -300,7 +310,7 @@ return {
                             "name": "evaluator",
                             "plural": false,
                             "selections": [
-                              (v6/*:: as any*/),
+                              (v7/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -319,8 +329,8 @@ return {
                                     "name": "prompt",
                                     "plural": false,
                                     "selections": [
-                                      (v7/*:: as any*/),
-                                      (v9/*:: as any*/)
+                                      (v8/*:: as any*/),
+                                      (v10/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -332,8 +342,8 @@ return {
                                     "name": "promptVersionTag",
                                     "plural": false,
                                     "selections": [
-                                      (v9/*:: as any*/),
-                                      (v7/*:: as any*/)
+                                      (v10/*:: as any*/),
+                                      (v8/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -359,7 +369,7 @@ return {
                                         "name": "modelProvider",
                                         "storageKey": null
                                       },
-                                      (v7/*:: as any*/)
+                                      (v8/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -385,8 +395,8 @@ return {
                                     "name": "sandboxConfig",
                                     "plural": false,
                                     "selections": [
-                                      (v7/*:: as any*/),
-                                      (v9/*:: as any*/),
+                                      (v8/*:: as any*/),
+                                      (v10/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -402,7 +412,7 @@ return {
                                             "name": "backendType",
                                             "storageKey": null
                                           },
-                                          (v7/*:: as any*/)
+                                          (v8/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -413,7 +423,7 @@ return {
                                 "type": "CodeEvaluator",
                                 "abstractKey": null
                               },
-                              (v7/*:: as any*/)
+                              (v8/*:: as any*/)
                             ],
                             "storageKey": null
                           },
@@ -425,17 +435,17 @@ return {
                             "name": "traceProject",
                             "plural": false,
                             "selections": [
-                              (v7/*:: as any*/),
+                              (v8/*:: as any*/),
                               {
                                 "alias": null,
-                                "args": (v10/*:: as any*/),
+                                "args": (v11/*:: as any*/),
                                 "kind": "ScalarField",
                                 "name": "traceCount",
                                 "storageKey": null
                               },
                               {
                                 "alias": null,
-                                "args": (v10/*:: as any*/),
+                                "args": (v11/*:: as any*/),
                                 "concreteType": "SpanCostSummary",
                                 "kind": "LinkedField",
                                 "name": "costSummary",
@@ -448,7 +458,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "total",
                                     "plural": false,
-                                    "selections": (v11/*:: as any*/),
+                                    "selections": (v12/*:: as any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -458,7 +468,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "prompt",
                                     "plural": false,
-                                    "selections": (v11/*:: as any*/),
+                                    "selections": (v12/*:: as any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -468,7 +478,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "completion",
                                     "plural": false,
-                                    "selections": (v11/*:: as any*/),
+                                    "selections": (v12/*:: as any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -477,7 +487,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v6/*:: as any*/)
+                          (v7/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -521,7 +531,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*:: as any*/),
+                "args": (v9/*:: as any*/),
                 "filters": [
                   "filter"
                 ],
@@ -540,16 +550,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1ab53bdd17dc16f12370cee5d9c1c505",
+    "cacheID": "dfe5c7d8668d466ef26001cf4189c5b2",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsPageQuery(\n  $projectId: ID!\n  $filter: ProjectEvaluatorFilter\n  $timeRange: TimeRange!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectEvaluatorsTable_project_3yoAX2\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_costs_3E0ZE6 on ProjectEvaluator {\n  traceProject {\n    id\n    traceCount(timeRange: $timeRange)\n    costSummary(timeRange: $timeRange) {\n      total {\n        cost\n      }\n      prompt {\n        cost\n      }\n      completion {\n        cost\n      }\n    }\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_3yoAX2 on Project {\n  evaluators(first: 30, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        ...ProjectEvaluatorsTable_costs_3E0ZE6\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  schedulabilityReason\n  runSummary {\n    status\n    lastRunAt\n    queuedCount\n    evaluatedCount\n    failedCount\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectEvaluatorsPageQuery(\n  $projectId: ID!\n  $filter: ProjectEvaluatorFilter\n  $timeRange: TimeRange!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      ...ProjectEvaluatorsTable_project_3yoAX2\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_costs_3E0ZE6 on ProjectEvaluator {\n  traceProject {\n    id\n    traceCount(timeRange: $timeRange)\n    costSummary(timeRange: $timeRange) {\n      total {\n        cost\n      }\n      prompt {\n        cost\n      }\n      completion {\n        cost\n      }\n    }\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_3yoAX2 on Project {\n  evaluators(first: 30, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        ...ProjectEvaluatorsTable_costs_3E0ZE6\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  schedulabilityReason\n  runSummary {\n    status\n    lastRunAt\n    queuedCount\n    evaluatedCount\n    failedCount\n  }\n  evaluator {\n    __typename\n    kind\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c84e1fffd62aa767ce032e42bd8175c4";
+(node as any).hash = "5feeb271094e288e1cd6ed6539b2fef8";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
@@ -1,0 +1,68 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function TestProjectEvaluatorPaths() {
+  const paths = useProjectEvaluatorPaths();
+  return (
+    <output
+      data-gallery={paths.gallery}
+      data-response-quality-gallery={paths.galleryCategory("RESPONSE_QUALITY")}
+      data-template-gallery={paths.galleryTemplate({
+        category: "RESPONSE_QUALITY",
+        templateName: "Correctness",
+      })}
+    />
+  );
+}
+
+describe("useProjectEvaluatorPaths", () => {
+  it("builds default and category gallery links without dropping URL state", () => {
+    act(() => {
+      root.render(
+        <MemoryRouter
+          initialEntries={[
+            "/projects/project-1/evaluators?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved",
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/projects/:projectId/:tab"
+              element={<TestProjectEvaluatorPaths />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+    });
+
+    const output = container.querySelector("output");
+    expect(output?.getAttribute("data-gallery")).toBe(
+      "/projects/project-1/evaluator-gallery?timeRangeKey=7d&proof=preserved"
+    );
+    expect(output?.getAttribute("data-response-quality-gallery")).toBe(
+      "/projects/project-1/evaluator-gallery?timeRangeKey=7d&category=RESPONSE_QUALITY&proof=preserved"
+    );
+    expect(output?.getAttribute("data-template-gallery")).toBe(
+      "/projects/project-1/evaluator-gallery?timeRangeKey=7d&category=RESPONSE_QUALITY&template=Correctness&proof=preserved"
+    );
+  });
+});

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
@@ -26,6 +26,7 @@ function TestProjectEvaluatorPaths() {
   return (
     <output
       data-gallery={paths.gallery}
+      data-gallery-return={paths.galleryReturn}
       data-response-quality-gallery={paths.galleryCategory("RESPONSE_QUALITY")}
       data-template-gallery={paths.galleryTemplate({
         category: "RESPONSE_QUALITY",
@@ -36,7 +37,7 @@ function TestProjectEvaluatorPaths() {
 }
 
 describe("useProjectEvaluatorPaths", () => {
-  it("builds default and category gallery links without dropping URL state", () => {
+  it("separates the default gallery entry and slideover return destinations", () => {
     act(() => {
       root.render(
         <MemoryRouter
@@ -55,6 +56,9 @@ describe("useProjectEvaluatorPaths", () => {
     });
 
     const output = container.querySelector("output");
+    expect(output?.getAttribute("data-gallery-return")).toBe(
+      "/projects/project-1/evaluator-gallery?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+    );
     expect(output?.getAttribute("data-gallery")).toBe(
       "/projects/project-1/evaluator-gallery?timeRangeKey=7d&proof=preserved"
     );

--- a/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -1,7 +1,13 @@
 import { useMemo } from "react";
 import { useLocation } from "react-router";
 
+import {
+  PROJECT_EVALUATOR_CATEGORY_PARAM,
+  PROJECT_EVALUATOR_TEMPLATE_PARAM,
+} from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
+import type { EvaluatorCategory } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
+import { withSearchParams } from "@phoenix/utils/urlUtils";
 
 const projectEvaluatorsPath = (projectRootPath: string) =>
   `${projectRootPath}/evaluators`;
@@ -39,9 +45,29 @@ export function useProjectEvaluatorPaths() {
     const list = projectEvaluatorsPath(rootPath);
     const gallery = projectEvaluatorGalleryPath(rootPath);
     const withCurrentSearch = (path: string) => `${path}${search}`;
+    const defaultGallerySearch = withSearchParams(search, (searchParams) => {
+      searchParams.delete(PROJECT_EVALUATOR_CATEGORY_PARAM);
+      searchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
+    });
     return {
       list: withCurrentSearch(list),
-      gallery: withCurrentSearch(gallery),
+      gallery: `${gallery}${defaultGallerySearch}`,
+      galleryCategory: (category: EvaluatorCategory) =>
+        `${gallery}${withSearchParams(search, (searchParams) => {
+          searchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);
+          searchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
+        })}`,
+      galleryTemplate: ({
+        category,
+        templateName,
+      }: {
+        category: EvaluatorCategory;
+        templateName: string;
+      }) =>
+        `${gallery}${withSearchParams(search, (searchParams) => {
+          searchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);
+          searchParams.set(PROJECT_EVALUATOR_TEMPLATE_PARAM, templateName);
+        })}`,
       newLlm: withCurrentSearch(newLlmProjectEvaluatorPath(rootPath)),
       newCode: withCurrentSearch(newCodeProjectEvaluatorPath(rootPath)),
       galleryNewLlm: withCurrentSearch(`${gallery}/new/llm`),

--- a/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -45,6 +45,8 @@ export function useProjectEvaluatorPaths() {
     const list = projectEvaluatorsPath(rootPath);
     const gallery = projectEvaluatorGalleryPath(rootPath);
     const withCurrentSearch = (path: string) => `${path}${search}`;
+    // A fresh gallery entry clears stale selection while preserving unrelated
+    // project-page state in the query string.
     const defaultGallerySearch = withSearchParams(search, (searchParams) => {
       searchParams.delete(PROJECT_EVALUATOR_CATEGORY_PARAM);
       searchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
@@ -52,6 +54,8 @@ export function useProjectEvaluatorPaths() {
     return {
       list: withCurrentSearch(list),
       gallery: `${gallery}${defaultGallerySearch}`,
+      // Nested gallery routes use this exact return URL when they close.
+      galleryReturn: withCurrentSearch(gallery),
       galleryCategory: (category: EvaluatorCategory) =>
         `${gallery}${withSearchParams(search, (searchParams) => {
           searchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTemplates.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTemplates.ts
@@ -29,18 +29,43 @@ export const projectEvaluatorTemplatesQuery = graphql`
 export type ProjectEvaluatorTemplate =
   projectEvaluatorTemplatesQuery$data["evaluatorGalleryConfigs"][number];
 
-const EVALUATOR_CATEGORY_LABELS: Record<EvaluatorCategory, string> = {
-  GROUNDING_AND_RETRIEVAL: "Grounding & retrieval",
-  AGENTS: "Agents",
-  RESPONSE_QUALITY: "Response quality",
-  SAFETY_AND_SECURITY: "Safety & security",
-  USER_EXPERIENCE: "User experience",
+const EVALUATOR_CATEGORY_DETAILS: Record<
+  EvaluatorCategory,
+  { label: string; description: string }
+> = {
+  GROUNDING_AND_RETRIEVAL: {
+    label: "Grounding & retrieval",
+    description: "Check whether responses are supported by retrieved context.",
+  },
+  AGENTS: {
+    label: "Agents",
+    description: "Evaluate tool use, task completion, and agent behavior.",
+  },
+  RESPONSE_QUALITY: {
+    label: "Response quality",
+    description: "Assess correctness, relevance, and response quality.",
+  },
+  SAFETY_AND_SECURITY: {
+    label: "Safety & security",
+    description: "Detect harmful, insecure, or sensitive behavior.",
+  },
+  USER_EXPERIENCE: {
+    label: "User experience",
+    description: "Measure tone, clarity, and the user experience.",
+  },
 };
+
+export const PROJECT_EVALUATOR_CATEGORIES = Object.entries(
+  EVALUATOR_CATEGORY_DETAILS
+).map(([value, details]) => ({
+  value: value as EvaluatorCategory,
+  ...details,
+}));
 
 export function getProjectEvaluatorTemplateCategoryLabel(
   category: EvaluatorCategory | null
 ): string {
-  return category ? EVALUATOR_CATEGORY_LABELS[category] : "Other";
+  return category ? EVALUATOR_CATEGORY_DETAILS[category].label : "Other";
 }
 
 export function getProjectEvaluatorTemplateChoices(config: {

--- a/js/app/tests/projects.spec.ts
+++ b/js/app/tests/projects.spec.ts
@@ -215,10 +215,10 @@ test.describe.serial("Projects", () => {
       page.getByRole("heading", { name: "Evaluators", exact: true })
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Browse by category" })
+      page.getByRole("link", { name: "Browse the library" })
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "Browse the library" })
+      page.getByRole("button", { name: "Build from scratch" })
     ).toBeVisible();
     await expect(
       page.getByRole("searchbox", { name: "Search evaluators by name" })
@@ -228,7 +228,10 @@ test.describe.serial("Projects", () => {
     ).toHaveCount(0);
     await expect(evaluatorsTab).toContainText("0");
 
-    await page.getByRole("button", { name: "Add evaluator" }).click();
+    await page.getByRole("button", { name: "Build from scratch" }).click();
+    await expect(
+      page.getByRole("menuitem", { name: "Browse the whole library" })
+    ).toHaveCount(0);
     await page
       .getByRole("menuitem", { name: "Create new LLM evaluator" })
       .click();
@@ -327,7 +330,7 @@ test.describe.serial("Projects", () => {
     await expect(updatedRow).not.toBeVisible();
     await expect(evaluatorsTab).toContainText("0");
     await expect(
-      page.getByRole("heading", { name: "Browse by category" })
+      page.getByRole("button", { name: "Build from scratch" })
     ).toBeVisible();
     await expect(
       page.getByRole("searchbox", { name: "Search evaluators by name" })

--- a/js/app/tests/projects.spec.ts
+++ b/js/app/tests/projects.spec.ts
@@ -212,8 +212,17 @@ test.describe.serial("Projects", () => {
     await expect(page).toHaveURL(EVALUATORS_URL);
 
     await expect(
-      page.getByText("No evaluators for this project")
+      page.getByRole("heading", { name: "Evaluators", exact: true })
     ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Browse by category" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Browse the library" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("searchbox", { name: "Search evaluators by name" })
+    ).toHaveCount(0);
     await expect(
       page.getByRole("table", { name: "Project evaluators" })
     ).toHaveCount(0);
@@ -248,6 +257,9 @@ test.describe.serial("Projects", () => {
     await expect(createDialog).not.toBeVisible();
 
     const table = page.getByRole("table", { name: "Project evaluators" });
+    await expect(
+      page.getByRole("searchbox", { name: "Search evaluators by name" })
+    ).toBeVisible();
     const evaluatorRow = table
       .getByRole("row")
       .filter({ hasText: evaluatorName });
@@ -314,6 +326,12 @@ test.describe.serial("Projects", () => {
     await expect(deleteDialog).not.toBeVisible();
     await expect(updatedRow).not.toBeVisible();
     await expect(evaluatorsTab).toContainText("0");
+    await expect(
+      page.getByRole("heading", { name: "Browse by category" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("searchbox", { name: "Search evaluators by name" })
+    ).toHaveCount(0);
   });
 
   test("project table remains usable after mutation workflows", async ({


### PR DESCRIPTION
## Summary

- add a dedicated empty-project evaluator header and a compact, accessible category carousel
- link category cards and individual evaluator templates into URL-backed gallery selections
- preserve gallery selection when nested creation slideovers close
- preserve the existing populated evaluator table and toolbar treatment
- share the project content max-width as a global text-width token

https://github.com/user-attachments/assets/93652520-b040-4d0a-9030-82e1485350d3


