### PR TITLE
fix(ci): cap pydantic-ai-slim below 2.34 in unit test requirements

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -9,6 +9,10 @@ grpc-interceptor[testing]
 httpx
 litellm>=1.83.14; python_version < '3.14'
 nest-asyncio # for executor testing
+# The vendored data-stream protocol types in src/phoenix/db/types are at
+# pydantic-ai 2.33 parity; test_data_stream_protocol_compatibility fails on
+# newer releases. Re-sync the vendored types before lifting this cap.
+pydantic-ai-slim<2.34
 numpy
 pandas-stubs==2.0.3.230814
 pandas>=1.0


### PR DESCRIPTION
Every PR's unit tests currently fail on `unit/db/types/test_data_stream_protocol_compatibility.py`: the tox `unit_tests` env installs with `uv pip install -U` and resolves `pydantic-ai-slim` fresh, and it now picks 2.34.0, whose source no longer matches the vendored data-stream protocol types in `src/phoenix/db/types`.

Verified deterministically: with 2.33.0 the three parity tests pass; with 2.34.0 `test_vendored_request_types_match_pydantic_ai_source` and `test_vendored_request_data_has_same_pydantic_schema` fail.

This caps the unit-test environment at 2.33 parity as a stopgap. The real fix is re-syncing the vendored types with upstream (the usual weekly dependency-upgrade flow), after which the cap should be lifted.

https://claude.ai/code/session_014gvDFFS2FTKCnjCnQpcdng
