### PR TITLE
fix(dsl): correlate the parent test to the span an annotation filter is reading

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -1153,8 +1153,19 @@ class SpanFilter:
         # a measured PostgreSQL regression (see `query.py`). An `OR ... parent_id IS
         # NULL` form is intentionally NOT used here.
         parent_span = aliased(models.Span)
+        # `Span` is named explicitly rather than left to auto-correlation, which omits
+        # only a relation the immediately enclosing query selects from. This subquery
+        # sits one level deeper than that whenever the same condition also reads an
+        # annotation, because the whole predicate is then evaluated inside a correlated
+        # `EXISTS`. Re-rendered there, `spans` is an unconstrained cross join and the
+        # test collapses to "no span anywhere has a parent" -- false for any non-empty
+        # project, so `parent_span is None and <annotation>` matched nothing at all and
+        # the `is not None` form matched everything.
         parent_exists = (
-            sqlalchemy.select(1).where(parent_span.span_id == models.Span.parent_id).exists()
+            sqlalchemy.select(1)
+            .where(parent_span.span_id == models.Span.parent_id)
+            .correlate(models.Span)
+            .exists()
         )
         predicate = eval(
             self.compiled,

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -1325,6 +1325,60 @@ async def test_parent_root_predicate_selects_expected_spans(
     assert span_ids == expected
 
 
+@pytest.fixture
+async def annotated_parent_predicate_project(
+    db: DbSessionFactory, parent_predicate_project: None
+) -> None:
+    """Every span in the parent fixture annotated alike, so only the parent half selects."""
+    async with db() as session:
+        result = await session.execute(select(models.Span.span_id, models.Span.id))
+        rowids: dict[str, int] = dict(result.tuples().all())
+        for span_id in ("A", "B", "C", "D"):
+            await session.execute(
+                insert(models.SpanAnnotation).values(
+                    span_rowid=rowids[span_id],
+                    name="q",
+                    label="ok",
+                    score=1.0,
+                    explanation="",
+                    metadata_={},
+                    annotator_kind="HUMAN",
+                    identifier="",
+                    source="APP",
+                )
+            )
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        ("parent_span is None and annotations['q'].score > 0.5", ["A", "C"]),
+        ("parent_span is not None and annotations['q'].score > 0.5", ["B", "D"]),
+    ],
+)
+async def test_parent_root_predicate_reads_this_span_beside_an_annotation(
+    db: DbSessionFactory,
+    annotated_parent_predicate_project: None,
+    condition: str,
+    expected: list[str],
+) -> None:
+    """The parent test has to keep meaning *this* span when an annotation is also read.
+
+    An annotation predicate is evaluated inside a correlated `EXISTS`, and the whole
+    compiled predicate rides along inside it, so the parent subquery ends up nested one
+    level deeper than the query it correlates to. Left to auto-correlation it re-rendered
+    `spans` in its own FROM as a cross join, and the test collapsed to "no span anywhere
+    has a parent": the `is None` form matched nothing and the `is not None` form matched
+    everything. Valid SQL either way, which is why this is asserted on rows.
+    """
+    f = SpanFilter(condition)
+    async with db() as session:
+        span_ids = list(
+            await session.scalars(f(select(models.Span.span_id)).order_by(models.Span.span_id))
+        )
+    assert span_ids == expected
+
+
 @pytest.mark.parametrize(
     "condition",
     [


### PR DESCRIPTION
`parent_span is None` returns the wrong rows whenever the same condition also reads an
annotation. Nothing raises — the SQL is valid, just not the query that was asked for.

## Symptom

| condition | matches |
| --- | --- |
| `parent_span is None and annotations['q'].score > 0.5` | nothing, ever |
| `parent_span is not None and annotations['q'].score > 0.5` | every annotated span |

Both forms are silently wrong, in opposite directions. `parent_span is None` on its own
is correct, which is why the existing row tests never caught this.

## Why

The parent test compiles to a correlated `NOT EXISTS` against `spans`, with the
correlation left to SQLAlchemy's inference. Auto-correlation omits only a relation the
*immediately enclosing* query selects from.

Since #14192 an annotation predicate is evaluated inside a correlated `EXISTS`, and the
whole compiled predicate rides along inside it — so the parent subquery sits one level
deeper than the query it means to correlate to. Re-rendered there, `spans` reappears in
its own `FROM` as an unconstrained cross join:

```sql
-- before
WHERE NOT (EXISTS (SELECT 1 FROM spans AS spans_1, spans
                   WHERE spans_1.span_id = spans.parent_id))
--                                  ^^^^^ cross join

-- after
WHERE NOT (EXISTS (SELECT 1 FROM spans AS spans_1
                   WHERE spans_1.span_id = spans.parent_id))
```

The test then asks "does any span anywhere have a parent" rather than "does *this* one" —
a constant for a given project. That constant is `true` for any non-empty project, so the
`is None` form matched nothing and the `is not None` form matched everything.

## Fix

Name the correlation explicitly with `.correlate(models.Span)` instead of inferring it.
Three lines of source; the rest of the diff is the comment and the regression test.

The standalone `parent_span is None` form emits byte-identical SQL before and after.

## Testing

`tests/unit/trace/dsl/test_filter.py::test_parent_root_predicate_reads_this_span_beside_an_annotation`
asserts on rows, not SQL, since both shapes compile and execute cleanly. Reverting the
one-line fix fails both parametrizations: the `is not None` case returns `['A','B','C','D']`
against an expected `['B','D']`.

Full `tests/unit/trace/dsl/` suite: 817 passed, 220 skipped.

## Notes

Found while auditing correlation defects in `SpanFilter.__call__`. Pre-existing on `main`
and independent of any in-flight work — verified by reproducing it on a clean checkout of
the merge base. No issue was filed for it.
