### PR TITLE
feat(phoenix-client): add project retention policy helper

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -947,6 +947,7 @@
                 "root": "docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-client",
                 "pages": [
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview",
+                  "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/projects",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/traces",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/spans",
                   "docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/annotations",

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Typed TypeScript client for Phoenix platform APIs"
 ---
 
-`@arizeai/phoenix-client` is the typed TypeScript client for Phoenix platform APIs. It ships a small root REST client plus focused module entrypoints for prompts, datasets, experiments, spans, sessions, traces, and CI-friendly dataset-backed eval tests.
+`@arizeai/phoenix-client` is the typed TypeScript client for Phoenix platform APIs. It ships a small root REST client plus focused module entrypoints for projects, prompts, datasets, experiments, spans, sessions, traces, and CI-friendly dataset-backed eval tests.
 
 ## Install
 
@@ -37,6 +37,7 @@ That gives the agent version-matched docs plus the exact implementation and gene
 | Import | Purpose |
 |--------|---------|
 | `@arizeai/phoenix-client` | `createClient`, generated OpenAPI types, config helpers |
+| `@arizeai/phoenix-client/projects` | Project listing and retention-policy assignment |
 | `@arizeai/phoenix-client/prompts` | Prompt CRUD plus `toSDK` conversion |
 | `@arizeai/phoenix-client/datasets` | Dataset creation and retrieval |
 | `@arizeai/phoenix-client/experiments` | Experiment execution and lifecycle |
@@ -158,7 +159,7 @@ Prefer this layer when:
 
 ## Where To Start
 
-- [Prompts](./prompts), [Datasets](./datasets), [Experiments](./experiments) — higher-level workflows
+- [Projects](./projects), [Prompts](./prompts), [Datasets](./datasets), [Experiments](./experiments) — higher-level workflows
 - [Annotations](./annotations) — annotation concepts, then [Span](./span-annotations), [Document](./document-annotations), and [Session](./session-annotations) annotations for detailed usage
 - [CI Eval Tests](./ci-evals) — Vitest/Jest eval suites backed by Phoenix datasets and experiments
 - [Spans](./spans), [Sessions](./sessions), [Traces](./traces) — retrieval and maintenance
@@ -171,6 +172,7 @@ Prefer this layer when:
     <li><code>src/config.ts</code></li>
     <li><code>src/__generated__/api/v1.ts</code></li>
     <li><code>src/types/core.ts</code></li>
+    <li><code>src/projects/</code></li>
     <li><code>src/prompts/</code></li>
     <li><code>src/datasets/</code></li>
     <li><code>src/experiments/</code></li>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/projects.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/projects.mdx
@@ -1,0 +1,71 @@
+---
+title: "Projects"
+description: "List projects and manage project retention-policy assignments"
+---
+
+The projects module lists Phoenix projects and assigns existing trace retention policies to them.
+
+<section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
+  <h2>Relevant Source Files</h2>
+  <ul>
+    <li><code>src/projects/getProjects.ts</code></li>
+    <li><code>src/projects/setProjectRetentionPolicy.ts</code></li>
+    <li><code>src/types/projects.ts</code></li>
+  </ul>
+</section>
+
+## List Projects
+
+`getProjects` handles cursor pagination automatically. Use `nameContains` for a case-insensitive, server-side substring filter.
+
+```ts
+import { getProjects } from "@arizeai/phoenix-client/projects";
+
+const projects = await getProjects({ nameContains: "support" });
+
+for (const project of projects) {
+  console.log(`${project.name} (${project.id})`);
+}
+```
+
+## Assign A Retention Policy
+
+`setProjectRetentionPolicy` accepts a project name or project GlobalID and the GlobalID of an existing trace retention policy.
+
+```ts
+import { setProjectRetentionPolicy } from "@arizeai/phoenix-client/projects";
+
+const assignment = await setProjectRetentionPolicy({
+  projectName: "support-bot",
+  policyId: "UHJvamVjdFRyYWNlUmV0ZW50aW9uUG9saWN5OjI=",
+});
+
+console.log(assignment.project_id, assignment.policy_id);
+```
+
+You can select the project with `projectName`, `projectId`, or the shorthand `project`. `projectId` must be the project's GlobalID.
+
+This helper only changes which existing retention policy the project uses. It does not create, read, update, or delete retention policies; policy CRUD is outside the TypeScript client's projects helper.
+
+## Reset To The Default Policy
+
+Pass `null` as `policyId` to remove the explicit assignment and return the project to Phoenix's default retention policy.
+
+```ts
+await setProjectRetentionPolicy({
+  projectId: "UHJvamVjdDox",
+  policyId: null,
+});
+```
+
+Assigning or resetting a retention policy requires an admin when authentication is enabled. Invalid policy GlobalIDs produce a `422` response, while callers without permission receive `403`; both are surfaced as `HttpError` instances by the client.
+
+<section className="hidden" data-agent-context="source-map" aria-label="Source map">
+  <h2>Source Map</h2>
+  <ul>
+    <li><code>src/projects/getProjects.ts</code></li>
+    <li><code>src/projects/setProjectRetentionPolicy.ts</code></li>
+    <li><code>src/projects/index.ts</code></li>
+    <li><code>src/types/projects.ts</code></li>
+  </ul>
+</section>

--- a/js/.changeset/bright-cranes-retain.md
+++ b/js/.changeset/bright-cranes-retain.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `setProjectRetentionPolicy` to the projects entry point for assigning an existing retention policy by GlobalID or resetting a project to the default policy.

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -732,7 +732,7 @@ await addSessionNote({
 
 ## Projects
 
-The `@arizeai/phoenix-client` package provides a `projects` export for listing projects.
+The `@arizeai/phoenix-client` package provides a `projects` export for listing projects and managing their retention-policy assignments.
 
 ### Fetching Projects
 
@@ -754,6 +754,30 @@ Pass `nameContains` to filter by a case-insensitive substring of the project nam
 ```ts
 const agentProjects = await getProjects({ nameContains: "agent" });
 ```
+
+### Assigning a Retention Policy
+
+Use `setProjectRetentionPolicy` to assign an existing trace retention policy by GlobalID. Select the project by name or GlobalID.
+
+```ts
+import { setProjectRetentionPolicy } from "@arizeai/phoenix-client/projects";
+
+await setProjectRetentionPolicy({
+  projectName: "support-bot",
+  policyId: "UHJvamVjdFRyYWNlUmV0ZW50aW9uUG9saWN5OjI=",
+});
+```
+
+Pass `policyId: null` to reset the project to Phoenix's default retention policy:
+
+```ts
+await setProjectRetentionPolicy({
+  projectId: "UHJvamVjdDox",
+  policyId: null,
+});
+```
+
+This helper only changes a project's assignment to an existing policy. Creating, reading, updating, and deleting retention policies is outside the scope of the TypeScript projects helper.
 
 ## Examples
 

--- a/js/packages/phoenix-client/src/projects/index.ts
+++ b/js/packages/phoenix-client/src/projects/index.ts
@@ -1,1 +1,2 @@
 export * from "./getProjects";
+export * from "./setProjectRetentionPolicy";

--- a/js/packages/phoenix-client/src/projects/setProjectRetentionPolicy.ts
+++ b/js/packages/phoenix-client/src/projects/setProjectRetentionPolicy.ts
@@ -1,0 +1,80 @@
+import invariant from "tiny-invariant";
+
+import type { components } from "../__generated__/api/v1";
+import { createClient } from "../client";
+import type { ClientFn } from "../types/core";
+import type { ProjectIdentifier } from "../types/projects";
+import { resolveProjectIdentifier } from "../types/projects";
+
+/**
+ * The retention-policy assignment returned for a project.
+ */
+export type ProjectRetentionPolicyAssignment =
+  components["schemas"]["ProjectRetentionPolicyData"];
+
+/**
+ * Parameters for assigning or resetting a project's retention policy.
+ */
+export type SetProjectRetentionPolicyParams = ClientFn &
+  ProjectIdentifier & {
+    /**
+     * The GlobalID of an existing trace retention policy, or `null` to reset
+     * the project to the default policy.
+     */
+    policyId: string | null;
+  };
+
+/**
+ * Assign an existing trace retention policy to a project, or reset the project
+ * to the default policy.
+ *
+ * This helper only changes the project's assignment. It does not create,
+ * retrieve, update, or delete retention policies.
+ *
+ * @param params - The project and policy assignment.
+ * @param params.project - A project name or GlobalID.
+ * @param params.projectId - A project GlobalID.
+ * @param params.projectName - A project name.
+ * @param params.policyId - An existing policy GlobalID, or `null` to reset.
+ * @param params.client - An optional Phoenix client instance.
+ * @returns The project's resulting retention-policy assignment.
+ *
+ * @example
+ * ```ts
+ * import { setProjectRetentionPolicy } from "@arizeai/phoenix-client/projects";
+ *
+ * await setProjectRetentionPolicy({
+ *   projectName: "support-bot",
+ *   policyId: "UHJvamVjdFRyYWNlUmV0ZW50aW9uUG9saWN5OjI=",
+ * });
+ *
+ * await setProjectRetentionPolicy({
+ *   projectId: "UHJvamVjdDox",
+ *   policyId: null,
+ * });
+ * ```
+ */
+export async function setProjectRetentionPolicy(
+  params: SetProjectRetentionPolicyParams
+): Promise<ProjectRetentionPolicyAssignment> {
+  const client = params.client ?? createClient();
+  const projectIdentifier = resolveProjectIdentifier(params);
+
+  const { data, error } = await client.PATCH(
+    "/v1/projects/{project_identifier}/retention",
+    {
+      params: {
+        path: {
+          project_identifier: projectIdentifier,
+        },
+      },
+      body: {
+        policy_id: params.policyId,
+      },
+    }
+  );
+
+  if (error) throw error;
+  invariant(data?.data, "Failed to set project retention policy");
+  return data.data;
+}

--- a/js/packages/phoenix-client/test/entryPoints.test.ts
+++ b/js/packages/phoenix-client/test/entryPoints.test.ts
@@ -9,6 +9,7 @@ const cjsEntries = {
   index: "../dist/src/index.js",
   experiments: "../dist/src/experiments/index.js",
   jest: "../dist/src/jest/index.js",
+  projects: "../dist/src/projects/index.js",
 } as const;
 // The index entry transitively require()s @arizeai/phoenix-otel's dist via the
 // workspace symlink, so an unbuilt sibling would fail the guard even though
@@ -48,6 +49,7 @@ const esmEntries = {
   index: "../dist/esm/index.js",
   experiments: "../dist/esm/experiments/index.js",
   jest: "../dist/esm/jest/index.js",
+  projects: "../dist/esm/projects/index.js",
 } as const;
 
 describe.skipIf(!isBuilt)("built ESM entry points", () => {

--- a/js/packages/phoenix-client/test/projects/setProjectRetentionPolicy.test.ts
+++ b/js/packages/phoenix-client/test/projects/setProjectRetentionPolicy.test.ts
@@ -1,0 +1,151 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { HttpError } from "../../src/errors";
+import { setProjectRetentionPolicy } from "../../src/projects";
+import { createTestClient } from "../testUtils";
+
+const http = createHttp();
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("setProjectRetentionPolicy", () => {
+  it("assigns an existing policy to a project selected by name", async () => {
+    const policyId = "UHJvamVjdFRyYWNlUmV0ZW50aW9uUG9saWN5OjI=";
+    let receivedProjectIdentifier: string | undefined;
+    let receivedBody: unknown;
+
+    server.use(
+      http.patch(
+        "/v1/projects/:projectIdentifier/retention",
+        async ({ params, request, response }) => {
+          receivedProjectIdentifier = String(params.projectIdentifier);
+          receivedBody = await request.json();
+          return response(200).json({
+            data: {
+              project_id: "UHJvamVjdDox",
+              policy_id: policyId,
+            },
+          });
+        }
+      )
+    );
+
+    const assignment = await setProjectRetentionPolicy({
+      client: createTestClient(),
+      projectName: "support-bot",
+      policyId,
+    });
+
+    expect(receivedProjectIdentifier).toBe("support-bot");
+    expect(receivedBody).toEqual({ policy_id: policyId });
+    expect(assignment).toEqual({
+      project_id: "UHJvamVjdDox",
+      policy_id: policyId,
+    });
+  });
+
+  it("resets a project selected by GlobalID to the default policy", async () => {
+    const projectId = "UHJvamVjdDox";
+    let receivedProjectIdentifier: string | undefined;
+    let receivedBody: unknown;
+
+    server.use(
+      http.patch(
+        "/v1/projects/:projectIdentifier/retention",
+        async ({ params, request, response }) => {
+          receivedProjectIdentifier = String(params.projectIdentifier);
+          receivedBody = await request.json();
+          return response(200).json({
+            data: {
+              project_id: projectId,
+              policy_id: null,
+            },
+          });
+        }
+      )
+    );
+
+    const assignment = await setProjectRetentionPolicy({
+      client: createTestClient(),
+      projectId,
+      policyId: null,
+    });
+
+    expect(receivedProjectIdentifier).toBe(projectId);
+    expect(receivedBody).toEqual({ policy_id: null });
+    expect(assignment).toEqual({
+      project_id: projectId,
+      policy_id: null,
+    });
+  });
+
+  it("surfaces retention-policy validation errors", async () => {
+    server.use(
+      http.patch("/v1/projects/:projectIdentifier/retention", ({ response }) =>
+        response(422).text("Invalid retention policy ID")
+      )
+    );
+
+    const error = await setProjectRetentionPolicy({
+      client: createTestClient(),
+      projectName: "support-bot",
+      policyId: "not-a-global-id",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({ status: 422 });
+  });
+
+  it("surfaces permission errors for non-admin callers", async () => {
+    server.use(
+      http.patch("/v1/projects/:projectIdentifier/retention", ({ response }) =>
+        response(403).text("Forbidden")
+      )
+    );
+
+    const error = await setProjectRetentionPolicy({
+      client: createTestClient(),
+      projectName: "support-bot",
+      policyId: null,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({ status: 403 });
+  });
+
+  it("throws when a successful response omits assignment data", async () => {
+    server.use(
+      http.patch("/v1/projects/:projectIdentifier/retention", ({ response }) =>
+        response.untyped(
+          new Response("{}", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      )
+    );
+
+    await expect(
+      setProjectRetentionPolicy({
+        client: createTestClient(),
+        projectName: "support-bot",
+        policyId: null,
+      })
+    ).rejects.toThrow("Failed to set project retention policy");
+  });
+});


### PR DESCRIPTION
## Summary

- add a typed `setProjectRetentionPolicy` helper to `@arizeai/phoenix-client/projects`
- accept project names or GlobalIDs and assign an existing policy GlobalID or reset with `null`
- cover assignment, reset, validation, permission errors, missing response data, and built CJS/ESM entrypoints
- document project retention-policy assignment while clarifying that policy CRUD remains out of scope
- add a minor changeset for `@arizeai/phoenix-client`

## Verification

- `make format-ts`
- `make lint-ts`
- `make typecheck-ts`
- Phoenix client suite: 536 passed, 1 skipped
- built CJS/ESM entrypoint and focused helper tests: 13 passed
- `npm pack --dry-run` with synced package docs

Closes #15662