### PR TITLE
fix(db): enforce unique span_costs.span_rowid

### DIFF
--- a/src/phoenix/db/ddl/postgresql_schema.sql
+++ b/src/phoenix/db/ddl/postgresql_schema.sql
@@ -343,7 +343,7 @@ CREATE TABLE public.span_costs (
 
 CREATE INDEX ix_span_costs_model_id_span_start_time ON public.span_costs
     USING btree (model_id, span_start_time);
-CREATE INDEX ix_span_costs_span_rowid ON public.span_costs
+CREATE UNIQUE INDEX ix_span_costs_span_rowid ON public.span_costs
     USING btree (span_rowid);
 CREATE INDEX ix_span_costs_span_start_time ON public.span_costs
     USING btree (span_start_time);

--- a/src/phoenix/db/ddl/sqlite_schema.sql
+++ b/src/phoenix/db/ddl/sqlite_schema.sql
@@ -325,7 +325,7 @@ CREATE TABLE span_costs (
 
 CREATE INDEX ix_span_costs_model_id_span_start_time ON span_costs
     (model_id, span_start_time);
-CREATE INDEX ix_span_costs_span_rowid ON span_costs (span_rowid);
+CREATE UNIQUE INDEX ix_span_costs_span_rowid ON span_costs (span_rowid);
 CREATE INDEX ix_span_costs_span_start_time ON span_costs (span_start_time);
 CREATE INDEX ix_span_costs_trace_rowid ON span_costs (trace_rowid);
 

--- a/src/phoenix/db/migrations/versions/d8f3a4c1e9b7_add_unique_span_costs_span_rowid.py
+++ b/src/phoenix/db/migrations/versions/d8f3a4c1e9b7_add_unique_span_costs_span_rowid.py
@@ -1,0 +1,183 @@
+"""add unique constraint on span_costs.span_rowid
+
+Revision ID: d8f3a4c1e9b7
+Revises: 4aad9107d196
+Create Date: 2026-08-31 12:00:00.000000
+
+Span.span_cost is modeled and consumed as a one-to-one relationship, but
+span_costs.span_rowid only ever had a regular (non-unique) index, so nothing
+in the database enforced that invariant. A duplicate row for one span lets
+joins against span_costs fan a span out into multiple rows, which corrupts
+span pagination/counts and inflates aggregated cost/token totals for any
+caller that already joins span_costs.
+
+Current writers avoid duplicates by only computing a span's cost after its
+(unique) span insert succeeds, so this is not expected to find anything to
+clean up in practice, but the invariant was never enforced against retries,
+future writers, imports, or direct database writes. Any pre-existing
+duplicates are pruned first, keeping the highest id per span_rowid (the most
+recently written row), before the plain index is replaced with a unique one
+of the same name.
+
+CONCURRENTLY support (opt-in via PHOENIX_MIGRATE_INDEX_CONCURRENTLY=true):
+
+  CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction, but
+  Alembic's env.py wraps each migration in one. The workaround is to commit
+  the current transaction and enable autocommit at the DBAPI level (psycopg)
+  before issuing the DDL, then restore transactional mode afterward. See the
+  spans session.id index migration (f1a6b2f0c9d5) for the rationale and
+  tradeoffs.
+
+  A plain index can't be upgraded to unique in place, so the concurrent path
+  builds the unique replacement under a temporary name, drops the old index,
+  and renames the replacement into the canonical name — span_costs is never
+  left without an index on span_rowid, and writers are never blocked on an
+  ACCESS EXCLUSIVE lock. A failed concurrent build leaves an INVALID index
+  behind under the temporary name, which IF NOT EXISTS matches on rerun, so
+  the index is checked for validity before anything else happens.
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d8f3a4c1e9b7"
+down_revision: Union[str, None] = "4aad9107d196"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "ix_span_costs_span_rowid"
+_TEMP_INDEX_NAME = "ix_span_costs_span_rowid_unique_tmp"
+
+
+def _use_concurrently() -> bool:
+    """CONCURRENTLY is opt-in (PostgreSQL only) via PHOENIX_MIGRATE_INDEX_CONCURRENTLY."""
+    connection = op.get_bind()
+    if connection.dialect.name != "postgresql":
+        return False
+    return os.environ.get("PHOENIX_MIGRATE_INDEX_CONCURRENTLY", "").lower() == "true"
+
+
+def _enable_autocommit() -> None:
+    """Exit the current transaction and enable autocommit at the DBAPI level."""
+    dbapi_conn = op.get_bind().connection.dbapi_connection
+    assert dbapi_conn is not None
+    dbapi_conn.commit()
+    dbapi_conn.autocommit = True
+
+
+def _disable_autocommit() -> None:
+    """Restore transactional mode at the DBAPI level."""
+    dbapi_conn = op.get_bind().connection.dbapi_connection
+    assert dbapi_conn is not None
+    dbapi_conn.autocommit = False
+
+
+def _assert_index_is_valid(index_name: str) -> None:
+    """Fail loudly if the named index exists but is INVALID (PostgreSQL only).
+
+    A failed CREATE INDEX CONCURRENTLY leaves an INVALID index that IF NOT
+    EXISTS matches by name, so without this check the migration could stamp
+    itself successful while the replacement index is unusable.
+    """
+    connection = op.get_bind()
+    if connection.dialect.name != "postgresql":
+        return
+    is_valid = connection.execute(
+        sa.text("SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(:name)"),
+        {"name": index_name},
+    ).scalar()
+    if is_valid is False:
+        raise RuntimeError(
+            f"Index {index_name} exists but is INVALID: a previous CONCURRENTLY build "
+            "failed, or another replica is still building it. If no build is in "
+            f"progress, run DROP INDEX CONCURRENTLY IF EXISTS {index_name} and rerun "
+            "the migration."
+        )
+
+
+def _dedupe_span_costs() -> None:
+    """Keep only the highest-id span_costs row per span_rowid.
+
+    Runs inside the migration's ambient transaction (before any switch to
+    autocommit for CONCURRENTLY), so it either fully applies or not at all.
+
+    Deletes the doomed rows' span_cost_details explicitly rather than relying
+    on the span_cost_details.span_cost_id FK's ON DELETE CASCADE: SQLite
+    migrations run with foreign key enforcement off (see
+    set_sqlite_migration_pragma in phoenix.db.engines), so on SQLite that
+    cascade never fires and would otherwise leave orphaned detail rows behind.
+    """
+    connection = op.get_bind()
+    duplicate_span_cost_ids = (
+        "SELECT id FROM span_costs WHERE id NOT IN "
+        "(SELECT MAX(id) FROM span_costs GROUP BY span_rowid)"
+    )
+    connection.execute(
+        sa.text(f"DELETE FROM span_cost_details WHERE span_cost_id IN ({duplicate_span_cost_ids})")
+    )
+    connection.execute(sa.text(f"DELETE FROM span_costs WHERE id IN ({duplicate_span_cost_ids})"))
+
+
+def upgrade() -> None:
+    _dedupe_span_costs()
+    concurrently = _use_concurrently()
+    if not concurrently:
+        op.drop_index(_INDEX_NAME, table_name="span_costs", if_exists=True)
+        op.create_index(
+            _INDEX_NAME,
+            "span_costs",
+            ["span_rowid"],
+            unique=True,
+            if_not_exists=True,
+        )
+        return
+    _enable_autocommit()
+    try:
+        op.create_index(
+            _TEMP_INDEX_NAME,
+            "span_costs",
+            ["span_rowid"],
+            unique=True,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+        )
+        _assert_index_is_valid(_TEMP_INDEX_NAME)
+        op.drop_index(
+            _INDEX_NAME,
+            table_name="span_costs",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.execute(f"ALTER INDEX {_TEMP_INDEX_NAME} RENAME TO {_INDEX_NAME}")
+    finally:
+        _disable_autocommit()
+
+
+def downgrade() -> None:
+    concurrently = _use_concurrently()
+    if concurrently:
+        _enable_autocommit()
+    try:
+        op.drop_index(
+            _INDEX_NAME,
+            table_name="span_costs",
+            if_exists=True,
+            postgresql_concurrently=concurrently,
+        )
+        op.create_index(
+            _INDEX_NAME,
+            "span_costs",
+            ["span_rowid"],
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=concurrently,
+        )
+        if concurrently:
+            _assert_index_is_valid(_INDEX_NAME)
+    finally:
+        if concurrently:
+            _disable_autocommit()

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2865,6 +2865,7 @@ class SpanCost(HasId):
     span_rowid: Mapped[int] = mapped_column(
         ForeignKey("spans.id", ondelete="CASCADE"),
         nullable=False,
+        unique=True,
         index=True,
     )
     trace_rowid: Mapped[int] = mapped_column(

--- a/tests/integration/db_migrations/test_data_migration_d8f3a4c1e9b7_dedupe_span_costs.py
+++ b/tests/integration/db_migrations/test_data_migration_d8f3a4c1e9b7_dedupe_span_costs.py
@@ -1,0 +1,198 @@
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import Column, Connection, MetaData, Table, insert, select
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
+
+from phoenix.db.models import JSON_
+
+from . import _run_async, _up, _verify_clean_state
+
+_DOWN = "4aad9107d196"
+_UP = "d8f3a4c1e9b7"
+
+
+async def test_dedupe_span_costs_before_enforcing_unique_span_rowid(
+    _engine: AsyncEngine,
+    _alembic_config: Config,
+    _schema: str,
+) -> None:
+    """A legacy database may already contain more than one span_costs row for
+    the same span_rowid, since nothing enforced uniqueness before this
+    migration. Upgrading must prune the extras (keeping the most recently
+    written row) without leaving their span_cost_details orphaned, must leave
+    an unrelated span's cost untouched, and must come out the other side
+    actually rejecting a second span_costs row for the same span.
+    """
+    await _verify_clean_state(_engine, _schema)
+    await _up(_engine, _alembic_config, _DOWN, _schema)
+
+    def _reflect(conn: Connection) -> tuple[Table, Table, Table, Table, Table]:
+        metadata = MetaData()
+        metadata.reflect(bind=conn)
+        t_projects = metadata.tables["projects"]
+        t_traces = metadata.tables["traces"]
+        # attributes/events are JSON columns; override their reflected type so
+        # Python dict/list values serialize correctly on insert (see the
+        # project_sessions data migration test for the same pattern).
+        t_spans = Table(
+            "spans",
+            MetaData(),
+            Column("attributes", JSON_),
+            Column("events", JSON_),
+            autoload_with=conn,
+        )
+        t_span_costs = metadata.tables["span_costs"]
+        t_span_cost_details = metadata.tables["span_cost_details"]
+        return t_projects, t_traces, t_spans, t_span_costs, t_span_cost_details
+
+    (
+        table_projects,
+        table_traces,
+        table_spans,
+        table_span_costs,
+        table_span_cost_details,
+    ) = await _run_async(_engine, _reflect)
+
+    now = datetime.now(timezone.utc)
+
+    def _seed(conn: Connection) -> tuple[int, int, int, int, int, int]:
+        project_id = conn.scalar(
+            insert(table_projects).returning(table_projects.c.id),
+            {"name": token_hex(8)},
+        )
+        assert project_id is not None
+        trace_id = conn.scalar(
+            insert(table_traces).returning(table_traces.c.id),
+            {
+                "trace_id": token_hex(16),
+                "project_rowid": project_id,
+                "start_time": now,
+                "end_time": now + timedelta(seconds=1),
+            },
+        )
+        assert trace_id is not None
+
+        def span_row(name: str) -> dict[str, object]:
+            return {
+                "span_id": token_hex(8),
+                "parent_id": None,
+                "name": name,
+                "span_kind": "LLM",
+                "trace_rowid": trace_id,
+                "start_time": now,
+                "end_time": now + timedelta(milliseconds=10),
+                "attributes": {},
+                "events": [],
+                "status_message": "",
+                "cumulative_error_count": 0,
+                "cumulative_llm_token_count_prompt": 0,
+                "cumulative_llm_token_count_completion": 0,
+            }
+
+        duplicated_span_id, lone_span_id = conn.scalars(
+            insert(table_spans).returning(table_spans.c.id),
+            [span_row("duplicated"), span_row("lone")],
+        ).all()
+
+        def cost_row(span_rowid: int, total_cost: float) -> dict[str, object]:
+            return {
+                "span_rowid": span_rowid,
+                "trace_rowid": trace_id,
+                "span_start_time": now,
+                "total_cost": total_cost,
+            }
+
+        stale_cost_id, fresh_cost_id = conn.scalars(
+            insert(table_span_costs).returning(table_span_costs.c.id),
+            [
+                cost_row(duplicated_span_id, 1.0),
+                cost_row(duplicated_span_id, 2.0),
+            ],
+        ).all()
+        lone_cost_id = conn.scalar(
+            insert(table_span_costs).returning(table_span_costs.c.id),
+            cost_row(lone_span_id, 3.0),
+        )
+        assert lone_cost_id is not None
+
+        def detail_row(span_cost_id: int, cost: float) -> dict[str, object]:
+            return {
+                "span_cost_id": span_cost_id,
+                "token_type": "input",
+                "is_prompt": True,
+                "cost": cost,
+                "tokens": 10,
+                "cost_per_token": 0.1,
+            }
+
+        conn.execute(
+            insert(table_span_cost_details),
+            [
+                detail_row(stale_cost_id, 1.0),
+                detail_row(fresh_cost_id, 2.0),
+                detail_row(lone_cost_id, 3.0),
+            ],
+        )
+        conn.commit()
+        return (
+            duplicated_span_id,
+            lone_span_id,
+            stale_cost_id,
+            fresh_cost_id,
+            lone_cost_id,
+            trace_id,
+        )
+
+    (
+        duplicated_span_id,
+        lone_span_id,
+        stale_cost_id,
+        fresh_cost_id,
+        lone_cost_id,
+        trace_id,
+    ) = await _run_async(_engine, _seed)
+
+    await _up(_engine, _alembic_config, _UP, _schema)
+
+    def _check(conn: Connection) -> None:
+        remaining_cost_ids = set(
+            conn.execute(
+                select(table_span_costs.c.id).where(
+                    table_span_costs.c.span_rowid == duplicated_span_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Only the most recently written duplicate survives.
+        assert remaining_cost_ids == {fresh_cost_id}
+
+        remaining_detail_cost_ids = set(
+            conn.execute(select(table_span_cost_details.c.span_cost_id)).scalars().all()
+        )
+        # The pruned duplicate's details are gone...
+        assert stale_cost_id not in remaining_detail_cost_ids
+        # ...but the surviving duplicate's and the unrelated span's are intact.
+        assert fresh_cost_id in remaining_detail_cost_ids
+        assert lone_cost_id in remaining_detail_cost_ids
+
+        # span_rowid is now unique: a second cost row for the same span cannot commit.
+        with pytest.raises((PostgreSQLIntegrityError, SQLiteIntegrityError)):
+            conn.execute(
+                insert(table_span_costs),
+                {
+                    "span_rowid": lone_span_id,
+                    "trace_rowid": trace_id,
+                    "span_start_time": now,
+                    "total_cost": 99.0,
+                },
+            )
+            conn.commit()
+        conn.rollback()
+
+    await _run_async(_engine, _check)

--- a/tests/unit/db/test_models.py
+++ b/tests/unit/db/test_models.py
@@ -10,7 +10,9 @@ from deepdiff.diff import DeepDiff
 from sqlalchemy import select
 from sqlalchemy.dialects import postgresql as postgresql_dialect
 from sqlalchemy.dialects import sqlite as sqlite_dialect
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.orm import selectinload
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
@@ -34,6 +36,7 @@ from phoenix.db.types.prompts import (
     PromptTemplateType,
 )
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _add_project, _add_span, _add_trace
 
 
 async def test_projects_with_session_injection(
@@ -66,6 +69,42 @@ async def test_empty_projects(
     async with db() as session:
         result = (await session.execute(statement)).scalars().first()
     assert not result
+
+
+async def test_span_cost_span_rowid_is_unique(
+    db: DbSessionFactory,
+) -> None:
+    """Span.span_cost is a one-to-one relationship: a span may have at most
+    one SpanCost row. This must be enforced by span_costs.span_rowid being
+    unique, on both SQLite and PostgreSQL (the `db` fixture is parametrized
+    over both dialects), otherwise a duplicate row would let joins against
+    span_costs silently fan a span out into multiple rows.
+    """
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+        session.add(
+            models.SpanCost(
+                span_rowid=span.id,
+                trace_rowid=trace.id,
+                span_start_time=span.start_time,
+                total_cost=1.0,
+            )
+        )
+        await session.flush()
+
+        session.add(
+            models.SpanCost(
+                span_rowid=span.id,
+                trace_rowid=trace.id,
+                span_start_time=span.start_time,
+                total_cost=2.0,
+            )
+        )
+        with pytest.raises((PostgreSQLIntegrityError, SQLiteIntegrityError)):
+            await session.flush()
+        await session.rollback()
 
 
 class TestCaseInsensitiveContains:


### PR DESCRIPTION
resolves #15754

## Summary

`Span.span_cost` is modeled as a one-to-one relationship, but `span_costs.span_rowid` was only backed by a regular index in both PostgreSQL and SQLite. That meant the database wasn't actually enforcing the one-to-one constraint.

If multiple cost rows existed for the same span, joins against `span_costs` could return the same span multiple times. This could break pagination and counts, as well as inflate aggregated cost and token totals.

## Changes

* Updated `SpanCost.span_rowid` to use `unique=True` in addition to `index=True`. This turns the existing `ix_span_costs_span_rowid` index into a unique index.
* Added migration `d8f3a4c1e9b7`, chained after `4aad9107d196`.

  * The migration first removes any existing duplicate `span_costs` rows, keeping the row with the highest `id` for each `span_rowid`.
  * Before removing those rows, it explicitly deletes their associated `span_cost_details`. We can't rely on `ON DELETE CASCADE` here because SQLite migrations run with foreign-key enforcement disabled via `set_sqlite_migration_pragma`; otherwise, those detail rows could be left orphaned.
  * The existing plain index is then replaced with a unique index using the same name.
  * The migration supports the existing `PHOENIX_MIGRATE_INDEX_CONCURRENTLY` option for PostgreSQL, allowing the unique index to be built without blocking writes. This follows the same approach used by `4aad9107d196` and `c9d0e1f2a3b4`.
  * `downgrade()` restores the original plain index.
* Regenerated the checked-in DDL snapshots so both `postgresql_schema.sql` and `sqlite_schema.sql` now contain `CREATE UNIQUE INDEX ix_span_costs_span_rowid`.

## Tests

Added `tests/unit/db/test_models.py::test_span_cost_span_rowid_is_unique` to verify that inserting a second `SpanCost` for the same span fails on both SQLite and PostgreSQL.

Also added `tests/integration/db_migrations/test_data_migration_d8f3a4c1e9b7_dedupe_span_costs.py`, which:

* Creates a legacy duplicate cost row and a separate control span.
* Runs the migration.
* Verifies that only the stale duplicate and its `span_cost_details` are removed.
* Verifies that the control span is left untouched.
* Confirms that inserting another duplicate after the migration is rejected.

The tests catch both `sqlalchemy.exc.IntegrityError` and `sqlean.dbapi2.IntegrityError`. In this repo's SQLite setup, `aiosqlite` uses the `sqlean` driver, and its dialect only translates stdlib `sqlite3` exceptions. As a result, constraint violations can surface as the raw `sqlean.dbapi2.IntegrityError`. This is already handled the same way by the production mutation handlers elsewhere in the codebase.

## Verification

* `ruff check` and `ruff format` pass.
* `mypy` passes for all files touched by this PR.
* The new tests pass on SQLite.
* The full `test_models.py` suite passes.
* The generic migration up/down cycle test passes, including all migrations being exercised twice in both the default and `PHOENIX_MIGRATE_INDEX_CONCURRENTLY` modes.
* The broader test files that exercise `SpanCost` also pass.
* I wasn't able to run the PostgreSQL tests locally because PostgreSQL/`pg_config` isn't available in the environment. The PostgreSQL leg should therefore be covered by CI.
