### PR TITLE
chore(deps): bump uv to 0.12.5 to match Dependabot

### DIFF
--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
 
       - name: Install PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/cost-sync.yml
+++ b/.github/workflows/cost-sync.yml
@@ -23,7 +23,7 @@ jobs:
       
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Sync model cost manifest with LiteLLM

--- a/.github/workflows/harbor-evals.yml
+++ b/.github/workflows/harbor-evals.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      UV_VERSION: "0.12.1"
+      UV_VERSION: "0.12.5"
       HARBOR_ENV: daytona
       # Two attempts, gated on the mean: a one-off agent slip passes while a
       # consistent regression still fails.

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
           python-version: "3.14"
 
       - name: Run Helm chart tests

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -97,7 +97,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install dependencies
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
         run: uv sync --extra container

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -110,7 +110,7 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Build distribution
         run: rm -rf dist && uv build
       - name: Verify bundled UI assets in wheel
@@ -219,7 +219,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uv build
         if: steps.check.outputs.needed == 'true'
         working-directory: ${{ matrix.path }}
@@ -544,7 +544,7 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
-          version: "0.12.1"
+          version: "0.12.5"
           enable-cache: false
       - name: Stamp dev version
         env:
@@ -616,7 +616,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.12.1"
+          version: "0.12.5"
           enable-cache: false
       - name: Stamp dev version
         if: steps.check.outputs.needed == 'true'

--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Check Phoenix connectivity

--- a/.github/workflows/pxi-online-evals.yml
+++ b/.github/workflows/pxi-online-evals.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --frozen

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -39,7 +39,7 @@ jobs:
             verify_latest: false
     env:
       PYTHON_VERSION: "3.12"
-      UV_VERSION: "0.12.1"
+      UV_VERSION: "0.12.5"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PHOENIX_HOST: "127.0.0.1"
       PHOENIX_PORT: "6606"

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -132,7 +132,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals:
@@ -156,7 +156,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
@@ -179,7 +179,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   test-json-canonicalization-schema:
@@ -215,7 +215,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install make (Windows)
         if: runner.os == 'Windows'
         run: choco install make --no-progress -y
@@ -249,7 +249,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Clean Jupyter notebooks
         run: make clean-notebooks
       - run: git diff --exit-code
@@ -275,7 +275,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Build GraphQL schema
         run: make schema-graphql
       - run: git diff --exit-code
@@ -308,7 +308,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Check UI filter DSL snippets against the Python filters
         run: make check-filter-dsl-snippets
 
@@ -333,7 +333,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Run doctests
         run: make doctest
 
@@ -358,7 +358,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Build OpenAPI schema
         run: make schema-openapi
       - run: git diff --exit-code
@@ -384,7 +384,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Create virtual environment
         # `make schema-ddl` installs its dependencies with `uv pip install`,
         # which requires an existing environment.
@@ -414,7 +414,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Compile Prompts
         run: make codegen-prompts
       - name: Check for changes
@@ -442,7 +442,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Check lockfile is up to date
         run: uv lock --check
 
@@ -466,7 +466,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Run formatter and linter
         run: |
           make format-python
@@ -503,7 +503,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Type check all Python code
@@ -542,7 +542,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql'
         # The floor version from the PGDG repository, not whatever the
@@ -616,7 +616,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 16
@@ -655,7 +655,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install arize-phoenix and database dependencies
         run: |
           uv pip install --system -qU 'arize-phoenix[pg]'
@@ -728,7 +728,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Run canary tests for ${{ matrix.pkg }}
         run: uvx tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
 

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql' && runner.os == 'Linux'
         # Floor version from PGDG; see the note in python-CI.yml. The macOS
@@ -184,7 +184,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
@@ -213,7 +213,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals-non-linux:
@@ -239,7 +239,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel-non-linux:
@@ -265,7 +265,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   slack-notification:

--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.12.1"
+          version: "0.12.5"
           enable-cache: false
 
       - name: Update lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG BASE_IMAGE=gcr.io/distroless/python3-debian13:nonroot
 # Two stages build on this image, so it is pinned once: they must resolve to
 # the same digest or the build pulls twice. Keep the uv version equal to
 # [tool.uv] required-version in pyproject.toml.
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.12.1-python3.13-trixie-slim
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.12.5-python3.13-trixie-slim
 
 # This Dockerfile is a multi-stage build. The first stage builds the frontend.
 FROM node:22-slim AS frontend-builder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,7 +445,7 @@ line-ending = "native"
 script_location = "src/phoenix/db/migrations"  # enables `uv run alembic <command>`
 
 [tool.uv]
-required-version = "==0.12.1"  # When updating this version, also update ARG UV_IMAGE in the Dockerfile
+required-version = "==0.12.5"  # When updating this version, also update ARG UV_IMAGE in the Dockerfile
 exclude-newer = "3 days"
 # Exempt our own packages from the `exclude-newer` window so freshly published
 # versions are immediately resolvable. arize-phoenix-sqlean is not a workspace

--- a/scripts/docker/devops/Dockerfile
+++ b/scripts/docker/devops/Dockerfile
@@ -24,7 +24,7 @@ FROM python:${PYTHON_VERSION}-slim-bullseye AS backend-builder
 WORKDIR /phoenix
 
 # Install uv - pin version to match pyproject.toml [tool.uv] required-version
-RUN pip install uv==0.12.1
+RUN pip install uv==0.12.5
 
 # Copy dependency files first for better layer caching
 COPY ./pyproject.toml ./uv.lock ./LICENSE ./IP_NOTICE ./README.md ./


### PR DESCRIPTION
## Summary

Bumps the pinned `uv` CLI version across the repo from `0.12.1` to `0.12.5`, matching the version supported by Dependabot's [uv Dockerfile](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile).

- Updated `version:` inputs for all `astral-sh/setup-uv` steps and `UV_VERSION` env vars in `.github/workflows/*.yml`
- Updated `ARG UV_IMAGE` in `Dockerfile`
- Updated `[tool.uv] required-version` in `pyproject.toml`
- Updated `pip install uv==` pin in `scripts/docker/devops/Dockerfile`
- Ran `uv lock` to regenerate the lockfile (no dependency resolution changes)

This PR was generated automatically by `.github/workflows/check-dependabot-uv-version.yml`.
