### PR TITLE
fix: contain retention policy loading state in drawer

### DIFF
--- a/js/app/src/pages/settings/RetentionPolicyDetailsDrawer.tsx
+++ b/js/app/src/pages/settings/RetentionPolicyDetailsDrawer.tsx
@@ -4,7 +4,15 @@ import { graphql, useLazyLoadQuery } from "react-relay";
 import { useNavigate, useParams } from "react-router";
 import invariant from "tiny-invariant";
 
-import { Dialog, Drawer, Flex, Loading, Text, View } from "@phoenix/components";
+import {
+  Dialog,
+  Drawer,
+  Flex,
+  Skeleton,
+  Text,
+  View,
+  VisuallyHidden,
+} from "@phoenix/components";
 import {
   DialogCloseButton,
   DialogContent,
@@ -44,6 +52,31 @@ const policyDetailsGridCSS = css`
 const policyDetailsValueCSS = css`
   margin-top: var(--global-dimension-size-50);
 `;
+
+function RetentionPolicyDetailsFallback() {
+  return (
+    <DialogContent>
+      <VisuallyHidden role="status">
+        Loading retention policy details
+      </VisuallyHidden>
+      <DialogHeader>
+        <Flex direction="row" gap="size-200" alignItems="center">
+          <DialogCloseButton slot="close" />
+          <Skeleton width={200} height={24} animation="wave" />
+        </Flex>
+      </DialogHeader>
+      <View padding="size-200">
+        <Flex direction="column" gap="size-200">
+          <Flex direction="row" gap="size-100">
+            <Skeleton height={60} animation="wave" />
+            <Skeleton height={60} animation="wave" />
+          </Flex>
+          <Skeleton height={200} animation="wave" />
+        </Flex>
+      </View>
+    </DialogContent>
+  );
+}
 
 function RetentionPolicyDetailsContent({ policyId }: { policyId: string }) {
   const navigate = useNavigate();
@@ -96,67 +129,65 @@ function RetentionPolicyDetailsContent({ policyId }: { policyId: string }) {
   const isDefaultPolicy = policy.name === DEFAULT_RETENTION_POLICY_NAME;
 
   return (
-    <Dialog aria-label={`Retention policy details for ${policy.name}`}>
-      <DialogContent>
-        <DialogHeader>
-          <Flex direction="row" gap="size-200" alignItems="center">
-            <DialogCloseButton slot="close" />
-            <DialogTitle>{`Policy: ${policy.name}`}</DialogTitle>
-          </Flex>
-          <DialogTitleExtra>
-            {canManageRetentionPolicy && (
-              <RetentionPolicyActionMenu
-                policyId={policy.id}
-                policyName={policy.name}
-                projectNames={projects.map((project) => project.name)}
-                onPolicyDelete={() => navigate("/settings/data")}
-              />
-            )}
-          </DialogTitleExtra>
-        </DialogHeader>
-        <div css={policyDetailsBodyCSS}>
-          <View padding="size-200">
-            <Flex direction="column" gap="size-200">
-              {isDefaultPolicy && (
-                <Text size="S" color="text-700">
-                  Projects without an explicitly assigned policy automatically
-                  use this default policy.
-                </Text>
-              )}
-              <ul css={policyDetailsGridCSS}>
-                <li>
-                  <Text size="XS" color="text-700">
-                    Schedule
-                  </Text>
-                  <div css={policyDetailsValueCSS}>
-                    <Text>
-                      {createPolicyScheduleSummaryText({
-                        schedule: policy.cronExpression,
-                      })}
-                    </Text>
-                  </div>
-                </li>
-                <li>
-                  <Text size="XS" color="text-700">
-                    Rule
-                  </Text>
-                  <div css={policyDetailsValueCSS}>
-                    <Text>{createPolicyRuleSummaryText(policy.rule)}</Text>
-                  </div>
-                </li>
-              </ul>
-            </Flex>
-          </View>
-          <View paddingX="size-200" paddingBottom="size-200">
-            <RetentionPolicyProjects
+    <DialogContent>
+      <DialogHeader>
+        <Flex direction="row" gap="size-200" alignItems="center">
+          <DialogCloseButton slot="close" />
+          <DialogTitle>{`Policy: ${policy.name}`}</DialogTitle>
+        </Flex>
+        <DialogTitleExtra>
+          {canManageRetentionPolicy && (
+            <RetentionPolicyActionMenu
               policyId={policy.id}
-              projects={projects}
-              canManage={canManageRetentionPolicy && !isDefaultPolicy}
+              policyName={policy.name}
+              projectNames={projects.map((project) => project.name)}
+              onPolicyDelete={() => navigate("/settings/data")}
             />
-          </View>
-        </div>
-      </DialogContent>
-    </Dialog>
+          )}
+        </DialogTitleExtra>
+      </DialogHeader>
+      <div css={policyDetailsBodyCSS}>
+        <View padding="size-200">
+          <Flex direction="column" gap="size-200">
+            {isDefaultPolicy && (
+              <Text size="S" color="text-700">
+                Projects without an explicitly assigned policy automatically use
+                this default policy.
+              </Text>
+            )}
+            <ul css={policyDetailsGridCSS}>
+              <li>
+                <Text size="XS" color="text-700">
+                  Schedule
+                </Text>
+                <div css={policyDetailsValueCSS}>
+                  <Text>
+                    {createPolicyScheduleSummaryText({
+                      schedule: policy.cronExpression,
+                    })}
+                  </Text>
+                </div>
+              </li>
+              <li>
+                <Text size="XS" color="text-700">
+                  Rule
+                </Text>
+                <div css={policyDetailsValueCSS}>
+                  <Text>{createPolicyRuleSummaryText(policy.rule)}</Text>
+                </div>
+              </li>
+            </ul>
+          </Flex>
+        </View>
+        <View paddingX="size-200" paddingBottom="size-200">
+          <RetentionPolicyProjects
+            policyId={policy.id}
+            projects={projects}
+            canManage={canManageRetentionPolicy && !isDefaultPolicy}
+          />
+        </View>
+      </div>
+    </DialogContent>
   );
 }
 
@@ -176,15 +207,11 @@ export function RetentionPolicyDetailsDrawer() {
       minSize={DRAWER_DEFAULT_MIN_SIZE}
       onResize={onSizeChange}
     >
-      <Suspense
-        fallback={
-          <View padding="size-400">
-            <Loading />
-          </View>
-        }
-      >
-        <RetentionPolicyDetailsContent policyId={policyId} />
-      </Suspense>
+      <Dialog aria-label="Retention policy details">
+        <Suspense fallback={<RetentionPolicyDetailsFallback />}>
+          <RetentionPolicyDetailsContent policyId={policyId} />
+        </Suspense>
+      </Dialog>
     </Drawer>
   );
 }

--- a/js/app/src/pages/settings/__tests__/RetentionPolicyDetailsDrawer.test.tsx
+++ b/js/app/src/pages/settings/__tests__/RetentionPolicyDetailsDrawer.test.tsx
@@ -1,0 +1,63 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type * as ReactRelay from "react-relay";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installTestMatchMedia } from "@phoenix/__tests__/installTestMatchMedia";
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+
+import { RetentionPolicyDetailsDrawer } from "../RetentionPolicyDetailsDrawer";
+
+vi.mock("react-relay", async (importOriginal) => {
+  const reactRelay = await importOriginal<typeof ReactRelay>();
+  return {
+    ...reactRelay,
+    useLazyLoadQuery: () => {
+      throw new Promise(() => {});
+    },
+  };
+});
+
+installTestMatchMedia();
+installTestStorage();
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("RetentionPolicyDetailsDrawer", () => {
+  it("renders its suspense fallback inside the drawer dialog", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/settings/data/policies/policy-1"]}>
+          <Routes>
+            <Route
+              path="/settings/data/policies/:policyId"
+              element={<RetentionPolicyDetailsDrawer />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+    });
+
+    const drawer = document.querySelector(".drawer");
+    const dialog = drawer?.querySelector("[data-testid='dialog']");
+
+    expect(dialog).not.toBeNull();
+    expect(dialog?.querySelector(".skeleton")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- keep the retention policy dialog mounted outside the suspending query
- render an accessible skeleton fallback within the drawer surface
- add regression coverage for the suspended loading state

## Screenshots

Suspended query state — the loading skeleton is contained within the drawer:

![Retention policy drawer loading state](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15717-retention-policy-drawer-loading.png)

Resolved retention policy details:

![Retention policy drawer loaded state](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15717-retention-policy-drawer-loaded.png)

## Testing
- make typecheck-frontend
- make lint-frontend
- make test-frontend (2334 passed, 12 skipped)