### PR TITLE
chore(js): upgrade pnpm to 12.0.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ uv sync --all-extras
 
 # 2. Install the pinned Node.js and pnpm versions
 nvm install
-npm i -g pnpm@11.11.0
+npm i -g pnpm@12.0.0
 
 # 3. Install the JavaScript workspace and build the web app
 cd js
@@ -92,7 +92,7 @@ nvm install
 # set it as default (optional)
 nvm alias default <version-that-was-installed>
 # install pnpm globally
-npm i -g pnpm@11.11.0
+npm i -g pnpm@12.0.0
 ```
 
 Then install the JavaScript workspace from its root and build the web app:

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ check-tools: ## Verify required tools are installed
 	@echo -e "$(CYAN)Checking required tools...$(NC)"
 	@command -v $(UV) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: uv is not installed. Install from https://github.com/astral-sh/uv$(NC)"; exit 1; }
 	@echo -e "$(GREEN)✓$(NC) uv found: $$($(UV) --version)"
-	@command -v $(PNPM) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: pnpm is not installed. Run: npm install -g pnpm$(NC)"; exit 1; }
+	@command -v $(PNPM) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: pnpm is not installed. Run: npm install -g pnpm@12.0.0$(NC)"; exit 1; }
 	@echo -e "$(GREEN)✓$(NC) pnpm found: $$($(PNPM) --version)"
 	@command -v $(TOX) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: tox is not installed. Run: pip install tox$(NC)"; exit 1; }
 	@echo -e "$(GREEN)✓$(NC) tox found: $$($(TOX) --version)"

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ check-tools: ## Verify required tools are installed
 	@echo -e "$(CYAN)Checking required tools...$(NC)"
 	@command -v $(UV) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: uv is not installed. Install from https://github.com/astral-sh/uv$(NC)"; exit 1; }
 	@echo -e "$(GREEN)✓$(NC) uv found: $$($(UV) --version)"
-	@command -v $(PNPM) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: pnpm is not installed. Run: npm install -g pnpm@12.0.0$(NC)"; exit 1; }
+	@command -v $(PNPM) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: pnpm is not installed. Run: npm install -g pnpm$(NC)"; exit 1; }
 	@echo -e "$(GREEN)✓$(NC) pnpm found: $$($(PNPM) --version)"
 	@command -v $(TOX) >/dev/null 2>&1 || { echo -e "$(RED)ERROR: tox is not installed. Run: pip install tox$(NC)"; exit 1; }
 	@echo -e "$(GREEN)✓$(NC) tox found: $$($(TOX) --version)"

--- a/js/DEVELOPMENT.md
+++ b/js/DEVELOPMENT.md
@@ -38,7 +38,7 @@ This repository is managed as a monorepo using [pnpm workspaces](https://pnpm.io
 ### 1. Install pnpm (if you don't have it)
 
 ```sh
-npm install -g pnpm
+npm install -g pnpm@12.0.0
 ```
 
 ### 2. Install all dependencies for all packages

--- a/js/examples/apps/mastra-quickstart/package.json
+++ b/js/examples/apps/mastra-quickstart/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "scripts": {
     "add_traces": "tsx src/mastra/evals/add_traces.ts",
-    "build": "echo 'mastra build skipped: @mastra/deployer@1.31.0 incompatible with pnpm 11 install-script approval — run `mastra build` directly with --config.dangerouslyAllowAllBuilds when needed' && exit 0",
+    "build": "echo 'mastra build skipped: @mastra/deployer@1.31.0 incompatible with pnpm install-script approval — run `mastra build` directly with --config.dangerouslyAllowAllBuilds when needed' && exit 0",
     "dev": "pnpx mastra dev",
     "evals": "tsx src/mastra/evals/evals.ts",
     "experiments": "tsx src/mastra/experiments/experiment.ts",

--- a/js/package.json
+++ b/js/package.json
@@ -52,5 +52,5 @@
     "node": ">=10",
     "pnpm": ">=3"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -4,8 +4,6 @@ packages:
   - examples/apps/*
   - benchmarks/*
 
-managePackageManagerVersions: true
-
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - "@arizeai/*"

--- a/scripts/docker/devops/oidc-server/frontend/package.json
+++ b/scripts/docker/devops/oidc-server/frontend/package.json
@@ -30,5 +30,5 @@
     "typescript": "^7.0.2",
     "vite": "^8.1.4"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/scripts/docker/devops/oidc-server/package.json
+++ b/scripts/docker/devops/oidc-server/package.json
@@ -38,5 +38,5 @@
     "tsx": "^4.23.0",
     "typescript": "^7.0.2"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/scripts/docker/devops/smtp-server/Dockerfile
+++ b/scripts/docker/devops/smtp-server/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:22-slim AS builder
 
 # Install pnpm globally
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@12.0.0 --activate
 
 # Set working directory
 WORKDIR /app

--- a/scripts/docker/devops/smtp-server/package.json
+++ b/scripts/docker/devops/smtp-server/package.json
@@ -42,5 +42,5 @@
     "tsx": "^4.23.0",
     "typescript": "^7.0.2"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/scripts/docker/devops/vite-dev/Dockerfile
+++ b/scripts/docker/devops/vite-dev/Dockerfile
@@ -5,7 +5,7 @@ FROM node:22-slim
 
 WORKDIR /phoenix/js/app
 
-# Skip pnpm 11's auto deps-status check before every script run. The CMD
+# Skip pnpm's auto deps-status check before every script run. The CMD
 # invokes `pnpm run` / `pnpm exec`, which would otherwise re-run
 # `pnpm install --production` on every container start — wasted work in a
 # dev container where node_modules is already populated at build time

--- a/scripts/gh-comment-watch/package.json
+++ b/scripts/gh-comment-watch/package.json
@@ -37,5 +37,5 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/scripts/gh-comment-watch/web/package.json
+++ b/scripts/gh-comment-watch/web/package.json
@@ -30,5 +30,5 @@
     "typescript": "~7.0.2",
     "vite": "^8.1.4"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/scripts/mock-llm-server/dashboard/package.json
+++ b/scripts/mock-llm-server/dashboard/package.json
@@ -32,5 +32,5 @@
     "typescript": "~7.0.2",
     "vite": "^8.1.4"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }

--- a/scripts/mock-llm-server/package.json
+++ b/scripts/mock-llm-server/package.json
@@ -39,5 +39,5 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@12.0.0"
 }


### PR DESCRIPTION
## Summary

- upgrade active pnpm package manager pins to 12.0.0
- migrate the workspace lockfile to pnpm 12 package-manager dependencies
- remove the obsolete `managePackageManagerVersions` setting
- update development and Docker installation guidance

## Testing

- `corepack pnpm@12.0.0 --dir js install --frozen-lockfile`
- `make PNPM="corepack pnpm@12.0.0" lint-ts`
- `make PNPM="corepack pnpm@12.0.0" typecheck-ts`
- `corepack pnpm@12.0.0 --dir js -r build`
- `corepack pnpm@12.0.0 --dir js -r test`
- `corepack pnpm@12.0.0 --dir js run fmt:check`