### PR TITLE
feat(js): preserve token counts in Session

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/sessions.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/sessions.mdx
@@ -29,9 +29,18 @@ const sessions = await listSessions({
 });
 
 for (const session of sessions) {
-  console.log(session.sessionId);
+  console.log({
+    sessionId: session.sessionId,
+    promptTokens: session.tokenCountPrompt,
+    completionTokens: session.tokenCountCompletion,
+    totalTokens: session.tokenCountTotal,
+  });
 }
 ```
+
+Each session includes cumulative prompt, completion, and total token counts across
+all of its spans. The fields may be `undefined` when using a Phoenix server that
+does not return session token usage.
 
 ## Retrieve A Session And Its Turns
 

--- a/js/.changeset/preserve-session-token-counts.md
+++ b/js/.changeset/preserve-session-token-counts.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Expose cumulative prompt, completion, and total token counts on the high-level `Session` objects returned by `getSession` and `listSessions`.

--- a/js/packages/phoenix-client/src/sessions/sessionUtils.ts
+++ b/js/packages/phoenix-client/src/sessions/sessionUtils.ts
@@ -13,6 +13,9 @@ export function toSession(data: SessionData): Session {
     projectId: data.project_id,
     startTime: data.start_time,
     endTime: data.end_time,
+    tokenCountPrompt: data.token_count_prompt,
+    tokenCountCompletion: data.token_count_completion,
+    tokenCountTotal: data.token_count_total,
     traces: data.traces.map((trace) => ({
       id: trace.id,
       traceId: trace.trace_id,

--- a/js/packages/phoenix-client/src/types/sessions.ts
+++ b/js/packages/phoenix-client/src/types/sessions.ts
@@ -24,6 +24,12 @@ export interface Session extends Node {
   startTime: string;
   /** ISO 8601 timestamp of when the last trace in the session ended */
   endTime: string;
+  /** Cumulative prompt token count across all spans in the session */
+  tokenCountPrompt?: number;
+  /** Cumulative completion token count across all spans in the session */
+  tokenCountCompletion?: number;
+  /** Cumulative total token count across all spans in the session */
+  tokenCountTotal?: number;
   /** The traces that belong to this session */
   traces: SessionTrace[];
 }

--- a/js/packages/phoenix-client/test/sessions/getSession.test.ts
+++ b/js/packages/phoenix-client/test/sessions/getSession.test.ts
@@ -14,6 +14,9 @@ const mockSessionData: components["schemas"]["SessionData"] = {
   project_id: "project-1",
   start_time: "2025-01-01T00:00:00.000Z",
   end_time: "2025-01-01T01:00:00.000Z",
+  token_count_prompt: 120,
+  token_count_completion: 30,
+  token_count_total: 150,
   traces: [
     {
       id: "trace-global-id",
@@ -66,6 +69,9 @@ describe("getSession", () => {
       projectId: "project-1",
       startTime: "2025-01-01T00:00:00.000Z",
       endTime: "2025-01-01T01:00:00.000Z",
+      tokenCountPrompt: 120,
+      tokenCountCompletion: 30,
+      tokenCountTotal: 150,
       traces: [
         {
           id: "trace-global-id",

--- a/js/packages/phoenix-client/test/sessions/listSessions.test.ts
+++ b/js/packages/phoenix-client/test/sessions/listSessions.test.ts
@@ -14,6 +14,9 @@ const firstSession: components["schemas"]["SessionData"] = {
   project_id: "project-1",
   start_time: "2025-01-01T00:00:00.000Z",
   end_time: "2025-01-01T01:00:00.000Z",
+  token_count_prompt: 80,
+  token_count_completion: 20,
+  token_count_total: 100,
   traces: [
     {
       id: "trace-1",
@@ -30,6 +33,9 @@ const secondSession: components["schemas"]["SessionData"] = {
   project_id: "project-1",
   start_time: "2025-01-02T00:00:00.000Z",
   end_time: "2025-01-02T01:00:00.000Z",
+  token_count_prompt: 0,
+  token_count_completion: 0,
+  token_count_total: 0,
   traces: [],
 };
 
@@ -88,6 +94,9 @@ describe("listSessions", () => {
       id: "session-1",
       sessionId: "sess-a",
       projectId: "project-1",
+      tokenCountPrompt: 80,
+      tokenCountCompletion: 20,
+      tokenCountTotal: 100,
     });
     expect(sessions[0]?.traces).toHaveLength(1);
     expect(sessions[0]?.traces[0]).toMatchObject({
@@ -95,6 +104,11 @@ describe("listSessions", () => {
       traceId: "t-1",
     });
     expect(sessions[1]?.traces).toHaveLength(0);
+    expect(sessions[1]).toMatchObject({
+      tokenCountPrompt: 0,
+      tokenCountCompletion: 0,
+      tokenCountTotal: 0,
+    });
   });
 
   it("should paginate through all sessions", async () => {


### PR DESCRIPTION
Resolves #15661

## Summary
- expose cumulative prompt, completion, and total token counts on the high-level `Session` type
- preserve all three REST fields in `getSession` and `listSessions` conversions while keeping the new properties optional for source compatibility
- cover zero and non-zero token totals and document token usage
- add a patch changeset for `@arizeai/phoenix-client`

## Testing
- `pnpm --filter @arizeai/phoenix-client test` (529 passed, 1 skipped)
- `make typecheck-ts`
- `make lint-ts`
- `npm_config_cache=/tmp/phoenix-issue-15661-npm-cache npm pack --dry-run`