### PR TITLE
ci: scope Playwright triggers to the app and its build inputs

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -34,10 +34,35 @@ jobs:
         with:
           filters: |
             e2e:
+              # The Python backend the suite runs against, plus the
+              # dependency set `uv sync --extra container` resolves.
               - "src/**"
+              - "pyproject.toml"
+              - "uv.lock"
+              # The app under test.
               - "js/app/**"
-              - "js/packages/**"
+              # Only the workspace packages the app actually builds
+              # against, i.e. the closure of
+              # `pnpm --filter 'phoenix-ui^...' run build` (see the
+              # `pretest:e2e` script in js/app/package.json):
+              # phoenix-client and phoenix-evals, plus their transitive
+              # workspace deps phoenix-config, phoenix-otel and
+              # phoenix-testing. phoenix-cli and phoenix-mcp are
+              # downstream consumers of the workspace, not inputs to the
+              # app build, so changes there must not trigger e2e. Add a
+              # package here if the app ever starts depending on it.
+              - "js/packages/phoenix-client/**"
+              - "js/packages/phoenix-config/**"
+              - "js/packages/phoenix-evals/**"
+              - "js/packages/phoenix-otel/**"
+              - "js/packages/phoenix-testing/**"
+              # Workspace-level config that changes how the app's
+              # dependencies are resolved, installed or compiled.
+              - "js/package.json"
               - "js/pnpm-lock.yaml"
+              - "js/pnpm-workspace.yaml"
+              - "js/tsconfig.base.json"
+              - "js/tsconfig.base.esm.json"
               - ".github/workflows/playwright.yaml"
 
 


### PR DESCRIPTION
The `e2e` path filter in `.github/workflows/playwright.yaml` matched all of `js/packages/**`, so a PR touching only `phoenix-cli` or `phoenix-mcp` — neither of which the app builds against — spun up the full Playwright matrix.

## Changes

**JS side — narrowed from `js/packages/**` to the app's actual build closure.** `js/app`'s `pretest:e2e` runs `pnpm --filter 'phoenix-ui^...' run build`, whose closure is:

- `@arizeai/phoenix-client` and `@arizeai/phoenix-evals` (direct deps of `phoenix-ui`)
- `@arizeai/phoenix-config`, `@arizeai/phoenix-otel`, `@arizeai/phoenix-testing` (transitive workspace deps of those)

`phoenix-cli` and `phoenix-mcp` are downstream consumers of the workspace, not inputs to the app build, so they no longer trigger e2e. Also added the workspace-level config that changes how those packages resolve and compile: `js/package.json`, `js/pnpm-workspace.yaml`, `js/tsconfig.base.json`, `js/tsconfig.base.esm.json` (`js/pnpm-lock.yaml` was already listed).

**Backend side — added `pyproject.toml` and `uv.lock`.** The suite runs against whatever `uv sync --extra container` resolves, so a dependency bump changes the server under test; previously such a PR skipped e2e entirely.

A comment on the filter records why the package list is enumerated and to extend it if the app takes on a new workspace dependency.

## Verification

No behavior change to the jobs themselves — only the `dorny/paths-filter` input. Confirmed the nested filter YAML still parses to the intended path list, and re-derived the workspace dependency graph from every `js/packages/*/package.json` rather than assuming it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BN4fJqP3eZ3qQB2KZ268Yq)_