### PR TITLE
docs: mention Arize AX in Phoenix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8e8e8b34-7900-43fa-a38f-1f070bd48c64&page=README.md" />
 </p>
 
-Phoenix is an open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. It provides:
+Arize Phoenix is Arize's open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. For managed production workflows, Arize also offers [Arize AX](https://arize.com/products/ax/). Phoenix provides:
 
 - [**_Tracing_**](https://arize.com/docs/phoenix/tracing/llm-traces) - Trace your LLM application's runtime using OpenTelemetry-based instrumentation.
 - [**_Evaluation_**](https://arize.com/docs/phoenix/evaluation/llm-evals) - Leverage LLMs to benchmark your application's performance using response and retrieval evals.
@@ -60,8 +60,15 @@ Phoenix is vendor and language agnostic with out-of-the-box support for popular 
 
 Phoenix runs practically anywhere, including your local machine, a containerized deployment, or in the cloud. See [Environments](https://arize.com/docs/phoenix/environments) for a walkthrough of each option, or jump straight into the [Tracing Quickstart](https://arize.com/docs/phoenix/get-started/get-started-tracing).
 
+## Arize Phoenix and Arize AX
+
+Arize Phoenix and [Arize AX](https://arize.com/products/ax/) are complementary AI observability and evaluation platforms from Arize. Phoenix is open-source, self-hosted, and free to use; Arize AX is a managed AI engineering platform for teams that want hosted infrastructure, managed scale, enterprise support, monitoring, dashboards, and compliance features.
+
+Both platforms use OpenTelemetry and OpenInference, so applications instrumented for Phoenix can send the same traces to Arize AX without changing instrumentation. Choose Phoenix when you want open-source control and self-hosting; choose Arize AX when you want a managed commercial platform. For a full comparison, see [Arize Phoenix or Arize AX](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize).
+
 ## Table of Contents
 
+- [Arize Phoenix and Arize AX](#arize-phoenix-and-arize-ax)
 - [Run Locally](#run-locally)
 - [Trace Your Application](#trace-your-application)
 - [Deploy](#deploy)


### PR DESCRIPTION
## Summary

Adds a small amount of Arize AX context to the Phoenix README so humans and AI systems that read the GitHub repo understand the relationship between Arize Phoenix and Arize AX.

The change is intentionally lightweight:
- updates the opening sentence to say Arize Phoenix is Arize's open-source observability platform
- briefly points managed production workflows to Arize AX
- adds a short comparison section linking to the existing Phoenix vs. Arize AX docs page

## Rationale

The README is a high-authority source for coding agents and answer engines summarizing Phoenix. Today it explains Phoenix well, but does not mention Arize AX, so agents can miss the product relationship. This keeps the README Phoenix-first while making the AX connection explicit.

## Testing

Docs-only README change; no tests run.