### PR TITLE
fix(frontend): expand users card to page height

### DIFF
--- a/js/app/src/pages/settings/UsersCard.tsx
+++ b/js/app/src/pages/settings/UsersCard.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { Suspense, useMemo, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
@@ -18,6 +19,20 @@ import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtil
 import type { UsersCardQuery } from "./__generated__/UsersCardQuery.graphql";
 import { NewUserDialog } from "./NewUserDialog";
 import { UsersTable } from "./UsersTable";
+
+const usersCardContainerCSS = css`
+  height: 100%;
+
+  & > .card {
+    max-height: 100%;
+  }
+
+  & .card__body {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+`;
 
 export function UsersCard() {
   const [fetchKey, setFetchKey] = useState(0);
@@ -52,57 +67,59 @@ export function UsersCard() {
   );
 
   return (
-    <Card
-      title="Users"
-      titleExtra={
-        <DocumentationHelp topic="userAccess">
-          Add users and manage access to this Phoenix instance.
-        </DocumentationHelp>
-      }
-      extra={
-        <Button
-          onPress={() => {
-            setDialog(
-              <NewUserDialog
-                onDismiss={() => {
-                  setDialog(null);
-                }}
-                onNewUserCreated={(username) => {
-                  setDialog(null);
-                  notifySuccess({
-                    title: "User added",
-                    message: `User ${username} has been added.`,
-                  });
-                  setFetchKey((prev) => prev + 1);
-                }}
-                onNewUserCreationError={(error) => {
-                  const formattedError =
-                    getErrorMessagesFromRelayMutationError(error);
-                  setError(formattedError?.[0] ?? error.message);
-                }}
-              />
-            );
-          }}
-          size="S"
-          variant="primary"
-          leadingVisual={<Icon svg={<Icons.Plus />} />}
-          isDisabled={isDisabled}
-        >
-          Add User
-        </Button>
-      }
-    >
-      {error && <Alert variant="danger">{error}</Alert>}
-      <Suspense
-        fallback={
-          <View padding="size-200">
-            <Loading />
-          </View>
+    <div css={usersCardContainerCSS}>
+      <Card
+        title="Users"
+        titleExtra={
+          <DocumentationHelp topic="userAccess">
+            Add users and manage access to this Phoenix instance.
+          </DocumentationHelp>
+        }
+        extra={
+          <Button
+            onPress={() => {
+              setDialog(
+                <NewUserDialog
+                  onDismiss={() => {
+                    setDialog(null);
+                  }}
+                  onNewUserCreated={(username) => {
+                    setDialog(null);
+                    notifySuccess({
+                      title: "User added",
+                      message: `User ${username} has been added.`,
+                    });
+                    setFetchKey((prev) => prev + 1);
+                  }}
+                  onNewUserCreationError={(error) => {
+                    const formattedError =
+                      getErrorMessagesFromRelayMutationError(error);
+                    setError(formattedError?.[0] ?? error.message);
+                  }}
+                />
+              );
+            }}
+            size="S"
+            variant="primary"
+            leadingVisual={<Icon svg={<Icons.Plus />} />}
+            isDisabled={isDisabled}
+          >
+            Add User
+          </Button>
         }
       >
-        <UsersTable query={data} />
-      </Suspense>
-      {dialog}
-    </Card>
+        {error && <Alert variant="danger">{error}</Alert>}
+        <Suspense
+          fallback={
+            <View padding="size-200">
+              <Loading />
+            </View>
+          }
+        >
+          <UsersTable query={data} />
+        </Suspense>
+        {dialog}
+      </Card>
+    </div>
   );
 }

--- a/js/app/src/pages/settings/UsersTable.tsx
+++ b/js/app/src/pages/settings/UsersTable.tsx
@@ -72,6 +72,8 @@ const userTableRowCSS = css`
  * Container for the users table with scrolling
  */
 const usersTableContainerCSS = css`
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
 `;
 


### PR DESCRIPTION
## Summary
- cap the Users card at the available settings page height
- let the users table fill the remaining card body before scrolling
- preserve the sticky table header while avoiding a small nested viewport

## Screenshots
Users card filling the available settings page height. User identities are redacted.

![Users card filling the available page height](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15716-users-card-full-height-redacted.png)

Detail of the table scrollbar terminating at the card bottom.

![Users table scroll boundary at the card bottom](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15716-users-card-scroll-boundary-redacted.png)

## Test plan
- `make format-frontend`
- `make lint-frontend`
- `make typecheck-frontend`
- `make build-frontend`
- visually verified at 1937x1280 and 1280x720 viewports