### PR TITLE
feat(js): add dataset split write helpers

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx
@@ -25,6 +25,7 @@ const { datasetId } = await createDataset({
   description: "Support questions with expected answers",
   examples: [
     {
+      id: "order-tracking",
       input: { question: "Where is my order?" },
       output: { answer: "Use the tracking page in your account." },
       metadata: { channel: "chat" },
@@ -48,6 +49,7 @@ const dataset = await createDataset({
   description: "Support questions with expected answers",
   examples: [
     {
+      id: "order-tracking",
       input: { question: "Where is my order?" },
       output: { answer: "Use the tracking page in your account." },
     },
@@ -58,6 +60,7 @@ await appendDatasetExamples({
   dataset,
   examples: [
     {
+      id: "password-reset",
       input: { question: "How do I reset my password?" },
       output: { answer: "Use the forgot password flow." },
     },
@@ -75,8 +78,8 @@ Use `getDataset`, `getDatasetExamples`, and `getDatasetInfo` to inspect datasets
 
 Use `createDatasetSplit`, `updateDatasetSplit`, and `deleteDatasetSplit` to
 manage train, test, validation, or other named subsets after a dataset exists.
-Select the dataset by name or GlobalID. Example membership uses the `nodeId`
-GlobalIDs returned by `getDatasetExamples`.
+Select the dataset by name or GlobalID. Example membership accepts either the
+user-provided `id` or Phoenix `nodeId` returned by `getDatasetExamples`.
 
 ```ts
 import {
@@ -91,12 +94,16 @@ const dataset = { datasetName: datasetIdentifier };
 const { examples } = await getDatasetExamples({
   dataset,
 });
+const [firstExample, secondExample] = examples;
+if (firstExample == null || secondExample == null) {
+  throw new Error("At least two examples are required to demonstrate split updates");
+}
 
 const testSplit = await createDatasetSplit({
   dataset,
   name: "test",
   description: "Held-out evaluation examples",
-  exampleIds: examples.slice(0, 2).map((example) => example.nodeId),
+  exampleIds: [firstExample.id],
 });
 
 // Only provided fields change. Adding an existing member or removing a
@@ -105,8 +112,8 @@ await updateDatasetSplit({
   dataset,
   splitId: testSplit.id,
   description: "Reviewed held-out examples",
-  addExampleIds: [examples[2].nodeId],
-  removeExampleIds: [examples[0].nodeId],
+  addExampleIds: [secondExample.id],
+  removeExampleIds: [firstExample.id],
 });
 
 // Deleting a split removes its memberships, not the underlying examples.

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx
@@ -3,7 +3,7 @@ title: "Datasets"
 description: "Create and inspect datasets with @arizeai/phoenix-client"
 ---
 
-Datasets are the foundation for experiment runs. The dataset helpers cover creation (which upserts by name), record inspection, and example appends.
+Datasets are the foundation for experiment runs. The dataset helpers cover creation (which upserts by name), record inspection, example appends, and split management.
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
@@ -71,6 +71,55 @@ await appendDatasetExamples({
 
 Use `getDataset`, `getDatasetExamples`, and `getDatasetInfo` to inspect datasets after creation.
 
+## Manage Splits On An Existing Dataset
+
+Use `createDatasetSplit`, `updateDatasetSplit`, and `deleteDatasetSplit` to
+manage train, test, validation, or other named subsets after a dataset exists.
+Select the dataset by name or GlobalID. Example membership uses the `nodeId`
+GlobalIDs returned by `getDatasetExamples`.
+
+```ts
+import {
+  createDatasetSplit,
+  deleteDatasetSplit,
+  getDatasetExamples,
+  updateDatasetSplit,
+} from "@arizeai/phoenix-client/datasets";
+
+const datasetIdentifier = "support-eval";
+const dataset = { datasetName: datasetIdentifier };
+const { examples } = await getDatasetExamples({
+  dataset,
+});
+
+const testSplit = await createDatasetSplit({
+  dataset,
+  name: "test",
+  description: "Held-out evaluation examples",
+  exampleIds: examples.slice(0, 2).map((example) => example.nodeId),
+});
+
+// Only provided fields change. Adding an existing member or removing a
+// non-member is an idempotent no-op.
+await updateDatasetSplit({
+  dataset,
+  splitId: testSplit.id,
+  description: "Reviewed held-out examples",
+  addExampleIds: [examples[2].nodeId],
+  removeExampleIds: [examples[0].nodeId],
+});
+
+// Deleting a split removes its memberships, not the underlying examples.
+await deleteDatasetSplit({
+  dataset,
+  splitId: testSplit.id,
+});
+```
+
+Split names are unique across the Phoenix instance. Creating or renaming a
+split to an existing name fails with HTTP 409. These helpers require Phoenix
+server 19.20.0 or newer.
+
 <section className="hidden" data-agent-context="source-map" aria-label="Source map">
   <h2>Source Map</h2>
   <ul>
@@ -79,5 +128,8 @@ Use `getDataset`, `getDatasetExamples`, and `getDatasetInfo` to inspect datasets
     <li><code>src/datasets/getDataset.ts</code></li>
     <li><code>src/datasets/getDatasetExamples.ts</code></li>
     <li><code>src/datasets/getDatasetInfo.ts</code></li>
+    <li><code>src/datasets/createDatasetSplit.ts</code></li>
+    <li><code>src/datasets/updateDatasetSplit.ts</code></li>
+    <li><code>src/datasets/deleteDatasetSplit.ts</code></li>
   </ul>
 </section>

--- a/js/.changeset/dataset-split-helpers.md
+++ b/js/.changeset/dataset-split-helpers.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `createDatasetSplit`, `updateDatasetSplit`, and `deleteDatasetSplit` helpers to the `datasets` subpath. The helpers select datasets by name or GlobalID, create splits on existing datasets, partially update split fields, add or remove example memberships idempotently, and delete splits without deleting their examples. They require Phoenix server 19.20.0 or newer.
+
+Also export the generated `DatasetSplit` response type and a `DatasetIdentifier` selector type from the datasets subpath.

--- a/js/app/src/api/__generated__/v1.ts
+++ b/js/app/src/api/__generated__/v1.ts
@@ -2647,7 +2647,7 @@ export interface components {
             };
             /**
              * Example Ids
-             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             * @description Optional dataset example identifiers (GlobalIDs or user-provided IDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
              */
             example_ids?: string[];
         };
@@ -6589,12 +6589,12 @@ export interface components {
             } | null;
             /**
              * Add Example Ids
-             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             * @description Dataset example identifiers (GlobalIDs or user-provided IDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
              */
             add_example_ids?: string[];
             /**
              * Remove Example Ids
-             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             * @description Dataset example identifiers (GlobalIDs or user-provided IDs) to remove from the split.
              */
             remove_example_ids?: string[];
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2647,7 +2647,7 @@ export interface components {
             };
             /**
              * Example Ids
-             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             * @description Optional dataset example identifiers (GlobalIDs or user-provided IDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
              */
             example_ids?: string[];
         };
@@ -6589,12 +6589,12 @@ export interface components {
             } | null;
             /**
              * Add Example Ids
-             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             * @description Dataset example identifiers (GlobalIDs or user-provided IDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
              */
             add_example_ids?: string[];
             /**
              * Remove Example Ids
-             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             * @description Dataset example identifiers (GlobalIDs or user-provided IDs) to remove from the split.
              */
             remove_example_ids?: string[];
         };

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -114,6 +114,27 @@ export const DATASET_UPLOAD_EXAMPLE_IDS: ParameterRequirement = {
   minServerVersion: [15, 0, 0],
 };
 
+export const CREATE_DATASET_SPLIT: RouteRequirement = {
+  kind: "route",
+  method: "POST",
+  path: "/v1/datasets/{dataset_identifier}/splits",
+  minServerVersion: [19, 20, 0],
+};
+
+export const UPDATE_DATASET_SPLIT: RouteRequirement = {
+  kind: "route",
+  method: "PATCH",
+  path: "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+  minServerVersion: [19, 20, 0],
+};
+
+export const DELETE_DATASET_SPLIT: RouteRequirement = {
+  kind: "route",
+  method: "DELETE",
+  path: "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+  minServerVersion: [19, 20, 0],
+};
+
 export const ADD_TRACE_NOTE_IDENTIFIER: ParameterRequirement = {
   kind: "parameter",
   parameterName: "identifier",
@@ -228,6 +249,9 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   GET_SPANS_BY_ATTRIBUTE,
   LIST_PROJECT_TRACES,
   DATASET_UPLOAD_EXAMPLE_IDS,
+  CREATE_DATASET_SPLIT,
+  UPDATE_DATASET_SPLIT,
+  DELETE_DATASET_SPLIT,
   ADD_TRACE_NOTE_IDENTIFIER,
   ADD_SPAN_NOTE_IDENTIFIER,
   ADD_SESSION_NOTE_IDENTIFIER,

--- a/js/packages/phoenix-client/src/datasets/createDatasetSplit.ts
+++ b/js/packages/phoenix-client/src/datasets/createDatasetSplit.ts
@@ -25,7 +25,7 @@ export interface CreateDatasetSplitParams extends ClientFn {
   color?: CreateDatasetSplitRequestBody["color"];
   /** Arbitrary JSON metadata for the split. */
   metadata?: CreateDatasetSplitRequestBody["metadata"];
-  /** Dataset example GlobalIDs with which to seed the split. */
+  /** Dataset example GlobalIDs or user-provided IDs with which to seed the split. */
   exampleIds?: CreateDatasetSplitRequestBody["example_ids"];
 }
 
@@ -39,7 +39,7 @@ export interface CreateDatasetSplitParams extends ClientFn {
  * @param params.description - An optional description of the split.
  * @param params.color - An optional hex color for the split.
  * @param params.metadata - Arbitrary JSON metadata for the split.
- * @param params.exampleIds - Dataset example GlobalIDs with which to seed the split.
+ * @param params.exampleIds - Dataset example GlobalIDs or user-provided IDs with which to seed the split.
  * @returns The created dataset split.
  * @throws {HttpError} If the dataset or an example does not exist, the name is
  * already in use, or the request is invalid.

--- a/js/packages/phoenix-client/src/datasets/createDatasetSplit.ts
+++ b/js/packages/phoenix-client/src/datasets/createDatasetSplit.ts
@@ -1,0 +1,80 @@
+import invariant from "tiny-invariant";
+
+import type { components } from "../__generated__/api/v1";
+import { createClient } from "../client";
+import { CREATE_DATASET_SPLIT } from "../constants/serverRequirements";
+import type { ClientFn } from "../types/core";
+import type { DatasetIdentifier, DatasetSplit } from "../types/datasets";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+import { resolveDatasetIdentifier } from "./resolveDatasetIdentifier";
+
+type CreateDatasetSplitRequestBody =
+  components["schemas"]["CreateDatasetSplitRequestBody"];
+type CreateDatasetSplitResponseBody =
+  components["schemas"]["CreateDatasetSplitResponseBody"];
+
+/** Parameters for creating a dataset split. */
+export interface CreateDatasetSplitParams extends ClientFn {
+  /** The dataset, selected by name or GlobalID. */
+  dataset: DatasetIdentifier;
+  /** A unique name for the split. */
+  name: CreateDatasetSplitRequestBody["name"];
+  /** An optional description of the split. */
+  description?: CreateDatasetSplitRequestBody["description"];
+  /** An optional hex color for the split. */
+  color?: CreateDatasetSplitRequestBody["color"];
+  /** Arbitrary JSON metadata for the split. */
+  metadata?: CreateDatasetSplitRequestBody["metadata"];
+  /** Dataset example GlobalIDs with which to seed the split. */
+  exampleIds?: CreateDatasetSplitRequestBody["example_ids"];
+}
+
+/**
+ * Create a split on an existing dataset.
+ *
+ * @param params - The split to create.
+ * @param params.client - Optional Phoenix client instance.
+ * @param params.dataset - The dataset, selected by name or GlobalID.
+ * @param params.name - A unique name for the split.
+ * @param params.description - An optional description of the split.
+ * @param params.color - An optional hex color for the split.
+ * @param params.metadata - Arbitrary JSON metadata for the split.
+ * @param params.exampleIds - Dataset example GlobalIDs with which to seed the split.
+ * @returns The created dataset split.
+ * @throws {HttpError} If the dataset or an example does not exist, the name is
+ * already in use, or the request is invalid.
+ *
+ * @requires Phoenix server >= 19.20.0
+ */
+export async function createDatasetSplit({
+  client: _client,
+  dataset,
+  name,
+  description,
+  color,
+  metadata,
+  exampleIds,
+}: CreateDatasetSplitParams): Promise<DatasetSplit> {
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: CREATE_DATASET_SPLIT });
+  const datasetIdentifier = resolveDatasetIdentifier(dataset);
+
+  const body: CreateDatasetSplitRequestBody = {
+    name,
+    ...(description !== undefined ? { description } : {}),
+    ...(color !== undefined ? { color } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+    ...(exampleIds !== undefined ? { example_ids: exampleIds } : {}),
+  };
+  const response = await client.POST(
+    "/v1/datasets/{dataset_identifier}/splits",
+    {
+      params: { path: { dataset_identifier: datasetIdentifier } },
+      body,
+    }
+  );
+  const responseBody: CreateDatasetSplitResponseBody | undefined =
+    response.data;
+  invariant(responseBody?.data, "Failed to create dataset split");
+  return responseBody.data;
+}

--- a/js/packages/phoenix-client/src/datasets/deleteDatasetSplit.ts
+++ b/js/packages/phoenix-client/src/datasets/deleteDatasetSplit.ts
@@ -1,0 +1,46 @@
+import { createClient } from "../client";
+import { DELETE_DATASET_SPLIT } from "../constants/serverRequirements";
+import type { ClientFn } from "../types/core";
+import type { DatasetIdentifier } from "../types/datasets";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+import { resolveDatasetIdentifier } from "./resolveDatasetIdentifier";
+
+/** Parameters for deleting a dataset split. */
+export interface DeleteDatasetSplitParams extends ClientFn {
+  /** The dataset, selected by name or GlobalID. */
+  dataset: DatasetIdentifier;
+  /** The dataset split GlobalID. */
+  splitId: string;
+}
+
+/**
+ * Delete a dataset split and its memberships without deleting its examples.
+ *
+ * @param params - The split to delete.
+ * @param params.client - Optional Phoenix client instance.
+ * @param params.dataset - The dataset, selected by name or GlobalID.
+ * @param params.splitId - The dataset split GlobalID.
+ * @returns A promise that resolves once the split is deleted.
+ * @throws {HttpError} If the dataset or split does not exist, or the split ID
+ * is invalid.
+ *
+ * @requires Phoenix server >= 19.20.0
+ */
+export async function deleteDatasetSplit({
+  client: _client,
+  dataset,
+  splitId,
+}: DeleteDatasetSplitParams): Promise<void> {
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: DELETE_DATASET_SPLIT });
+  const datasetIdentifier = resolveDatasetIdentifier(dataset);
+
+  await client.DELETE("/v1/datasets/{dataset_identifier}/splits/{split_id}", {
+    params: {
+      path: {
+        dataset_identifier: datasetIdentifier,
+        split_id: splitId,
+      },
+    },
+  });
+}

--- a/js/packages/phoenix-client/src/datasets/index.ts
+++ b/js/packages/phoenix-client/src/datasets/index.ts
@@ -1,5 +1,9 @@
 export * from "./createDataset";
+export * from "./createDatasetSplit";
+export * from "./deleteDatasetSplit";
 export * from "./getDataset";
 export * from "./getDatasetExamples";
 export * from "./appendDatasetExamples";
 export * from "./getDatasetInfo";
+export * from "./updateDatasetSplit";
+export type { DatasetIdentifier, DatasetSplit } from "../types/datasets";

--- a/js/packages/phoenix-client/src/datasets/resolveDatasetIdentifier.ts
+++ b/js/packages/phoenix-client/src/datasets/resolveDatasetIdentifier.ts
@@ -1,0 +1,6 @@
+import type { DatasetIdentifier } from "../types/datasets";
+
+/** Resolve a typed dataset selector to the REST path identifier. */
+export function resolveDatasetIdentifier(dataset: DatasetIdentifier): string {
+  return "datasetName" in dataset ? dataset.datasetName : dataset.datasetId;
+}

--- a/js/packages/phoenix-client/src/datasets/updateDatasetSplit.ts
+++ b/js/packages/phoenix-client/src/datasets/updateDatasetSplit.ts
@@ -1,0 +1,99 @@
+import invariant from "tiny-invariant";
+
+import type { components } from "../__generated__/api/v1";
+import { createClient } from "../client";
+import { UPDATE_DATASET_SPLIT } from "../constants/serverRequirements";
+import type { ClientFn } from "../types/core";
+import type { DatasetIdentifier, DatasetSplit } from "../types/datasets";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+import { resolveDatasetIdentifier } from "./resolveDatasetIdentifier";
+
+type UpdateDatasetSplitRequestBody =
+  components["schemas"]["UpdateDatasetSplitRequestBody"];
+type UpdateDatasetSplitResponseBody =
+  components["schemas"]["UpdateDatasetSplitResponseBody"];
+
+/** Parameters for partially updating a dataset split. */
+export interface UpdateDatasetSplitParams extends ClientFn {
+  /** The dataset, selected by name or GlobalID. */
+  dataset: DatasetIdentifier;
+  /** The dataset split GlobalID. */
+  splitId: string;
+  /** A new unique name for the split. */
+  name?: UpdateDatasetSplitRequestBody["name"];
+  /** A new description, or null to clear it. */
+  description?: UpdateDatasetSplitRequestBody["description"];
+  /** A new hex color for the split. */
+  color?: UpdateDatasetSplitRequestBody["color"];
+  /** JSON metadata that replaces the existing metadata. */
+  metadata?: UpdateDatasetSplitRequestBody["metadata"];
+  /** Dataset example GlobalIDs to add. Existing memberships are no-ops. */
+  addExampleIds?: UpdateDatasetSplitRequestBody["add_example_ids"];
+  /** Dataset example GlobalIDs to remove. Missing memberships are no-ops. */
+  removeExampleIds?: UpdateDatasetSplitRequestBody["remove_example_ids"];
+}
+
+/**
+ * Partially update a dataset split and/or its example membership.
+ *
+ * Only provided fields change. Membership additions and removals are
+ * idempotent; if an example appears in both arrays, removal wins.
+ *
+ * @param params - The split fields and memberships to update.
+ * @param params.client - Optional Phoenix client instance.
+ * @param params.dataset - The dataset, selected by name or GlobalID.
+ * @param params.splitId - The dataset split GlobalID.
+ * @param params.name - A new unique name for the split.
+ * @param params.description - A new description, or null to clear it.
+ * @param params.color - A new hex color for the split.
+ * @param params.metadata - JSON metadata that replaces the existing metadata.
+ * @param params.addExampleIds - Dataset example GlobalIDs to add.
+ * @param params.removeExampleIds - Dataset example GlobalIDs to remove.
+ * @returns The updated dataset split.
+ * @throws {HttpError} If the dataset, split, or an example does not exist, the
+ * name is already in use, or the request is invalid.
+ *
+ * @requires Phoenix server >= 19.20.0
+ */
+export async function updateDatasetSplit({
+  client: _client,
+  dataset,
+  splitId,
+  name,
+  description,
+  color,
+  metadata,
+  addExampleIds,
+  removeExampleIds,
+}: UpdateDatasetSplitParams): Promise<DatasetSplit> {
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: UPDATE_DATASET_SPLIT });
+  const datasetIdentifier = resolveDatasetIdentifier(dataset);
+
+  const body: UpdateDatasetSplitRequestBody = {
+    ...(name !== undefined ? { name } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(color !== undefined ? { color } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+    ...(addExampleIds !== undefined ? { add_example_ids: addExampleIds } : {}),
+    ...(removeExampleIds !== undefined
+      ? { remove_example_ids: removeExampleIds }
+      : {}),
+  };
+  const response = await client.PATCH(
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+    {
+      params: {
+        path: {
+          dataset_identifier: datasetIdentifier,
+          split_id: splitId,
+        },
+      },
+      body,
+    }
+  );
+  const responseBody: UpdateDatasetSplitResponseBody | undefined =
+    response.data;
+  invariant(responseBody?.data, "Failed to update dataset split");
+  return responseBody.data;
+}

--- a/js/packages/phoenix-client/src/datasets/updateDatasetSplit.ts
+++ b/js/packages/phoenix-client/src/datasets/updateDatasetSplit.ts
@@ -27,9 +27,9 @@ export interface UpdateDatasetSplitParams extends ClientFn {
   color?: UpdateDatasetSplitRequestBody["color"];
   /** JSON metadata that replaces the existing metadata. */
   metadata?: UpdateDatasetSplitRequestBody["metadata"];
-  /** Dataset example GlobalIDs to add. Existing memberships are no-ops. */
+  /** Dataset example GlobalIDs or user-provided IDs to add. Existing memberships are no-ops. */
   addExampleIds?: UpdateDatasetSplitRequestBody["add_example_ids"];
-  /** Dataset example GlobalIDs to remove. Missing memberships are no-ops. */
+  /** Dataset example GlobalIDs or user-provided IDs to remove. Missing memberships are no-ops. */
   removeExampleIds?: UpdateDatasetSplitRequestBody["remove_example_ids"];
 }
 
@@ -47,8 +47,8 @@ export interface UpdateDatasetSplitParams extends ClientFn {
  * @param params.description - A new description, or null to clear it.
  * @param params.color - A new hex color for the split.
  * @param params.metadata - JSON metadata that replaces the existing metadata.
- * @param params.addExampleIds - Dataset example GlobalIDs to add.
- * @param params.removeExampleIds - Dataset example GlobalIDs to remove.
+ * @param params.addExampleIds - Dataset example GlobalIDs or user-provided IDs to add.
+ * @param params.removeExampleIds - Dataset example GlobalIDs or user-provided IDs to remove.
  * @returns The updated dataset split.
  * @throws {HttpError} If the dataset, split, or an example does not exist, the
  * name is already in use, or the request is invalid.

--- a/js/packages/phoenix-client/src/types/datasets.ts
+++ b/js/packages/phoenix-client/src/types/datasets.ts
@@ -1,13 +1,18 @@
+import type { components } from "../__generated__/api/v1";
 import type { Node } from "./core";
 
+/** A named subset of examples in a dataset. */
+export type DatasetSplit = components["schemas"]["DatasetSplit"];
+
 type DatasetSelectorBase = { versionId?: string; splits?: string[] };
+
+/** A dataset identified by either its GlobalID or name. */
+export type DatasetIdentifier = { datasetId: string } | { datasetName: string };
 
 /**
  * A dataset can be identified by its datasetId, datasetName, or datasetVersionId
  */
-export type DatasetSelector =
-  | (DatasetSelectorBase & { datasetId: string })
-  | (DatasetSelectorBase & { datasetName: string });
+export type DatasetSelector = DatasetSelectorBase & DatasetIdentifier;
 
 /**
  * Overview information about a dataset

--- a/js/packages/phoenix-client/test/datasets/datasetSplits.test.ts
+++ b/js/packages/phoenix-client/test/datasets/datasetSplits.test.ts
@@ -1,0 +1,316 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.unmock("../../src/utils/serverVersionUtils");
+
+import {
+  createDatasetSplit,
+  deleteDatasetSplit,
+  updateDatasetSplit,
+} from "../../src/datasets";
+import { HttpError } from "../../src/errors";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+const DATASET_SPLIT = {
+  id: "RGF0YXNldFNwbGl0OjE=",
+  name: "train",
+  description: "Training examples",
+  color: "#33c5e8",
+  metadata: { purpose: "training" },
+  example_count: 2,
+  created_at: "2026-08-29T00:00:00Z",
+  updated_at: "2026-08-29T00:00:00Z",
+};
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+function serverVersionHandler(version = "19.20.0") {
+  return http.get("/arize_phoenix_version", ({ response }) =>
+    response.untyped(new Response(version, { status: 200 }))
+  );
+}
+
+describe("createDatasetSplit", () => {
+  it("creates a seeded split and returns the generated response type", async () => {
+    const captured: { body?: unknown; datasetIdentifier?: string } = {};
+    server.use(
+      serverVersionHandler(),
+      http.post(
+        "/v1/datasets/{dataset_identifier}/splits",
+        async ({ params, request, response }) => {
+          captured.datasetIdentifier = params.dataset_identifier;
+          captured.body = await request.json();
+          return response(201).json({ data: DATASET_SPLIT });
+        }
+      )
+    );
+
+    const split = await createDatasetSplit({
+      client: createTestClient(),
+      dataset: { datasetName: "support-eval" },
+      name: "train",
+      description: "Training examples",
+      color: "#33c5e8",
+      metadata: { purpose: "training" },
+      exampleIds: ["RGF0YXNldEV4YW1wbGU6MQ=="],
+    });
+
+    expect(captured.datasetIdentifier).toBe("support-eval");
+    expect(captured.body).toEqual({
+      name: "train",
+      description: "Training examples",
+      color: "#33c5e8",
+      metadata: { purpose: "training" },
+      example_ids: ["RGF0YXNldEV4YW1wbGU6MQ=="],
+    });
+    expect(split).toEqual(DATASET_SPLIT);
+  });
+
+  it("surfaces duplicate names as an HttpError", async () => {
+    server.use(
+      serverVersionHandler(),
+      http.post("/v1/datasets/{dataset_identifier}/splits", ({ response }) =>
+        response.untyped(
+          new Response("A dataset split named 'train' already exists", {
+            status: 409,
+          })
+        )
+      )
+    );
+
+    const error = await createDatasetSplit({
+      client: createTestClient(),
+      dataset: { datasetName: "support-eval" },
+      name: "train",
+    }).catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(409);
+  });
+});
+
+describe("updateDatasetSplit", () => {
+  it("sends only fields supplied for a partial update", async () => {
+    const captured: { body?: unknown; splitId?: string } = {};
+    server.use(
+      serverVersionHandler(),
+      http.patch(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        async ({ params, request, response }) => {
+          captured.splitId = params.split_id;
+          captured.body = await request.json();
+          return response(200).json({
+            data: { ...DATASET_SPLIT, description: null, metadata: {} },
+          });
+        }
+      )
+    );
+
+    const split = await updateDatasetSplit({
+      client: createTestClient(),
+      dataset: { datasetName: "support-eval" },
+      splitId: DATASET_SPLIT.id,
+      description: null,
+      metadata: {},
+    });
+
+    expect(captured.splitId).toBe(DATASET_SPLIT.id);
+    expect(captured.body).toEqual({ description: null, metadata: {} });
+    expect(split.description).toBeNull();
+  });
+
+  it("keeps repeated membership additions and removals idempotent", async () => {
+    const existingExampleId = "RGF0YXNldEV4YW1wbGU6MQ==";
+    const newExampleId = "RGF0YXNldEV4YW1wbGU6Mg==";
+    const missingExampleId = "RGF0YXNldEV4YW1wbGU6OTk=";
+    const memberIds = new Set([existingExampleId]);
+    const capturedBodies: unknown[] = [];
+    server.use(
+      serverVersionHandler(),
+      http.patch(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        async ({ request, response }) => {
+          const body = (await request.json()) as {
+            add_example_ids?: string[];
+            remove_example_ids?: string[];
+          };
+          capturedBodies.push(body);
+          body.add_example_ids?.forEach((exampleId) =>
+            memberIds.add(exampleId)
+          );
+          body.remove_example_ids?.forEach((exampleId) =>
+            memberIds.delete(exampleId)
+          );
+          return response(200).json({
+            data: { ...DATASET_SPLIT, example_count: memberIds.size },
+          });
+        }
+      )
+    );
+    const params = {
+      client: createTestClient(),
+      dataset: { datasetName: "support-eval" },
+      splitId: DATASET_SPLIT.id,
+      addExampleIds: [existingExampleId, newExampleId],
+      removeExampleIds: [missingExampleId],
+    };
+
+    const firstResult = await updateDatasetSplit(params);
+    const secondResult = await updateDatasetSplit(params);
+
+    expect(firstResult.example_count).toBe(2);
+    expect(secondResult.example_count).toBe(2);
+    expect(capturedBodies).toEqual([
+      {
+        add_example_ids: [existingExampleId, newExampleId],
+        remove_example_ids: [missingExampleId],
+      },
+      {
+        add_example_ids: [existingExampleId, newExampleId],
+        remove_example_ids: [missingExampleId],
+      },
+    ]);
+  });
+
+  it("surfaces update errors", async () => {
+    server.use(
+      serverVersionHandler(),
+      http.patch(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        ({ response }) =>
+          response.untyped(
+            new Response("Dataset split not found", { status: 404 })
+          )
+      )
+    );
+
+    await expect(
+      updateDatasetSplit({
+        client: createTestClient(),
+        dataset: { datasetName: "support-eval" },
+        splitId: "missing",
+        name: "validation",
+      })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("surfaces a duplicate name during a partial update", async () => {
+    server.use(
+      serverVersionHandler(),
+      http.patch(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        ({ response }) =>
+          response.untyped(
+            new Response("A dataset split with this name already exists", {
+              status: 409,
+            })
+          )
+      )
+    );
+
+    await expect(
+      updateDatasetSplit({
+        client: createTestClient(),
+        dataset: { datasetName: "support-eval" },
+        splitId: DATASET_SPLIT.id,
+        name: "validation",
+      })
+    ).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+describe("deleteDatasetSplit", () => {
+  it("deletes the split selected by dataset and split identifiers", async () => {
+    const captured: { datasetIdentifier?: string; splitId?: string } = {};
+    server.use(
+      serverVersionHandler(),
+      http.delete(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        ({ params, response }) => {
+          captured.datasetIdentifier = params.dataset_identifier;
+          captured.splitId = params.split_id;
+          return response(204).empty();
+        }
+      )
+    );
+
+    await expect(
+      deleteDatasetSplit({
+        client: createTestClient(),
+        dataset: { datasetId: "RGF0YXNldDox" },
+        splitId: DATASET_SPLIT.id,
+      })
+    ).resolves.toBeUndefined();
+    expect(captured).toEqual({
+      datasetIdentifier: "RGF0YXNldDox",
+      splitId: DATASET_SPLIT.id,
+    });
+  });
+
+  it("surfaces delete errors", async () => {
+    server.use(
+      serverVersionHandler(),
+      http.delete(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        ({ response }) =>
+          response.untyped(
+            new Response("Invalid dataset split ID", { status: 422 })
+          )
+      )
+    );
+
+    await expect(
+      deleteDatasetSplit({
+        client: createTestClient(),
+        dataset: { datasetName: "support-eval" },
+        splitId: "invalid",
+      })
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("fails before deleting against an older Phoenix server", async () => {
+    let deleteRequestCount = 0;
+    server.use(
+      serverVersionHandler("19.19.0"),
+      http.delete(
+        "/v1/datasets/{dataset_identifier}/splits/{split_id}",
+        ({ response }) => {
+          deleteRequestCount += 1;
+          return response(204).empty();
+        }
+      )
+    );
+
+    await expect(
+      deleteDatasetSplit({
+        client: createTestClient(),
+        dataset: { datasetName: "support-eval" },
+        splitId: DATASET_SPLIT.id,
+      })
+    ).rejects.toThrow(/requires Phoenix server >= 19\.20\.0/);
+    expect(deleteRequestCount).toBe(0);
+  });
+});

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -2647,7 +2647,7 @@ export interface components {
             };
             /**
              * Example Ids
-             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             * @description Optional dataset example identifiers (GlobalIDs or user-provided IDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
              */
             example_ids?: string[];
         };
@@ -6589,12 +6589,12 @@ export interface components {
             } | null;
             /**
              * Add Example Ids
-             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             * @description Dataset example identifiers (GlobalIDs or user-provided IDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
              */
             add_example_ids?: string[];
             /**
              * Remove Example Ids
-             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             * @description Dataset example identifiers (GlobalIDs or user-provided IDs) to remove from the split.
              */
             remove_example_ids?: string[];
         };

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -11729,7 +11729,7 @@
             },
             "type": "array",
             "title": "Example Ids",
-            "description": "Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split."
+            "description": "Optional dataset example identifiers (GlobalIDs or user-provided IDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split."
           }
         },
         "type": "object",
@@ -21304,7 +21304,7 @@
             },
             "type": "array",
             "title": "Add Example Ids",
-            "description": "Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op."
+            "description": "Dataset example identifiers (GlobalIDs or user-provided IDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op."
           },
           "remove_example_ids": {
             "items": {
@@ -21312,7 +21312,7 @@
             },
             "type": "array",
             "title": "Remove Example Ids",
-            "description": "Dataset example IDs (GlobalIDs) to remove from the split."
+            "description": "Dataset example identifiers (GlobalIDs or user-provided IDs) to remove from the split."
           }
         },
         "type": "object",

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -20,7 +20,7 @@ from anyio import to_thread
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Query
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import Field
-from sqlalchemy import and_, case, delete, func, insert, select
+from sqlalchemy import and_, case, delete, func, insert, or_, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -1528,8 +1528,8 @@ class CreateDatasetSplitRequestBody(V1RoutesBaseModel):
     example_ids: list[str] = Field(
         default_factory=list,
         description=(
-            "Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must "
-            "belong to this dataset. Omit to create an empty split."
+            "Optional dataset example identifiers (GlobalIDs or user-provided IDs) to seed the "
+            "split with. Each example must belong to this dataset. Omit to create an empty split."
         ),
     )
 
@@ -1550,13 +1550,16 @@ class UpdateDatasetSplitRequestBody(V1RoutesBaseModel):
     add_example_ids: list[str] = Field(
         default_factory=list,
         description=(
-            "Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to "
-            "this dataset. Adding an example already in the split is a no-op."
+            "Dataset example identifiers (GlobalIDs or user-provided IDs) to add to the split. "
+            "Each example must belong to this dataset. Adding an example already in the split "
+            "is a no-op."
         ),
     )
     remove_example_ids: list[str] = Field(
         default_factory=list,
-        description="Dataset example IDs (GlobalIDs) to remove from the split.",
+        description=(
+            "Dataset example identifiers (GlobalIDs or user-provided IDs) to remove from the split."
+        ),
     )
 
 
@@ -1569,46 +1572,72 @@ async def _resolve_dataset_example_rowids(
     dataset_id: int,
     example_ids: list[str],
 ) -> list[int]:
-    """Parse dataset example GlobalIDs and confirm each belongs to the dataset.
+    """Resolve dataset example GlobalIDs or user-provided IDs within a dataset.
 
     Returns the unique example row IDs, preserving the order in which they were
-    first seen. Raises 422 for malformed IDs and 404 if any example does not
-    exist in the dataset.
+    first seen. Valid DatasetExample GlobalIDs take precedence over matching
+    user-provided IDs. Raises 404 if any example does not exist in the dataset.
     """
     if not example_ids:
         return []
-    unique_rowids: dict[int, None] = {}
-    for example_gid in example_ids:
+
+    global_rowids_by_identifier: dict[str, int] = {}
+    external_identifiers: set[str] = set()
+    for example_identifier in example_ids:
         try:
             rowid = from_global_id_with_expected_type(
-                GlobalID.from_id(example_gid),
+                GlobalID.from_id(example_identifier),
                 DATASET_EXAMPLE_NODE_NAME,
             )
         except Exception:
-            raise HTTPException(
-                detail=f"Invalid dataset example ID: {example_gid}",
-                status_code=422,
-            )
-        unique_rowids[rowid] = None
-    rowids = list(unique_rowids)
-    found = set(
+            external_identifiers.add(example_identifier)
+        else:
+            global_rowids_by_identifier[example_identifier] = rowid
+
+    lookup_conditions = []
+    if global_rowids_by_identifier:
+        lookup_conditions.append(models.DatasetExample.id.in_(global_rowids_by_identifier.values()))
+    if external_identifiers:
+        lookup_conditions.append(models.DatasetExample.external_id.in_(external_identifiers))
+
+    examples = list(
         await session.scalars(
-            select(models.DatasetExample.id).where(
-                models.DatasetExample.id.in_(rowids),
+            select(models.DatasetExample).where(
                 models.DatasetExample.dataset_id == dataset_id,
+                or_(*lookup_conditions),
             )
         )
     )
-    missing = [rowid for rowid in rowids if rowid not in found]
-    if missing:
-        missing_gids = ", ".join(
-            str(GlobalID(DATASET_EXAMPLE_NODE_NAME, str(rowid))) for rowid in missing
-        )
+    found_rowids = {example.id for example in examples}
+    rowids_by_external_identifier = {
+        example.external_id: example.id for example in examples if example.external_id is not None
+    }
+
+    resolved_rowids: dict[int, None] = {}
+    missing_identifiers: dict[str, None] = {}
+    for example_identifier in example_ids:
+        if example_identifier in global_rowids_by_identifier:
+            global_rowid = global_rowids_by_identifier[example_identifier]
+            if global_rowid not in found_rowids:
+                missing_identifiers[example_identifier] = None
+                continue
+            resolved_rowids[global_rowid] = None
+            continue
+
+        external_rowid = rowids_by_external_identifier.get(example_identifier)
+        if external_rowid is None:
+            missing_identifiers[example_identifier] = None
+        else:
+            resolved_rowids[external_rowid] = None
+
+    if missing_identifiers:
         raise HTTPException(
-            detail=f"Dataset examples not found in this dataset: {missing_gids}",
+            detail=(
+                f"Dataset examples not found in this dataset: {', '.join(missing_identifiers)}"
+            ),
             status_code=404,
         )
-    return rowids
+    return list(resolved_rowids)
 
 
 async def _dataset_scoped_example_count(

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4593,6 +4593,31 @@ async def _create_dataset_with_examples(
     return dataset_id, example_ids
 
 
+async def _create_dataset_with_user_ids(
+    httpx_client: httpx.AsyncClient,
+    name: str,
+    user_ids: list[str],
+) -> tuple[str, list[str]]:
+    """Create a dataset and return its ID and example GlobalIDs."""
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        json={
+            "action": "create",
+            "name": name,
+            "inputs": [{"q": f"Q{index}"} for index, _ in enumerate(user_ids)],
+            "outputs": [{"a": f"A{index}"} for index, _ in enumerate(user_ids)],
+            "example_ids": user_ids,
+        },
+    )
+    assert response.status_code == 200
+    dataset_id = response.json()["data"]["dataset_id"]
+    examples_response = await httpx_client.get(f"/v1/datasets/{dataset_id}/examples")
+    assert examples_response.status_code == 200
+    examples = examples_response.json()["data"]["examples"]
+    assert [example["id"] for example in examples] == user_ids
+    return dataset_id, [example["node_id"] for example in examples]
+
+
 async def test_create_dataset_split_empty(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,
@@ -4648,6 +4673,24 @@ async def test_create_dataset_split_with_examples(
         assert member_count == 2
 
 
+async def test_create_dataset_split_accepts_mixed_example_identifiers(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    user_ids = ["example-one", "example-two"]
+    dataset_id, global_ids = await _create_dataset_with_user_ids(
+        httpx_client, "ds_split_mixed_ids", user_ids
+    )
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={
+            "name": "mixed",
+            "example_ids": [global_ids[0], user_ids[0], user_ids[1]],
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["data"]["example_count"] == 2
+
+
 async def test_create_dataset_split_accepts_dataset_name(
     httpx_client: httpx.AsyncClient,
 ) -> None:
@@ -4697,6 +4740,21 @@ async def test_create_dataset_split_example_not_in_dataset(
         json={"name": "cross", "example_ids": other_examples},
     )
     assert response.status_code == 404
+
+
+async def test_create_dataset_split_user_id_not_in_dataset(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_a, _ = await _create_dataset_with_user_ids(
+        httpx_client, "ds_split_external_a", ["dataset-a-example"]
+    )
+    await _create_dataset_with_user_ids(httpx_client, "ds_split_external_b", ["dataset-b-example"])
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_a}/splits",
+        json={"name": "cross-external", "example_ids": ["dataset-b-example"]},
+    )
+    assert response.status_code == 404
+    assert "dataset-b-example" in response.text
 
 
 async def test_create_dataset_split_dataset_not_found(
@@ -4773,6 +4831,31 @@ async def test_update_dataset_split_add_and_remove_examples(
     assert response.status_code == 200
     # example 0 removed, examples 1 and 2 added -> 2 members
     assert response.json()["data"]["example_count"] == 2
+
+
+async def test_update_dataset_split_membership_by_user_id(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    user_ids = ["example-one", "example-two"]
+    dataset_id, _ = await _create_dataset_with_user_ids(
+        httpx_client, "ds_patch_external_membership", user_ids
+    )
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train", "example_ids": [user_ids[0]]},
+    )
+    assert created.status_code == 201
+    split_id = created.json()["data"]["id"]
+
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{split_id}",
+        json={
+            "add_example_ids": [user_ids[1]],
+            "remove_example_ids": [user_ids[0]],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["example_count"] == 1
 
 
 async def test_update_dataset_split_not_found(


### PR DESCRIPTION
resolves #15669
fixes #15802

## Summary
- add typed create, partial update, membership add/remove, and delete helpers under the datasets subpath
- accept either Phoenix GlobalIDs or dataset-scoped user-provided example IDs for split membership, with GlobalID-first precedence
- regenerate OpenAPI clients and document both identifier forms
- use generated OpenAPI request and response types with Phoenix 19.20.0 capability guards
- document per-example ID uniqueness, and note that 19.20.0–20.15.0 resolve split membership by `nodeId` only
- add a minor package changeset

## Tests
Rebased onto `main` (`7c56f1d`) and re-verified:

- `make schema-openapi`, `make codegen-ts-client`, `make codegen-ts-app` — all generated artifacts regenerate byte-identically, so the rebase preserved them
- `make format-python`, `make lint-python` — clean
- `make typecheck-python` — no issues in 1106 source files
- `pytest tests/unit/server/api/routers/v1/test_datasets.py` — 184 passed (56 split tests, including the new user-ID cases)
- `pnpm run fmt:check`, `pnpm run lint`, `pnpm run typecheck` — clean
- `pnpm --filter phoenix-client test` — 60 files, 589 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HadRAaNeh44SRURW4YvGDz