### PR TITLE
fix(ui): truncate long annotation names in experiment comparisons

### DIFF
--- a/js/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/js/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -58,6 +58,7 @@ import {
   TriggerWrap,
 } from "@phoenix/components/core/tooltip";
 import { LineClamp } from "@phoenix/components/core/utility/LineClamp";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { useExperimentColors } from "@phoenix/components/experiment";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import type { ExperimentCompareListPageQuery } from "@phoenix/pages/experiment/__generated__/ExperimentCompareListPageQuery.graphql";
@@ -937,25 +938,35 @@ export function ExperimentCompareListPage({
             ) => {
               return (
                 <Flex direction="column" gap="size-100">
-                  <Flex direction="row" gap="size-100" alignItems="center">
+                  <Flex
+                    direction="row"
+                    gap="size-100"
+                    alignItems="center"
+                    minWidth={0}
+                  >
                     <AnnotationColorSwatch
                       annotationName={annotationSummary.annotationName}
                     />
                     <div
+                      css={css`
+                        flex: 1 1 auto;
+                        min-width: 0;
+                      `}
                       {...{
                         className: headerContext.column.getCanSort()
                           ? "sort"
                           : "",
                         onClick: headerContext.column.getToggleSortingHandler(),
-                        style: {
-                          left: headerContext.column.getStart(),
-                          width: headerContext.column.getSize(),
-                        },
                       }}
                     >
-                      <Text size="S" weight="heavy">
-                        {annotationSummary.annotationName}
-                      </Text>
+                      <Truncate
+                        maxWidth="100%"
+                        title={annotationSummary.annotationName}
+                      >
+                        <Text size="S" weight="heavy">
+                          {annotationSummary.annotationName}
+                        </Text>
+                      </Truncate>
                       {headerContext.column.getIsSorted() ? (
                         <Icon
                           className="sort-icon"


### PR DESCRIPTION
## Summary

- Prevent long annotation names from overflowing into adjacent headers in the experiment comparison list view.
- Let sortable annotation labels shrink within their fixed-width columns while keeping the color swatch and sort indicator visible.
- Truncate overflowing names with the shared `Truncate` component and preserve the full annotation name in a tooltip.

## Screenshots

### Before

![Long annotation names overflowing into adjacent headers](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15722-experiment-compare-annotation-overflow-before.png)

### After

![Long annotation names truncated within their headers](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15722-experiment-compare-annotation-overflow-after.png)
