### PR TITLE
feat(client): add TypeScript trace transfer helper

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -42,7 +42,7 @@ That gives the agent version-matched docs plus the exact implementation and gene
 | `@arizeai/phoenix-client/experiments` | Experiment execution and lifecycle |
 | `@arizeai/phoenix-client/spans` | Span search, notes, and span/document annotations |
 | `@arizeai/phoenix-client/sessions` | Session listing, retrieval, and session annotations |
-| `@arizeai/phoenix-client/traces` | Project trace retrieval and trace annotations |
+| `@arizeai/phoenix-client/traces` | Project trace retrieval, transfers, and trace annotations |
 | `@arizeai/phoenix-client/vitest` | Vitest entrypoint for dataset-backed eval tests |
 | `@arizeai/phoenix-client/vitest/reporter` | Vitest reporter for Phoenix eval summaries |
 | `@arizeai/phoenix-client/jest` | Jest entrypoint for dataset-backed eval tests |

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/traces.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/traces.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Traces"
-description: "Retrieve traces and annotate them with @arizeai/phoenix-client"
+description: "Retrieve, move, and annotate traces with @arizeai/phoenix-client"
 ---
 
-The traces module provides trace retrieval and trace-level annotation functions.
+The traces module provides trace retrieval, project transfer, and trace-level annotation functions.
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
@@ -17,6 +17,9 @@ The traces module provides trace retrieval and trace-level annotation functions.
     </li>
     <li>
       <code>src/traces/logTraceAnnotations.ts</code> for batched annotation writes
+    </li>
+    <li>
+      <code>src/traces/transferTraces.ts</code> for moving traces between projects
     </li>
     <li>
       <code>src/traces/types.ts</code> for the <code>TraceAnnotation</code> type
@@ -64,6 +67,28 @@ console.log(result.nextCursor);
 - Use the returned `nextCursor` to continue pagination
 - Set `includeSpans` when you need a trace-centric fetch that also contains span details
 - `project` accepts `{ project }`, `{ projectId }`, or `{ projectName }`
+
+## Move Traces To Another Project
+
+Use `transferTraces` to move one or more traces from their current project to a destination project. This operation **moves rather than copies** the traces: after a successful transfer, they no longer appear in the source project.
+
+All traces in one call must currently belong to the same source project. Each trace identifier can be either an OpenTelemetry trace ID or a Phoenix trace GlobalID, and the destination can be either a project name or project GlobalID.
+
+```ts
+import { transferTraces } from "@arizeai/phoenix-client/traces";
+
+const result = await transferTraces({
+  traceIdentifiers: ["8f3a...", "VHJhY2U6Mg=="],
+  destinationProjectIdentifier: "production",
+});
+
+console.log(`Moved ${result.transferredTraceCount} traces`);
+console.log(`Destination project: ${result.destinationProjectId}`);
+```
+
+The result contains the number of distinct traces moved and the resolved GlobalID of the destination project. Phoenix rejects an empty list, trace or project identifiers that do not resolve, and requests that combine traces from multiple source projects.
+
+`transferTraces` requires Phoenix server 20.4.0 or newer.
 
 ## Annotate a Single Trace
 
@@ -128,6 +153,7 @@ for (const r of results) {
     <li><code>src/traces/getTraces.ts</code></li>
     <li><code>src/traces/addTraceAnnotation.ts</code></li>
     <li><code>src/traces/logTraceAnnotations.ts</code></li>
+    <li><code>src/traces/transferTraces.ts</code></li>
     <li><code>src/traces/types.ts</code></li>
     <li><code>src/types/projects.ts</code></li>
   </ul>

--- a/js/.changeset/clean-traces-move.md
+++ b/js/.changeset/clean-traces-move.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `transferTraces` to the traces subpath for moving traces between Phoenix projects.

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -98,6 +98,13 @@ export const LIST_PROJECT_TRACES: RouteRequirement = {
   minServerVersion: [13, 15, 0],
 };
 
+export const TRANSFER_TRACES: RouteRequirement = {
+  kind: "route",
+  method: "POST",
+  path: "/v1/traces/transfer",
+  minServerVersion: [20, 4, 0],
+};
+
 export const GET_SPANS_BY_ATTRIBUTE: ParameterRequirement = {
   kind: "parameter",
   parameterName: "attribute",
@@ -227,6 +234,7 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   GET_SPANS_FILTERS,
   GET_SPANS_BY_ATTRIBUTE,
   LIST_PROJECT_TRACES,
+  TRANSFER_TRACES,
   DATASET_UPLOAD_EXAMPLE_IDS,
   ADD_TRACE_NOTE_IDENTIFIER,
   ADD_SPAN_NOTE_IDENTIFIER,

--- a/js/packages/phoenix-client/src/traces/index.ts
+++ b/js/packages/phoenix-client/src/traces/index.ts
@@ -2,4 +2,5 @@ export * from "./addTraceAnnotation";
 export * from "./addTraceNote";
 export * from "./getTraces";
 export * from "./logTraceAnnotations";
+export * from "./transferTraces";
 export type { TraceAnnotation } from "./types";

--- a/js/packages/phoenix-client/src/traces/transferTraces.ts
+++ b/js/packages/phoenix-client/src/traces/transferTraces.ts
@@ -1,0 +1,89 @@
+import { createClient } from "../client";
+import { TRANSFER_TRACES } from "../constants/serverRequirements";
+import type { ClientFn } from "../types/core";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+
+/**
+ * Parameters for moving traces to another project.
+ */
+export interface TransferTracesParams extends ClientFn {
+  /**
+   * Trace GlobalIDs or OpenTelemetry trace IDs to move. All traces must
+   * currently belong to the same source project.
+   */
+  traceIdentifiers: string[];
+  /**
+   * The destination project name or GlobalID.
+   */
+  destinationProjectIdentifier: string;
+}
+
+/**
+ * The result of moving traces to another project.
+ */
+export interface TransferTracesResult {
+  /** The number of distinct traces moved. */
+  transferredTraceCount: number;
+  /** The destination project's GlobalID. */
+  destinationProjectId: string;
+}
+
+/**
+ * Move traces from one project to another.
+ *
+ * This operation re-parents the traces; it does not copy them. After the move,
+ * the traces no longer appear in their original project. Every trace must
+ * currently belong to the same source project.
+ *
+ * @param params - The parameters for moving traces.
+ * @param params.traceIdentifiers - Trace GlobalIDs or OpenTelemetry trace IDs to move.
+ * @param params.destinationProjectIdentifier - The destination project name or GlobalID.
+ * @returns The number of traces moved and the destination project's GlobalID.
+ * @throws {RangeError} If no trace identifiers are provided.
+ * @throws {HttpError} If a trace or destination project is missing, the traces
+ * belong to multiple source projects, or the transfer otherwise fails.
+ *
+ * @requires Phoenix server >= 20.4.0
+ *
+ * @example
+ * ```ts
+ * import { transferTraces } from "@arizeai/phoenix-client/traces";
+ *
+ * const result = await transferTraces({
+ *   traceIdentifiers: ["8f3a...", "VHJhY2U6Mg=="],
+ *   destinationProjectIdentifier: "production",
+ * });
+ *
+ * console.log(result.transferredTraceCount);
+ * console.log(result.destinationProjectId);
+ * ```
+ */
+export async function transferTraces({
+  client: _client,
+  traceIdentifiers,
+  destinationProjectIdentifier,
+}: TransferTracesParams): Promise<TransferTracesResult> {
+  if (traceIdentifiers.length === 0) {
+    throw new RangeError("At least one trace identifier is required");
+  }
+
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: TRANSFER_TRACES });
+
+  const { data, error } = await client.POST("/v1/traces/transfer", {
+    body: {
+      trace_identifiers: traceIdentifiers,
+      destination_project_identifier: destinationProjectIdentifier,
+    },
+  });
+
+  if (error) throw error;
+  if (!data?.data) {
+    throw new Error("Failed to transfer traces: no data returned");
+  }
+
+  return {
+    transferredTraceCount: data.data.transferred_trace_count,
+    destinationProjectId: data.data.destination_project_id,
+  };
+}

--- a/js/packages/phoenix-client/test/entryPoints.test.ts
+++ b/js/packages/phoenix-client/test/entryPoints.test.ts
@@ -8,6 +8,7 @@ const requireCjs = createRequire(import.meta.url);
 const cjsEntries = {
   index: "../dist/src/index.js",
   experiments: "../dist/src/experiments/index.js",
+  traces: "../dist/src/traces/index.js",
   jest: "../dist/src/jest/index.js",
 } as const;
 // The index entry transitively require()s @arizeai/phoenix-otel's dist via the
@@ -47,6 +48,7 @@ describe.skipIf(!isBuilt)("built CommonJS entry points", () => {
 const esmEntries = {
   index: "../dist/esm/index.js",
   experiments: "../dist/esm/experiments/index.js",
+  traces: "../dist/esm/traces/index.js",
   jest: "../dist/esm/jest/index.js",
 } as const;
 

--- a/js/packages/phoenix-client/test/traces/transferTraces.test.ts
+++ b/js/packages/phoenix-client/test/traces/transferTraces.test.ts
@@ -1,0 +1,150 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { HttpError } from "../../src/errors";
+import { transferTraces } from "../../src/traces";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("transferTraces", () => {
+  it("moves traces to the destination project and returns the transfer result", async () => {
+    let receivedRequestBody: unknown;
+
+    server.use(
+      http.post("/v1/traces/transfer", async ({ request, response }) => {
+        receivedRequestBody = await request.json();
+        return response(200).json({
+          data: {
+            transferred_trace_count: 2,
+            destination_project_id: "UHJvamVjdDoy",
+          },
+        });
+      })
+    );
+
+    const result = await transferTraces({
+      client: createTestClient(),
+      traceIdentifiers: ["otel-trace-id", "VHJhY2U6Mg=="],
+      destinationProjectIdentifier: "destination-project",
+    });
+
+    expect(receivedRequestBody).toEqual({
+      trace_identifiers: ["otel-trace-id", "VHJhY2U6Mg=="],
+      destination_project_identifier: "destination-project",
+    });
+    expect(result).toEqual({
+      transferredTraceCount: 2,
+      destinationProjectId: "UHJvamVjdDoy",
+    });
+  });
+
+  it("rejects an empty trace identifier list before sending a request", async () => {
+    let transferRequestCount = 0;
+
+    server.use(
+      http.post("/v1/traces/transfer", ({ response }) => {
+        transferRequestCount += 1;
+        return response(200).json({
+          data: {
+            transferred_trace_count: 0,
+            destination_project_id: "UHJvamVjdDoy",
+          },
+        });
+      })
+    );
+
+    await expect(
+      transferTraces({
+        client: createTestClient(),
+        traceIdentifiers: [],
+        destinationProjectIdentifier: "destination-project",
+      })
+    ).rejects.toThrow("At least one trace identifier is required");
+
+    expect(transferRequestCount).toBe(0);
+  });
+
+  it("surfaces validation errors for traces from multiple source projects", async () => {
+    server.use(
+      http.post("/v1/traces/transfer", ({ response }) =>
+        response(422).json({
+          detail: [
+            {
+              type: "value_error",
+              loc: ["body", "trace_identifiers"],
+              msg: "Cannot transfer traces from multiple projects",
+              input: ["trace-a", "trace-b"],
+            },
+          ],
+        })
+      )
+    );
+
+    const transferPromise = transferTraces({
+      client: createTestClient(),
+      traceIdentifiers: ["trace-a", "trace-b"],
+      destinationProjectIdentifier: "destination-project",
+    });
+
+    await expect(transferPromise).rejects.toThrow(HttpError);
+    await expect(transferPromise).rejects.toMatchObject({ status: 422 });
+  });
+
+  it.each([
+    ["a missing trace", "One or more traces not found"],
+    ["a missing destination project", "Project not found"],
+  ])("surfaces not-found errors for %s", async (_caseName, detail) => {
+    server.use(
+      http.post("/v1/traces/transfer", ({ response }) =>
+        response(404).text(detail)
+      )
+    );
+
+    const transferPromise = transferTraces({
+      client: createTestClient(),
+      traceIdentifiers: ["trace-a"],
+      destinationProjectIdentifier: "destination-project",
+    });
+
+    await expect(transferPromise).rejects.toThrow(HttpError);
+    await expect(transferPromise).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("throws when a successful response has no transfer data", async () => {
+    server.use(
+      http.post("/v1/traces/transfer", ({ response }) =>
+        response.untyped(
+          new Response("{}", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      )
+    );
+
+    await expect(
+      transferTraces({
+        client: createTestClient(),
+        traceIdentifiers: ["trace-a"],
+        destinationProjectIdentifier: "destination-project",
+      })
+    ).rejects.toThrow("Failed to transfer traces: no data returned");
+  });
+});


### PR DESCRIPTION
## Summary

- add a typed `transferTraces` helper to `@arizeai/phoenix-client/traces`
- return camel-cased transfer results and guard the route behind Phoenix 20.4.0
- cover successful moves, empty inputs, mixed-source validation, missing resources, and malformed success responses
- document that transferring traces moves rather than copies them

Closes #15657

## Testing

- `make format-ts`
- `make lint-ts`
- `make typecheck-ts`
- `pnpm --filter @arizeai/phoenix-client build`
- `pnpm --filter @arizeai/phoenix-client exec vitest run test/traces/transferTraces.test.ts test/entryPoints.test.ts` (14 passed)
- `pnpm --filter @arizeai/phoenix-client exec vitest run test/experiments/resumeEvaluation.test.ts` (12 passed)
- `npm pack --dry-run` with an isolated cache; verified CJS/ESM transfer helper artifacts, source, and bundled trace docs

`make test-ts` was also run. The changed client and entrypoint tests pass, but the full parallel workspace run currently trips the unrelated wall-clock assertion in `resumeEvaluation.test.ts` (`<100ms` expected, about 160ms observed). That test passes when run on its own.
