### PR TITLE
feat(python-client): add prompt deletion

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
+++ b/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
@@ -96,3 +96,9 @@ PATCH_PROMPT = RouteRequirement(
     path="/v1/prompts/{prompt_identifier}",
     min_server_version=Version(19, 18, 0),
 )
+
+DELETE_PROMPT = RouteRequirement(
+    method="DELETE",
+    path="/v1/prompts/{prompt_identifier}",
+    min_server_version=Version(13, 20, 0),
+)

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -8,7 +8,7 @@ import httpx
 from httpx import HTTPStatusError
 
 from phoenix.client.__generated__ import v1
-from phoenix.client.constants.server_requirements import PATCH_PROMPT
+from phoenix.client.constants.server_requirements import DELETE_PROMPT, PATCH_PROMPT
 from phoenix.client.types.prompts import PromptVersion
 from phoenix.client.types.sentinels import NOT_GIVEN, NotGiven
 from phoenix.client.utils.encode_path_param import encode_path_param
@@ -38,7 +38,7 @@ def _build_patch_prompt_body(
 class Prompts:
     """Provides methods for interacting with prompt resources.
 
-    This class allows you to retrieve, create, and update prompts and prompt versions.
+    This class allows you to retrieve, create, update, and delete prompts and prompt versions.
 
     Examples:
         Basic prompt operations::
@@ -248,6 +248,37 @@ class Prompts:
             raise
         return cast(v1.PatchPromptResponseBody, response.json())["data"]
 
+    def delete(self, *, prompt_identifier: str) -> None:
+        """Delete a prompt by name or GlobalID.
+
+        Warning:
+            Deleting a prompt also deletes all of its versions, tags, and labels.
+
+        Args:
+            prompt_identifier (str): The prompt name or GlobalID.
+
+        Raises:
+            ValueError: If the prompt is not found.
+            httpx.HTTPStatusError: If the HTTP request returned another unsuccessful
+                status code, including a permission error.
+
+        Example::
+
+            from phoenix.client import Client
+            client = Client()
+
+            client.prompts.delete(prompt_identifier="my-prompt")
+        """
+        self._guard.require(DELETE_PROMPT)
+        url = f"v1/prompts/{encode_path_param(prompt_identifier)}"
+        try:
+            response = self._client.delete(url)
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Prompt not found: {prompt_identifier}") from e
+            raise
+
 
 class PromptVersionTags:
     """
@@ -388,7 +419,7 @@ class AsyncPrompts:
     """
     Provides asynchronous methods for interacting with prompt resources.
 
-    This class allows you to retrieve, create, and update prompts and prompt
+    This class allows you to retrieve, create, update, and delete prompts and prompt
     versions asynchronously.
 
     Examples:
@@ -598,6 +629,37 @@ class AsyncPrompts:
                 raise ValueError(f"Prompt not found: {prompt_identifier}") from e
             raise
         return cast(v1.PatchPromptResponseBody, response.json())["data"]
+
+    async def delete(self, *, prompt_identifier: str) -> None:
+        """Asynchronously delete a prompt by name or GlobalID.
+
+        Warning:
+            Deleting a prompt also deletes all of its versions, tags, and labels.
+
+        Args:
+            prompt_identifier (str): The prompt name or GlobalID.
+
+        Raises:
+            ValueError: If the prompt is not found.
+            httpx.HTTPStatusError: If the HTTP request returned another unsuccessful
+                status code, including a permission error.
+
+        Example::
+
+            from phoenix.client import AsyncClient
+            async_client = AsyncClient()
+
+            await async_client.prompts.delete(prompt_identifier="my-prompt")
+        """
+        await self._guard.require(DELETE_PROMPT)
+        url = f"v1/prompts/{encode_path_param(prompt_identifier)}"
+        try:
+            response = await self._client.delete(url)
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Prompt not found: {prompt_identifier}") from e
+            raise
 
 
 class AsyncPromptVersionTags:

--- a/packages/phoenix-client/tests/client/resources/prompts/test_prompts.py
+++ b/packages/phoenix-client/tests/client/resources/prompts/test_prompts.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 
 from phoenix.client.__generated__ import v1
-from phoenix.client.constants.server_requirements import PATCH_PROMPT
+from phoenix.client.constants.server_requirements import DELETE_PROMPT, PATCH_PROMPT
 from phoenix.client.resources.prompts import AsyncPrompts, Prompts
 from phoenix.client.types import NOT_GIVEN
 
@@ -176,4 +176,102 @@ class TestAsyncPromptsUpdate:
             await AsyncPrompts(client, _guard=_Guard()).update(  # type: ignore[arg-type]
                 prompt_identifier="my-prompt",
                 prompt_description="x",
+            )
+
+
+class TestPromptsDelete:
+    def test_delete_by_name_returns_none_on_204(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "DELETE"
+            assert request.url.path == "/v1/prompts/my-prompt"
+            return httpx.Response(204)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        Prompts(client).delete(prompt_identifier="my-prompt")
+
+    def test_delete_safely_encodes_global_id(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.raw_path == b"/v1/prompts/UHJvbXB0OjE%3D"
+            return httpx.Response(204)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        Prompts(client).delete(prompt_identifier="UHJvbXB0OjE=")
+
+    def test_delete_maps_404_to_value_error(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda request: httpx.Response(404)),
+            base_url="http://test",
+        )
+        with pytest.raises(ValueError, match="Prompt not found: missing"):
+            Prompts(client).delete(prompt_identifier="missing")
+
+    def test_delete_propagates_permission_error(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda request: httpx.Response(403)),
+            base_url="http://test",
+        )
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            Prompts(client).delete(prompt_identifier="my-prompt")
+        assert exc_info.value.response.status_code == 403
+
+    def test_delete_calls_guard_before_request(self) -> None:
+        class _Guard:
+            def require(self, requirement: object) -> None:
+                if requirement is DELETE_PROMPT:
+                    raise _GuardSentinel
+
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda r: pytest.fail("transport must not be reached")),
+            base_url="http://test",
+        )
+        with pytest.raises(_GuardSentinel):
+            Prompts(client, _guard=_Guard()).delete(  # type: ignore[arg-type]
+                prompt_identifier="my-prompt"
+            )
+
+
+class TestAsyncPromptsDelete:
+    @pytest.mark.asyncio
+    async def test_delete_by_global_id_returns_none_on_204(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "DELETE"
+            assert request.url.raw_path == b"/v1/prompts/UHJvbXB0OjE%3D"
+            return httpx.Response(204)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+        await AsyncPrompts(client).delete(prompt_identifier="UHJvbXB0OjE=")
+
+    @pytest.mark.asyncio
+    async def test_delete_maps_404_to_value_error(self) -> None:
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(404)),
+            base_url="http://test",
+        )
+        with pytest.raises(ValueError, match="Prompt not found: missing"):
+            await AsyncPrompts(client).delete(prompt_identifier="missing")
+
+    @pytest.mark.asyncio
+    async def test_delete_propagates_permission_error(self) -> None:
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(403)),
+            base_url="http://test",
+        )
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await AsyncPrompts(client).delete(prompt_identifier="my-prompt")
+        assert exc_info.value.response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_delete_calls_guard_before_request(self) -> None:
+        class _Guard:
+            async def require(self, requirement: object) -> None:
+                if requirement is DELETE_PROMPT:
+                    raise _GuardSentinel
+
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda r: pytest.fail("transport must not be reached")),
+            base_url="http://test",
+        )
+        with pytest.raises(_GuardSentinel):
+            await AsyncPrompts(client, _guard=_Guard()).delete(  # type: ignore[arg-type]
+                prompt_identifier="my-prompt"
             )


### PR DESCRIPTION
Closes #15666

## Summary

- add synchronous and asynchronous prompt deletion by name or GlobalID
- safely encode prompt identifiers and gate the route on Phoenix 13.20.0+
- map missing prompts to `ValueError` while preserving permission errors
- document cascading deletion of prompt versions, tags, and labels
- cover success, encoded GlobalIDs, missing prompts, permission errors, and version guards

## Tests

- `tox run -q -e phoenix_client -- tests/client/resources/prompts/test_prompts.py -q` (666 passed, 5 skipped, 1 xfailed)
- `make lint-python`
- `git diff --check`