### PR TITLE
docs: add Arize AX callout to the top-level Phoenix overview page

### DIFF
--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -10,12 +10,10 @@ Phoenix helps you understand and improve AI applications by giving you a workflo
 Phoenix is built by [Arize AI](https://www.arize.com) and the open-source community. It is built on top of OpenTelemetry and is powered by [OpenInference](https://github.com/Arize-ai/openinference) instrumentation. See [Integrations](/docs/phoenix/integrations) for details.
 
 <Info>
-  **Prefer a managed platform?** Phoenix is open source and self-hosted. Arize
-  also offers [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix),
-  a managed, enterprise-grade platform built on the same open standards — the
-  same instrumentation works with both. To learn how the two platforms compare
-  and which fits your team, see
-  [Arize Phoenix or Arize AX](/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize).
+  Arize also offers [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix),
+  a managed, enterprise-grade platform. See
+  [Arize Phoenix or Arize AX](/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize)
+  for how the two compare.
 </Info>
 
 ## Features
@@ -142,5 +140,8 @@ The best next step is to start using Phoenix. Start with a quickstart to send da
   </Card>
   <Card title="Community" icon="users" href="https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g">
     Join the Phoenix Slack to ask questions and connect with developers
+  </Card>
+  <Card title="Arize Phoenix or Arize AX" icon="circle-question" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize">
+    How the open-source and managed platforms differ and how to choose
   </Card>
 </CardGroup>

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -9,6 +9,8 @@ Phoenix helps you understand and improve AI applications by giving you a workflo
 
 Phoenix is built by [Arize AI](https://www.arize.com) and the open-source community. It is built on top of OpenTelemetry and is powered by [OpenInference](https://github.com/Arize-ai/openinference) instrumentation. See [Integrations](/docs/phoenix/integrations) for details.
 
+In addition to Phoenix, Arize offers Arize AX, a managed enterprise platform built on the same open standards. Learn more about Arize AX and how the two platforms compare:
+
 <CardGroup cols={2}>
   <Card title="Arize AX" icon="cloud" href="https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix" horizontal arrow>
     A managed enterprise platform from Arize

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -11,7 +11,7 @@ Phoenix is built by [Arize AI](https://www.arize.com) and the open-source commun
 
 <Info>
   Arize also offers [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix),
-  a managed, enterprise-grade platform. See
+  a managed enterprise platform. See
   [Arize Phoenix or Arize AX](/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize)
   for how the two compare.
 </Info>

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -9,6 +9,15 @@ Phoenix helps you understand and improve AI applications by giving you a workflo
 
 Phoenix is built by [Arize AI](https://www.arize.com) and the open-source community. It is built on top of OpenTelemetry and is powered by [OpenInference](https://github.com/Arize-ai/openinference) instrumentation. See [Integrations](/docs/phoenix/integrations) for details.
 
+<Info>
+  **Prefer a managed platform?** Phoenix is open source and self-hosted. Arize
+  also offers [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix),
+  a managed, enterprise-grade platform built on the same open standards — the
+  same instrumentation works with both. To learn how the two platforms compare
+  and which fits your team, see
+  [Arize Phoenix or Arize AX](/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize).
+</Info>
+
 ## Features
 
 <Tabs>

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -9,6 +9,10 @@ Phoenix helps you understand and improve AI applications by giving you a workflo
 
 Phoenix is built by [Arize AI](https://www.arize.com) and the open-source community. It is built on top of OpenTelemetry and is powered by [OpenInference](https://github.com/Arize-ai/openinference) instrumentation. See [Integrations](/docs/phoenix/integrations) for details.
 
+<Card title="Looking for a managed platform? Meet Arize AX" icon="building" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize" horizontal>
+  Arize also offers Arize AX, a managed enterprise platform. See how Phoenix and Arize AX compare and which fits your team.
+</Card>
+
 ## Features
 
 <Tabs>

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -9,13 +9,6 @@ Phoenix helps you understand and improve AI applications by giving you a workflo
 
 Phoenix is built by [Arize AI](https://www.arize.com) and the open-source community. It is built on top of OpenTelemetry and is powered by [OpenInference](https://github.com/Arize-ai/openinference) instrumentation. See [Integrations](/docs/phoenix/integrations) for details.
 
-<Info>
-  Arize also offers [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix),
-  a managed enterprise platform. See
-  [Arize Phoenix or Arize AX](/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize)
-  for how the two compare.
-</Info>
-
 ## Features
 
 <Tabs>

--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -9,9 +9,14 @@ Phoenix helps you understand and improve AI applications by giving you a workflo
 
 Phoenix is built by [Arize AI](https://www.arize.com) and the open-source community. It is built on top of OpenTelemetry and is powered by [OpenInference](https://github.com/Arize-ai/openinference) instrumentation. See [Integrations](/docs/phoenix/integrations) for details.
 
-<Card title="Looking for a managed platform? Meet Arize AX" icon="building" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize" horizontal>
-  Arize also offers Arize AX, a managed enterprise platform. See how Phoenix and Arize AX compare and which fits your team.
-</Card>
+<CardGroup cols={2}>
+  <Card title="Arize AX" icon="cloud" href="https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=phoenix" horizontal arrow>
+    A managed enterprise platform from Arize
+  </Card>
+  <Card title="Arize Phoenix or Arize AX" icon="scale-balanced" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize" horizontal>
+    How the two platforms compare and how to choose
+  </Card>
+</CardGroup>
 
 ## Features
 


### PR DESCRIPTION
## Summary

Many users don't understand the relationship between Arize Phoenix and Arize AX. This adds a short, tactful callout to the top-level docs landing page (\`docs/phoenix.mdx\`), directly after the introductory section, noting that Arize also offers a managed, enterprise-grade platform in Arize AX.

The callout links to:
- The [Arize AX product page](https://arize.com/products/ax)
- The existing FAQ: [Arize Phoenix or Arize AX](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize)

The wording is deliberately neutral toward both platforms — it emphasizes the shared open standards and that the same instrumentation works with both, rather than positioning one above the other.