### PR TITLE
feat(online-evals): reorganize code evaluator form with shared authoring fields

### DIFF
--- a/js/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
+++ b/js/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
@@ -20,12 +20,10 @@ import {
 import type { CreateCodeDatasetEvaluatorSlideover_createCodeEvaluatorMutation } from "@phoenix/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideover_createCodeEvaluatorMutation.graphql";
 import type { CreateCodeDatasetEvaluatorSlideover_createDatasetCodeEvaluatorMutation } from "@phoenix/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideover_createDatasetCodeEvaluatorMutation.graphql";
 import type { CreateCodeDatasetEvaluatorSlideoverQuery } from "@phoenix/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql";
+import { createDefaultFreeformOutputConfig } from "@phoenix/components/evaluators/CodeEvaluatorAnnotationSection";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import { getDefaultCodeEvaluatorSource } from "@phoenix/components/evaluators/codeEvaluatorUtils";
-import {
-  createDefaultFreeformOutputConfig,
-  EditCodeEvaluatorDialogContent,
-} from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
+import { EditCodeEvaluatorDialogContent } from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
 import { buildOutputConfigsInput } from "@phoenix/components/evaluators/utils";
 import { EvaluatorStoreProvider } from "@phoenix/contexts/EvaluatorContext";
 import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";

--- a/js/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
+++ b/js/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
@@ -16,11 +16,9 @@ import type { EditCodeDatasetEvaluatorSlideover_createCodeEvaluatorVersionMutati
 import type { EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery } from "@phoenix/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql";
 import type { EditCodeDatasetEvaluatorSlideover_patchCodeEvaluatorMutation } from "@phoenix/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_patchCodeEvaluatorMutation.graphql";
 import type { EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation } from "@phoenix/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_updateDatasetCodeEvaluatorMutation.graphql";
+import { createDefaultFreeformOutputConfig } from "@phoenix/components/evaluators/CodeEvaluatorAnnotationSection";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
-import {
-  createDefaultFreeformOutputConfig,
-  EditCodeEvaluatorDialogContent,
-} from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
+import { EditCodeEvaluatorDialogContent } from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
 import { buildOutputConfigsInput } from "@phoenix/components/evaluators/utils";
 import { EvaluatorStoreProvider } from "@phoenix/contexts/EvaluatorContext";
 import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";

--- a/js/app/src/components/evaluators/CodeAuthoringFields.tsx
+++ b/js/app/src/components/evaluators/CodeAuthoringFields.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+
+import { Flex } from "@phoenix/components";
+import { CodeEvaluatorAnnotationSection } from "@phoenix/components/evaluators/CodeEvaluatorAnnotationSection";
+import {
+  CodeEvaluatorLanguageField,
+  CodeEvaluatorSandboxField,
+  type SandboxConfigOption,
+} from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
+import { CodeEvaluatorSourceEditor } from "@phoenix/components/evaluators/CodeEvaluatorSourceEditor";
+import { EvaluatorSectionHeader } from "@phoenix/components/evaluators/EvaluatorSectionHeader";
+import type { CodeEvaluatorLanguage } from "@phoenix/types";
+
+/**
+ * The "Evaluator Code" section of a code evaluator form: the section header
+ * hosting the compact language and sandbox pickers, the source editor, and
+ * the output annotation config.
+ */
+export const CodeAuthoringFields = ({
+  language,
+  onLanguageChange,
+  sandboxConfigs,
+  selectedSandboxConfigId,
+  onSandboxChange,
+  sourceCode,
+  onSourceCodeChange,
+  isLanguageDisabled = false,
+  isSandboxRequired = true,
+  onFieldChange,
+}: {
+  language: CodeEvaluatorLanguage;
+  onLanguageChange: (language: CodeEvaluatorLanguage) => void;
+  sandboxConfigs: SandboxConfigOption[];
+  selectedSandboxConfigId: string | null;
+  onSandboxChange: (sandboxConfigId: string | null) => void;
+  sourceCode: string;
+  onSourceCodeChange: (sourceCode: string) => void;
+  isLanguageDisabled?: boolean;
+  isSandboxRequired?: boolean;
+  onFieldChange?: () => void;
+}): ReactNode => (
+  <Flex direction="column" gap="size-200">
+    <EvaluatorSectionHeader
+      title="Evaluator Code"
+      description="Define the source code for your evaluator."
+      extra={
+        <Flex direction="row" gap="size-100" alignItems="center">
+          <CodeEvaluatorLanguageField
+            language={language}
+            onChange={(nextLanguage) => {
+              onFieldChange?.();
+              onLanguageChange(nextLanguage);
+            }}
+            isDisabled={isLanguageDisabled}
+            isRequired
+            hideLabel
+          />
+          <CodeEvaluatorSandboxField
+            sandboxConfigs={sandboxConfigs}
+            language={language}
+            selectedSandboxConfigId={selectedSandboxConfigId}
+            onSelectionChange={(sandboxConfigId) => {
+              onFieldChange?.();
+              onSandboxChange(sandboxConfigId);
+            }}
+            isRequired={isSandboxRequired}
+            hideLabel
+          />
+        </Flex>
+      }
+    />
+    <CodeEvaluatorSourceEditor
+      language={language}
+      sourceCode={sourceCode}
+      onChange={(nextSourceCode) => {
+        onFieldChange?.();
+        onSourceCodeChange(nextSourceCode);
+      }}
+    />
+    <CodeEvaluatorAnnotationSection onChange={onFieldChange} />
+  </Flex>
+);

--- a/js/app/src/components/evaluators/CodeEvaluatorAnnotationSection.tsx
+++ b/js/app/src/components/evaluators/CodeEvaluatorAnnotationSection.tsx
@@ -1,0 +1,238 @@
+import { css } from "@emotion/react";
+import { useEffect } from "react";
+
+import {
+  Flex,
+  Heading,
+  Input,
+  Label,
+  NumberField,
+  Text,
+  TextField,
+  View,
+} from "@phoenix/components";
+import { OptimizationDirectionField } from "@phoenix/components/evaluators/OptimizationDirectionField";
+import {
+  useEvaluatorStore,
+  useEvaluatorStoreInstance,
+} from "@phoenix/contexts/EvaluatorContext";
+import type { FreeformEvaluatorAnnotationConfig } from "@phoenix/types";
+
+export const createDefaultFreeformOutputConfig = (
+  name: string
+): FreeformEvaluatorAnnotationConfig => ({
+  name,
+  optimizationDirection: "NONE",
+  threshold: null,
+  lowerBound: null,
+  upperBound: null,
+});
+
+/**
+ * Heading + bordered card for the evaluator's output annotation config.
+ */
+export const CodeEvaluatorAnnotationSection = ({
+  onChange,
+}: {
+  onChange?: () => void;
+} = {}) => {
+  return (
+    <View flex="none">
+      <Flex direction="column" gap="size-100">
+        <Heading level={2} weight="heavy">
+          Evaluator Annotation
+        </Heading>
+        <Text color="text-500">
+          Define the annotation that your evaluator will create. Optimization
+          direction, score range, and threshold apply only when your evaluator
+          returns a numeric score.
+        </Text>
+        <View
+          borderRadius="medium"
+          borderWidth="thin"
+          padding="size-200"
+          marginTop="size-50"
+          borderColor="default"
+        >
+          <OutputConfigSection onChange={onChange} />
+        </View>
+      </Flex>
+    </View>
+  );
+};
+
+const OutputConfigSection = ({ onChange }: { onChange?: () => void }) => {
+  const store = useEvaluatorStoreInstance();
+  const outputConfig = useEvaluatorStore((state) => state.outputConfigs[0]);
+  const setOutputConfigThresholdAtIndex = useEvaluatorStore(
+    (state) => state.setOutputConfigThresholdAtIndex
+  );
+  const setOutputConfigLowerBoundAtIndex = useEvaluatorStore(
+    (state) => state.setOutputConfigLowerBoundAtIndex
+  );
+  const setOutputConfigUpperBoundAtIndex = useEvaluatorStore(
+    (state) => state.setOutputConfigUpperBoundAtIndex
+  );
+
+  useEffect(() => {
+    if (!outputConfig) {
+      const state = store.getState();
+      const name = state.evaluator.name || state.evaluator.globalName;
+      state.setOutputConfigs([createDefaultFreeformOutputConfig(name)]);
+    }
+  }, [outputConfig, store]);
+
+  if (!outputConfig) {
+    return null;
+  }
+
+  if ("values" in outputConfig) {
+    return (
+      <Flex direction="column" gap="size-200">
+        <Flex direction="row" gap="size-200" alignItems="start">
+          <TextField isDisabled value={outputConfig.name}>
+            <Label>Name</Label>
+            <Input />
+          </TextField>
+          <OptimizationDirectionField
+            description="Whether higher or lower scores are better."
+            onChange={onChange}
+          />
+        </Flex>
+        <Flex direction="column" gap="size-100">
+          <OutputConfigValuesHeader />
+          {outputConfig.values.map((value, index) => (
+            <OutputConfigValuesRow
+              key={`${value.label}-${index}`}
+              label={value.label}
+              score={value.score ?? null}
+              index={index}
+            />
+          ))}
+        </Flex>
+      </Flex>
+    );
+  }
+
+  const threshold =
+    "threshold" in outputConfig ? (outputConfig.threshold ?? null) : null;
+  const lowerBound =
+    "lowerBound" in outputConfig ? (outputConfig.lowerBound ?? null) : null;
+  const upperBound =
+    "upperBound" in outputConfig ? (outputConfig.upperBound ?? null) : null;
+  const optimizationDirection = outputConfig.optimizationDirection;
+  const isThresholdDisabled = optimizationDirection === "NONE";
+
+  const thresholdDescription =
+    optimizationDirection === "MAXIMIZE"
+      ? "Scores at or above this value display as good; lower scores display as bad."
+      : optimizationDirection === "MINIMIZE"
+        ? "Scores at or below this value display as good; higher scores display as bad."
+        : "Combined with the optimization direction, this is the cutoff used to visually distinguish “good” from “bad” scores.";
+
+  return (
+    <Flex direction="column" gap="size-200">
+      <Flex direction="row" gap="size-200" alignItems="start">
+        <TextField isDisabled value={outputConfig.name}>
+          <Label>Name</Label>
+          <Input />
+        </TextField>
+        <OptimizationDirectionField
+          description="Whether higher or lower scores are better."
+          onChange={onChange}
+        />
+        <NumberField
+          value={threshold ?? undefined}
+          onChange={(value) => {
+            onChange?.();
+            setOutputConfigThresholdAtIndex(
+              0,
+              Number.isNaN(value) ? null : value
+            );
+          }}
+          isDisabled={isThresholdDisabled}
+        >
+          <Label>Score threshold (optional)</Label>
+          <Input />
+          <Text slot="description">{thresholdDescription}</Text>
+        </NumberField>
+      </Flex>
+      <Flex direction="row" gap="size-200" alignItems="start">
+        <NumberField
+          value={lowerBound ?? undefined}
+          onChange={(value) => {
+            onChange?.();
+            setOutputConfigLowerBoundAtIndex(
+              0,
+              Number.isNaN(value) ? null : value
+            );
+          }}
+        >
+          <Label>Minimum score (optional)</Label>
+          <Input />
+          <Text slot="description">
+            The lowest score your evaluator is expected to produce.
+          </Text>
+        </NumberField>
+        <NumberField
+          value={upperBound ?? undefined}
+          onChange={(value) => {
+            onChange?.();
+            setOutputConfigUpperBoundAtIndex(
+              0,
+              Number.isNaN(value) ? null : value
+            );
+          }}
+        >
+          <Label>Maximum score (optional)</Label>
+          <Input />
+          <Text slot="description">
+            The highest score your evaluator is expected to produce.
+          </Text>
+        </NumberField>
+      </Flex>
+    </Flex>
+  );
+};
+
+const OutputConfigValuesHeader = () => {
+  return (
+    <div css={outputConfigValuesGridCSS}>
+      <Text>Choice</Text>
+      <Text>Score</Text>
+    </div>
+  );
+};
+
+const OutputConfigValuesRow = ({
+  label,
+  score,
+  index,
+}: {
+  label: string;
+  score: number | null;
+  index: number;
+}) => {
+  return (
+    <div css={outputConfigValuesGridCSS}>
+      <TextField isDisabled value={label} aria-label={`Choice ${index + 1}`}>
+        <Input />
+      </TextField>
+      <TextField
+        isDisabled
+        value={score != null ? String(score) : ""}
+        aria-label={`Score ${index + 1}`}
+      >
+        <Input />
+      </TextField>
+    </div>
+  );
+};
+
+const outputConfigValuesGridCSS = css`
+  width: 100%;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: var(--global-dimension-size-100);
+  align-items: start;
+`;

--- a/js/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/js/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -49,6 +49,12 @@ export type CodeEvaluatorLanguageFieldProps = {
   onChange: (language: CodeEvaluatorLanguage) => void;
   isDisabled?: boolean;
   isRequired?: boolean;
+  /**
+   * Replaces the visible label with an aria-label, for compact placements
+   * such as a section header. Note the required indicator renders inside the
+   * visible label, so hiding it also hides that indicator.
+   */
+  hideLabel?: boolean;
 };
 
 /**
@@ -59,15 +65,17 @@ export const CodeEvaluatorLanguageField = ({
   onChange,
   isDisabled,
   isRequired,
+  hideLabel = false,
 }: CodeEvaluatorLanguageFieldProps) => {
   return (
     <Select
       value={language}
       isDisabled={isDisabled}
       isRequired={isRequired}
+      aria-label={hideLabel ? "Language" : undefined}
       onChange={(value) => onChange(value as CodeEvaluatorLanguage)}
     >
-      <Label>Language</Label>
+      {hideLabel ? null : <Label>Language</Label>}
       <Button>
         <SelectValue />
         <SelectChevronUpDownIcon />
@@ -105,6 +113,12 @@ export type CodeEvaluatorSandboxFieldProps = {
   size?: "M" | "L";
   /** Whether the selection is required for form submission. */
   isRequired?: boolean;
+  /**
+   * Replaces the visible label with an aria-label, for compact placements
+   * such as a section header. Note the required indicator renders inside the
+   * visible label, so hiding it also hides that indicator.
+   */
+  hideLabel?: boolean;
 };
 
 /**
@@ -118,6 +132,7 @@ export const CodeEvaluatorSandboxField = ({
   onSelectionChange,
   size = "M",
   isRequired,
+  hideLabel = false,
 }: CodeEvaluatorSandboxFieldProps) => {
   // Filter configs to only show those matching the current language
   const compatibleConfigs = useMemo(
@@ -144,6 +159,7 @@ export const CodeEvaluatorSandboxField = ({
         onSelectionChange(typeof key === "string" ? key : null);
       }}
       isDisabled={hasNoCompatibleConfigs}
+      aria-label={hideLabel ? "Sandbox" : undefined}
       placeholder={
         hasNoProviders
           ? "No sandboxes configured"
@@ -152,7 +168,7 @@ export const CodeEvaluatorSandboxField = ({
             : "Select a sandbox..."
       }
     >
-      <Label>Sandbox</Label>
+      {hideLabel ? null : <Label>Sandbox</Label>}
       <Button>
         <SelectValue />
         <SelectChevronUpDownIcon />

--- a/js/app/src/components/evaluators/CodeEvaluatorSourceEditor.tsx
+++ b/js/app/src/components/evaluators/CodeEvaluatorSourceEditor.tsx
@@ -1,0 +1,288 @@
+import { javascript } from "@codemirror/lang-javascript";
+import { python } from "@codemirror/lang-python";
+import { indentUnit } from "@codemirror/language";
+import { css } from "@emotion/react";
+import CodeMirror from "@uiw/react-codemirror";
+import { useMemo, useState } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+
+import {
+  Button,
+  CopyToClipboardButton,
+  Flex,
+  Icon,
+  Icons,
+  Switch,
+  Text,
+} from "@phoenix/components";
+import { pierreDark, pierreLight } from "@phoenix/components/code";
+import {
+  Menu,
+  MenuContainer,
+  MenuItem,
+  MenuTrigger,
+} from "@phoenix/components/core/menu";
+import { createEvaluatorAutocompletion } from "@phoenix/components/evaluators/codeEvaluatorAutocomplete";
+import { CODE_EVALUATOR_TEMPLATES } from "@phoenix/components/evaluators/codeEvaluatorTemplates";
+import { generateEvaluatorTypes } from "@phoenix/components/evaluators/codeEvaluatorTypeGeneration";
+import { getDefaultCodeEvaluatorSource } from "@phoenix/components/evaluators/codeEvaluatorUtils";
+import { compactResizeHandleCSS } from "@phoenix/components/resize";
+import { useTheme } from "@phoenix/contexts";
+import { useEvaluatorStore } from "@phoenix/contexts/EvaluatorContext";
+import type { CodeEvaluatorLanguage } from "@phoenix/types";
+
+/**
+ * Editable source-code editor with a read-only auto-generated type footer.
+ * Ships its own description line and Reset-to-default button.
+ */
+export const CodeEvaluatorSourceEditor = ({
+  language,
+  sourceCode,
+  onChange,
+}: {
+  language: CodeEvaluatorLanguage;
+  sourceCode: string;
+  onChange: (value: string) => void;
+}) => {
+  const { theme } = useTheme();
+  const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
+  // The auto-generated type footer is hidden by default.
+  const [showTypes, setShowTypes] = useState(false);
+
+  // Get the evaluator mapping source from the store for type generation
+  const evaluatorMappingSource = useEvaluatorStore(
+    (state) => state.evaluatorMappingSource.source
+  );
+
+  // Generate the type footer based on language and available data
+  const typeFooter = useMemo(
+    () => generateEvaluatorTypes(language, evaluatorMappingSource),
+    [language, evaluatorMappingSource]
+  );
+
+  const extensions = useMemo(
+    () => [
+      language === "PYTHON" ? python() : javascript({ typescript: true }),
+      // Python: 4-space indent; JS/TS: 2-space.
+      indentUnit.of(language === "PYTHON" ? "    " : "  "),
+      createEvaluatorAutocompletion(evaluatorMappingSource, language),
+    ],
+    [language, evaluatorMappingSource]
+  );
+
+  const descriptionText =
+    "Define an evaluate function that returns a score or label.";
+
+  return (
+    <Flex direction="column" gap="size-100">
+      {/* Editor header with controls */}
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        gap="size-200"
+        flex="none"
+      >
+        <Text color="text-500" size="XS">
+          {descriptionText}
+        </Text>
+        <Flex direction="row" alignItems="center" gap="size-100" flex="none">
+          <MenuTrigger>
+            <Button
+              size="S"
+              variant="quiet"
+              leadingVisual={<Icon svg={<Icons.Code />} />}
+            >
+              Templates
+            </Button>
+            <MenuContainer placement="bottom end" maxWidth={360}>
+              <Menu
+                onAction={(key) => {
+                  const template = CODE_EVALUATOR_TEMPLATES.find(
+                    (t) => t.id === key
+                  );
+                  if (!template) {
+                    return;
+                  }
+                  onChange(template.getSource(language));
+                }}
+              >
+                {CODE_EVALUATOR_TEMPLATES.map((template) => (
+                  <MenuItem
+                    key={template.id}
+                    id={template.id}
+                    textValue={`${template.name}\n${template.description}`}
+                  >
+                    <Flex direction="column" gap="size-50">
+                      <Text weight="heavy">{template.name}</Text>
+                      <Text size="S" color="text-700">
+                        {template.description}
+                      </Text>
+                    </Flex>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </MenuContainer>
+          </MenuTrigger>
+          <Button
+            size="S"
+            variant="quiet"
+            leadingVisual={<Icon svg={<Icons.Refresh />} />}
+            onPress={() => onChange(getDefaultCodeEvaluatorSource(language))}
+          >
+            Reset
+          </Button>
+          <CopyToClipboardButton
+            text={sourceCode}
+            size="S"
+            variant="quiet"
+            tooltipText="Copy code"
+          >
+            Copy
+          </CopyToClipboardButton>
+          {typeFooter ? (
+            <Switch
+              isSelected={showTypes}
+              onChange={setShowTypes}
+              labelPlacement="start"
+            >
+              <Text size="S">Show types</Text>
+            </Switch>
+          ) : null}
+        </Flex>
+      </Flex>
+
+      {/* Code editor and type footer with resizable panels */}
+      <div css={editorContainerCSS}>
+        <Group orientation="vertical" style={{ flex: 1, minHeight: 0 }}>
+          {/* Editable code editor panel */}
+          <Panel defaultSize="75%" minSize="30%" style={editorPanelStyle}>
+            <div
+              css={[editorWrapCSS, cmLineNumberGutterCSS]}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" || e.key === "Tab") {
+                  e.stopPropagation();
+                }
+              }}
+            >
+              <CodeMirror
+                // Key on language to force remount when language changes
+                key={language}
+                value={sourceCode}
+                onChange={onChange}
+                theme={codeMirrorTheme}
+                extensions={extensions}
+                height="100%"
+                indentWithTab
+                basicSetup={{
+                  lineNumbers: true,
+                  foldGutter: true,
+                  bracketMatching: true,
+                  syntaxHighlighting: true,
+                  highlightActiveLine: false,
+                  highlightActiveLineGutter: false,
+                  tabSize: language === "PYTHON" ? 4 : 2,
+                }}
+              />
+            </div>
+          </Panel>
+
+          {/* Read-only type footer panel */}
+          {showTypes && typeFooter && (
+            <>
+              <Separator css={compactResizeHandleCSS} />
+              <Panel defaultSize="25%" minSize="10%" style={editorPanelStyle}>
+                <div css={[typeFooterCSS, cmLineNumberGutterCSS]}>
+                  <CodeMirror
+                    value={typeFooter}
+                    theme={codeMirrorTheme}
+                    extensions={extensions}
+                    editable={false}
+                    basicSetup={{
+                      lineNumbers: true,
+                      foldGutter: true,
+                      bracketMatching: true,
+                      syntaxHighlighting: true,
+                      highlightActiveLine: false,
+                      highlightActiveLineGutter: false,
+                      tabSize: language === "PYTHON" ? 4 : 2,
+                    }}
+                  />
+                </div>
+              </Panel>
+            </>
+          )}
+        </Group>
+      </div>
+    </Flex>
+  );
+};
+
+const editorContainerCSS = css`
+  display: flex;
+  flex-direction: column;
+  min-height: 500px;
+  border: 1px solid var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+  overflow: hidden;
+  background-color: var(--code-mirror-editor-background-color);
+`;
+
+const editorPanelStyle = {
+  display: "flex",
+  flexDirection: "column" as const,
+  minHeight: 0,
+  overflow: "hidden" as const,
+};
+
+const cmLineNumberGutterCSS = css`
+  & .cm-gutter.cm-lineNumbers .cm-gutterElement {
+    min-width: 2.25em;
+    box-sizing: border-box;
+  }
+`;
+
+const editorWrapCSS = css`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  & .cm-theme {
+    height: 100% !important;
+  }
+
+  & .cm-editor {
+    height: 100% !important;
+  }
+
+  & .cm-scroller {
+    overflow: auto !important;
+  }
+`;
+
+const typeFooterCSS = css`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  & .cm-theme {
+    height: 100% !important;
+  }
+
+  & .cm-editor {
+    height: 100% !important;
+    background-color: var(--global-color-gray-100);
+  }
+
+  & .cm-gutters {
+    background-color: var(--global-color-gray-100);
+  }
+
+  & .cm-scroller {
+    overflow: auto !important;
+  }
+`;

--- a/js/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -1,8 +1,4 @@
-import { javascript } from "@codemirror/lang-javascript";
-import { python } from "@codemirror/lang-python";
-import { indentUnit } from "@codemirror/language";
 import { css } from "@emotion/react";
-import CodeMirror from "@uiw/react-codemirror";
 import {
   useCallback,
   useEffect,
@@ -37,24 +33,15 @@ import {
 import {
   Alert,
   Button,
-  CopyToClipboardButton,
   Flex,
   Heading,
-  Icon,
-  Icons,
-  Input,
-  Label,
   LinkButton,
   List,
   ListItem,
-  NumberField,
   SectionHeading,
-  Switch,
   Text,
-  TextField,
   View,
 } from "@phoenix/components";
-import { pierreDark, pierreLight } from "@phoenix/components/code";
 import {
   DialogCloseButton,
   DialogContent,
@@ -63,55 +50,23 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
-import {
-  Menu,
-  MenuContainer,
-  MenuItem,
-  MenuTrigger,
-} from "@phoenix/components/core/menu";
-import { createEvaluatorAutocompletion } from "@phoenix/components/evaluators/codeEvaluatorAutocomplete";
-import {
-  CodeEvaluatorLanguageField,
-  CodeEvaluatorSandboxField,
-  type SandboxConfigOption,
-} from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
-import { CODE_EVALUATOR_TEMPLATES } from "@phoenix/components/evaluators/codeEvaluatorTemplates";
+import { CodeAuthoringFields } from "@phoenix/components/evaluators/CodeAuthoringFields";
+import type { SandboxConfigOption } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import { CodeEvaluatorTestSection } from "@phoenix/components/evaluators/CodeEvaluatorTestSection";
-import { generateEvaluatorTypes } from "@phoenix/components/evaluators/codeEvaluatorTypeGeneration";
 import {
   extractCodeEvaluatorVariables,
-  getAllGeneratedSources,
-  getDefaultCodeEvaluatorSource,
+  getNextCodeEvaluatorSource,
 } from "@phoenix/components/evaluators/codeEvaluatorUtils";
-import { EvaluatorDescriptionInput } from "@phoenix/components/evaluators/EvaluatorDescriptionInput";
 import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
 import { EvaluatorInputMapping } from "@phoenix/components/evaluators/EvaluatorInputMapping";
 import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
 import { CodeEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/CodeEvaluatorInputVariablesProvider";
-import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorNameInput";
-import { OptimizationDirectionField } from "@phoenix/components/evaluators/OptimizationDirectionField";
+import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { useTheme } from "@phoenix/contexts";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
-import {
-  useEvaluatorStore,
-  useEvaluatorStoreInstance,
-} from "@phoenix/contexts/EvaluatorContext";
+import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
-import type {
-  CodeEvaluatorLanguage,
-  FreeformEvaluatorAnnotationConfig,
-} from "@phoenix/types";
-
-export const createDefaultFreeformOutputConfig = (
-  name: string
-): FreeformEvaluatorAnnotationConfig => ({
-  name,
-  optimizationDirection: "NONE",
-  threshold: null,
-  lowerBound: null,
-  upperBound: null,
-});
+import type { CodeEvaluatorLanguage } from "@phoenix/types";
 
 export const EditCodeEvaluatorDialogContent = ({
   onSubmit,
@@ -445,6 +400,13 @@ export const EditCodeEvaluatorDialogContent = ({
     onCancel?.();
   };
 
+  const handleLanguageChange = (nextLanguage: CodeEvaluatorLanguage) => {
+    setSourceCode(
+      getNextCodeEvaluatorSource({ sourceCode, language, nextLanguage })
+    );
+    setLanguage(nextLanguage);
+  };
+
   const variables = useMemo(
     () => extractCodeEvaluatorVariables({ language, sourceCode }),
     [language, sourceCode]
@@ -579,34 +541,21 @@ export const EditCodeEvaluatorDialogContent = ({
             {/* Left panel: Code Editor (60%) */}
             <Panel defaultSize="60%" minSize="40%" style={panelStyle}>
               <div css={editorPanelCSS}>
-                <EvaluatorMetadataForm
+                <EvaluatorNameAndDescriptionFields
+                  isNameRequired
+                  descriptionPlaceholder="e.g. code evaluator description"
+                />
+                <CodeAuthoringFields
                   language={language}
-                  onLanguageChange={(nextLanguage) => {
-                    setLanguage((currentLanguage) => {
-                      // Auto-swap only if sourceCode is still a generated
-                      // placeholder — never overwrite user-authored code.
-                      const currentDefaults =
-                        getAllGeneratedSources(currentLanguage);
-                      if (currentDefaults.includes(sourceCode)) {
-                        setSourceCode(
-                          getDefaultCodeEvaluatorSource(nextLanguage)
-                        );
-                      }
-                      return nextLanguage;
-                    });
-                  }}
+                  onLanguageChange={handleLanguageChange}
                   sandboxConfigs={sandboxConfigs}
                   selectedSandboxConfigId={selectedSandboxConfigId}
                   onSandboxChange={setSandboxConfigId}
-                  isLanguageEditable={mode === "create"}
+                  sourceCode={sourceCode}
+                  onSourceCodeChange={setSourceCode}
+                  isLanguageDisabled={mode !== "create"}
                   isSandboxRequired={mode === "create"}
                 />
-                <CodeEvaluatorSourceEditor
-                  language={language}
-                  sourceCode={sourceCode}
-                  onChange={setSourceCode}
-                />
-                <CodeEvaluatorAnnotationSection />
                 <InputMappingSection />
               </div>
             </Panel>
@@ -648,56 +597,6 @@ export const EditCodeEvaluatorDialogContent = ({
         </Button>
       </DialogFooter>
     </DialogContent>
-  );
-};
-
-/**
- * Top-of-panel form for the evaluator's identifying metadata:
- * Name, Language, Sandbox, and Description.
- */
-const EvaluatorMetadataForm = ({
-  language,
-  onLanguageChange,
-  sandboxConfigs,
-  selectedSandboxConfigId,
-  onSandboxChange,
-  isLanguageEditable,
-  isSandboxRequired,
-}: {
-  language: CodeEvaluatorLanguage;
-  onLanguageChange: (language: CodeEvaluatorLanguage) => void;
-  sandboxConfigs: SandboxConfigOption[];
-  selectedSandboxConfigId: string | null;
-  onSandboxChange: (sandboxConfigId: string | null) => void;
-  isLanguageEditable?: boolean;
-  isSandboxRequired?: boolean;
-}) => {
-  return (
-    <div css={metadataFormCSS}>
-      <div style={{ flex: "1 1 220px", minWidth: 220 }}>
-        <EvaluatorNameInput isRequired />
-      </div>
-      <div style={{ flex: "1 1 220px", minWidth: 220 }}>
-        <CodeEvaluatorLanguageField
-          language={language}
-          onChange={onLanguageChange}
-          isDisabled={!isLanguageEditable}
-          isRequired
-        />
-      </div>
-      <div style={{ flex: "1 1 220px", minWidth: 220 }}>
-        <CodeEvaluatorSandboxField
-          sandboxConfigs={sandboxConfigs}
-          language={language}
-          selectedSandboxConfigId={selectedSandboxConfigId}
-          onSelectionChange={onSandboxChange}
-          isRequired={isSandboxRequired}
-        />
-      </div>
-      <div style={{ flex: "2 1 240px", minWidth: 240 }}>
-        <EvaluatorDescriptionInput placeholder="e.g. code evaluator description" />
-      </div>
-    </div>
   );
 };
 
@@ -839,226 +738,6 @@ function getSandboxDependenciesConfigLabel(config: SandboxConfigForLabels) {
 }
 
 /**
- * Editable source-code editor with a read-only auto-generated type footer.
- * Ships its own description line and Reset-to-default button.
- */
-export const CodeEvaluatorSourceEditor = ({
-  language,
-  sourceCode,
-  onChange,
-}: {
-  language: CodeEvaluatorLanguage;
-  sourceCode: string;
-  onChange: (value: string) => void;
-}) => {
-  const { theme } = useTheme();
-  const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
-  // The auto-generated type footer is hidden by default.
-  const [showTypes, setShowTypes] = useState(false);
-
-  // Get the evaluator mapping source from the store for type generation
-  const evaluatorMappingSource = useEvaluatorStore(
-    (state) => state.evaluatorMappingSource.source
-  );
-
-  // Generate the type footer based on language and available data
-  const typeFooter = useMemo(
-    () => generateEvaluatorTypes(language, evaluatorMappingSource),
-    [language, evaluatorMappingSource]
-  );
-
-  const extensions = useMemo(
-    () => [
-      language === "PYTHON" ? python() : javascript({ typescript: true }),
-      // Python: 4-space indent; JS/TS: 2-space.
-      indentUnit.of(language === "PYTHON" ? "    " : "  "),
-      createEvaluatorAutocompletion(evaluatorMappingSource, language),
-    ],
-    [language, evaluatorMappingSource]
-  );
-
-  const descriptionText =
-    "Define an evaluate function that returns a score or label.";
-
-  return (
-    <Flex direction="column" gap="size-100">
-      {/* Editor header with controls */}
-      <Flex
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-        gap="size-200"
-        flex="none"
-      >
-        <Text color="text-500" size="XS">
-          {descriptionText}
-        </Text>
-        <Flex direction="row" alignItems="center" gap="size-100" flex="none">
-          <MenuTrigger>
-            <Button
-              size="S"
-              variant="quiet"
-              leadingVisual={<Icon svg={<Icons.Code />} />}
-            >
-              Templates
-            </Button>
-            <MenuContainer placement="bottom end" maxWidth={360}>
-              <Menu
-                onAction={(key) => {
-                  const template = CODE_EVALUATOR_TEMPLATES.find(
-                    (t) => t.id === key
-                  );
-                  if (!template) {
-                    return;
-                  }
-                  onChange(template.getSource(language));
-                }}
-              >
-                {CODE_EVALUATOR_TEMPLATES.map((template) => (
-                  <MenuItem
-                    key={template.id}
-                    id={template.id}
-                    textValue={`${template.name}\n${template.description}`}
-                  >
-                    <Flex direction="column" gap="size-50">
-                      <Text weight="heavy">{template.name}</Text>
-                      <Text size="S" color="text-700">
-                        {template.description}
-                      </Text>
-                    </Flex>
-                  </MenuItem>
-                ))}
-              </Menu>
-            </MenuContainer>
-          </MenuTrigger>
-          <Button
-            size="S"
-            variant="quiet"
-            leadingVisual={<Icon svg={<Icons.Refresh />} />}
-            onPress={() => onChange(getDefaultCodeEvaluatorSource(language))}
-          >
-            Reset
-          </Button>
-          <CopyToClipboardButton
-            text={sourceCode}
-            size="S"
-            variant="quiet"
-            tooltipText="Copy code"
-          >
-            Copy
-          </CopyToClipboardButton>
-          {typeFooter ? (
-            <Switch
-              isSelected={showTypes}
-              onChange={setShowTypes}
-              labelPlacement="start"
-            >
-              <Text size="S">Show types</Text>
-            </Switch>
-          ) : null}
-        </Flex>
-      </Flex>
-
-      {/* Code editor and type footer with resizable panels */}
-      <div css={editorContainerCSS}>
-        <Group orientation="vertical" style={{ flex: 1, minHeight: 0 }}>
-          {/* Editable code editor panel */}
-          <Panel defaultSize="75%" minSize="30%" style={editorPanelStyle}>
-            <div
-              css={[editorWrapCSS, cmLineNumberGutterCSS]}
-              onKeyDown={(e) => {
-                if (e.key === "Escape" || e.key === "Tab") {
-                  e.stopPropagation();
-                }
-              }}
-            >
-              <CodeMirror
-                // Key on language to force remount when language changes
-                key={language}
-                value={sourceCode}
-                onChange={onChange}
-                theme={codeMirrorTheme}
-                extensions={extensions}
-                height="100%"
-                indentWithTab
-                basicSetup={{
-                  lineNumbers: true,
-                  foldGutter: true,
-                  bracketMatching: true,
-                  syntaxHighlighting: true,
-                  highlightActiveLine: false,
-                  highlightActiveLineGutter: false,
-                  tabSize: language === "PYTHON" ? 4 : 2,
-                }}
-              />
-            </div>
-          </Panel>
-
-          {/* Read-only type footer panel */}
-          {showTypes && typeFooter && (
-            <>
-              <Separator css={compactResizeHandleCSS} />
-              <Panel defaultSize="25%" minSize="10%" style={editorPanelStyle}>
-                <div css={[typeFooterCSS, cmLineNumberGutterCSS]}>
-                  <CodeMirror
-                    value={typeFooter}
-                    theme={codeMirrorTheme}
-                    extensions={extensions}
-                    editable={false}
-                    basicSetup={{
-                      lineNumbers: true,
-                      foldGutter: true,
-                      bracketMatching: true,
-                      syntaxHighlighting: true,
-                      highlightActiveLine: false,
-                      highlightActiveLineGutter: false,
-                      tabSize: language === "PYTHON" ? 4 : 2,
-                    }}
-                  />
-                </div>
-              </Panel>
-            </>
-          )}
-        </Group>
-      </div>
-    </Flex>
-  );
-};
-
-/**
- * Heading + bordered card for the evaluator's output annotation config.
- */
-export const CodeEvaluatorAnnotationSection = ({
-  onChange,
-}: {
-  onChange?: () => void;
-} = {}) => {
-  return (
-    <View flex="none">
-      <Flex direction="column" gap="size-100">
-        <Heading level={2} weight="heavy">
-          Evaluator Annotation
-        </Heading>
-        <Text color="text-500">
-          Define the annotation that your evaluator will create. Optimization
-          direction, score range, and threshold apply only when your evaluator
-          returns a numeric score.
-        </Text>
-        <View
-          borderRadius="medium"
-          borderWidth="thin"
-          padding="size-200"
-          marginTop="size-50"
-          borderColor="default"
-        >
-          <OutputConfigSection onChange={onChange} />
-        </View>
-      </Flex>
-    </View>
-  );
-};
-
-/**
  * Heading + bordered card for mapping evaluator arguments to dataset fields.
  */
 const InputMappingSection = () => {
@@ -1083,174 +762,6 @@ const InputMappingSection = () => {
         </View>
       </Flex>
     </View>
-  );
-};
-
-const OutputConfigSection = ({ onChange }: { onChange?: () => void }) => {
-  const store = useEvaluatorStoreInstance();
-  const outputConfig = useEvaluatorStore((state) => state.outputConfigs[0]);
-  const setOutputConfigThresholdAtIndex = useEvaluatorStore(
-    (state) => state.setOutputConfigThresholdAtIndex
-  );
-  const setOutputConfigLowerBoundAtIndex = useEvaluatorStore(
-    (state) => state.setOutputConfigLowerBoundAtIndex
-  );
-  const setOutputConfigUpperBoundAtIndex = useEvaluatorStore(
-    (state) => state.setOutputConfigUpperBoundAtIndex
-  );
-
-  useEffect(() => {
-    if (!outputConfig) {
-      const state = store.getState();
-      const name = state.evaluator.name || state.evaluator.globalName;
-      state.setOutputConfigs([createDefaultFreeformOutputConfig(name)]);
-    }
-  }, [outputConfig, store]);
-
-  if (!outputConfig) {
-    return null;
-  }
-
-  if ("values" in outputConfig) {
-    return (
-      <Flex direction="column" gap="size-200">
-        <Flex direction="row" gap="size-200" alignItems="start">
-          <TextField isDisabled value={outputConfig.name}>
-            <Label>Name</Label>
-            <Input />
-          </TextField>
-          <OptimizationDirectionField
-            description="Whether higher or lower scores are better."
-            onChange={onChange}
-          />
-        </Flex>
-        <Flex direction="column" gap="size-100">
-          <OutputConfigValuesHeader />
-          {outputConfig.values.map((value, index) => (
-            <OutputConfigValuesRow
-              key={`${value.label}-${index}`}
-              label={value.label}
-              score={value.score ?? null}
-              index={index}
-            />
-          ))}
-        </Flex>
-      </Flex>
-    );
-  }
-
-  const threshold =
-    "threshold" in outputConfig ? (outputConfig.threshold ?? null) : null;
-  const lowerBound =
-    "lowerBound" in outputConfig ? (outputConfig.lowerBound ?? null) : null;
-  const upperBound =
-    "upperBound" in outputConfig ? (outputConfig.upperBound ?? null) : null;
-  const optimizationDirection = outputConfig.optimizationDirection;
-  const isThresholdDisabled = optimizationDirection === "NONE";
-
-  const thresholdDescription =
-    optimizationDirection === "MAXIMIZE"
-      ? "Scores at or above this value display as good; lower scores display as bad."
-      : optimizationDirection === "MINIMIZE"
-        ? "Scores at or below this value display as good; higher scores display as bad."
-        : "Combined with the optimization direction, this is the cutoff used to visually distinguish “good” from “bad” scores.";
-
-  return (
-    <Flex direction="column" gap="size-200">
-      <Flex direction="row" gap="size-200" alignItems="start">
-        <TextField isDisabled value={outputConfig.name}>
-          <Label>Name</Label>
-          <Input />
-        </TextField>
-        <OptimizationDirectionField
-          description="Whether higher or lower scores are better."
-          onChange={onChange}
-        />
-        <NumberField
-          value={threshold ?? undefined}
-          onChange={(value) => {
-            onChange?.();
-            setOutputConfigThresholdAtIndex(
-              0,
-              Number.isNaN(value) ? null : value
-            );
-          }}
-          isDisabled={isThresholdDisabled}
-        >
-          <Label>Score threshold (optional)</Label>
-          <Input />
-          <Text slot="description">{thresholdDescription}</Text>
-        </NumberField>
-      </Flex>
-      <Flex direction="row" gap="size-200" alignItems="start">
-        <NumberField
-          value={lowerBound ?? undefined}
-          onChange={(value) => {
-            onChange?.();
-            setOutputConfigLowerBoundAtIndex(
-              0,
-              Number.isNaN(value) ? null : value
-            );
-          }}
-        >
-          <Label>Minimum score (optional)</Label>
-          <Input />
-          <Text slot="description">
-            The lowest score your evaluator is expected to produce.
-          </Text>
-        </NumberField>
-        <NumberField
-          value={upperBound ?? undefined}
-          onChange={(value) => {
-            onChange?.();
-            setOutputConfigUpperBoundAtIndex(
-              0,
-              Number.isNaN(value) ? null : value
-            );
-          }}
-        >
-          <Label>Maximum score (optional)</Label>
-          <Input />
-          <Text slot="description">
-            The highest score your evaluator is expected to produce.
-          </Text>
-        </NumberField>
-      </Flex>
-    </Flex>
-  );
-};
-
-const OutputConfigValuesHeader = () => {
-  return (
-    <div css={outputConfigValuesGridCSS}>
-      <Text>Choice</Text>
-      <Text>Score</Text>
-    </div>
-  );
-};
-
-const OutputConfigValuesRow = ({
-  label,
-  score,
-  index,
-}: {
-  label: string;
-  score: number | null;
-  index: number;
-}) => {
-  return (
-    <div css={outputConfigValuesGridCSS}>
-      <TextField isDisabled value={label} aria-label={`Choice ${index + 1}`}>
-        <Input />
-      </TextField>
-      <TextField
-        isDisabled
-        value={score != null ? String(score) : ""}
-        aria-label={`Score ${index + 1}`}
-      >
-        <Input />
-      </TextField>
-    </div>
   );
 };
 
@@ -1289,18 +800,6 @@ const fieldsetCSS = css`
   overflow: hidden;
 `;
 
-const metadataFormCSS = css`
-  display: flex;
-  flex-direction: row;
-  // The form lives in a splitter-resizable panel, so wrapping keys off the
-  // fields' flex bases rather than a viewport breakpoint: fields share one
-  // row while they fit and wrap onto additional rows as the panel narrows.
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: var(--global-dimension-size-150);
-  flex-shrink: 0;
-`;
-
 const panelStyle = {
   height: "100%",
   display: "flex",
@@ -1334,14 +833,6 @@ const sidebarPanelCSS = css`
   border-left: 1px solid var(--global-border-color-default);
 `;
 
-const outputConfigValuesGridCSS = css`
-  width: 100%;
-  display: grid;
-  grid-template-columns: 3fr 1fr;
-  gap: var(--global-dimension-size-100);
-  align-items: start;
-`;
-
 // The "Test Evaluator" region grows to fill the panel and scrolls on overflow.
 const sidebarScrollAreaCSS = css`
   flex: 1 1 auto;
@@ -1366,73 +857,4 @@ const sidebarFooterCSS = css`
 const sectionContentCSS = css`
   padding: var(--global-dimension-size-50) 0;
   padding-bottom: var(--global-dimension-size-150);
-`;
-
-const editorContainerCSS = css`
-  display: flex;
-  flex-direction: column;
-  min-height: 500px;
-  border: 1px solid var(--global-border-color-default);
-  border-radius: var(--global-rounding-medium);
-  overflow: hidden;
-  background-color: var(--code-mirror-editor-background-color);
-`;
-
-const editorPanelStyle = {
-  display: "flex",
-  flexDirection: "column" as const,
-  minHeight: 0,
-  overflow: "hidden" as const,
-};
-
-const cmLineNumberGutterCSS = css`
-  & .cm-gutter.cm-lineNumbers .cm-gutterElement {
-    min-width: 2.25em;
-    box-sizing: border-box;
-  }
-`;
-
-const editorWrapCSS = css`
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-
-  & .cm-theme {
-    height: 100% !important;
-  }
-
-  & .cm-editor {
-    height: 100% !important;
-  }
-
-  & .cm-scroller {
-    overflow: auto !important;
-  }
-`;
-
-const typeFooterCSS = css`
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-
-  & .cm-theme {
-    height: 100% !important;
-  }
-
-  & .cm-editor {
-    height: 100% !important;
-    background-color: var(--global-color-gray-100);
-  }
-
-  & .cm-gutters {
-    background-color: var(--global-color-gray-100);
-  }
-
-  & .cm-scroller {
-    overflow: auto !important;
-  }
 `;

--- a/js/app/src/components/evaluators/EvaluatorNameAndDescriptionFields.tsx
+++ b/js/app/src/components/evaluators/EvaluatorNameAndDescriptionFields.tsx
@@ -8,13 +8,25 @@ import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorName
  */
 export const EvaluatorNameAndDescriptionFields = ({
   onValueChange,
+  isNameRequired = false,
+  descriptionPlaceholder,
 }: {
   onValueChange?: () => void;
+  /** Marks the name input as required for form submission. */
+  isNameRequired?: boolean;
+  /** Overrides the description input's default example placeholder. */
+  descriptionPlaceholder?: string;
 } = {}) => (
   <View marginBottom="size-200" flex="none">
     <Flex direction="row" alignItems="baseline" width="100%" gap="size-100">
-      <EvaluatorNameInput onValueChange={onValueChange} />
-      <EvaluatorDescriptionInput onValueChange={onValueChange} />
+      <EvaluatorNameInput
+        onValueChange={onValueChange}
+        isRequired={isNameRequired}
+      />
+      <EvaluatorDescriptionInput
+        onValueChange={onValueChange}
+        placeholder={descriptionPlaceholder}
+      />
     </Flex>
   </View>
 );

--- a/js/app/src/components/evaluators/EvaluatorSectionHeader.tsx
+++ b/js/app/src/components/evaluators/EvaluatorSectionHeader.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+import { Flex, Heading, Text } from "@phoenix/components";
+
+/** The heading and description an evaluator form section opens with. */
+export const EvaluatorSectionHeader = ({
+  title,
+  description,
+  extra,
+}: {
+  title: string;
+  description: string;
+  /** Controls rendered on the right side of the header, e.g. compact fields. */
+  extra?: ReactNode;
+}) => (
+  // The row wraps so the extra controls drop onto their own line instead of
+  // forcing a horizontal scrollbar when the host panel is resized narrow.
+  <Flex
+    direction="row"
+    justifyContent="space-between"
+    alignItems="center"
+    gap="size-200"
+    wrap
+  >
+    <Flex direction="column" gap="size-25">
+      <Heading level={2} weight="heavy">
+        {title}
+      </Heading>
+      <Text color="text-500" size="S">
+        {description}
+      </Text>
+    </Flex>
+    {extra}
+  </Flex>
+);

--- a/js/app/src/components/evaluators/__tests__/codeEvaluatorUtils.test.ts
+++ b/js/app/src/components/evaluators/__tests__/codeEvaluatorUtils.test.ts
@@ -1,7 +1,32 @@
 import {
   extractCodeEvaluatorVariables,
   extractRequiredCodeEvaluatorVariables,
+  getDefaultCodeEvaluatorSource,
+  getNextCodeEvaluatorSource,
 } from "../codeEvaluatorUtils";
+
+describe("getNextCodeEvaluatorSource", () => {
+  it("swaps a generated placeholder for the next language's placeholder", () => {
+    expect(
+      getNextCodeEvaluatorSource({
+        sourceCode: getDefaultCodeEvaluatorSource("PYTHON"),
+        language: "PYTHON",
+        nextLanguage: "TYPESCRIPT",
+      })
+    ).toEqual(getDefaultCodeEvaluatorSource("TYPESCRIPT"));
+  });
+
+  it("never overwrites user-authored code", () => {
+    const sourceCode = "def evaluate(output):\n    return 1.0\n";
+    expect(
+      getNextCodeEvaluatorSource({
+        sourceCode,
+        language: "PYTHON",
+        nextLanguage: "TYPESCRIPT",
+      })
+    ).toEqual(sourceCode);
+  });
+});
 
 describe("code evaluator variable extraction", () => {
   it.each([

--- a/js/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/js/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -38,6 +38,26 @@ export function getAllGeneratedSources(
   return [getDefaultCodeEvaluatorSource(language)];
 }
 
+/**
+ * The source code a language switch should land on: the default placeholder
+ * for the next language when the current source is still a generated
+ * placeholder, otherwise the current source untouched — never overwrite
+ * user-authored code.
+ */
+export function getNextCodeEvaluatorSource({
+  sourceCode,
+  language,
+  nextLanguage,
+}: {
+  sourceCode: string;
+  language: CodeEvaluatorLanguage;
+  nextLanguage: CodeEvaluatorLanguage;
+}): string {
+  return getAllGeneratedSources(language).includes(sourceCode)
+    ? getDefaultCodeEvaluatorSource(nextLanguage)
+    : sourceCode;
+}
+
 export const extractCodeEvaluatorVariables = ({
   language,
   sourceCode,

--- a/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import {
   graphql,
   useLazyLoadQuery,
@@ -6,25 +6,17 @@ import {
   useRelayEnvironment,
 } from "react-relay";
 
-import { Alert, Flex, LinkButton } from "@phoenix/components";
+import { Alert, LinkButton } from "@phoenix/components";
+import { CodeAuthoringFields } from "@phoenix/components/evaluators/CodeAuthoringFields";
+import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import {
-  CodeEvaluatorLanguageField,
-  CodeEvaluatorSandboxField,
-  mapSandboxConfigOptions,
-} from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
-import {
-  getAllGeneratedSources,
-  getDefaultCodeEvaluatorSource,
   extractCodeEvaluatorVariables,
   extractRequiredCodeEvaluatorVariables,
+  getDefaultCodeEvaluatorSource,
+  getNextCodeEvaluatorSource,
 } from "@phoenix/components/evaluators/codeEvaluatorUtils";
-import {
-  CodeEvaluatorAnnotationSection,
-  CodeEvaluatorSourceEditor,
-} from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
 import { EvaluatorFormDialogContent } from "@phoenix/components/evaluators/EvaluatorFormDialogContent";
 import { CodeEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/CodeEvaluatorInputVariablesProvider";
-import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
 import {
   buildOutputConfigsInput,
   getOutputConfigValidationErrors,
@@ -145,10 +137,12 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
       }
     `);
 
+  const clearValidationMessage = () => setValidationMessage(undefined);
+
   const handleLanguageChange = (nextLanguage: CodeEvaluatorLanguage) => {
-    if (getAllGeneratedSources(language).includes(sourceCode)) {
-      setSourceCode(getDefaultCodeEvaluatorSource(nextLanguage));
-    }
+    setSourceCode(
+      getNextCodeEvaluatorSource({ sourceCode, language, nextLanguage })
+    );
     setLanguage(nextLanguage);
   };
 
@@ -257,6 +251,11 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
       )}
       left={
         <ProjectCodeEvaluatorFormSections
+          projectId={projectId}
+          scope={scope}
+          onScopeChange={onScopeChange}
+          onFilterValidityChange={setIsFilterValid}
+          onFieldChange={clearValidationMessage}
           codeDefinition={
             <CodeAuthoringFields
               language={language}
@@ -266,7 +265,7 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
               onSandboxChange={setSandboxConfigId}
               sourceCode={sourceCode}
               onSourceCodeChange={setSourceCode}
-              onFieldChange={() => setValidationMessage(undefined)}
+              onFieldChange={clearValidationMessage}
             />
           }
         />
@@ -275,8 +274,6 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
         <ProjectEvaluatorScopePanel
           projectId={projectId}
           scope={scope}
-          onScopeChange={onScopeChange}
-          onFilterValidityChange={setIsFilterValid}
           inlineCode={{
             language,
             sourceCode,
@@ -288,61 +285,3 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
     />
   );
 };
-
-export const CodeAuthoringFields = ({
-  language,
-  onLanguageChange,
-  sandboxConfigs,
-  selectedSandboxConfigId,
-  onSandboxChange,
-  sourceCode,
-  onSourceCodeChange,
-  isLanguageDisabled = false,
-  onFieldChange,
-}: {
-  language: CodeEvaluatorLanguage;
-  onLanguageChange: (language: CodeEvaluatorLanguage) => void;
-  sandboxConfigs: Parameters<
-    typeof CodeEvaluatorSandboxField
-  >[0]["sandboxConfigs"];
-  selectedSandboxConfigId: string | null;
-  onSandboxChange: (sandboxConfigId: string | null) => void;
-  sourceCode: string;
-  onSourceCodeChange: (sourceCode: string) => void;
-  isLanguageDisabled?: boolean;
-  onFieldChange?: () => void;
-}): ReactNode => (
-  <Flex direction="column" gap="size-200">
-    <EvaluatorNameAndDescriptionFields onValueChange={onFieldChange} />
-    <Flex direction="row" gap="size-200" alignItems="start">
-      <CodeEvaluatorLanguageField
-        language={language}
-        onChange={(nextLanguage) => {
-          onFieldChange?.();
-          onLanguageChange(nextLanguage);
-        }}
-        isDisabled={isLanguageDisabled}
-        isRequired
-      />
-      <CodeEvaluatorSandboxField
-        sandboxConfigs={sandboxConfigs}
-        language={language}
-        selectedSandboxConfigId={selectedSandboxConfigId}
-        onSelectionChange={(sandboxConfigId) => {
-          onFieldChange?.();
-          onSandboxChange(sandboxConfigId);
-        }}
-        isRequired
-      />
-    </Flex>
-    <CodeEvaluatorSourceEditor
-      language={language}
-      sourceCode={sourceCode}
-      onChange={(nextSourceCode) => {
-        onFieldChange?.();
-        onSourceCodeChange(nextSourceCode);
-      }}
-    />
-    <CodeEvaluatorAnnotationSection onChange={onFieldChange} />
-  </Flex>
-);

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -4,7 +4,7 @@ import { graphql, useMutation, useRelayEnvironment } from "react-relay";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import { createDefaultFreeformOutputConfig } from "@phoenix/components/evaluators/EditCodeEvaluatorDialogContent";
+import { createDefaultFreeformOutputConfig } from "@phoenix/components/evaluators/CodeEvaluatorAnnotationSection";
 import { EditLLMEvaluatorDialogContent } from "@phoenix/components/evaluators/EditLLMEvaluatorDialogContent";
 import { getSpanEvaluatorDefaultMessages } from "@phoenix/components/evaluators/EvaluatorChatTemplate/utils";
 import { EvaluatorPlaygroundProvider } from "@phoenix/components/evaluators/EvaluatorPlaygroundProvider";
@@ -376,6 +376,7 @@ function AttachCodeProjectEvaluatorDialog({
       onScopeChange={onScopeChange}
       isSubmitting={isAddingCodeEvaluator}
       error={error}
+      onFieldChange={() => setError(undefined)}
       onSubmit={() => {
         setError(undefined);
         addCodeEvaluator({
@@ -557,11 +558,7 @@ const ScratchLlmDialogContent = ({
         />
       }
       formRightPanel={
-        <ProjectEvaluatorScopePanel
-          projectId={projectId}
-          scope={scope}
-          showScopeFields={false}
-        />
+        <ProjectEvaluatorScopePanel projectId={projectId} scope={scope} />
       }
     />
   );

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -5,6 +5,7 @@ import { useRevalidator } from "react-router";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
+import { CodeAuthoringFields } from "@phoenix/components/evaluators/CodeAuthoringFields";
 import type { SandboxConfigOption } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import { mapSandboxConfigOptions } from "@phoenix/components/evaluators/CodeEvaluatorLanguageSandboxFields";
 import {
@@ -28,7 +29,6 @@ import {
 import type { EditProjectEvaluatorSlideoverQuery } from "@phoenix/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverQuery.graphql";
 import type { EditProjectEvaluatorSlideoverUpdateCodeMutation } from "@phoenix/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateCodeMutation.graphql";
 import type { EditProjectEvaluatorSlideoverUpdateLlmMutation } from "@phoenix/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateLlmMutation.graphql";
-import { CodeAuthoringFields } from "@phoenix/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent";
 import { ProjectCodeEvaluatorDialogContent } from "@phoenix/pages/project/evaluators/ProjectCodeEvaluatorDialogContent";
 import { ProjectLlmEvaluatorFormSections } from "@phoenix/pages/project/evaluators/ProjectEvaluatorFormSections";
 import { convertProjectEvaluatorOutputConfigs } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
@@ -457,7 +457,6 @@ function EditLlmProjectEvaluatorContent({
               <ProjectEvaluatorScopePanel
                 projectId={evaluator.project.id}
                 scope={scope}
-                showScopeFields={false}
               />
             }
           />
@@ -582,6 +581,7 @@ function EditCodeProjectEvaluator({
             onScopeChange={setScope}
             isSubmitting={isUpdating}
             error={error}
+            onFieldChange={() => setError(undefined)}
             onSubmit={() => {
               setError(undefined);
               const state = store.getState();

--- a/js/app/src/pages/project/evaluators/ProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectCodeEvaluatorDialogContent.tsx
@@ -21,6 +21,7 @@ export const ProjectCodeEvaluatorDialogContent = ({
   inlineCode,
   scope,
   onScopeChange,
+  onFieldChange,
   onSubmit,
   isSubmitting,
   error,
@@ -38,6 +39,8 @@ export const ProjectCodeEvaluatorDialogContent = ({
   inlineCode?: ProjectEvaluatorInlineCode;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
+  /** Fires on any form-section edit, so stale error banners can be cleared. */
+  onFieldChange?: () => void;
   onSubmit: () => void;
   isSubmitting: boolean;
   error?: string;
@@ -65,20 +68,23 @@ export const ProjectCodeEvaluatorDialogContent = ({
       )}
       left={
         <ProjectCodeEvaluatorFormSections
+          projectId={projectId}
+          scope={scope}
+          onScopeChange={onScopeChange}
+          onFilterValidityChange={setIsFilterValid}
+          isTargetDisabled={mode === "update"}
           codeEvaluatorName={evaluatorName}
           codeDefinition={codeDefinition}
+          onFieldChange={onFieldChange}
         />
       }
       right={
         <ProjectEvaluatorScopePanel
           projectId={projectId}
           scope={scope}
-          onScopeChange={onScopeChange}
-          onFilterValidityChange={setIsFilterValid}
           codeEvaluatorId={inlineCode ? undefined : evaluatorId}
           inlineCode={inlineCode}
           requiredVariables={requiredVariables}
-          isTargetDisabled={mode === "update"}
         />
       }
     />

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorFormSections.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorFormSections.tsx
@@ -1,26 +1,14 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 
-import { Flex, Heading, Text, View } from "@phoenix/components";
+import { Flex, Heading, View } from "@phoenix/components";
 import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
+import { EvaluatorSectionHeader } from "@phoenix/components/evaluators/EvaluatorSectionHeader";
 import { LLMEvaluatorForm } from "@phoenix/components/evaluators/LLMEvaluatorForm";
 import { ProjectEvaluatorScopeFieldGroup } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeFields";
 import type { ProjectEvaluatorScope } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
-/**
- * The left definition panel for an LLM project evaluator; the matching-span
- * preview lives in {@link ProjectEvaluatorScopePanel}.
- *
- * The layout mirrors the dataset evaluator form: name and description, then
- * target, sampling, and the span filter, then the prompt with the annotation
- * config below it.
- */
-export const ProjectLlmEvaluatorFormSections = ({
-  projectId,
-  scope,
-  onScopeChange,
-  onFilterValidityChange,
-  isTargetDisabled = false,
-}: {
+/** Scope-editing props shared by every left definition panel. */
+type ProjectEvaluatorScopeProps = {
   /** The span filter autocompletes against this project's spans. */
   projectId: string;
   /** Target, sampling, and the span filter render below the name. */
@@ -28,71 +16,106 @@ export const ProjectLlmEvaluatorFormSections = ({
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
   onFilterValidityChange?: (isValid: boolean) => void;
   isTargetDisabled?: boolean;
-}) => {
-  return (
-    <>
-      <EvaluatorNameAndDescriptionFields />
+};
+
+/**
+ * The "Evaluator Scope" section every project evaluator form renders under
+ * the name and description: target, sampling, and the record filter.
+ */
+const ProjectEvaluatorScopeSection = memo(
+  function ProjectEvaluatorScopeSection({
+    projectId,
+    scope,
+    onScopeChange,
+    onFilterValidityChange,
+    isTargetDisabled,
+  }: ProjectEvaluatorScopeProps) {
+    return (
       <View marginBottom="size-200" flex="none">
         <Flex direction="column" gap="size-200">
-          <Flex direction="column" gap="size-25">
-            <Heading level={2} weight="heavy">
-              Evaluator Scope
-            </Heading>
-            <Text color="text-500" size="S">
-              {scope.targetType === "SESSION"
+          <EvaluatorSectionHeader
+            title="Evaluator Scope"
+            description={
+              scope.targetType === "SESSION"
                 ? "Select which sessions this evaluator runs on and how often."
-                : "Select which spans this evaluator runs on and how often."}
-            </Text>
-          </Flex>
+                : "Select which spans this evaluator runs on and how often."
+            }
+          />
           <ProjectEvaluatorScopeFieldGroup
             projectId={projectId}
             scope={scope}
             onScopeChange={onScopeChange}
             onFilterValidityChange={onFilterValidityChange}
             isTargetDisabled={isTargetDisabled}
-            fillSampling
           />
         </Flex>
       </View>
+    );
+  }
+);
+
+/**
+ * The left definition panel for an LLM project evaluator; the matching-record
+ * test preview lives in {@link ProjectEvaluatorScopePanel}.
+ *
+ * The layout mirrors the dataset evaluator form: name and description, then
+ * target, sampling, and the span filter, then the prompt with the annotation
+ * config below it.
+ */
+export const ProjectLlmEvaluatorFormSections = (
+  scopeProps: ProjectEvaluatorScopeProps
+) => {
+  return (
+    <>
+      <EvaluatorNameAndDescriptionFields />
+      <ProjectEvaluatorScopeSection {...scopeProps} />
       <LLMEvaluatorForm showInputMapping={false} />
     </>
   );
 };
 
 /**
- * The left definition panel for a code project evaluator: either the code
- * authoring fields, or a summary of the existing evaluator being attached.
+ * The left definition panel for a code project evaluator, laid out the same
+ * way as {@link ProjectLlmEvaluatorFormSections}: name and description, then
+ * the scope, then the definition — either the code authoring fields, or a
+ * summary of the existing evaluator being attached.
  */
 export const ProjectCodeEvaluatorFormSections = ({
   codeEvaluatorName,
   codeDefinition,
-}: {
+  onFieldChange,
+  ...scopeProps
+}: ProjectEvaluatorScopeProps & {
   codeEvaluatorName?: string;
-  /** Rendered in the definition section for an editable code evaluator. */
+  /** Rendered as the definition section for an editable code evaluator. */
   codeDefinition?: ReactNode;
+  /** Fires when the name or description changes. */
+  onFieldChange?: () => void;
 }) => {
   return (
-    <Flex direction="column" gap="size-200">
-      <Flex direction="column" gap="size-200" flex="none">
-        <Flex direction="column" gap="size-25">
-          <Heading level={2}>Evaluator</Heading>
-          <Text color="text-500" size="S">
-            {codeDefinition
-              ? "Define your evaluator's source code and annotation output."
-              : "Attach the selected code evaluator to this project."}
-          </Text>
-        </Flex>
-        {codeDefinition ?? (
-          <View
-            borderRadius="medium"
-            borderWidth="thin"
-            borderColor="default"
-            padding="size-200"
-          >
-            <Heading level={3}>{codeEvaluatorName}</Heading>
-          </View>
-        )}
-      </Flex>
-    </Flex>
+    <>
+      {codeDefinition ? (
+        <EvaluatorNameAndDescriptionFields onValueChange={onFieldChange} />
+      ) : (
+        <View marginBottom="size-200" flex="none">
+          <Flex direction="column" gap="size-100">
+            <EvaluatorSectionHeader
+              title="Evaluator"
+              description="Attach the selected code evaluator to this project."
+            />
+            <View
+              borderRadius="medium"
+              borderWidth="thin"
+              borderColor="default"
+              padding="size-200"
+            >
+              <Heading level={3}>{codeEvaluatorName}</Heading>
+            </View>
+          </Flex>
+        </View>
+      )}
+      <ProjectEvaluatorScopeSection {...scopeProps} />
+      {codeDefinition}
+    </>
   );
 };

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -1,5 +1,4 @@
 import { css } from "@emotion/react";
-import type { ReactNode } from "react";
 import { Suspense, useState } from "react";
 
 import {
@@ -12,9 +11,11 @@ import {
   SliderNumberField,
   Text,
 } from "@phoenix/components";
+import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 import {
   isProjectEvaluatorTarget,
   MIN_EVALUATION_DELAY_SECONDS,
+  toEvaluatorMappingSourceGrain,
   toProjectEvaluatorSamplingFraction,
   type ProjectEvaluatorScope,
   type ProjectEvaluatorTarget,
@@ -30,36 +31,35 @@ import {
   type SpanFilterValidConditionArgs,
 } from "@phoenix/pages/project/SpanFilterConditionField";
 
-/**
- * The target, sampling, delay, and filter fields wired to a scope object.
- * `children` renders additional fields at the end of the first row, after
- * every setting the scope persists.
- */
+/** The target, sampling, delay, and filter fields wired to a scope object. */
 export const ProjectEvaluatorScopeFieldGroup = ({
   projectId,
   scope,
   onScopeChange,
   onFilterValidityChange,
   isTargetDisabled = false,
-  fillSampling = false,
-  children,
 }: {
   projectId: string;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
   onFilterValidityChange?: (isValid: boolean) => void;
   isTargetDisabled?: boolean;
-  /** Grow the sampling slider to fill the row. */
-  fillSampling?: boolean;
-  children?: ReactNode;
 }) => {
   const isSessionTarget = scope.targetType === "SESSION";
+  const evaluatorStore = useEvaluatorStoreInstance();
   // Spans and sessions are filtered in different languages, so a condition
   // written for one target cannot carry over to the other.
   const handleTargetChange = (targetType: ProjectEvaluatorTarget) => {
     if (targetType === scope.targetType) {
       return;
     }
+    // Span and session contexts are structurally identical, so the store
+    // cannot infer the grain from one; changing the target has to say so.
+    evaluatorStore
+      .getState()
+      .setEvaluatorMappingSourceGrain(
+        toEvaluatorMappingSourceGrain(targetType)
+      );
     onScopeChange({ ...scope, targetType, filterCondition: "" });
   };
   return (
@@ -73,7 +73,7 @@ export const ProjectEvaluatorScopeFieldGroup = ({
         <ProjectEvaluatorSamplingField
           // A filled slider takes the whole row, which would wrap the delay
           // field onto a line of its own.
-          fill={fillSampling && !isSessionTarget}
+          fill={!isSessionTarget}
           value={scope.samplingRate}
           onChange={(samplingRate) => onScopeChange({ ...scope, samplingRate })}
         />
@@ -85,7 +85,6 @@ export const ProjectEvaluatorScopeFieldGroup = ({
             }
           />
         ) : null}
-        {children}
       </Flex>
       {isSessionTarget ? (
         <Text size="XS" color="text-500">

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
-import type { ComponentProps } from "react";
 import {
   Suspense,
+  useDeferredValue,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -40,6 +40,7 @@ import {
   AnnotationPreviewPopoverButton,
   AnnotationPreviewSkeletonCard,
 } from "@phoenix/components/evaluators/EvaluatorOutputPreview";
+import { EvaluatorSectionHeader } from "@phoenix/components/evaluators/EvaluatorSectionHeader";
 import {
   buildOutputConfigsInput,
   createLLMEvaluatorPayload,
@@ -62,10 +63,8 @@ import type {
 import type { ProjectEvaluatorScopePanelSessionCountQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionCountQuery.graphql";
 import type { ProjectEvaluatorScopePanelSessionsQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSessionsQuery.graphql";
 import type { ProjectEvaluatorScopePanelSpansQuery } from "@phoenix/pages/project/evaluators/__generated__/ProjectEvaluatorScopePanelSpansQuery.graphql";
-import { ProjectEvaluatorScopeFieldGroup } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeFields";
 import {
   getProjectEvaluatorMappingDiagnostics,
-  toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { getSampleSpanEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSpanEvaluationContext";
@@ -141,45 +140,37 @@ function makeTimeWindow(presetId: TimeWindowPresetId): TimeWindow {
   };
 }
 
-type ProjectEvaluatorScopePanelScopeFieldsProps =
-  | {
-      /** Target, sampling, and the span filter render in this panel. */
-      showScopeFields?: true;
-      onScopeChange: (scope: ProjectEvaluatorScope) => void;
-      onFilterValidityChange?: (isValid: boolean) => void;
-      isTargetDisabled?: boolean;
-    }
-  | {
-      /**
-       * The scope fields render in the definition panel instead; the panel
-       * starts at the matching-span preview and edits no scope.
-       */
-      showScopeFields: false;
-    };
-
-/** Scope is committed by the form's create/save action, not by this panel. */
-export const ProjectEvaluatorScopePanel = (
-  props: {
-    projectId: string;
-    scope: ProjectEvaluatorScope;
-    codeEvaluatorId?: string;
-    inlineCode?: ProjectEvaluatorInlineCode;
-    requiredVariables?: string[];
-  } & ProjectEvaluatorScopePanelScopeFieldsProps
-) => {
-  const { projectId, scope, codeEvaluatorId, inlineCode, requiredVariables } =
-    props;
+/**
+ * The scope fields render in the definition panel; this panel previews the
+ * matching records and tests the evaluator against them.
+ */
+export const ProjectEvaluatorScopePanel = ({
+  projectId,
+  scope,
+  codeEvaluatorId,
+  inlineCode,
+  requiredVariables,
+}: {
+  projectId: string;
+  scope: ProjectEvaluatorScope;
+  codeEvaluatorId?: string;
+  inlineCode?: ProjectEvaluatorInlineCode;
+  requiredVariables?: string[];
+}) => {
   const [timeWindow, setTimeWindow] = useState(() => makeTimeWindow("7d"));
   const isSessionTarget = scope.targetType === "SESSION";
-  // Span and session contexts are structurally identical, so the store cannot
-  // infer the grain from one; changing the target has to say so.
-  const evaluatorStore = useEvaluatorStoreInstance();
-  const mappingSourceGrain = toEvaluatorMappingSourceGrain(scope.targetType);
-  useEffect(() => {
-    evaluatorStore
-      .getState()
-      .setEvaluatorMappingSourceGrain(mappingSourceGrain);
-  }, [evaluatorStore, mappingSourceGrain]);
+  const recordNoun: RecordedRunNoun = isSessionTarget ? "session" : "span";
+  // A keystroke in the span filter commits a new condition per valid draft;
+  // deferring it keeps the current count and rows visible while the queries
+  // for the newer condition load, instead of collapsing to the fallbacks.
+  const filterCondition = useDeferredValue(scope.filterCondition);
+  // The span and session variants of each block are structurally identical;
+  // the target picks which components fill the shared layout below.
+  const MatchedCountLine = isSessionTarget
+    ? MatchedSessionCountLine
+    : MatchedSpanCountLine;
+  const CodeRunList = isSessionTarget ? SessionRunList : SpanRunList;
+  const LlmRunList = isSessionTarget ? LlmSessionRunList : LlmSpanRunList;
   // The run list below the Suspense boundary owns the records and the run
   // machinery; it hands the header's Test All button the latest run-all
   // closure through this ref and reports readiness through the state.
@@ -199,182 +190,58 @@ export const ProjectEvaluatorScopePanel = (
   return (
     <div css={panelCSS}>
       <div css={panelScrollCSS}>
-        {props.showScopeFields !== false ? (
-          <>
-            <Flex direction="column" gap="size-25">
-              <Heading level={2}>Scope</Heading>
-              <Text color="text-500" size="S">
-                {isSessionTarget
-                  ? "Select which sessions this evaluator runs on and how often."
-                  : "Select which spans this evaluator runs on and how often."}
+        {isSessionTarget ? <SessionInputNote /> : null}
+        <Flex direction="column" gap="size-25">
+          <EvaluatorSectionHeader
+            title={isSessionTarget ? "Test with a Session" : "Test with a Span"}
+            description={`Test your evaluator on recent ${recordNoun}s that match your scope.`}
+            extra={
+              <Flex direction="row" alignItems="center" gap="size-100">
+                <TimeWindowSegmentedControl
+                  value={timeWindow.presetId}
+                  onChange={setTimeWindow}
+                />
+                {testAllButton}
+              </Flex>
+            }
+          />
+          <Suspense
+            fallback={
+              <Text size="S" color="text-500">
+                Counting matching {recordNoun}s…
               </Text>
-            </Flex>
-            <ScopeEditorCard
+            }
+          >
+            <MatchedCountLine
               projectId={projectId}
-              scope={scope}
-              onScopeChange={props.onScopeChange}
-              onFilterValidityChange={props.onFilterValidityChange}
+              filterCondition={filterCondition}
               timeWindow={timeWindow}
-              onTimeWindowChange={setTimeWindow}
-              isTargetDisabled={props.isTargetDisabled ?? false}
             />
-          </>
-        ) : null}
-        {isSessionTarget ? (
-          <>
-            <SessionInputNote />
-            <Flex direction="column" gap="size-25">
-              {props.showScopeFields !== false ? (
-                <Flex
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="center"
-                  gap="size-200"
-                >
-                  <Heading level={2}>Matching sessions</Heading>
-                  {testAllButton}
-                </Flex>
-              ) : (
-                <>
-                  <Flex
-                    direction="row"
-                    justifyContent="space-between"
-                    alignItems="center"
-                    gap="size-200"
-                  >
-                    <Heading level={2} weight="heavy">
-                      Test with a Session
-                    </Heading>
-                    <Flex direction="row" alignItems="center" gap="size-100">
-                      <TimeWindowSegmentedControl
-                        size="S"
-                        value={timeWindow.presetId}
-                        onChange={setTimeWindow}
-                      />
-                      {testAllButton}
-                    </Flex>
-                  </Flex>
-                  <Text color="text-500">
-                    Test your evaluator on recent sessions that match your
-                    scope.
-                  </Text>
-                </>
-              )}
-              <Suspense
-                fallback={
-                  <Text size="S" color="text-500">
-                    Counting matching sessions…
-                  </Text>
-                }
-              >
-                <MatchedSessionCountLine
-                  projectId={projectId}
-                  filterCondition={scope.filterCondition}
-                  timeWindow={timeWindow}
-                />
-              </Suspense>
-            </Flex>
-            <Suspense fallback={<Loading />}>
-              {codeEvaluatorId || inlineCode ? (
-                <SessionRunList
-                  projectId={projectId}
-                  filterCondition={scope.filterCondition}
-                  timeWindow={timeWindow}
-                  codeEvaluatorId={codeEvaluatorId}
-                  inlineCode={inlineCode}
-                  requiredVariables={requiredVariables}
-                  runAllRecordsRef={runAllRecordsRef}
-                  onCanRunAllChange={setCanRunAllRecords}
-                />
-              ) : (
-                <LlmSessionRunList
-                  projectId={projectId}
-                  filterCondition={scope.filterCondition}
-                  timeWindow={timeWindow}
-                  requiredVariables={requiredVariables}
-                  runAllRecordsRef={runAllRecordsRef}
-                  onCanRunAllChange={setCanRunAllRecords}
-                />
-              )}
-            </Suspense>
-          </>
-        ) : (
-          <>
-            <Flex direction="column" gap="size-25">
-              {props.showScopeFields !== false ? (
-                <Flex
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="center"
-                  gap="size-200"
-                >
-                  <Heading level={2}>Matching spans</Heading>
-                  {testAllButton}
-                </Flex>
-              ) : (
-                <>
-                  <Flex
-                    direction="row"
-                    justifyContent="space-between"
-                    alignItems="center"
-                    gap="size-200"
-                  >
-                    <Heading level={2} weight="heavy">
-                      Test with a Span
-                    </Heading>
-                    <Flex direction="row" alignItems="center" gap="size-100">
-                      <TimeWindowSegmentedControl
-                        size="S"
-                        value={timeWindow.presetId}
-                        onChange={setTimeWindow}
-                      />
-                      {testAllButton}
-                    </Flex>
-                  </Flex>
-                  <Text color="text-500">
-                    Test your evaluator on recent spans that match your scope.
-                  </Text>
-                </>
-              )}
-              <Suspense
-                fallback={
-                  <Text size="S" color="text-500">
-                    Counting matching spans…
-                  </Text>
-                }
-              >
-                <MatchedSpanCountLine
-                  projectId={projectId}
-                  filterCondition={scope.filterCondition}
-                  timeWindow={timeWindow}
-                />
-              </Suspense>
-            </Flex>
-            <Suspense fallback={<Loading />}>
-              {codeEvaluatorId || inlineCode ? (
-                <SpanRunList
-                  projectId={projectId}
-                  filterCondition={scope.filterCondition}
-                  timeWindow={timeWindow}
-                  codeEvaluatorId={codeEvaluatorId}
-                  inlineCode={inlineCode}
-                  requiredVariables={requiredVariables}
-                  runAllRecordsRef={runAllRecordsRef}
-                  onCanRunAllChange={setCanRunAllRecords}
-                />
-              ) : (
-                <LlmSpanRunList
-                  projectId={projectId}
-                  filterCondition={scope.filterCondition}
-                  timeWindow={timeWindow}
-                  requiredVariables={requiredVariables}
-                  runAllRecordsRef={runAllRecordsRef}
-                  onCanRunAllChange={setCanRunAllRecords}
-                />
-              )}
-            </Suspense>
-          </>
-        )}
+          </Suspense>
+        </Flex>
+        <Suspense fallback={<Loading />}>
+          {codeEvaluatorId || inlineCode ? (
+            <CodeRunList
+              projectId={projectId}
+              filterCondition={filterCondition}
+              timeWindow={timeWindow}
+              codeEvaluatorId={codeEvaluatorId}
+              inlineCode={inlineCode}
+              requiredVariables={requiredVariables}
+              runAllRecordsRef={runAllRecordsRef}
+              onCanRunAllChange={setCanRunAllRecords}
+            />
+          ) : (
+            <LlmRunList
+              projectId={projectId}
+              filterCondition={filterCondition}
+              timeWindow={timeWindow}
+              requiredVariables={requiredVariables}
+              runAllRecordsRef={runAllRecordsRef}
+              onCanRunAllChange={setCanRunAllRecords}
+            />
+          )}
+        </Suspense>
       </div>
     </div>
   );
@@ -456,16 +323,14 @@ function useMatchedSpanCount({
 function TimeWindowSegmentedControl({
   value,
   onChange,
-  size,
 }: {
   value: TimeWindowPresetId;
   onChange: (timeWindow: TimeWindow) => void;
-  size?: ComponentProps<typeof SegmentedControl>["size"];
 }) {
   return (
     <SegmentedControl
       aria-label="Preview window"
-      size={size}
+      size="S"
       selectedKey={value}
       onSelectionChange={(key) => {
         if (typeof key === "string" && isTimeWindowPresetId(key)) {
@@ -483,46 +348,6 @@ function TimeWindowSegmentedControl({
         </SegmentedControlItem>
       ))}
     </SegmentedControl>
-  );
-}
-
-function ScopeEditorCard({
-  projectId,
-  scope,
-  onScopeChange,
-  onFilterValidityChange,
-  timeWindow,
-  onTimeWindowChange,
-  isTargetDisabled,
-}: {
-  projectId: string;
-  scope: ProjectEvaluatorScope;
-  onScopeChange: (scope: ProjectEvaluatorScope) => void;
-  onFilterValidityChange?: (isValid: boolean) => void;
-  timeWindow: TimeWindow;
-  onTimeWindowChange: (timeWindow: TimeWindow) => void;
-  isTargetDisabled: boolean;
-}) {
-  return (
-    <div css={scopeEditorCardCSS}>
-      <ProjectEvaluatorScopeFieldGroup
-        projectId={projectId}
-        scope={scope}
-        onScopeChange={onScopeChange}
-        onFilterValidityChange={onFilterValidityChange}
-        isTargetDisabled={isTargetDisabled}
-      >
-        <Flex direction="column" gap="size-50">
-          <Text size="XS" weight="heavy" color="text-700">
-            Preview window
-          </Text>
-          <TimeWindowSegmentedControl
-            value={timeWindow.presetId}
-            onChange={onTimeWindowChange}
-          />
-        </Flex>
-      </ProjectEvaluatorScopeFieldGroup>
-    </div>
   );
 }
 
@@ -723,12 +548,6 @@ function SessionRunList({
     />
   );
 }
-
-const scopeEditorCardCSS = css`
-  border: 1px solid var(--global-border-color-default);
-  border-radius: var(--global-rounding-medium);
-  padding: var(--global-dimension-size-200);
-`;
 
 type RecordedRunResult = {
   readonly evaluatorName: string;


### PR DESCRIPTION

<img width="2537" height="1175" alt="Screenshot 2026-08-27 at 6 06 22 PM" src="https://github.com/user-attachments/assets/80e29e82-9469-43e1-9ed2-efdf85058622" />


Part of #15308.

Compacts the code evaluator form and consolidates its duplicated pieces into shared components used by every code evaluator flow (create dialog, edit slideover, and the standalone code evaluator dialog).

### Layout

- The **Language** and **Sandbox** pickers move into the top-right of the "Evaluator Code" section header (`EvaluatorSectionHeader` gains an `extra` slot), reclaiming a full row of vertical space. The header row wraps when the panel is resized narrow.
- The pickers hide their visible labels in this compact placement via a new `hideLabel` prop that swaps in an `aria-label`; default (vertical-form) usage keeps the visible labels and the required indicator.
