### PR TITLE
feat(js): add deletePrompt helper to the TypeScript client

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts.mdx
@@ -64,10 +64,15 @@ Requires a Phoenix server on 19.18.0 or later.
 ```ts
 import { deletePrompt } from "@arizeai/phoenix-client/prompts";
 
-await deletePrompt({ promptIdentifier: "support-response" });
+await deletePrompt({ prompt: { name: "support-response" } });
+
+// Or by prompt id
+await deletePrompt({ prompt: { promptId: "UHJvbXB0OjE=" } });
 ```
 
-`promptIdentifier` is a prompt name or ID, the same selector `updatePrompt` takes. Deletion cascades: every version of the prompt, along with its version tags and labels, is removed with it, and the deletion cannot be undone. A prompt that does not exist rejects with `Prompt not found: <identifier>`.
+`prompt` takes the same selector style as `getPrompt`, narrowed to the two selectors that identify a prompt rather than one of its versions: `{ name }` and `{ promptId }`. Passing a version selector — `{ versionId }`, or `{ name, tag }` — rejects instead of falling back to the whole prompt, so a variable holding a version never deletes more than you named.
+
+Deletion cascades: every version of the prompt, along with its version tags and labels, is removed with it, and the deletion cannot be undone. A prompt that does not exist rejects with `Prompt not found: <identifier>`.
 
 Requires a Phoenix server on 13.20.0 or later.
 

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts.mdx
@@ -3,7 +3,7 @@ title: "Prompts"
 description: "Manage prompts with @arizeai/phoenix-client"
 ---
 
-The prompts module lets you create prompt versions in Phoenix, fetch them back by selector, list prompts, update a prompt's description and metadata, and adapt prompt versions to supported provider SDKs.
+The prompts module lets you create prompt versions in Phoenix, fetch them back by selector, list prompts, update a prompt's description and metadata, delete a prompt, and adapt prompt versions to supported provider SDKs.
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
@@ -59,6 +59,18 @@ await updatePrompt({
 
 Requires a Phoenix server on 19.18.0 or later.
 
+## Delete A Prompt
+
+```ts
+import { deletePrompt } from "@arizeai/phoenix-client/prompts";
+
+await deletePrompt({ promptIdentifier: "support-response" });
+```
+
+`promptIdentifier` is a prompt name or ID, the same selector `updatePrompt` takes. Deletion cascades: every version of the prompt, along with its version tags and labels, is removed with it, and the deletion cannot be undone. A prompt that does not exist rejects with `Prompt not found: <identifier>`.
+
+Requires a Phoenix server on 13.20.0 or later.
+
 ## Convert To Another SDK
 
 ```ts
@@ -81,6 +93,7 @@ Supported `sdk` targets:
   <h2>Source Map</h2>
   <ul>
     <li><code>src/prompts/createPrompt.ts</code></li>
+    <li><code>src/prompts/deletePrompt.ts</code></li>
     <li><code>src/prompts/getPrompt.ts</code></li>
     <li><code>src/prompts/listPrompts.ts</code></li>
     <li><code>src/prompts/updatePrompt.ts</code></li>

--- a/js/.changeset/delete-prompt-helper.md
+++ b/js/.changeset/delete-prompt-helper.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add a `deletePrompt` helper to the `prompts` subpath. It accepts a prompt name or Global ID and calls `DELETE /v1/prompts/{prompt_identifier}` (Phoenix server >= 13.20.0). Deletion cascades to every version of the prompt along with its version tags and labels.

--- a/js/.changeset/delete-prompt-helper.md
+++ b/js/.changeset/delete-prompt-helper.md
@@ -2,4 +2,6 @@
 "@arizeai/phoenix-client": minor
 ---
 
-Add a `deletePrompt` helper to the `prompts` subpath. It accepts a prompt name or Global ID and calls `DELETE /v1/prompts/{prompt_identifier}` (Phoenix server >= 13.20.0). Deletion cascades to every version of the prompt along with its version tags and labels.
+Add a `deletePrompt` helper to the `prompts` subpath. It takes a `prompt` selector — `{ name }` or `{ promptId }` — matching the selector style `getPrompt` already uses, and calls `DELETE /v1/prompts/{prompt_identifier}` (Phoenix server >= 13.20.0). Version-level selectors (`{ versionId }`, `{ name, tag }`) are rejected rather than widened to the whole prompt. Deletion cascades to every version of the prompt along with its version tags and labels.
+
+Also exports a `PromptIdentifier` type from `types/prompts` for the prompt-level selector union.

--- a/js/packages/phoenix-client/.agents/skills/phoenix-client-development/SKILL.md
+++ b/js/packages/phoenix-client/.agents/skills/phoenix-client-development/SKILL.md
@@ -20,6 +20,7 @@ Read existing code in the directory you're working in before writing new code.
 | Rule file              | When to read                                              |
 | ---------------------- | --------------------------------------------------------- |
 | `rules/experiments.md` | Experiment execution, task runners, evaluator wiring      |
+| `rules/prompts.md`     | Prompt helpers, selector shapes, server version gating    |
 | `rules/tracing.md`     | OpenTelemetry tracer providers, span export, global state |
 | `rules/testing.md`     | Unit tests, integration tests, test fixtures              |
 

--- a/js/packages/phoenix-client/.agents/skills/phoenix-client-development/rules/prompts.md
+++ b/js/packages/phoenix-client/.agents/skills/phoenix-client-development/rules/prompts.md
@@ -5,16 +5,16 @@
 Helpers in `src/prompts/` take a **selector object** under a `prompt` key, never a
 bare identifier string. `getPrompt` established this with `PromptSelector`
 (`{ promptId }` | `{ name }` | `{ versionId }` | `{ tag, name }`), and new helpers
-follow it — a call site reads as `{ prompt: { name: "x" } }`, which says *which
-kind* of thing `"x"` is.
+follow it — a call site reads as `{ prompt: { name: "x" } }`, which says _which
+kind_ of thing `"x"` is.
 
 Two selector unions live in `src/types/prompts.ts`. Pick by what the operation
 acts on:
 
-| Union              | Members                        | For                                             |
-| ------------------ | ------------------------------ | ----------------------------------------------- |
-| `PromptSelector`   | id, name, versionId, tag+name  | Operations that resolve to a prompt **version** |
-| `PromptIdentifier` | `{ promptId }` \| `{ name }`   | Operations on the **prompt itself**             |
+| Union              | Members                       | For                                             |
+| ------------------ | ----------------------------- | ----------------------------------------------- |
+| `PromptSelector`   | id, name, versionId, tag+name | Operations that resolve to a prompt **version** |
+| `PromptIdentifier` | `{ promptId }` \| `{ name }`  | Operations on the **prompt itself**             |
 
 `PromptIdentifier` is what the REST `{prompt_identifier}` path segment accepts.
 Resolve it with `resolvePromptIdentifier()` from `src/utils/` rather than reaching

--- a/js/packages/phoenix-client/.agents/skills/phoenix-client-development/rules/prompts.md
+++ b/js/packages/phoenix-client/.agents/skills/phoenix-client-development/rules/prompts.md
@@ -1,0 +1,44 @@
+# Prompt APIs
+
+## Select Prompts With A Selector, Not A Bare String
+
+Helpers in `src/prompts/` take a **selector object** under a `prompt` key, never a
+bare identifier string. `getPrompt` established this with `PromptSelector`
+(`{ promptId }` | `{ name }` | `{ versionId }` | `{ tag, name }`), and new helpers
+follow it — a call site reads as `{ prompt: { name: "x" } }`, which says *which
+kind* of thing `"x"` is.
+
+Two selector unions live in `src/types/prompts.ts`. Pick by what the operation
+acts on:
+
+| Union              | Members                        | For                                             |
+| ------------------ | ------------------------------ | ----------------------------------------------- |
+| `PromptSelector`   | id, name, versionId, tag+name  | Operations that resolve to a prompt **version** |
+| `PromptIdentifier` | `{ promptId }` \| `{ name }`   | Operations on the **prompt itself**             |
+
+`PromptIdentifier` is what the REST `{prompt_identifier}` path segment accepts.
+Resolve it with `resolvePromptIdentifier()` from `src/utils/` rather than reaching
+into the selector inline.
+
+## Guard Version Selectors At Runtime
+
+TypeScript alone will not keep a version selector out of a `PromptIdentifier`
+parameter: `GetPromptByTagSelector` is structurally assignable to
+`GetPromptByNameSelector`, so a `{ name, tag }` variable type-checks and would
+silently widen to the whole prompt. `resolvePromptIdentifier()` therefore
+rejects `versionId` and `tag` at runtime. Keep that guard in place — for
+destructive operations it is the difference between deleting one version's worth
+of intent and deleting everything.
+
+## Known Inconsistency
+
+`updatePrompt` predates this convention and still takes `promptIdentifier: string`.
+Do not copy it for new helpers. If you touch its signature, add `prompt` as the
+supported form and deprecate `promptIdentifier` rather than breaking callers.
+
+## Version-Gate New Routes
+
+Prompt routes have landed across many server releases. Add a `RouteRequirement`
+to `src/constants/serverRequirements.ts` (with the release the route shipped in,
+confirmed from `CHANGELOG.md` — not guessed) and call `ensureServerCapability()`
+before the request so old servers fail with a clear message instead of a 404.

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -138,6 +138,13 @@ export const ADD_SESSION_NOTE_IDENTIFIER: ParameterRequirement = {
   minServerVersion: [15, 5, 0],
 };
 
+export const DELETE_PROMPT: RouteRequirement = {
+  kind: "route",
+  method: "DELETE",
+  path: "/v1/prompts/{prompt_identifier}",
+  minServerVersion: [13, 20, 0],
+};
+
 export const PATCH_PROMPT: RouteRequirement = {
   kind: "route",
   method: "PATCH",
@@ -224,6 +231,7 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   ADD_TRACE_NOTE_IDENTIFIER,
   ADD_SPAN_NOTE_IDENTIFIER,
   ADD_SESSION_NOTE_IDENTIFIER,
+  DELETE_PROMPT,
   PATCH_PROMPT,
   AGENT_SESSION_CREATE,
   AGENT_SESSION_LIST,

--- a/js/packages/phoenix-client/src/prompts/deletePrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/deletePrompt.ts
@@ -2,6 +2,8 @@ import { createClient } from "../client";
 import { DELETE_PROMPT } from "../constants/serverRequirements";
 import { HttpError } from "../errors";
 import type { ClientFn } from "../types/core";
+import type { PromptIdentifier } from "../types/prompts";
+import { resolvePromptIdentifier } from "../utils/resolvePromptIdentifier";
 import { ensureServerCapability } from "../utils/serverVersionUtils";
 
 /**
@@ -9,9 +11,11 @@ import { ensureServerCapability } from "../utils/serverVersionUtils";
  */
 export interface DeletePromptParams extends ClientFn {
   /**
-   * The prompt name or ID (a Phoenix Global ID, base64-encoded).
+   * The prompt to delete. Selected either by `name` or by `promptId` — the same
+   * selector style {@link getPrompt} takes, minus the version-level selectors,
+   * which do not identify a prompt.
    */
-  promptIdentifier: string;
+  prompt: PromptIdentifier;
 }
 
 /**
@@ -21,6 +25,7 @@ export interface DeletePromptParams extends ClientFn {
  * and labels, is removed with it. This cannot be undone.
  *
  * @param params - The parameters to delete the prompt.
+ * @param params.prompt - The prompt to delete, selected by `name` or `promptId`.
  * @returns A promise that resolves once the prompt is deleted.
  * @throws An error if the prompt does not exist, or if the deletion fails.
  *
@@ -31,19 +36,17 @@ export interface DeletePromptParams extends ClientFn {
  * import { deletePrompt } from "@arizeai/phoenix-client/prompts";
  *
  * // Delete by name
- * await deletePrompt({ promptIdentifier: "my-prompt" });
+ * await deletePrompt({ prompt: { name: "my-prompt" } });
  *
- * // Delete by Global ID
- * await deletePrompt({ promptIdentifier: "UHJvbXB0OjE=" });
+ * // Delete by prompt id
+ * await deletePrompt({ prompt: { promptId: "UHJvbXB0OjE=" } });
  * ```
  */
 export async function deletePrompt({
   client: _client,
-  promptIdentifier,
+  prompt,
 }: DeletePromptParams): Promise<void> {
-  if (!promptIdentifier) {
-    throw new Error("promptIdentifier must be a non-empty prompt name or ID.");
-  }
+  const promptIdentifier = resolvePromptIdentifier(prompt);
 
   const client = _client ?? createClient();
   await ensureServerCapability({ client, requirement: DELETE_PROMPT });

--- a/js/packages/phoenix-client/src/prompts/deletePrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/deletePrompt.ts
@@ -1,0 +1,67 @@
+import { createClient } from "../client";
+import { DELETE_PROMPT } from "../constants/serverRequirements";
+import { HttpError } from "../errors";
+import type { ClientFn } from "../types/core";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+
+/**
+ * Parameters for deleting a prompt.
+ */
+export interface DeletePromptParams extends ClientFn {
+  /**
+   * The prompt name or ID (a Phoenix Global ID, base64-encoded).
+   */
+  promptIdentifier: string;
+}
+
+/**
+ * Delete a prompt via `DELETE /v1/prompts/{prompt_identifier}`.
+ *
+ * Deletion cascades: every version of the prompt, along with its version tags
+ * and labels, is removed with it. This cannot be undone.
+ *
+ * @param params - The parameters to delete the prompt.
+ * @returns A promise that resolves once the prompt is deleted.
+ * @throws An error if the prompt does not exist, or if the deletion fails.
+ *
+ * @requires Phoenix server >= 13.20.0
+ *
+ * @example
+ * ```ts
+ * import { deletePrompt } from "@arizeai/phoenix-client/prompts";
+ *
+ * // Delete by name
+ * await deletePrompt({ promptIdentifier: "my-prompt" });
+ *
+ * // Delete by Global ID
+ * await deletePrompt({ promptIdentifier: "UHJvbXB0OjE=" });
+ * ```
+ */
+export async function deletePrompt({
+  client: _client,
+  promptIdentifier,
+}: DeletePromptParams): Promise<void> {
+  if (!promptIdentifier) {
+    throw new Error("promptIdentifier must be a non-empty prompt name or ID.");
+  }
+
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: DELETE_PROMPT });
+
+  try {
+    await client.DELETE("/v1/prompts/{prompt_identifier}", {
+      params: {
+        path: {
+          prompt_identifier: promptIdentifier,
+        },
+      },
+    });
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 404) {
+      throw new Error(`Prompt not found: ${promptIdentifier}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}

--- a/js/packages/phoenix-client/src/prompts/index.ts
+++ b/js/packages/phoenix-client/src/prompts/index.ts
@@ -1,5 +1,6 @@
 export * from "./getPrompt";
 export * from "./createPrompt";
+export * from "./deletePrompt";
 export * from "./listPrompts";
 export * from "./updatePrompt";
 export * from "./sdks";

--- a/js/packages/phoenix-client/src/types/prompts.ts
+++ b/js/packages/phoenix-client/src/types/prompts.ts
@@ -76,6 +76,16 @@ export type PromptSelector =
   | GetPromptByTagSelector;
 
 /**
+ * A selector for a prompt as a whole, rather than for one of its versions.
+ *
+ * Narrower than {@link PromptSelector}: a version id or a name + tag picks out a
+ * single version, which is not what operations on the prompt itself act on. Use
+ * this wherever the API needs the `{prompt_identifier}` path segment — the name
+ * and the prompt id are the two things the Phoenix REST API accepts there.
+ */
+export type PromptIdentifier = GetPromptByIdSelector | GetPromptByNameSelector;
+
+/**
  * The prompt data needed to create a prompt.
  */
 export type PromptData = components["schemas"]["PromptData"];

--- a/js/packages/phoenix-client/src/utils/resolvePromptIdentifier.ts
+++ b/js/packages/phoenix-client/src/utils/resolvePromptIdentifier.ts
@@ -1,0 +1,41 @@
+import type { PromptIdentifier } from "../types/prompts";
+
+/**
+ * Resolve a prompt-level selector to the `{prompt_identifier}` path segment the
+ * Phoenix REST API expects.
+ *
+ * Version-level selectors are rejected rather than silently widened: structural
+ * typing lets a `{ name, tag }` or `{ versionId }` value reach a
+ * {@link PromptIdentifier} parameter, and quietly dropping the version would
+ * point the caller at the whole prompt instead of the version they named.
+ *
+ * @param prompt - the prompt, selected by `name` or by `promptId`
+ * @returns The identifier to interpolate into the request path.
+ * @throws An error if the selector is empty, or selects a version rather than a
+ * prompt.
+ */
+export function resolvePromptIdentifier(prompt: PromptIdentifier): string {
+  if ("versionId" in prompt) {
+    throw new Error(
+      "A prompt version id selects a single version, not a prompt. Select the prompt by name or promptId."
+    );
+  }
+  if ("tag" in prompt) {
+    throw new Error(
+      "A tag selects a single version, not a prompt. Select the prompt by name or promptId."
+    );
+  }
+  if ("promptId" in prompt) {
+    if (!prompt.promptId) {
+      throw new Error("promptId must be a non-empty prompt id.");
+    }
+    return prompt.promptId;
+  }
+  if ("name" in prompt) {
+    if (!prompt.name) {
+      throw new Error("name must be a non-empty prompt name.");
+    }
+    return prompt.name;
+  }
+  throw new Error("A prompt must be selected by either name or promptId.");
+}

--- a/js/packages/phoenix-client/test/prompts/deletePrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/deletePrompt.test.ts
@@ -4,6 +4,7 @@ import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   it,
@@ -14,6 +15,10 @@ vi.unmock("../../src/utils/serverVersionUtils");
 
 import { HttpError } from "../../src/errors";
 import { deletePrompt } from "../../src/prompts";
+import type {
+  GetPromptByTagSelector,
+  PromptIdentifier,
+} from "../../src/types/prompts";
 import { createTestClient } from "../testUtils";
 
 const http = createHttp();
@@ -44,62 +49,116 @@ afterAll(() => {
   server.close();
 });
 
+/**
+ * Handler that records the `{prompt_identifier}` the client interpolated into
+ * the request path and answers 204, as a successful deletion does.
+ */
+function captureDeleteHandler(captured: { identifier?: string }) {
+  return http.delete(
+    "/v1/prompts/{prompt_identifier}",
+    ({ params, response }) => {
+      captured.identifier = params.prompt_identifier;
+      return response(204).empty();
+    }
+  );
+}
+
 describe("deletePrompt", () => {
-  it("DELETEs the prompt by name", async () => {
+  it("DELETEs the prompt selected by name", async () => {
     const captured: { identifier?: string } = {};
-    server.use(
-      serverVersionHandler("13.20.0"),
-      http.delete("/v1/prompts/{prompt_identifier}", ({ params, response }) => {
-        captured.identifier = params.prompt_identifier;
-        return response(204).empty();
-      })
-    );
+    server.use(serverVersionHandler("13.20.0"), captureDeleteHandler(captured));
 
     await expect(
       deletePrompt({
         client: createTestClient(),
-        promptIdentifier: "my-prompt",
+        prompt: { name: "my-prompt" },
       })
     ).resolves.toBeUndefined();
 
     expect(captured.identifier).toBe("my-prompt");
   });
 
-  it("DELETEs the prompt by global ID", async () => {
+  it("DELETEs the prompt selected by prompt id", async () => {
     const captured: { identifier?: string } = {};
-    server.use(
-      serverVersionHandler("13.20.0"),
-      http.delete("/v1/prompts/{prompt_identifier}", ({ params, response }) => {
-        captured.identifier = params.prompt_identifier;
-        return response(204).empty();
-      })
-    );
+    server.use(serverVersionHandler("13.20.0"), captureDeleteHandler(captured));
 
     await deletePrompt({
       client: createTestClient(),
-      promptIdentifier: "UHJvbXB0OjE=",
+      prompt: { promptId: "UHJvbXB0OjE=" },
     });
 
     expect(captured.identifier).toBe("UHJvbXB0OjE=");
   });
 
-  it("rejects an empty identifier without calling the server", async () => {
+  describe("selector validation", () => {
     let deleteRequestCount = 0;
-    server.use(
-      serverVersionHandler("13.20.0"),
-      http.delete("/v1/prompts/{prompt_identifier}", ({ response }) => {
-        deleteRequestCount += 1;
-        return response(204).empty();
-      })
-    );
 
-    await expect(
-      deletePrompt({ client: createTestClient(), promptIdentifier: "" })
-    ).rejects.toThrow(
-      "promptIdentifier must be a non-empty prompt name or ID."
-    );
+    beforeEach(() => {
+      deleteRequestCount = 0;
+      server.use(
+        serverVersionHandler("13.20.0"),
+        http.delete("/v1/prompts/{prompt_identifier}", ({ response }) => {
+          deleteRequestCount += 1;
+          return response(204).empty();
+        })
+      );
+    });
 
-    expect(deleteRequestCount).toBe(0);
+    it("rejects an empty name", async () => {
+      await expect(
+        deletePrompt({ client: createTestClient(), prompt: { name: "" } })
+      ).rejects.toThrow("name must be a non-empty prompt name.");
+
+      expect(deleteRequestCount).toBe(0);
+    });
+
+    it("rejects an empty prompt id", async () => {
+      await expect(
+        deletePrompt({ client: createTestClient(), prompt: { promptId: "" } })
+      ).rejects.toThrow("promptId must be a non-empty prompt id.");
+
+      expect(deleteRequestCount).toBe(0);
+    });
+
+    it("rejects a version selector rather than deleting the whole prompt", async () => {
+      const versionSelector = {
+        versionId: "UHJvbXB0VmVyc2lvbjox",
+      } as unknown as PromptIdentifier;
+
+      await expect(
+        deletePrompt({ client: createTestClient(), prompt: versionSelector })
+      ).rejects.toThrow(/selects a single version, not a prompt/);
+
+      expect(deleteRequestCount).toBe(0);
+    });
+
+    it("rejects a name + tag selector rather than ignoring the tag", async () => {
+      // Structural typing lets a tag selector reach a PromptIdentifier
+      // parameter, so the guard has to be a runtime one.
+      const tagSelector: PromptIdentifier = {
+        name: "my-prompt",
+        tag: "production",
+      } as GetPromptByTagSelector;
+
+      await expect(
+        deletePrompt({ client: createTestClient(), prompt: tagSelector })
+      ).rejects.toThrow(/selects a single version, not a prompt/);
+
+      expect(deleteRequestCount).toBe(0);
+    });
+
+    it("rejects a selector with neither name nor prompt id", async () => {
+      await expect(
+        deletePrompt({
+          client: createTestClient(),
+          prompt: {} as unknown as PromptIdentifier,
+        })
+      ).rejects.toThrow(
+        "A prompt must be selected by either name or promptId."
+      );
+
+      expect(deleteRequestCount).toBe(0);
+    });
   });
 
   it("reports a missing prompt by identifier", async () => {
@@ -112,7 +171,7 @@ describe("deletePrompt", () => {
 
     const error = await deletePrompt({
       client: createTestClient(),
-      promptIdentifier: "missing-prompt",
+      prompt: { name: "missing-prompt" },
     }).catch((e: unknown) => e);
 
     expect(error).toBeInstanceOf(Error);
@@ -131,7 +190,7 @@ describe("deletePrompt", () => {
 
     const error = await deletePrompt({
       client: createTestClient(),
-      promptIdentifier: "my-prompt",
+      prompt: { name: "my-prompt" },
     }).catch((e: unknown) => e);
 
     expect(error).toBeInstanceOf(HttpError);
@@ -152,7 +211,7 @@ describe("deletePrompt", () => {
     await expect(
       deletePrompt({
         client: createTestClient(),
-        promptIdentifier: "my-prompt",
+        prompt: { name: "my-prompt" },
       })
     ).rejects.toThrow(/requires Phoenix server >= 13\.20\.0/);
 

--- a/js/packages/phoenix-client/test/prompts/deletePrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/deletePrompt.test.ts
@@ -1,0 +1,161 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.unmock("../../src/utils/serverVersionUtils");
+
+import { HttpError } from "../../src/errors";
+import { deletePrompt } from "../../src/prompts";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+
+/**
+ * Handler that reports the given Phoenix server version. The capability guard
+ * in deletePrompt resolves the server version by fetching this endpoint, and
+ * the endpoint returns the version string as plain text.
+ */
+function serverVersionHandler(version: string) {
+  return http.get("/arize_phoenix_version", ({ response }) =>
+    response.untyped(new Response(version, { status: 200 }))
+  );
+}
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("deletePrompt", () => {
+  it("DELETEs the prompt by name", async () => {
+    const captured: { identifier?: string } = {};
+    server.use(
+      serverVersionHandler("13.20.0"),
+      http.delete("/v1/prompts/{prompt_identifier}", ({ params, response }) => {
+        captured.identifier = params.prompt_identifier;
+        return response(204).empty();
+      })
+    );
+
+    await expect(
+      deletePrompt({
+        client: createTestClient(),
+        promptIdentifier: "my-prompt",
+      })
+    ).resolves.toBeUndefined();
+
+    expect(captured.identifier).toBe("my-prompt");
+  });
+
+  it("DELETEs the prompt by global ID", async () => {
+    const captured: { identifier?: string } = {};
+    server.use(
+      serverVersionHandler("13.20.0"),
+      http.delete("/v1/prompts/{prompt_identifier}", ({ params, response }) => {
+        captured.identifier = params.prompt_identifier;
+        return response(204).empty();
+      })
+    );
+
+    await deletePrompt({
+      client: createTestClient(),
+      promptIdentifier: "UHJvbXB0OjE=",
+    });
+
+    expect(captured.identifier).toBe("UHJvbXB0OjE=");
+  });
+
+  it("rejects an empty identifier without calling the server", async () => {
+    let deleteRequestCount = 0;
+    server.use(
+      serverVersionHandler("13.20.0"),
+      http.delete("/v1/prompts/{prompt_identifier}", ({ response }) => {
+        deleteRequestCount += 1;
+        return response(204).empty();
+      })
+    );
+
+    await expect(
+      deletePrompt({ client: createTestClient(), promptIdentifier: "" })
+    ).rejects.toThrow(
+      "promptIdentifier must be a non-empty prompt name or ID."
+    );
+
+    expect(deleteRequestCount).toBe(0);
+  });
+
+  it("reports a missing prompt by identifier", async () => {
+    server.use(
+      serverVersionHandler("13.20.0"),
+      http.delete("/v1/prompts/{prompt_identifier}", ({ response }) =>
+        response.untyped(new Response("Prompt not found", { status: 404 }))
+      )
+    );
+
+    const error = await deletePrompt({
+      client: createTestClient(),
+      promptIdentifier: "missing-prompt",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Prompt not found: missing-prompt");
+    expect((error as Error).cause).toBeInstanceOf(HttpError);
+    expect(((error as Error).cause as HttpError).status).toBe(404);
+  });
+
+  it("surfaces other server errors as HttpError", async () => {
+    server.use(
+      serverVersionHandler("13.20.0"),
+      http.delete("/v1/prompts/{prompt_identifier}", ({ response }) =>
+        response.untyped(new Response("Boom", { status: 500 }))
+      )
+    );
+
+    const error = await deletePrompt({
+      client: createTestClient(),
+      promptIdentifier: "my-prompt",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(500);
+  });
+
+  it("fails fast on older Phoenix servers", async () => {
+    let deleteRequestCount = 0;
+
+    server.use(
+      serverVersionHandler("13.19.2"),
+      http.delete("/v1/prompts/{prompt_identifier}", ({ response }) => {
+        deleteRequestCount += 1;
+        return response(204).empty();
+      })
+    );
+
+    await expect(
+      deletePrompt({
+        client: createTestClient(),
+        promptIdentifier: "my-prompt",
+      })
+    ).rejects.toThrow(/requires Phoenix server >= 13\.20\.0/);
+
+    expect(deleteRequestCount).toBe(0);
+  });
+});


### PR DESCRIPTION
resolves #15668

## What changed

The `prompts` subpath of `@arizeai/phoenix-client` exported get/create/list/update helpers but nothing for deletion, even though the REST route has existed since server 13.20.0. This adds the missing helper, following the selector convention `getPrompt` established.

- **`src/prompts/deletePrompt.ts`** — `deletePrompt({ prompt })` where `prompt` is `{ name }` or `{ promptId }`, returning `void`. A 404 is rethrown as `Prompt not found: <identifier>` with the underlying `HttpError` as `cause`; other statuses surface as `HttpError`.
- **`src/types/prompts.ts`** — new `PromptIdentifier` union, the prompt-level half of `PromptSelector`. `PromptSelector` resolves to a prompt *version* (it includes `{ versionId }` and `{ tag, name }`); `PromptIdentifier` is what the REST `{prompt_identifier}` path segment accepts.
- **`src/utils/resolvePromptIdentifier.ts`** — maps a selector onto the path segment, rejecting version-level selectors at runtime. This guard is load-bearing rather than belt-and-braces: `GetPromptByTagSelector` is structurally assignable to `GetPromptByNameSelector`, so a `{ name, tag }` variable type-checks against a prompt-level parameter and would otherwise silently widen from "this version" to "the whole prompt".
- **`src/constants/serverRequirements.ts`** — `DELETE_PROMPT` route requirement pinned to `13.20.0`, the release the endpoint shipped in (confirmed from `CHANGELOG.md`), added to `ALL_REQUIREMENTS`. The helper fails fast via `ensureServerCapability` on older servers.
- **`test/prompts/deletePrompt.test.ts`** — 10 tests: deletion by name and by prompt id, five selector-validation cases (empty name, empty id, `{ versionId }`, `{ name, tag }`, `{}`) each asserting no request is made, 404 handling, a 500 surfacing as `HttpError`, and the version guard rejecting on 13.19.2 without issuing the DELETE.
- **Docs** — a "Delete A Prompt" section in the `phoenix-client` prompts reference, covering both selectors, the version-selector rejection, and that deletion cascades to every version plus its tags and labels and cannot be undone.
- **`phoenix-client-development` skill** — new `rules/prompts.md` codifying the selector convention, the runtime guard and its reason, and the server-version gating step, so the next prompt helper follows it.
- **Changeset** — minor bump for `@arizeai/phoenix-client`.

## API shape

```ts
await deletePrompt({ prompt: { name: "support-response" } });
await deletePrompt({ prompt: { promptId: "UHJvbXB0OjE=" } });
```

## Known inconsistency, not addressed here

`updatePrompt` takes `promptIdentifier: string` and predates this convention. Making it consistent means adding `prompt` and deprecating `promptIdentifier` — a public-API change to a shipped helper, so it is called out in the skill rule and left for a separate decision rather than folded in here.

`px prompt delete <prompt-identifier>` in the CLI is unaffected: a positional CLI argument is necessarily a string. It still calls `client.DELETE` directly and could be switched to this helper (which would also gain it the version guard) as a follow-up.

## Validation

- `pnpm test` in `js/packages/phoenix-client`: 55 files, 529 passed / 1 skipped.
- `pnpm run typecheck` (src + examples): clean.
- `oxlint` and `oxfmt` clean across `src` and `test`.
- Re-running the package's `generate` step produced no diff in `src/__generated__/api/v1.ts` — the `deletePrompt` operation was already in the generated types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tm1GwErUWb2ggbULebSjnF