### PR TITLE
feat(js): add getCurrentUser helper

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -954,6 +954,7 @@
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/document-annotations",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/session-annotations",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/sessions",
+                  "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/users",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/prompts",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/experiments",

--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-client.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-client.mdx
@@ -27,6 +27,7 @@ Browse the website version under [@arizeai/phoenix-client Docs](/docs/phoenix/sd
 - [CI Eval Tests](/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/ci-evals)
 - [Spans](/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/spans)
 - [Sessions](/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/sessions)
+- [Users](/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/users)
 
 ## Local Install Pattern
 

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Typed TypeScript client for Phoenix platform APIs"
 ---
 
-`@arizeai/phoenix-client` is the typed TypeScript client for Phoenix platform APIs. It ships a small root REST client plus focused module entrypoints for prompts, datasets, experiments, spans, sessions, traces, and CI-friendly dataset-backed eval tests.
+`@arizeai/phoenix-client` is the typed TypeScript client for Phoenix platform APIs. It ships a small root REST client plus focused module entrypoints for prompts, datasets, experiments, spans, sessions, traces, users, and CI-friendly dataset-backed eval tests.
 
 ## Install
 
@@ -43,6 +43,7 @@ That gives the agent version-matched docs plus the exact implementation and gene
 | `@arizeai/phoenix-client/spans` | Span search, notes, and span/document annotations |
 | `@arizeai/phoenix-client/sessions` | Session listing, retrieval, and session annotations |
 | `@arizeai/phoenix-client/traces` | Project trace retrieval and trace annotations |
+| `@arizeai/phoenix-client/users` | Current authenticated user retrieval |
 | `@arizeai/phoenix-client/vitest` | Vitest entrypoint for dataset-backed eval tests |
 | `@arizeai/phoenix-client/vitest/reporter` | Vitest reporter for Phoenix eval summaries |
 | `@arizeai/phoenix-client/jest` | Jest entrypoint for dataset-backed eval tests |
@@ -161,7 +162,7 @@ Prefer this layer when:
 - [Prompts](./prompts), [Datasets](./datasets), [Experiments](./experiments) — higher-level workflows
 - [Annotations](./annotations) — annotation concepts, then [Span](./span-annotations), [Document](./document-annotations), and [Session](./session-annotations) annotations for detailed usage
 - [CI Eval Tests](./ci-evals) — Vitest/Jest eval suites backed by Phoenix datasets and experiments
-- [Spans](./spans), [Sessions](./sessions), [Traces](./traces) — retrieval and maintenance
+- [Spans](./spans), [Sessions](./sessions), [Traces](./traces), [Users](./users) — retrieval and maintenance
 
 <section className="hidden" data-agent-context="source-map" aria-label="Source map">
   <h2>Source Map</h2>
@@ -177,6 +178,7 @@ Prefer this layer when:
     <li><code>src/spans/</code></li>
     <li><code>src/sessions/</code></li>
     <li><code>src/traces/</code></li>
+    <li><code>src/users/</code></li>
     <li><code>src/vitest/</code></li>
     <li><code>src/jest/</code></li>
     <li><code>src/testing/</code></li>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/users.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/users.mdx
@@ -1,0 +1,44 @@
+---
+title: "Users"
+description: "Get the current Phoenix user with @arizeai/phoenix-client"
+---
+
+The users module identifies the user associated with the client's current credentials.
+
+## Get The Current User
+
+```ts
+import { getCurrentUser } from "@arizeai/phoenix-client/users";
+
+const user = await getCurrentUser();
+
+if (user.auth_method === "ANONYMOUS") {
+  console.log("Authentication is disabled");
+} else {
+  console.log(`${user.username} has the ${user.role} role`);
+}
+```
+
+`getCurrentUser()` returns the generated Phoenix API user union. Authenticated deployments return a local, OAuth 2, or LDAP user profile. When authentication is disabled, it returns `{ auth_method: "ANONYMOUS" }`. Invalid credentials reject with an `HttpError` whose `status` is `401`; other authorization failures retain their HTTP status as well.
+
+Pass a client explicitly when you need custom configuration:
+
+```ts
+import { createClient } from "@arizeai/phoenix-client";
+import { getCurrentUser } from "@arizeai/phoenix-client/users";
+
+const client = createClient({
+  options: { baseUrl: "https://phoenix.example.com" },
+});
+
+const user = await getCurrentUser({ client });
+```
+
+<section className="hidden" data-agent-context="source-map" aria-label="Source map">
+  <h2>Source Map</h2>
+  <ul>
+    <li><code>src/users/getCurrentUser.ts</code></li>
+    <li><code>src/users/index.ts</code></li>
+    <li><code>src/__generated__/api/v1.ts</code></li>
+  </ul>
+</section>

--- a/js/.changeset/current-user-helper.md
+++ b/js/.changeset/current-user-helper.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add a typed `getCurrentUser` helper through the `@arizeai/phoenix-client/users` entrypoint.

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -57,6 +57,10 @@
       "import": "./dist/esm/projects/index.js",
       "require": "./dist/src/projects/index.js"
     },
+    "./users": {
+      "import": "./dist/esm/users/index.js",
+      "require": "./dist/src/users/index.js"
+    },
     "./traces": {
       "import": "./dist/esm/traces/index.js",
       "require": "./dist/src/traces/index.js"

--- a/js/packages/phoenix-client/src/users/getCurrentUser.ts
+++ b/js/packages/phoenix-client/src/users/getCurrentUser.ts
@@ -1,0 +1,39 @@
+import invariant from "tiny-invariant";
+
+import type { components } from "../__generated__/api/v1";
+import { createClient } from "../client";
+import type { ClientFn } from "../types/core";
+
+/** The user profile returned for the current Phoenix client credentials. */
+export type CurrentUser =
+  components["schemas"]["GetViewerResponseBody"]["data"];
+
+/**
+ * Get the currently authenticated user.
+ *
+ * When authentication is disabled, Phoenix returns an anonymous user with
+ * `auth_method: "ANONYMOUS"`.
+ *
+ * @param params - The parameters for fetching the current user.
+ * @param params.client - An optional Phoenix client instance.
+ * @returns The current user's generated API profile shape.
+ * @throws {HttpError} If the request is not authenticated or is forbidden.
+ *
+ * @example
+ * ```ts
+ * import { getCurrentUser } from "@arizeai/phoenix-client/users";
+ *
+ * const user = await getCurrentUser();
+ * console.log(user.auth_method);
+ * ```
+ */
+export async function getCurrentUser({
+  client: _client,
+}: ClientFn = {}): Promise<CurrentUser> {
+  const client = _client ?? createClient();
+  const { data, error } = await client.GET("/v1/user");
+
+  if (error) throw error;
+  invariant(data?.data, "Failed to get current user");
+  return data.data;
+}

--- a/js/packages/phoenix-client/src/users/index.ts
+++ b/js/packages/phoenix-client/src/users/index.ts
@@ -1,0 +1,1 @@
+export * from "./getCurrentUser";

--- a/js/packages/phoenix-client/test/entryPoints.test.ts
+++ b/js/packages/phoenix-client/test/entryPoints.test.ts
@@ -9,6 +9,7 @@ const cjsEntries = {
   index: "../dist/src/index.js",
   experiments: "../dist/src/experiments/index.js",
   jest: "../dist/src/jest/index.js",
+  users: "../dist/src/users/index.js",
 } as const;
 // The index entry transitively require()s @arizeai/phoenix-otel's dist via the
 // workspace symlink, so an unbuilt sibling would fail the guard even though
@@ -48,6 +49,7 @@ const esmEntries = {
   index: "../dist/esm/index.js",
   experiments: "../dist/esm/experiments/index.js",
   jest: "../dist/esm/jest/index.js",
+  users: "../dist/esm/users/index.js",
 } as const;
 
 describe.skipIf(!isBuilt)("built ESM entry points", () => {

--- a/js/packages/phoenix-client/test/users/getCurrentUser.test.ts
+++ b/js/packages/phoenix-client/test/users/getCurrentUser.test.ts
@@ -1,0 +1,80 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { HttpError } from "../../src/errors";
+import type { CurrentUser } from "../../src/users";
+import { getCurrentUser } from "../../src/users";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("getCurrentUser", () => {
+  it("returns the generated authenticated-user shape", async () => {
+    const currentUser: CurrentUser = {
+      id: "user-1",
+      created_at: "2026-08-29T12:00:00Z",
+      updated_at: "2026-08-29T12:00:00Z",
+      email: "member@example.com",
+      username: "member",
+      role: "MEMBER",
+      auth_method: "LOCAL",
+      password_needs_reset: false,
+    };
+
+    server.use(
+      http.get("/v1/user", ({ response }) =>
+        response(200).json({ data: currentUser })
+      )
+    );
+
+    await expect(
+      getCurrentUser({ client: createTestClient() })
+    ).resolves.toEqual(currentUser);
+  });
+
+  it("returns the anonymous user when authentication is disabled", async () => {
+    server.use(
+      http.get("/v1/user", ({ response }) =>
+        response(200).json({ data: { auth_method: "ANONYMOUS" } })
+      )
+    );
+
+    await expect(
+      getCurrentUser({ client: createTestClient() })
+    ).resolves.toEqual({ auth_method: "ANONYMOUS" });
+  });
+
+  it.each([401, 403] as const)(
+    "surfaces a %i authentication error as HttpError",
+    async (status) => {
+      server.use(
+        http.get("/v1/user", ({ response }) =>
+          response(status).text(
+            status === 401 ? "Not authenticated" : "Forbidden"
+          )
+        )
+      );
+
+      const promise = getCurrentUser({ client: createTestClient() });
+
+      await expect(promise).rejects.toMatchObject({ status });
+      await expect(promise).rejects.toBeInstanceOf(HttpError);
+    }
+  );
+});


### PR DESCRIPTION
resolves #15648

## Summary

- add a typed `getCurrentUser` helper backed by `GET /v1/user`
- export the helper and generated `CurrentUser` union from `@arizeai/phoenix-client/users`
- cover authenticated, anonymous, 401, and 403 responses
- document the new users entrypoint and include it in bundled package docs

## Verification

- `make format-ts`
- `make lint-ts`
- `make typecheck-ts`
- `make build-ts`
- `pnpm --filter @arizeai/phoenix-client test` (535 passed, 1 skipped)
- `node js/scripts/sync-package-docs.mjs phoenix-client`
- `npm pack --dry-run --json`

`make test-ts` also passed the client and frontend suites, but an unrelated existing wall-clock assertion in `resumeEvaluation.test.ts` exceeded its 100 ms threshold during the workspace run. The complete phoenix-client suite passed on a clean rerun.
