### PR TITLE
fix(ci): create git tags and GitHub releases for JS package publishes

### DIFF
--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -60,6 +60,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # `changeset publish` builds its own publish flags and never passes
+          # --provenance, so request it through npm config instead.
+          NPM_CONFIG_PROVENANCE: true
       # - name: Release docs
       # Run pnpm run docs in js/packages/phoenix-client
       # Deploy the static files in js/packages/phoenix-client/docs to github pages

--- a/js/.changeset/config.json
+++ b/js/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["phoenix-experiment-runner", "demo-document-relevancy-experiment"],

--- a/js/package.json
+++ b/js/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "pnpm run -r build",
-    "ci:publish": "pnpm --filter './packages/*' run -r build && pnpm publish -r --access public --provenance",
+    "ci:publish": "pnpm --filter './packages/*' run -r build && pnpm changeset publish",
     "ci:version": "pnpm changeset version",
     "clean": "pnpm run clean:node_modules",
     "clean:node_modules": "rimraf --glob '**/node_modules/**'",


### PR DESCRIPTION
## Problem

`createGithubReleases: true` in the TypeScript publish workflow has never done anything. No `@arizeai/*` package has ever been tagged or given a GitHub release — `git for-each-ref refs/tags` contains zero of them, and every tag in the repo comes from release-please.

The cause is that `ci:publish` used `pnpm publish -r` rather than `changeset publish`. `changesets/action` discovers what was published *only* by regex-scanning the publish script's stdout for `changeset publish`'s marker lines ([`src/run.ts:102`](https://github.com/changesets/action/blob/d183df40791e90508058cd180e6435cdd9ba16a4/src/run.ts#L102) at our pinned v1.5.2):

```js
let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
for (let line of changesetPublishOutput.stdout.split("\n")) { ... releasedPackages.push(pkg) }
if (createGithubReleases) {
  await Promise.all(releasedPackages.map(async (pkg) => {
    await git.pushTag(tagName); await createRelease(octokit, { pkg, tagName });
  }));
}
```

`pnpm publish` never prints `New tag:`, so `releasedPackages` stayed empty, the release loop iterated zero times, and the action reported `published: false`.

Confirmed on run [33192427434](https://github.com/Arize-ai/phoenix/actions/runs/33192427434) (the `chore(js): update versions` merge for #15704):

```
$ pnpm --filter './packages/*' run -r build && pnpm publish -r --access public --provenance
📦 @arizeai/phoenix-evals@2.4.0 → https://registry.npmjs.org/
✅ Published package @arizeai/phoenix-evals@2.4.0
Post job cleanup.
```

npm publish succeeded, then the job ended — no `New tag:`, no tag push, no release API call.

## Fix

Switch `ci:publish` to `changeset publish`, which tags each published package and emits the marker lines the action looks for. Two changes come along necessarily:

- **`access` must become `public`.** It was `restricted` in the changesets config but unused, because the old script passed `--access public` explicitly. `changeset publish` *does* honor the config value (`access: publishConfig?.access || access`), so leaving it would attempt restricted publishes.
- **Provenance has to move to npm config.** `changeset publish` builds its own publish flags and never passes `--provenance`, so `NPM_CONFIG_PROVENANCE: true` requests it instead. `id-token: write` is already set at job level.

## Verification

- Changesets parses the new config with no schema complaint; only the 6 `@arizeai/phoenix-{cli,client,config,evals,mcp,otel}` packages are non-private, so `changeset publish` targets exactly the right set. `app`, `examples/apps/*`, `benchmarks/*` and `phoenix-testing` are all private.
- `tool` resolves non-root, so tags are `@arizeai/phoenix-client@7.5.0`-style, matching the action's regex.
- `oxfmt --check` passes on both JSON files; `ci:publish` keeps its alphabetical slot under `experimentalSortPackageJson.sortScripts`.
- `ci:publish` has exactly one consumer. The experimental workflow uses `pkg-pr-new publish` and is untouched.
- release-please `exclude-paths` for the root component covers both `.github` and `js`, so this commit won't bump any Python package.
- No changeset file: this touches no publishable package, and no CI job enforces `changeset status`.

## Two things to know

**Provenance can't be verified before merge.** `changeset publish` has no `--dry-run` and provenance needs CI's OIDC, so the first release after this merges is the test. Check the npm page for the provenance badge; if it's missing, the fallback is `"publishConfig": { "provenance": true }` in each of the 6 package.json files, which npm reads directly. Worst case is one version shipping without an attestation.

**This does not backfill.** `changeset publish` only tags what it publishes in a given run, so the 6 packages' current versions stay untagged permanently. Tagging starts from the next release. Backfilling the existing versions would be a separate one-off.

Low blast radius on the publish step itself: `changeset publish` queries npm per package and skips versions already there, so a failure doesn't double-publish and a re-run finishes the job.
