### PR TITLE
docs: remove supported stacks from agent-assisted setup

### DIFF
--- a/docs/phoenix/agent-assisted-setup.mdx
+++ b/docs/phoenix/agent-assisted-setup.mdx
@@ -8,10 +8,6 @@ import StartPhoenix from "../snippets/start-phoenix.mdx";
 
 The fastest way to add Phoenix tracing to your application. `px setup` hands the instrumentation to your coding agent and doesn't finish until a real trace arrives.
 
-<Info>
-**Supported stacks:** Python and TypeScript/JavaScript. See the [full integration list](/docs/phoenix/integrations) for the LLM providers and frameworks Phoenix instruments.
-</Info>
-
 <Steps>
   <Step title={<span className="step-title">Start Phoenix</span>}>
     `px setup` needs a running Phoenix. Already have a deployment? Skip to the next step.


### PR DESCRIPTION
## Summary

Removes the supported-stacks callout from the Agent-Assisted Setup page. Phoenix supports integrations across additional languages, including Go, and the setup instructions do not need to maintain a separate language inventory.