### PR TITLE
ci: scope test dependency upgrades to all-platform tests

### DIFF
--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: discover-branches
     if: ${{ needs.discover-branches.outputs.branches != '[]' }}
+    env:
+      PHOENIX_UPGRADE_TEST_DEPENDENCIES: "-U"
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +152,7 @@ jobs:
             db: postgresql
     env:
       CI_TEST_DB_BACKEND: ${{ matrix.db }}
+      PHOENIX_UPGRADE_TEST_DEPENDENCIES: "-U"
     services:
       postgres:
         # Applying this workaround: https://github.com/actions/runner/issues/822

--- a/tox.ini
+++ b/tox.ini
@@ -132,7 +132,7 @@ changedir = tests/integration
 setenv =
   PHOENIX_MASK_INTERNAL_SERVER_ERRORS = false
 commands_pre =
-  uv pip install --strict -U -r {toxinidir}/requirements/integration-tests.txt
+  uv pip install --strict {env:PHOENIX_UPGRADE_TEST_DEPENDENCIES:} -r {toxinidir}/requirements/integration-tests.txt
   uv pip install --strict --reinstall-package arize-phoenix-evals {toxinidir}/packages/phoenix-evals
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
   python -c "import sysconfig, re, pathlib; vf=pathlib.Path(sysconfig.get_path('purelib'))/'phoenix'/'version.py'; m=re.search(r'\"(\d+)\.',vf.read_text()); vf.write_text(f'__version__ = \"{int(m.group(1))+1}.0.0\"\n')"  # Return the next major version in response headers so all client methods work; otherwise, some may be version-gated. Avoids importing phoenix (which triggers heavy deps like pandas/numpy).
@@ -147,7 +147,7 @@ changedir = tests
 setenv =
   PHOENIX_MASK_INTERNAL_SERVER_ERRORS = false
 commands_pre =
-  uv pip install --strict -U -r {toxinidir}/requirements/unit-tests.txt
+  uv pip install --strict {env:PHOENIX_UPGRADE_TEST_DEPENDENCIES:} -r {toxinidir}/requirements/unit-tests.txt
   uv pip install --strict --reinstall-package arize-phoenix-evals {toxinidir}/packages/phoenix-evals
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
 commands =


### PR DESCRIPTION
## Summary

- make dependency upgrades opt-in for unit and integration tox environments
- enable upgrades in the all-platform test workflow
- leave the primary Python CI workflow on its installed dependency versions

## Validation

- verified tox command expansion with the toggle unset and set
- parsed both workflow YAML files
- ran git diff --check