### PR TITLE
docs(skills): clean up terminology in the phoenix-cli skill docs

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -478,7 +478,7 @@ Picking the wrong accessor fails silently rather than erroring: filtering with
 `annotations[...]` for an annotation that was written at the trace level joins
 against span annotations and matches nothing.
 
-Each filter accepts only the accessors for its level, and only the span filter accepts more than one:
+Which accessors a filter accepts depends on the filter, and only the span filter accepts more than one:
 
 | Filter | Accepted annotation accessors |
 | ------ | ----------------------------- |

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -451,9 +451,8 @@ Key root fields: `projects`, `datasets`, `prompts`, `evaluators`, `projectCount`
 
 `Project.spans` takes a `filterCondition` — a Python expression over per-span
 values, the same language the UI's **spans** filter bar compiles. (The traces
-tab compiles the separate trace-grain language below; the two are siblings, not
-the same expression at different scopes.) Annotations are reached through three
-subscript accessors, and **the accessor picks the grain**:
+tab compiles the separate trace-level language described below.) Annotations are reached through three
+subscript accessors, and **the accessor picks the level**:
 
 | Accessor | Matches annotations on | Written by |
 | -------- | ---------------------- | ---------- |
@@ -476,10 +475,10 @@ px api graphql '{
 ```
 
 Picking the wrong accessor fails silently rather than erroring: filtering with
-`annotations[...]` for an annotation that was written at the trace grain joins
+`annotations[...]` for an annotation that was written at the trace level joins
 against span annotations and matches nothing.
 
-Accessors are scoped per grain, and only the span filter accepts more than one:
+Each filter accepts only the accessors for its level, and only the span filter accepts more than one:
 
 | Filter | Accepted annotation accessors |
 | ------ | ----------------------------- |
@@ -487,16 +486,16 @@ Accessors are scoped per grain, and only the span filter accepts more than one:
 | `traceFilterCondition` (trace) | `trace_annotations[...]` |
 | `sessionFilterCondition` (session) | `session_annotations[...]` |
 
-An accessor used at the wrong grain is a compile error, not a silent miss —
+An accessor used at the wrong level is a compile error, not a silent miss —
 e.g. `annotations[...]` in a trace filter fails with `` `annotations[...]` is
 not available in the trace filter; use `trace_annotations[...]` for trace
 annotations, or iterate `span_annotations` for span-level annotations ``.
 
 ### Trace filter expressions
 
-`Project.spans` also takes a `traceFilterCondition` — a trace-grain expression
+`Project.spans` also takes a `traceFilterCondition` — a trace-level expression
 that keeps spans whose **trace** matches. It is the language the UI's traces
-table compiles, and it is the grain to reach for when the question is about
+table compiles, and it is the filter to reach for when the question is about
 whole traces ("which traces errored and took over a second") rather than
 individual spans. Pair it with `rootSpansOnly: true` for one row per trace:
 
@@ -510,7 +509,7 @@ px api graphql '{
 }' | jq '.data.projects.edges[0].node.spans.edges[].node'
 ```
 
-`traceFilterCondition` and the span-grain `filterCondition` are **not** mutually
+`traceFilterCondition` and the span-level `filterCondition` are **not** mutually
 exclusive on `spans` — passing both narrows to matching spans inside matching
 traces.
 
@@ -546,17 +545,17 @@ any(span.parent_span.span_kind == "LLM" and span.span_kind == "TOOL" for span in
 any(annotation.label == "hallucinated" for annotation in span_annotations)
 ```
 
-Four rules the trace grain legislates, the first two of which differ from the
-span grain:
+Four rules the trace filter enforces, the first two of which differ from the
+span filter:
 
 - **Unknown names are rejected**, with a `did you mean "…"?` suggestion. Span
   filters instead read an unknown name as an attribute path, so a typo there
-  matches nothing silently; here it fails loudly.
+  matches nothing; here a typo is an explicit error.
 - **Rollups are `0`, never null.** `error_count == 0` matches traces with no
   errors; there is no missing case to test with `is None`.
 - **Datetime literals need an explicit offset** — `start_time >=
-  "2026-07-01T00:00:00Z"`. A naive literal is rejected, as at every grain.
-- **Root-grain reads follow the displayed root.** `input`, `output`,
+  "2026-07-01T00:00:00Z"`. A naive literal is rejected, as in every filter.
+- **Root-span reads follow the displayed root.** `input`, `output`,
   `attributes[...]`, `user.id`, and `metadata[...]` bind to the same
   representative span the traces table shows, so a predicate matches what you
   see. A trace with no root candidate has no values for these.
@@ -565,8 +564,7 @@ span grain:
 
 `px session list` has no filter flag, so selecting sessions by shape means going
 through GraphQL. `Project.sessions` takes a `sessionFilterCondition` — a Python
-expression over per-session values, the session-grain sibling of the span filter
-language:
+expression over per-session values, analogous to the span filter language:
 
 ```bash
 px api graphql '{
@@ -577,9 +575,9 @@ px api graphql '{
 }' | jq '.data.projects.edges[0].node.sessions.edges[].node'
 ```
 
-Discover the bindable names for a project rather than guessing — the vocabulary
-is generated from the compiler's own bindings, so it cannot drift from what
-compiles:
+Discover the bindable names for a project with the vocabulary query. The
+vocabulary is generated from the compiler's own bindings, so it always matches
+what compiles:
 
 ```bash
 px api graphql '{ projects(first: 1) { edges { node { sessionFilterVocabulary {
@@ -602,18 +600,18 @@ Commonly bound names: `session_id`, `start_time`, `end_time`, `duration_ms`,
 `spans`, `traces`, `session_annotations`, and `span_annotations` for
 comprehensions (`any(...)` / `all(...)` / `len([...])`), and
 `session_annotations["name"].score|.label` for session annotations. Three rules
-the DSL legislates and an agent will otherwise get wrong:
+the DSL enforces and an agent will otherwise get wrong:
 
 - **A missing value fails every comparison, in both directions.** A session with
   no recorded input matches neither `'x' in first_input` nor its negation. Target
   the missing case explicitly with `is None`.
 - **`in` against a string ignores case; `==` matches exactly.** This holds at
-  every grain, so the same query gives the same answer in the spans view.
+  every filter, so the same query gives the same answer in the spans view.
 - **`any_input` / `any_output` are containment tests, not values.** Write
   `'refund' in any_input`, never `any_input == 'refund'`.
 
-On fields that accept both grains (e.g. `Project.recordCount`),
-`sessionFilterCondition` and the span-grain `filterCondition` are mutually
+On fields that accept both filter levels (e.g. `Project.recordCount`),
+`sessionFilterCondition` and the span-level `filterCondition` are mutually
 exclusive — passing both is a request error.
 
 ## Docs

--- a/.agents/skills/phoenix-cli/references/axial-coding.md
+++ b/.agents/skills/phoenix-cli/references/axial-coding.md
@@ -144,11 +144,11 @@ Axial coding categorizes the entities you took notes on during open coding. Use 
 
 ## Wrapping up
 
-After axial coding finishes, share the Phoenix UI link with the user. The link points to the project's **spans** table filtered by the `coding_session_id` annotation. The search param is `spanFilterCondition`, which only applies on the `/spans` tab — the traces tab compiles a trace filter it keeps in component state, so the same link at `/traces` renders unfiltered behind a "Traces now use trace-level filters" notice. The spans tab compiles a **span** filter, so the accessor must match the grain the annotation was written at: `trace_annotations['coding_session_id']` for a trace-grain run, `annotations['coding_session_id']` for a span-grain run. Both mistakes fail silently (see [open-coding.md](open-coding.md#wrapping-up)). The UI route `/projects/:projectId` expects an encoded GraphQL node ID, not a project name — resolve it via `px project get`:
+After axial coding finishes, share the Phoenix UI link with the user. The link points to the project's **spans** table filtered by the `coding_session_id` annotation. The search param is `spanFilterCondition`, which only applies on the `/spans` tab — the traces tab compiles a trace filter it keeps in component state, so the same link at `/traces` renders unfiltered behind a "Traces now use trace-level filters" notice. The spans tab compiles a **span** filter, so the accessor must match the level the annotation was written at: `trace_annotations['coding_session_id']` for a trace-level run, `annotations['coding_session_id']` for a span-level run. Both mistakes fail silently (see [open-coding.md](open-coding.md#wrapping-up)). The UI route `/projects/:projectId` expects an encoded GraphQL node ID, not a project name — resolve it via `px project get`:
 
 ```bash
 project_id=$(px project get "$PHOENIX_PROJECT" --format raw --no-progress | jq -r '.id')
-# Trace-grain run. For a span-grain run swap in annotations[...].
+# Trace-level run (px trace annotate). For a span-level run (px span annotate), swap in annotations[...].
 encoded=$(python3 -c 'import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))' \
   "trace_annotations['coding_session_id'].label == '$CODING_ANNOTATION_IDENTIFIER'")
 echo "Phoenix UI: $PHOENIX_ENDPOINT/projects/$project_id/spans?spanFilterCondition=$encoded"

--- a/.agents/skills/phoenix-cli/references/open-coding.md
+++ b/.agents/skills/phoenix-cli/references/open-coding.md
@@ -31,7 +31,7 @@ The unit is about **where the failure modes you're investigating actually live**
      '
    ```
 
-   `with_session: 0` → sessions not wired; trace is the grain. `median_traces_per_session: 1` → single-trace sessions; still trace. `median_traces_per_session: 5+` → sessions are meaningful; session is plausibly right.
+   `with_session: 0` → sessions not wired; annotate at the trace level. `median_traces_per_session: 1` → single-trace sessions; still trace level. `median_traces_per_session: 5+` → sessions are meaningful; session level is plausibly right.
 
 3. **System type.** Open one recent trace and inspect the root span's input. A single user message → one turn or one shot. A message *array* (`[{role: user}, {role: assistant}, ...]`) → that's a turn within a longer dialogue; the dialogue lives at the session level.
 
@@ -218,23 +218,23 @@ The local sidecar is the handoff record for notes written this run. Inspect it d
 
 ## Wrapping up
 
-When the run is done, share the Phoenix UI link with the user. The link filters the project's **spans** page by the `coding_session_id` annotation written alongside each note. Three details the UI legislates:
+When the run is done, share the Phoenix UI link with the user. The link filters the project's **spans** page by the `coding_session_id` annotation written alongside each note. Three details the UI enforces:
 
 - **The search param is `spanFilterCondition`.** An unrecognized param is dropped silently and the user lands on an unfiltered table.
-- **Link to the `/spans` tab, not `/traces`.** The traces tab now compiles a *trace* filter that lives in component state with no URL param of its own. A link that carries `spanFilterCondition` to `/traces` leaves that table unfiltered and pops a "Traces now use trace-level filters" notice; the condition only takes effect once the user switches to Spans.
-- **The spans tab compiles a *span* filter**, so the annotation accessor has to match the grain the annotation was written at — `trace_annotations['coding_session_id']` for a trace-grain run (`px trace annotate`), `annotations['coding_session_id']` for a span-grain run (`px span annotate`). A grain mismatch joins the wrong annotation table and matches nothing, silently.
+- **Link to the `/spans` tab, not `/traces`.** The traces tab now compiles a *trace* filter that lives in component state with no URL param of its own. A link that carries `spanFilterCondition` to `/traces` leaves that table unfiltered and shows a "Traces now use trace-level filters" notice; the condition only takes effect once the user switches to Spans.
+- **The spans tab compiles a *span* filter**, so the annotation accessor has to match the level the annotation was written at — `trace_annotations['coding_session_id']` for a trace-level run (`px trace annotate`), `annotations['coding_session_id']` for a span-level run (`px span annotate`). A level mismatch silently joins the wrong annotation table and matches nothing.
 
 The UI route `/projects/:projectId` expects an encoded GraphQL node ID, not a project name — resolve it via `px project get`:
 
 ```bash
 project_id=$(px project get "$PHOENIX_PROJECT" --format raw --no-progress | jq -r '.id')
-# Trace-grain run. For a span-grain run swap in annotations[...].
+# Trace-level run (px trace annotate). For a span-level run (px span annotate), swap in annotations[...].
 encoded=$(python3 -c 'import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))' \
   "trace_annotations['coding_session_id'].label == '$CODING_ANNOTATION_IDENTIFIER'")
 echo "Phoenix UI: $PHOENIX_ENDPOINT/projects/$project_id/spans?spanFilterCondition=$encoded"
 ```
 
-A session-grain run has no equivalent link: the sessions tab keeps its filter in
+A session-level run has no equivalent link: the sessions tab keeps its filter in
 component state rather than the URL, so share the plain project link and, if the
 user wants the selection reproduced, the `sessionFilterCondition` GraphQL query.
 


### PR DESCRIPTION
Terminology and voice cleanup in the phoenix-cli skill docs, split out of the datagen stack (#15614 / #15698 / #15699):

- Replace internal vocabulary with plain terms (e.g. "grain" → "level", "legislates" → "enforces")
- Remove conversational flourishes so the docs read in a terse, informative voice

No behavioral changes.

https://claude.ai/code/session_014gvDFFS2FTKCnjCnQpcdng
