### PR TITLE
feat(ui): add custom evaluators to gallery

### DIFF
--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -4176,7 +4176,7 @@ type Query {
     names: [String!]
   ): DatasetSplitConnection!
   builtInEvaluators: [BuiltInEvaluator!]!
-  evaluators(first: Int = 50, last: Int, after: String, before: String, sort: EvaluatorSort, filter: EvaluatorFilter): EvaluatorConnection!
+  evaluators(first: Int = 50, last: Int, after: String, before: String, sort: EvaluatorSort, filter: EvaluatorFilter, excludeProjectId: ID): EvaluatorConnection!
   annotationConfigs(first: Int = 50, last: Int = null, after: String = null, before: String = null): AnnotationConfigConnection!
   classificationEvaluatorConfigs(labels: [String!]): [ClassificationEvaluatorConfig!]!
   evaluatorGalleryConfigs: [ClassificationEvaluatorConfig!]!

--- a/js/app/src/constants/searchParams.ts
+++ b/js/app/src/constants/searchParams.ts
@@ -68,6 +68,11 @@ export const CREATE_LLM_EVALUATOR_PARAM = "createLlmEvaluator";
 export const PROJECT_EVALUATOR_CATEGORY_PARAM = "category";
 
 /**
+ * The existing evaluator selected in the project evaluator gallery.
+ */
+export const PROJECT_EVALUATOR_PARAM = "evaluator";
+
+/**
  * The evaluator template selected in the project evaluator gallery.
  */
 export const PROJECT_EVALUATOR_TEMPLATE_PARAM = "template";

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -401,24 +401,24 @@ function AttachCodeProjectEvaluatorDialog({
               inputMapping: null,
             },
           },
-          updater: (relayStore) => {
-            const galleryConnection = ConnectionHandler.getConnection(
-              relayStore.getRoot(),
-              PROJECT_EVALUATOR_GALLERY_CUSTOM_EVALUATORS_CONNECTION_KEY,
-              { excludeProjectId: projectId }
-            );
-            if (galleryConnection) {
-              ConnectionHandler.deleteNode(
-                galleryConnection,
-                creationMode.evaluatorId
-              );
-            }
-          },
           onCompleted: (_response, errors) => {
             if (errors?.length) {
               setError(errors.map(({ message }) => message).join("\n"));
               return;
             }
+            environment.commitUpdate((relayStore) => {
+              const galleryConnection = ConnectionHandler.getConnection(
+                relayStore.getRoot(),
+                PROJECT_EVALUATOR_GALLERY_CUSTOM_EVALUATORS_CONNECTION_KEY,
+                { excludeProjectId: projectId }
+              );
+              if (galleryConnection) {
+                ConnectionHandler.deleteNode(
+                  galleryConnection,
+                  creationMode.evaluatorId
+                );
+              }
+            });
             void refetchProjectEvaluators({
               environment,
               projectId,

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import type { ModalOverlayProps } from "react-aria-components";
-import { graphql, useMutation, useRelayEnvironment } from "react-relay";
+import {
+  ConnectionHandler,
+  graphql,
+  useMutation,
+  useRelayEnvironment,
+} from "react-relay";
 import invariant from "tiny-invariant";
 
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
@@ -28,6 +33,7 @@ import { CreateProjectCodeEvaluatorDialogContent } from "@phoenix/pages/project/
 import { createProjectLlmEvaluator } from "@phoenix/pages/project/evaluators/createProjectLlmEvaluator";
 import { ProjectCodeEvaluatorDialogContent } from "@phoenix/pages/project/evaluators/ProjectCodeEvaluatorDialogContent";
 import { ProjectLlmEvaluatorFormSections } from "@phoenix/pages/project/evaluators/ProjectEvaluatorFormSections";
+import { PROJECT_EVALUATOR_GALLERY_CUSTOM_EVALUATORS_CONNECTION_KEY } from "@phoenix/pages/project/evaluators/projectEvaluatorGalleryConstants";
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
 import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideover";
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
@@ -394,6 +400,19 @@ function AttachCodeProjectEvaluatorDialog({
               enabled: true,
               inputMapping: null,
             },
+          },
+          updater: (relayStore) => {
+            const galleryConnection = ConnectionHandler.getConnection(
+              relayStore.getRoot(),
+              PROJECT_EVALUATOR_GALLERY_CUSTOM_EVALUATORS_CONNECTION_KEY,
+              { excludeProjectId: projectId }
+            );
+            if (galleryConnection) {
+              ConnectionHandler.deleteNode(
+                galleryConnection,
+                creationMode.evaluatorId
+              );
+            }
           },
           onCompleted: (_response, errors) => {
             if (errors?.length) {

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -90,7 +90,7 @@ type CustomEvaluator = {
   readonly description: string | null;
 };
 
-type SelectedGalleryItem =
+type GalleryItem =
   | { kind: "custom"; evaluator: CustomEvaluator }
   | { kind: "template"; template: ProjectEvaluatorTemplate };
 
@@ -143,6 +143,18 @@ const getCustomEvaluatorItemKey = (id: string) => `custom:${id}`;
 const getTemplateItemKey = (name: string) => `template:${name}`;
 const getCustomEvaluatorKind = (evaluator: CustomEvaluator) =>
   evaluator.__typename === "LLMEvaluator" ? "LLM" : "CODE";
+
+function getGalleryItemKey(item: GalleryItem): string {
+  return item.kind === "custom"
+    ? getCustomEvaluatorItemKey(item.evaluator.id)
+    : getTemplateItemKey(item.template.name);
+}
+
+function getGalleryItemSection(item: GalleryItem): GallerySection {
+  return item.kind === "custom"
+    ? CUSTOM_EVALUATORS_SECTION
+    : getGalleryCategory(item.template.category);
+}
 
 export function ProjectEvaluatorGalleryPage() {
   return (
@@ -208,6 +220,19 @@ function EvaluatorGallery() {
       ),
     [categories, templates]
   );
+  const galleryItems: GalleryItem[] = [
+    ...customEvaluators.map((evaluator) => ({
+      kind: "custom" as const,
+      evaluator,
+    })),
+    ...templates.map((template) => ({
+      kind: "template" as const,
+      template,
+    })),
+  ];
+  const galleryItemsByKey = new Map(
+    galleryItems.map((item) => [getGalleryItemKey(item), item])
+  );
   const sections = useMemo<GallerySection[]>(
     () =>
       hasCustomEvaluators
@@ -233,45 +258,41 @@ function EvaluatorGallery() {
     requestedCategoryParam && categories.includes(requestedCategoryParam)
       ? requestedCategoryParam
       : undefined;
-  const requestedTemplate = templates.find(
-    ({ name }) => name === requestedTemplateName
-  );
-  const requestedEvaluator = customEvaluators.find(
-    ({ id }) => id === requestedEvaluatorId
-  );
-  const requestedItemKeyToScroll = requestedEvaluator
-    ? getCustomEvaluatorItemKey(requestedEvaluator.id)
-    : requestedTemplate
-      ? getTemplateItemKey(requestedTemplate.name)
-      : undefined;
-  const requestedTemplateCategory = requestedTemplate
-    ? getGalleryCategory(requestedTemplate.category)
+
+  // URL selections are optional deep links. Resolve them through the same item
+  // index that backs card selection so invalid or stale values are harmless.
+  let requestedItem: GalleryItem | undefined;
+  if (requestedEvaluatorId) {
+    requestedItem = galleryItemsByKey.get(
+      getCustomEvaluatorItemKey(requestedEvaluatorId)
+    );
+  }
+  if (!requestedItem && requestedTemplateName) {
+    requestedItem = galleryItemsByKey.get(
+      getTemplateItemKey(requestedTemplateName)
+    );
+  }
+
+  const requestedItemKeyToScroll = requestedItem
+    ? getGalleryItemKey(requestedItem)
     : undefined;
-  const requestedSectionToScroll = requestedEvaluator
-    ? CUSTOM_EVALUATORS_SECTION
-    : (requestedTemplateCategory ?? requestedCategory);
-  const selectedItem: SelectedGalleryItem | undefined = requestedEvaluator
-    ? { kind: "custom", evaluator: requestedEvaluator }
-    : requestedTemplate
-      ? { kind: "template", template: requestedTemplate }
-      : requestedCategory
-        ? (() => {
-            const template = templatesByCategory.get(requestedCategory)?.[0];
-            return template
-              ? { kind: "template" as const, template }
-              : undefined;
-          })()
-        : customEvaluators[0]
-          ? { kind: "custom", evaluator: customEvaluators[0] }
-          : templates[0]
-            ? { kind: "template", template: templates[0] }
-            : undefined;
-  const selectedItemKey =
-    selectedItem?.kind === "custom"
-      ? getCustomEvaluatorItemKey(selectedItem.evaluator.id)
-      : selectedItem?.kind === "template"
-        ? getTemplateItemKey(selectedItem.template.name)
-        : undefined;
+  const requestedSectionToScroll = requestedItem
+    ? getGalleryItemSection(requestedItem)
+    : requestedCategory;
+  const requestedCategoryTemplate = requestedCategory
+    ? templatesByCategory.get(requestedCategory)?.[0]
+    : undefined;
+  const requestedCategoryItem: GalleryItem | undefined =
+    requestedCategoryTemplate
+      ? { kind: "template", template: requestedCategoryTemplate }
+      : undefined;
+
+  // Prefer deep-linked content, then fall back to the first available card.
+  const selectedItem =
+    requestedItem ?? requestedCategoryItem ?? galleryItems[0];
+  const selectedItemKey = selectedItem
+    ? getGalleryItemKey(selectedItem)
+    : undefined;
 
   // Section headings double as scroll-spy targets, so the sidebar can track
   // whichever gallery section is currently in view.
@@ -292,7 +313,7 @@ function EvaluatorGallery() {
   };
 
   // Keep the scroll position synchronized with gallery deep links. Prefer the
-  // requested template and fall back to its category when no card is available.
+  // requested card and fall back to its section when no card is available.
   useEffect(() => {
     // Wait for the route commit and React Aria collection layout before moving
     // the scroll port; otherwise router scroll restoration can win this race.
@@ -370,28 +391,23 @@ function EvaluatorGallery() {
     };
   }, [sections]);
 
-  const setSelectedItem = (itemKey: string) => {
+  const setSelectedItem = (item: GalleryItem) => {
     setSearchParams((currentSearchParams) => {
       const nextSearchParams = new URLSearchParams(currentSearchParams);
-      const evaluator = customEvaluators.find(
-        ({ id }) => getCustomEvaluatorItemKey(id) === itemKey
-      );
-      if (evaluator) {
-        nextSearchParams.set(PROJECT_EVALUATOR_PARAM, evaluator.id);
+      if (item.kind === "custom") {
+        nextSearchParams.set(PROJECT_EVALUATOR_PARAM, item.evaluator.id);
         nextSearchParams.delete(PROJECT_EVALUATOR_CATEGORY_PARAM);
         nextSearchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
       } else {
-        const template = templates.find(
-          ({ name }) => getTemplateItemKey(name) === itemKey
+        nextSearchParams.set(
+          PROJECT_EVALUATOR_CATEGORY_PARAM,
+          getGalleryCategory(item.template.category)
         );
-        if (template) {
-          nextSearchParams.set(
-            PROJECT_EVALUATOR_CATEGORY_PARAM,
-            getGalleryCategory(template.category)
-          );
-          nextSearchParams.set(PROJECT_EVALUATOR_TEMPLATE_PARAM, template.name);
-          nextSearchParams.delete(PROJECT_EVALUATOR_PARAM);
-        }
+        nextSearchParams.set(
+          PROJECT_EVALUATOR_TEMPLATE_PARAM,
+          item.template.name
+        );
+        nextSearchParams.delete(PROJECT_EVALUATOR_PARAM);
       }
       return nextSearchParams;
     });
@@ -520,27 +536,25 @@ function EvaluatorGallery() {
             if (selection === "all") return;
             const itemKey = selection.keys().next().value;
             if (typeof itemKey === "string") {
-              setSelectedItem(itemKey);
+              const item = galleryItemsByKey.get(itemKey);
+              if (item) {
+                setSelectedItem(item);
+              }
             }
           }}
           onAction={(key) => {
             if (typeof key !== "string") return;
-            const evaluator = customEvaluators.find(
-              ({ id }) => getCustomEvaluatorItemKey(id) === key
-            );
-            if (evaluator) {
+            const item = galleryItemsByKey.get(key);
+            if (item?.kind === "custom") {
               navigate(
-                getCustomEvaluatorKind(evaluator) === "LLM"
-                  ? paths.galleryCreation.copyLlm(evaluator.id)
-                  : paths.galleryCreation.attachCode(evaluator.id)
+                getCustomEvaluatorKind(item.evaluator) === "LLM"
+                  ? paths.galleryCreation.copyLlm(item.evaluator.id)
+                  : paths.galleryCreation.attachCode(item.evaluator.id)
               );
               return;
             }
-            const template = templates.find(
-              ({ name }) => getTemplateItemKey(name) === key
-            );
-            if (template) {
-              navigate(paths.galleryNewLlmFromTemplate(template.name));
+            if (item?.kind === "template") {
+              navigate(paths.galleryNewLlmFromTemplate(item.template.name));
             }
           }}
         >

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -45,9 +45,8 @@ import type { EvaluatorCategory } from "@phoenix/pages/project/evaluators/__gene
 import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
 import { EvaluatorTemplateCard } from "@phoenix/pages/project/evaluators/EvaluatorTemplateCard";
 import {
-  isCodeProjectEvaluatorDetails,
-  isLlmProjectEvaluatorDetails,
   projectEvaluatorDetailsQueryNode,
+  readProjectEvaluatorDetails,
   type CodeProjectEvaluatorDetails,
   type LlmProjectEvaluatorDetails,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
@@ -792,11 +791,11 @@ function CustomEvaluatorDetails({
     { id: evaluatorSummary.id },
     { fetchPolicy: "store-and-network" }
   );
-  const evaluator = data.evaluator;
+  const evaluator = readProjectEvaluatorDetails(data.evaluator);
   if (!evaluator) {
     return <EvaluatorDetailsError />;
   }
-  if (isLlmProjectEvaluatorDetails(evaluator)) {
+  if (evaluator.__typename === "LLMEvaluator") {
     return (
       <LlmCustomEvaluatorDetails
         evaluator={evaluator}
@@ -804,7 +803,7 @@ function CustomEvaluatorDetails({
       />
     );
   }
-  if (isCodeProjectEvaluatorDetails(evaluator)) {
+  if (evaluator.__typename === "CodeEvaluator") {
     return (
       <CodeCustomEvaluatorDetails
         evaluator={evaluator}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -184,6 +184,7 @@ function EvaluatorGallery() {
         ),
     [data.evaluators.edges]
   );
+  const hasCustomEvaluators = customEvaluators.length > 0;
   const categories = useMemo(() => {
     const orderedCategories: TemplateCategory[] = [
       ...PROJECT_EVALUATOR_CATEGORIES.map(({ value }) => value),
@@ -208,8 +209,11 @@ function EvaluatorGallery() {
     [categories, templates]
   );
   const sections = useMemo<GallerySection[]>(
-    () => [CUSTOM_EVALUATORS_SECTION, ...categories],
-    [categories]
+    () =>
+      hasCustomEvaluators
+        ? [CUSTOM_EVALUATORS_SECTION, ...categories]
+        : categories,
+    [categories, hasCustomEvaluators]
   );
   const categoryItems = categories.map((category) => ({
     id: category,
@@ -277,6 +281,10 @@ function EvaluatorGallery() {
   const [activeSection, setActiveSection] = useState<
     GallerySection | undefined
   >(() => requestedSectionToScroll ?? sections[0]);
+  const selectedSection =
+    activeSection && sections.includes(activeSection)
+      ? activeSection
+      : sections[0];
 
   const scrollToSection = (section: GallerySection) => {
     headingRefs.current.get(section)?.scrollIntoView({ block: "start" });
@@ -417,7 +425,7 @@ function EvaluatorGallery() {
             selectionMode="single"
             selectionBehavior="replace"
             disallowEmptySelection
-            selectedKeys={activeSection ? [activeSection] : []}
+            selectedKeys={selectedSection ? [selectedSection] : []}
             onSelectionChange={(selection) => {
               if (selection === "all") return;
               const section = selection.keys().next().value;
@@ -426,13 +434,15 @@ function EvaluatorGallery() {
               }
             }}
           >
-            <ListBoxSection id="custom-evaluators-navigation">
-              {renderSectionItem({
-                id: CUSTOM_EVALUATORS_SECTION,
-                name: "Custom evaluators",
-                count: customEvaluators.length,
-              })}
-            </ListBoxSection>
+            {hasCustomEvaluators ? (
+              <ListBoxSection id="custom-evaluators-navigation">
+                {renderSectionItem({
+                  id: CUSTOM_EVALUATORS_SECTION,
+                  name: "Custom evaluators",
+                  count: customEvaluators.length,
+                })}
+              </ListBoxSection>
+            ) : null}
             <ListBoxSection id="categories">
               <Header className="project-evaluator-gallery__category-section-heading">
                 <Text
@@ -460,7 +470,7 @@ function EvaluatorGallery() {
         <Select
           aria-label="Evaluator gallery section"
           className="project-evaluator-gallery__compact-category-select"
-          value={activeSection}
+          value={selectedSection}
           onChange={(section) => {
             if (typeof section === "string") {
               scrollToSection(section as GallerySection);
@@ -473,13 +483,15 @@ function EvaluatorGallery() {
           </Button>
           <Popover isNonModal closeOnInteractOutside>
             <ListBox css={compactCategoryListCSS}>
-              <ListBoxSection id="compact-custom-evaluators">
-                {renderSectionItem({
-                  id: CUSTOM_EVALUATORS_SECTION,
-                  name: "Custom evaluators",
-                  count: customEvaluators.length,
-                })}
-              </ListBoxSection>
+              {hasCustomEvaluators ? (
+                <ListBoxSection id="compact-custom-evaluators">
+                  {renderSectionItem({
+                    id: CUSTOM_EVALUATORS_SECTION,
+                    name: "Custom evaluators",
+                    count: customEvaluators.length,
+                  })}
+                </ListBoxSection>
+              ) : null}
               <ListBoxSection id="compact-categories">
                 <Header className="project-evaluator-gallery__category-section-heading">
                   <Text
@@ -532,63 +544,63 @@ function EvaluatorGallery() {
             }
           }}
         >
-          <ListBoxSection
-            id={CUSTOM_EVALUATORS_SECTION}
-            className="project-evaluator-gallery__template-category-section"
-          >
-            <Header className="project-evaluator-gallery__template-category-header">
-              <Text
-                ref={(element) => {
-                  if (element) {
-                    headingRefs.current.set(CUSTOM_EVALUATORS_SECTION, element);
-                  } else {
-                    headingRefs.current.delete(CUSTOM_EVALUATORS_SECTION);
-                  }
-                }}
-                id={getSectionHeadingId(CUSTOM_EVALUATORS_SECTION)}
-                className="project-evaluator-gallery__template-category-heading"
-                elementType="h2"
-                size="M"
-                weight="heavy"
-              >
-                Custom evaluators
-              </Text>
-              {customEvaluators.length === 0 ? (
-                <Text size="S" color="text-500">
-                  No custom evaluators are available.
-                </Text>
-              ) : null}
-            </Header>
-            {customEvaluators.map((evaluator) => {
-              const itemKey = getCustomEvaluatorItemKey(evaluator.id);
-              return (
-                <EvaluatorTemplateCard
-                  key={itemKey}
+          {hasCustomEvaluators ? (
+            <ListBoxSection
+              id={CUSTOM_EVALUATORS_SECTION}
+              className="project-evaluator-gallery__template-category-section"
+            >
+              <Header className="project-evaluator-gallery__template-category-header">
+                <Text
                   ref={(element) => {
                     if (element) {
-                      cardRefs.current.set(itemKey, element);
+                      headingRefs.current.set(
+                        CUSTOM_EVALUATORS_SECTION,
+                        element
+                      );
                     } else {
-                      cardRefs.current.delete(itemKey);
+                      headingRefs.current.delete(CUSTOM_EVALUATORS_SECTION);
                     }
                   }}
-                  id={itemKey}
-                  textValue={evaluator.name}
+                  id={getSectionHeadingId(CUSTOM_EVALUATORS_SECTION)}
+                  className="project-evaluator-gallery__template-category-heading"
+                  elementType="h2"
+                  size="M"
+                  weight="heavy"
                 >
-                  <Text size="S" weight="heavy">
-                    {evaluator.name}
-                  </Text>
-                  <LineClamp lines={3}>
-                    <Text size="XS" color="text-700">
-                      {evaluator.description || "No description"}
+                  Custom evaluators
+                </Text>
+              </Header>
+              {customEvaluators.map((evaluator) => {
+                const itemKey = getCustomEvaluatorItemKey(evaluator.id);
+                return (
+                  <EvaluatorTemplateCard
+                    key={itemKey}
+                    ref={(element) => {
+                      if (element) {
+                        cardRefs.current.set(itemKey, element);
+                      } else {
+                        cardRefs.current.delete(itemKey);
+                      }
+                    }}
+                    id={itemKey}
+                    textValue={evaluator.name}
+                  >
+                    <Text size="S" weight="heavy">
+                      {evaluator.name}
                     </Text>
-                  </LineClamp>
-                  <EvaluatorTemplateCardFooter
-                    evaluatorKind={getCustomEvaluatorKind(evaluator)}
-                  />
-                </EvaluatorTemplateCard>
-              );
-            })}
-          </ListBoxSection>
+                    <LineClamp lines={3}>
+                      <Text size="XS" color="text-700">
+                        {evaluator.description || "No description"}
+                      </Text>
+                    </LineClamp>
+                    <EvaluatorTemplateCardFooter
+                      evaluatorKind={getCustomEvaluatorKind(evaluator)}
+                    />
+                  </EvaluatorTemplateCard>
+                );
+              })}
+            </ListBoxSection>
+          ) : null}
           {categories.map((category) => {
             const headingId = getSectionHeadingId(category);
             return (

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { Header, ListBoxSection } from "react-aria-components";
-import { useLazyLoadQuery } from "react-relay";
-import { Outlet, useNavigate, useSearchParams } from "react-router";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { Outlet, useNavigate, useParams, useSearchParams } from "react-router";
 
 import {
   Badge,
@@ -27,19 +27,30 @@ import {
   getOptimizationBounds,
   getPositiveOptimization,
 } from "@phoenix/components/annotation/optimizationUtils";
+import {
+  PythonBlockWithCopy,
+  TypeScriptBlockWithCopy,
+} from "@phoenix/components/code";
 import { LineClamp } from "@phoenix/components/core/utility/LineClamp";
 import { EvaluatorKindToken } from "@phoenix/components/evaluators/EvaluatorKindToken";
 import { ErrorBoundary } from "@phoenix/components/exception";
 import {
   PROJECT_EVALUATOR_CATEGORY_PARAM,
+  PROJECT_EVALUATOR_PARAM,
   PROJECT_EVALUATOR_TEMPLATE_PARAM,
 } from "@phoenix/constants/searchParams";
-import type {
-  EvaluatorCategory,
-  projectEvaluatorTemplatesQuery as ProjectEvaluatorTemplatesQueryType,
-} from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
+import type { projectEvaluatorDetailsQuery as ProjectEvaluatorDetailsQueryType } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql";
+import type { projectEvaluatorGalleryPageQuery as ProjectEvaluatorGalleryPageQueryType } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorGalleryPageQuery.graphql";
+import type { EvaluatorCategory } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql";
 import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
 import { EvaluatorTemplateCard } from "@phoenix/pages/project/evaluators/EvaluatorTemplateCard";
+import {
+  isCodeProjectEvaluatorDetails,
+  isLlmProjectEvaluatorDetails,
+  projectEvaluatorDetailsQueryNode,
+  type CodeProjectEvaluatorDetails,
+  type LlmProjectEvaluatorDetails,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
 import {
   type ProjectEvaluatorCreationPaths,
   useProjectEvaluatorPaths,
@@ -50,14 +61,16 @@ import {
   getProjectEvaluatorTemplateMessages,
   PROJECT_EVALUATOR_CATEGORIES,
   type ProjectEvaluatorTemplate,
-  projectEvaluatorTemplatesQuery,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTemplates";
 import {
   formatEvaluationTargetPlural,
   type ProjectEvaluatorTarget,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { PlaygroundChatTemplate } from "@phoenix/store";
+import { convertPromptVersionMessagesToPlaygroundInstanceMessages } from "@phoenix/utils/promptUtils";
 
 const OTHER_CATEGORY = "other" as const;
+const CUSTOM_EVALUATORS_SECTION = "custom-evaluators" as const;
 const GALLERY_SKELETON_HEIGHT = 440;
 /** The combined minimum width of the category, template, and details columns. */
 const GALLERY_EXPANDED_MIN_WIDTH = 960;
@@ -68,6 +81,53 @@ const GALLERY_EXPANDED_MIN_WIDTH = 960;
 const SCROLL_SPY_ROOT_MARGIN = "0px 0px -70% 0px";
 
 type TemplateCategory = EvaluatorCategory | typeof OTHER_CATEGORY;
+type GallerySection = TemplateCategory | typeof CUSTOM_EVALUATORS_SECTION;
+
+type CustomEvaluator = {
+  readonly __typename: "LLMEvaluator" | "CodeEvaluator";
+  readonly id: string;
+  readonly name: string;
+  readonly description: string | null;
+};
+
+type SelectedGalleryItem =
+  | { kind: "custom"; evaluator: CustomEvaluator }
+  | { kind: "template"; template: ProjectEvaluatorTemplate };
+
+const projectEvaluatorGalleryPageQuery = graphql`
+  query projectEvaluatorGalleryPageQuery($projectId: ID!) {
+    evaluatorGalleryConfigs {
+      name
+      description
+      choices
+      optimizationDirection
+      scope
+      category
+      details
+      messages {
+        ...promptUtils_promptMessages
+      }
+    }
+    evaluators(
+      first: 100
+      sort: { col: updatedAt, dir: desc }
+      excludeProjectId: $projectId
+    )
+      @connection(
+        key: "ProjectEvaluatorGallery__evaluators"
+        filters: ["excludeProjectId"]
+      ) {
+      edges {
+        evaluator: node {
+          __typename
+          id
+          name
+          description
+        }
+      }
+    }
+  }
+`;
 
 function getGalleryCategory(
   category: EvaluatorCategory | null
@@ -75,9 +135,14 @@ function getGalleryCategory(
   return category ?? OTHER_CATEGORY;
 }
 
-function getCategoryHeadingId(category: TemplateCategory): string {
-  return `project-evaluator-gallery-category-${category.toLowerCase()}`;
+function getSectionHeadingId(section: GallerySection): string {
+  return `project-evaluator-gallery-section-${section.toLowerCase()}`;
 }
+
+const getCustomEvaluatorItemKey = (id: string) => `custom:${id}`;
+const getTemplateItemKey = (name: string) => `template:${name}`;
+const getCustomEvaluatorKind = (evaluator: CustomEvaluator) =>
+  evaluator.__typename === "LLMEvaluator" ? "LLM" : "CODE";
 
 export function ProjectEvaluatorGalleryPage() {
   return (
@@ -97,13 +162,28 @@ export function ProjectEvaluatorGalleryPage() {
 function EvaluatorGallery() {
   const navigate = useNavigate();
   const paths = useProjectEvaluatorPaths();
+  const { projectId } = useParams();
+  if (!projectId) {
+    throw new Error("projectId is required");
+  }
   const [searchParams, setSearchParams] = useSearchParams();
-  const data = useLazyLoadQuery<ProjectEvaluatorTemplatesQueryType>(
-    projectEvaluatorTemplatesQuery,
-    {},
+  const data = useLazyLoadQuery<ProjectEvaluatorGalleryPageQueryType>(
+    projectEvaluatorGalleryPageQuery,
+    { projectId },
     { fetchPolicy: "store-and-network" }
   );
   const templates = data.evaluatorGalleryConfigs;
+  const customEvaluators = useMemo(
+    () =>
+      data.evaluators.edges
+        .map(({ evaluator }) => evaluator)
+        .filter(
+          (evaluator): evaluator is CustomEvaluator =>
+            evaluator.__typename === "LLMEvaluator" ||
+            evaluator.__typename === "CodeEvaluator"
+        ),
+    [data.evaluators.edges]
+  );
   const categories = useMemo(() => {
     const orderedCategories: TemplateCategory[] = [
       ...PROJECT_EVALUATOR_CATEGORIES.map(({ value }) => value),
@@ -127,6 +207,10 @@ function EvaluatorGallery() {
       ),
     [categories, templates]
   );
+  const sections = useMemo<GallerySection[]>(
+    () => [CUSTOM_EVALUATORS_SECTION, ...categories],
+    [categories]
+  );
   const categoryItems = categories.map((category) => ({
     id: category,
     name: getProjectEvaluatorTemplateCategoryLabel(
@@ -137,6 +221,7 @@ function EvaluatorGallery() {
   const requestedTemplateName = searchParams.get(
     PROJECT_EVALUATOR_TEMPLATE_PARAM
   );
+  const requestedEvaluatorId = searchParams.get(PROJECT_EVALUATOR_PARAM);
   const requestedCategoryParam = searchParams.get(
     PROJECT_EVALUATOR_CATEGORY_PARAM
   ) as TemplateCategory | null;
@@ -147,28 +232,55 @@ function EvaluatorGallery() {
   const requestedTemplate = templates.find(
     ({ name }) => name === requestedTemplateName
   );
-  const requestedTemplateNameToScroll = requestedTemplate?.name;
+  const requestedEvaluator = customEvaluators.find(
+    ({ id }) => id === requestedEvaluatorId
+  );
+  const requestedItemKeyToScroll = requestedEvaluator
+    ? getCustomEvaluatorItemKey(requestedEvaluator.id)
+    : requestedTemplate
+      ? getTemplateItemKey(requestedTemplate.name)
+      : undefined;
   const requestedTemplateCategory = requestedTemplate
     ? getGalleryCategory(requestedTemplate.category)
     : undefined;
-  const requestedCategoryToScroll =
-    requestedTemplateCategory ?? requestedCategory;
-  const selectedTemplate =
-    requestedTemplate ??
-    templatesByCategory.get(requestedCategory ?? categories[0])?.[0];
+  const requestedSectionToScroll = requestedEvaluator
+    ? CUSTOM_EVALUATORS_SECTION
+    : (requestedTemplateCategory ?? requestedCategory);
+  const selectedItem: SelectedGalleryItem | undefined = requestedEvaluator
+    ? { kind: "custom", evaluator: requestedEvaluator }
+    : requestedTemplate
+      ? { kind: "template", template: requestedTemplate }
+      : requestedCategory
+        ? (() => {
+            const template = templatesByCategory.get(requestedCategory)?.[0];
+            return template
+              ? { kind: "template" as const, template }
+              : undefined;
+          })()
+        : customEvaluators[0]
+          ? { kind: "custom", evaluator: customEvaluators[0] }
+          : templates[0]
+            ? { kind: "template", template: templates[0] }
+            : undefined;
+  const selectedItemKey =
+    selectedItem?.kind === "custom"
+      ? getCustomEvaluatorItemKey(selectedItem.evaluator.id)
+      : selectedItem?.kind === "template"
+        ? getTemplateItemKey(selectedItem.template.name)
+        : undefined;
 
   // Section headings double as scroll-spy targets, so the sidebar can track
-  // whichever category is currently in view.
-  const headingRefs = useRef(new Map<TemplateCategory, HTMLElement>());
-  const templateCardRefs = useRef(new Map<string, HTMLDivElement>());
-  const templateScrollRegionRef = useRef<HTMLDivElement>(null);
-  const [activeCategory, setActiveCategory] = useState<
-    TemplateCategory | undefined
-  >(() => requestedCategory ?? categories[0]);
+  // whichever gallery section is currently in view.
+  const headingRefs = useRef(new Map<GallerySection, HTMLElement>());
+  const cardRefs = useRef(new Map<string, HTMLDivElement>());
+  const galleryScrollRegionRef = useRef<HTMLDivElement>(null);
+  const [activeSection, setActiveSection] = useState<
+    GallerySection | undefined
+  >(() => requestedSectionToScroll ?? sections[0]);
 
-  const scrollToCategory = (category: TemplateCategory) => {
-    headingRefs.current.get(category)?.scrollIntoView({ block: "start" });
-    setActiveCategory(category);
+  const scrollToSection = (section: GallerySection) => {
+    headingRefs.current.get(section)?.scrollIntoView({ block: "start" });
+    setActiveSection(section);
   };
 
   // Keep the scroll position synchronized with gallery deep links. Prefer the
@@ -177,35 +289,33 @@ function EvaluatorGallery() {
     // Wait for the route commit and React Aria collection layout before moving
     // the scroll port; otherwise router scroll restoration can win this race.
     const animationFrameId = requestAnimationFrame(() => {
-      const requestedTemplateCard = requestedTemplateNameToScroll
-        ? templateCardRefs.current.get(requestedTemplateNameToScroll)
+      const requestedCard = requestedItemKeyToScroll
+        ? cardRefs.current.get(requestedItemKeyToScroll)
         : undefined;
-      const requestedCategoryHeading = requestedCategoryToScroll
-        ? headingRefs.current.get(requestedCategoryToScroll)
+      const requestedSectionHeading = requestedSectionToScroll
+        ? headingRefs.current.get(requestedSectionToScroll)
         : undefined;
-      const scrollTarget = requestedTemplateCard ?? requestedCategoryHeading;
+      const scrollTarget = requestedCard ?? requestedSectionHeading;
       scrollTarget?.scrollIntoView({
-        block: requestedTemplateCard ? "nearest" : "start",
+        block: requestedCard ? "nearest" : "start",
       });
-      if (requestedCategoryToScroll) {
-        setActiveCategory(requestedCategoryToScroll);
+      if (requestedSectionToScroll) {
+        setActiveSection(requestedSectionToScroll);
       }
     });
     return () => cancelAnimationFrame(animationFrameId);
-  }, [requestedCategoryToScroll, requestedTemplateNameToScroll]);
+  }, [requestedItemKeyToScroll, requestedSectionToScroll]);
 
   useEffect(() => {
-    const scrollRegion = templateScrollRegionRef.current;
+    const scrollRegion = galleryScrollRegionRef.current;
     if (!scrollRegion) return undefined;
     // Snapshot the mounted headings so observer entries can be mapped back to
     // the category selection used by the sidebar and compact picker.
-    const headingsByElement = new Map<Element, TemplateCategory>(
-      categories
-        .map(
-          (category) => [headingRefs.current.get(category), category] as const
-        )
+    const headingsByElement = new Map<Element, GallerySection>(
+      sections
+        .map((section) => [headingRefs.current.get(section), section] as const)
         .filter(
-          (entry): entry is [HTMLElement, TemplateCategory] => entry[0] != null
+          (entry): entry is [HTMLElement, GallerySection] => entry[0] != null
         )
     );
     if (headingsByElement.size === 0) return undefined;
@@ -222,38 +332,55 @@ function EvaluatorGallery() {
         const isAtScrollEnd =
           scrollRegion.scrollTop + scrollRegion.clientHeight >=
           scrollRegion.scrollHeight - 1;
-        const category = isAtScrollEnd
-          ? categories.at(-1)
+        const section = isAtScrollEnd
+          ? sections.at(-1)
           : topmostVisibleEntry
             ? headingsByElement.get(topmostVisibleEntry.target)
             : undefined;
-        if (category) {
-          setActiveCategory(category);
+        if (section) {
+          setActiveSection(section);
         }
       },
       { root: scrollRegion, rootMargin: SCROLL_SPY_ROOT_MARGIN }
     );
     // Observe every mounted category heading and release them together when
     // the category collection changes or the gallery unmounts.
-    headingsByElement.forEach((_category, heading) =>
-      observer.observe(heading)
-    );
+    headingsByElement.forEach((_section, heading) => observer.observe(heading));
     return () => observer.disconnect();
-  }, [categories]);
+  }, [sections]);
 
-  const setSelectedTemplate = (templateName: string) => {
+  const setSelectedItem = (itemKey: string) => {
     setSearchParams((currentSearchParams) => {
       const nextSearchParams = new URLSearchParams(currentSearchParams);
-      nextSearchParams.set(PROJECT_EVALUATOR_TEMPLATE_PARAM, templateName);
+      const evaluator = customEvaluators.find(
+        ({ id }) => getCustomEvaluatorItemKey(id) === itemKey
+      );
+      if (evaluator) {
+        nextSearchParams.set(PROJECT_EVALUATOR_PARAM, evaluator.id);
+        nextSearchParams.delete(PROJECT_EVALUATOR_CATEGORY_PARAM);
+        nextSearchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
+      } else {
+        const template = templates.find(
+          ({ name }) => getTemplateItemKey(name) === itemKey
+        );
+        if (template) {
+          nextSearchParams.set(
+            PROJECT_EVALUATOR_CATEGORY_PARAM,
+            getGalleryCategory(template.category)
+          );
+          nextSearchParams.set(PROJECT_EVALUATOR_TEMPLATE_PARAM, template.name);
+          nextSearchParams.delete(PROJECT_EVALUATOR_PARAM);
+        }
+      }
       return nextSearchParams;
     });
   };
-  const renderCategoryItem = ({
+  const renderSectionItem = ({
     id,
     name,
     count,
   }: {
-    id: TemplateCategory;
+    id: GallerySection;
     name: string;
     count: number;
   }) => (
@@ -272,20 +399,27 @@ function EvaluatorGallery() {
         <EvaluatorGalleryAddMenu creationPaths={paths.galleryCreation} />
         <div className="project-evaluator-gallery__category-scroll-region">
           <ListBox
-            aria-label="Categories"
+            aria-label="Evaluator gallery sections"
             className="project-evaluator-gallery__category-list"
             selectionMode="single"
             selectionBehavior="replace"
             disallowEmptySelection
-            selectedKeys={activeCategory ? [activeCategory] : []}
+            selectedKeys={activeSection ? [activeSection] : []}
             onSelectionChange={(selection) => {
               if (selection === "all") return;
-              const category = selection.keys().next().value;
-              if (typeof category === "string") {
-                scrollToCategory(category as TemplateCategory);
+              const section = selection.keys().next().value;
+              if (typeof section === "string") {
+                scrollToSection(section as GallerySection);
               }
             }}
           >
+            <ListBoxSection id="custom-evaluators-navigation">
+              {renderSectionItem({
+                id: CUSTOM_EVALUATORS_SECTION,
+                name: "Custom evaluators",
+                count: customEvaluators.length,
+              })}
+            </ListBoxSection>
             <ListBoxSection id="categories">
               <Header className="project-evaluator-gallery__category-section-heading">
                 <Text
@@ -297,7 +431,7 @@ function EvaluatorGallery() {
                   Categories
                 </Text>
               </Header>
-              {categoryItems.map(renderCategoryItem)}
+              {categoryItems.map(renderSectionItem)}
             </ListBoxSection>
           </ListBox>
         </div>
@@ -311,12 +445,12 @@ function EvaluatorGallery() {
           <EvaluatorGalleryAddMenu creationPaths={paths.galleryCreation} />
         </div>
         <Select
-          aria-label="Evaluator category"
+          aria-label="Evaluator gallery section"
           className="project-evaluator-gallery__compact-category-select"
-          value={activeCategory}
-          onChange={(category) => {
-            if (typeof category === "string") {
-              scrollToCategory(category as TemplateCategory);
+          value={activeSection}
+          onChange={(section) => {
+            if (typeof section === "string") {
+              scrollToSection(section as GallerySection);
             }
           }}
         >
@@ -326,6 +460,13 @@ function EvaluatorGallery() {
           </Button>
           <Popover isNonModal closeOnInteractOutside>
             <ListBox css={compactCategoryListCSS}>
+              <ListBoxSection id="compact-custom-evaluators">
+                {renderSectionItem({
+                  id: CUSTOM_EVALUATORS_SECTION,
+                  name: "Custom evaluators",
+                  count: customEvaluators.length,
+                })}
+              </ListBoxSection>
               <ListBoxSection id="compact-categories">
                 <Header className="project-evaluator-gallery__category-section-heading">
                   <Text
@@ -337,34 +478,106 @@ function EvaluatorGallery() {
                     Categories
                   </Text>
                 </Header>
-                {categoryItems.map(renderCategoryItem)}
+                {categoryItems.map(renderSectionItem)}
               </ListBoxSection>
             </ListBox>
           </Popover>
         </Select>
         <ListBox
-          ref={templateScrollRegionRef}
-          aria-label="Evaluator templates"
+          ref={galleryScrollRegionRef}
+          aria-label="Evaluators and templates"
           className="project-evaluator-gallery__template-card-scroll-region"
           layout="grid"
           selectionMode="single"
           selectionBehavior="replace"
-          selectedKeys={selectedTemplate ? [selectedTemplate.name] : []}
+          selectedKeys={selectedItemKey ? [selectedItemKey] : []}
           onSelectionChange={(selection) => {
             if (selection === "all") return;
-            const templateName = selection.keys().next().value;
-            if (typeof templateName === "string") {
-              setSelectedTemplate(templateName);
+            const itemKey = selection.keys().next().value;
+            if (typeof itemKey === "string") {
+              setSelectedItem(itemKey);
             }
           }}
           onAction={(key) => {
-            if (typeof key === "string") {
-              navigate(paths.galleryNewLlmFromTemplate(key));
+            if (typeof key !== "string") return;
+            const evaluator = customEvaluators.find(
+              ({ id }) => getCustomEvaluatorItemKey(id) === key
+            );
+            if (evaluator) {
+              navigate(
+                getCustomEvaluatorKind(evaluator) === "LLM"
+                  ? paths.galleryCreation.copyLlm(evaluator.id)
+                  : paths.galleryCreation.attachCode(evaluator.id)
+              );
+              return;
+            }
+            const template = templates.find(
+              ({ name }) => getTemplateItemKey(name) === key
+            );
+            if (template) {
+              navigate(paths.galleryNewLlmFromTemplate(template.name));
             }
           }}
         >
+          <ListBoxSection
+            id={CUSTOM_EVALUATORS_SECTION}
+            className="project-evaluator-gallery__template-category-section"
+          >
+            <Header className="project-evaluator-gallery__template-category-header">
+              <Text
+                ref={(element) => {
+                  if (element) {
+                    headingRefs.current.set(CUSTOM_EVALUATORS_SECTION, element);
+                  } else {
+                    headingRefs.current.delete(CUSTOM_EVALUATORS_SECTION);
+                  }
+                }}
+                id={getSectionHeadingId(CUSTOM_EVALUATORS_SECTION)}
+                className="project-evaluator-gallery__template-category-heading"
+                elementType="h2"
+                size="M"
+                weight="heavy"
+              >
+                Custom evaluators
+              </Text>
+              {customEvaluators.length === 0 ? (
+                <Text size="S" color="text-500">
+                  No custom evaluators are available.
+                </Text>
+              ) : null}
+            </Header>
+            {customEvaluators.map((evaluator) => {
+              const itemKey = getCustomEvaluatorItemKey(evaluator.id);
+              return (
+                <EvaluatorTemplateCard
+                  key={itemKey}
+                  ref={(element) => {
+                    if (element) {
+                      cardRefs.current.set(itemKey, element);
+                    } else {
+                      cardRefs.current.delete(itemKey);
+                    }
+                  }}
+                  id={itemKey}
+                  textValue={evaluator.name}
+                >
+                  <Text size="S" weight="heavy">
+                    {evaluator.name}
+                  </Text>
+                  <LineClamp lines={3}>
+                    <Text size="XS" color="text-700">
+                      {evaluator.description || "No description"}
+                    </Text>
+                  </LineClamp>
+                  <EvaluatorTemplateCardFooter
+                    evaluatorKind={getCustomEvaluatorKind(evaluator)}
+                  />
+                </EvaluatorTemplateCard>
+              );
+            })}
+          </ListBoxSection>
           {categories.map((category) => {
-            const headingId = getCategoryHeadingId(category);
+            const headingId = getSectionHeadingId(category);
             return (
               <ListBoxSection
                 key={category}
@@ -393,15 +606,20 @@ function EvaluatorGallery() {
                 </Header>
                 {(templatesByCategory.get(category) ?? []).map((template) => (
                   <EvaluatorTemplateCard
-                    key={template.name}
+                    key={getTemplateItemKey(template.name)}
                     ref={(element) => {
                       if (element) {
-                        templateCardRefs.current.set(template.name, element);
+                        cardRefs.current.set(
+                          getTemplateItemKey(template.name),
+                          element
+                        );
                       } else {
-                        templateCardRefs.current.delete(template.name);
+                        cardRefs.current.delete(
+                          getTemplateItemKey(template.name)
+                        );
                       }
                     }}
-                    id={template.name}
+                    id={getTemplateItemKey(template.name)}
                     textValue={template.name}
                   >
                     <Text size="S" weight="heavy">
@@ -425,16 +643,35 @@ function EvaluatorGallery() {
       </section>
 
       <aside className="project-evaluator-gallery__details" aria-live="polite">
-        {selectedTemplate ? (
+        {selectedItem?.kind === "custom" ? (
+          <ErrorBoundary fallback={EvaluatorDetailsError}>
+            <Suspense fallback={<EvaluatorDetailsSkeleton />}>
+              <CustomEvaluatorDetails
+                evaluator={selectedItem.evaluator}
+                onUseEvaluator={() =>
+                  navigate(
+                    getCustomEvaluatorKind(selectedItem.evaluator) === "LLM"
+                      ? paths.galleryCreation.copyLlm(selectedItem.evaluator.id)
+                      : paths.galleryCreation.attachCode(
+                          selectedItem.evaluator.id
+                        )
+                  )
+                }
+              />
+            </Suspense>
+          </ErrorBoundary>
+        ) : selectedItem?.kind === "template" ? (
           <EvaluatorTemplateDetails
-            template={selectedTemplate}
+            template={selectedItem.template}
             onUseTemplate={() =>
-              navigate(paths.galleryNewLlmFromTemplate(selectedTemplate.name))
+              navigate(
+                paths.galleryNewLlmFromTemplate(selectedItem.template.name)
+              )
             }
           />
         ) : (
           <Text size="S" color="text-500">
-            No templates are available in the gallery.
+            No evaluators or templates are available in the gallery.
           </Text>
         )}
       </aside>
@@ -463,7 +700,7 @@ function EvaluatorTemplateCardFooter({
   evaluationTargets,
 }: {
   evaluatorKind: "CODE" | "LLM";
-  evaluationTargets: readonly [
+  evaluationTargets?: readonly [
     ProjectEvaluatorTarget,
     ...ProjectEvaluatorTarget[],
   ];
@@ -479,22 +716,313 @@ function EvaluatorTemplateCardFooter({
       <Flex className="project-evaluator-gallery__template-kind">
         <EvaluatorKindToken kind={evaluatorKind} size="S" />
       </Flex>
-      <Flex
-        className="project-evaluator-gallery__template-targets"
-        direction="row"
-        gap="size-50"
-        wrap
-      >
-        {evaluationTargets.map((target) => (
-          <Badge
-            key={target}
-            size="S"
-            title={`Evaluates ${formatEvaluationTargetPlural(target)}`}
-          >
-            {capitalize(formatEvaluationTargetPlural(target))}
-          </Badge>
-        ))}
+      {evaluationTargets ? (
+        <Flex
+          className="project-evaluator-gallery__template-targets"
+          direction="row"
+          gap="size-50"
+          wrap
+        >
+          {evaluationTargets.map((target) => (
+            <Badge
+              key={target}
+              size="S"
+              title={`Evaluates ${formatEvaluationTargetPlural(target)}`}
+            >
+              {capitalize(formatEvaluationTargetPlural(target))}
+            </Badge>
+          ))}
+        </Flex>
+      ) : null}
+    </Flex>
+  );
+}
+
+function CustomEvaluatorDetails({
+  evaluator: evaluatorSummary,
+  onUseEvaluator,
+}: {
+  evaluator: CustomEvaluator;
+  onUseEvaluator: () => void;
+}) {
+  const data = useLazyLoadQuery<ProjectEvaluatorDetailsQueryType>(
+    projectEvaluatorDetailsQueryNode,
+    { id: evaluatorSummary.id },
+    { fetchPolicy: "store-and-network" }
+  );
+  const evaluator = data.evaluator;
+  if (!evaluator) {
+    return <EvaluatorDetailsError />;
+  }
+  if (isLlmProjectEvaluatorDetails(evaluator)) {
+    return (
+      <LlmCustomEvaluatorDetails
+        evaluator={evaluator}
+        onUseEvaluator={onUseEvaluator}
+      />
+    );
+  }
+  if (isCodeProjectEvaluatorDetails(evaluator)) {
+    return (
+      <CodeCustomEvaluatorDetails
+        evaluator={evaluator}
+        onUseEvaluator={onUseEvaluator}
+      />
+    );
+  }
+  return <EvaluatorDetailsError />;
+}
+
+function CustomEvaluatorDetailsHeader({
+  evaluator,
+}: {
+  evaluator: LlmProjectEvaluatorDetails | CodeProjectEvaluatorDetails;
+}) {
+  return (
+    <Flex direction="column" gap="size-100">
+      <Heading level={2}>{evaluator.name}</Heading>
+      <Flex direction="row" gap="size-75" wrap>
+        <EvaluatorKindToken
+          kind={evaluator.__typename === "LLMEvaluator" ? "LLM" : "CODE"}
+          size="S"
+        />
       </Flex>
+      <Text
+        size="S"
+        color={evaluator.description ? "text-700" : "text-500"}
+        css={evaluator.description ? undefined : emptyDescriptionCSS}
+      >
+        {evaluator.description || "No description"}
+      </Text>
+    </Flex>
+  );
+}
+
+function EvaluatorOutputSummary({
+  outputConfigs,
+}: {
+  outputConfigs: LlmProjectEvaluatorDetails["outputConfigs"];
+}) {
+  const supportedOutputConfigs = outputConfigs.filter(
+    (config) => config.__typename !== "%other"
+  );
+  if (supportedOutputConfigs.length === 0) return null;
+  return (
+    <Flex direction="column" gap="size-200">
+      {supportedOutputConfigs.map((config) => (
+        <Flex key={config.name} direction="column" gap="size-100">
+          {supportedOutputConfigs.length > 1 ? (
+            <Text elementType="h3" size="S" weight="heavy">
+              {config.name}
+            </Text>
+          ) : null}
+          <dl className="project-evaluator-gallery__definition-list">
+            <div>
+              <dt>
+                <Text size="XS" color="text-500">
+                  Optimization
+                </Text>
+              </dt>
+              <dd>
+                <Text size="S">
+                  {capitalize(config.optimizationDirection.toLowerCase())}
+                </Text>
+              </dd>
+            </div>
+          </dl>
+          {config.__typename === "CategoricalAnnotationConfig" &&
+          config.values.length > 0 ? (
+            <AnnotationValues
+              values={config.values}
+              optimizationDirection={config.optimizationDirection}
+            />
+          ) : null}
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
+
+function AnnotationValues({
+  values,
+  optimizationDirection,
+}: {
+  values: ReadonlyArray<{
+    readonly label: string;
+    readonly score: number | null;
+  }>;
+  optimizationDirection: string;
+}) {
+  const optimizationBounds = getOptimizationBounds({
+    annotationType: "CATEGORICAL",
+    optimizationDirection,
+    values,
+  });
+  return (
+    <Flex direction="column" gap="size-75">
+      <Text elementType="h3" size="S" weight="heavy">
+        Annotation values
+      </Text>
+      <List size="S">
+        {values.map(({ label, score }) => (
+          <ListItem key={label}>
+            <Flex
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              gap="size-100"
+            >
+              <Text size="S">{label}</Text>
+              <Text size="XS" color="text-500">
+                <AnnotationScoreText
+                  elementType="span"
+                  fontFamily="mono"
+                  size="XS"
+                  positiveOptimization={getPositiveOptimization({
+                    score,
+                    ...optimizationBounds,
+                  })}
+                >
+                  {score ?? "—"}
+                </AnnotationScoreText>
+              </Text>
+            </Flex>
+          </ListItem>
+        ))}
+      </List>
+    </Flex>
+  );
+}
+
+function LlmCustomEvaluatorDetails({
+  evaluator,
+  onUseEvaluator,
+}: {
+  evaluator: LlmProjectEvaluatorDetails;
+  onUseEvaluator: () => void;
+}) {
+  const promptTemplate = evaluator.promptVersion?.template;
+  const messages: PlaygroundChatTemplate["messages"] =
+    promptTemplate?.__typename === "PromptChatTemplate"
+      ? convertPromptVersionMessagesToPlaygroundInstanceMessages({
+          promptMessagesRefs: promptTemplate.messages,
+        })
+      : promptTemplate?.__typename === "PromptStringTemplate"
+        ? [
+            {
+              id: 0,
+              role: "user",
+              content: promptTemplate.template,
+            },
+          ]
+        : [];
+  return (
+    <Flex direction="column" gap="size-200" height="100%">
+      <CustomEvaluatorDetailsHeader evaluator={evaluator} />
+      <EvaluatorOutputSummary outputConfigs={evaluator.outputConfigs} />
+      <EvaluatorPromptPreview messages={messages} />
+      <EvaluatorDetailsAction onPress={onUseEvaluator}>
+        Duplicate this evaluator
+      </EvaluatorDetailsAction>
+    </Flex>
+  );
+}
+
+function CodeCustomEvaluatorDetails({
+  evaluator,
+  onUseEvaluator,
+}: {
+  evaluator: CodeProjectEvaluatorDetails;
+  onUseEvaluator: () => void;
+}) {
+  return (
+    <Flex direction="column" gap="size-200" height="100%">
+      <CustomEvaluatorDetailsHeader evaluator={evaluator} />
+      <dl className="project-evaluator-gallery__definition-list">
+        <div>
+          <dt>
+            <Text size="XS" color="text-500">
+              Language
+            </Text>
+          </dt>
+          <dd>
+            <Text size="S">{capitalize(evaluator.language.toLowerCase())}</Text>
+          </dd>
+        </div>
+      </dl>
+      <EvaluatorOutputSummary outputConfigs={evaluator.outputConfigs} />
+      <Flex direction="column" gap="size-75">
+        <Text elementType="h3" size="S" weight="heavy">
+          Code
+        </Text>
+        <div css={codePreviewWellCSS}>
+          <ExpandableContent
+            height={CODE_PREVIEW_COLLAPSED_HEIGHT}
+            expandedBehavior="grow"
+            overlayBackgroundColor="var(--global-background-color-100)"
+          >
+            {evaluator.language === "PYTHON" ? (
+              <PythonBlockWithCopy value={evaluator.sourceCode} />
+            ) : (
+              <TypeScriptBlockWithCopy value={evaluator.sourceCode} />
+            )}
+          </ExpandableContent>
+        </div>
+      </Flex>
+      <EvaluatorDetailsAction onPress={onUseEvaluator}>
+        Use this evaluator
+      </EvaluatorDetailsAction>
+    </Flex>
+  );
+}
+
+function EvaluatorPromptPreview({
+  messages,
+}: {
+  messages: PlaygroundChatTemplate["messages"];
+}) {
+  if (messages.length === 0) return null;
+  return (
+    <Flex direction="column" gap="size-75">
+      <Text elementType="h3" size="S" weight="heavy">
+        Prompt
+      </Text>
+      <div css={promptPreviewWellCSS}>
+        <ExpandableContent
+          height={PROMPT_PREVIEW_COLLAPSED_HEIGHT}
+          expandedBehavior="grow"
+          overlayBackgroundColor="var(--global-background-color-100)"
+        >
+          <Flex direction="column" gap="size-150">
+            {messages.map((message) => (
+              <Flex key={message.id} direction="column" gap="size-25">
+                <Text size="XS" color="text-500" weight="heavy">
+                  {capitalize(message.role)}
+                </Text>
+                <Text size="S" css={promptPreviewMessageCSS}>
+                  {message.content}
+                </Text>
+              </Flex>
+            ))}
+          </Flex>
+        </ExpandableContent>
+      </div>
+    </Flex>
+  );
+}
+
+function EvaluatorDetailsAction({
+  children,
+  onPress,
+}: {
+  children: string;
+  onPress: () => void;
+}) {
+  return (
+    <Flex direction="column" css={stickyUseTemplateFooterCSS}>
+      <Button variant="primary" onPress={onPress}>
+        {children}
+      </Button>
     </Flex>
   );
 }
@@ -507,11 +1035,6 @@ function EvaluatorTemplateDetails({
   onUseTemplate: () => void;
 }) {
   const choices = getProjectEvaluatorTemplateChoices(template);
-  const optimizationBounds = getOptimizationBounds({
-    annotationType: "CATEGORICAL",
-    optimizationDirection: template.optimizationDirection,
-    values: choices,
-  });
   const messages = getProjectEvaluatorTemplateMessages(template);
   return (
     <Flex direction="column" gap="size-200" height="100%">
@@ -555,70 +1078,14 @@ function EvaluatorTemplateDetails({
           </dd>
         </div>
       </dl>
-      <Flex direction="column" gap="size-75">
-        <Text elementType="h3" size="S" weight="heavy">
-          Annotation values
-        </Text>
-        <List size="S">
-          {choices.map(({ label, score }) => (
-            <ListItem key={label}>
-              <Flex
-                direction="row"
-                alignItems="center"
-                justifyContent="space-between"
-                gap="size-100"
-              >
-                <Text size="S">{label}</Text>
-                <Text size="XS" color="text-500">
-                  <AnnotationScoreText
-                    elementType="span"
-                    fontFamily="mono"
-                    size="XS"
-                    positiveOptimization={getPositiveOptimization({
-                      score,
-                      ...optimizationBounds,
-                    })}
-                  >
-                    {score}
-                  </AnnotationScoreText>
-                </Text>
-              </Flex>
-            </ListItem>
-          ))}
-        </List>
-      </Flex>
-      {messages.length > 0 ? (
-        <Flex direction="column" gap="size-75">
-          <Text elementType="h3" size="S" weight="heavy">
-            Prompt
-          </Text>
-          <div css={promptPreviewWellCSS}>
-            <ExpandableContent
-              height={PROMPT_PREVIEW_COLLAPSED_HEIGHT}
-              expandedBehavior="grow"
-              overlayBackgroundColor="var(--global-background-color-100)"
-            >
-              <Flex direction="column" gap="size-150">
-                {messages.map((message) => (
-                  <Flex key={message.id} direction="column" gap="size-25">
-                    <Text size="XS" color="text-500" weight="heavy">
-                      {capitalize(message.role)}
-                    </Text>
-                    <Text size="S" css={promptPreviewMessageCSS}>
-                      {message.content}
-                    </Text>
-                  </Flex>
-                ))}
-              </Flex>
-            </ExpandableContent>
-          </div>
-        </Flex>
-      ) : null}
-      <Flex direction="column" css={stickyUseTemplateFooterCSS}>
-        <Button variant="primary" onPress={onUseTemplate}>
-          Customize this evaluator
-        </Button>
-      </Flex>
+      <AnnotationValues
+        values={choices}
+        optimizationDirection={template.optimizationDirection}
+      />
+      <EvaluatorPromptPreview messages={messages} />
+      <EvaluatorDetailsAction onPress={onUseTemplate}>
+        Customize this evaluator
+      </EvaluatorDetailsAction>
     </Flex>
   );
 }
@@ -640,6 +1107,7 @@ const stickyUseTemplateFooterCSS = css`
 `;
 
 const PROMPT_PREVIEW_COLLAPSED_HEIGHT = 160;
+const CODE_PREVIEW_COLLAPSED_HEIGHT = 240;
 
 const promptPreviewWellCSS = css`
   background-color: var(--global-background-color-100);
@@ -651,6 +1119,17 @@ const promptPreviewWellCSS = css`
 
 const promptPreviewMessageCSS = css`
   white-space: pre-wrap;
+`;
+
+const codePreviewWellCSS = css`
+  overflow: hidden;
+  border: var(--global-border-size-thin) solid
+    var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+`;
+
+const emptyDescriptionCSS = css`
+  font-style: italic;
 `;
 
 function capitalize(value: string): string {
@@ -667,6 +1146,18 @@ function EvaluatorGalleryError() {
   return (
     <Text size="S" color="text-500">
       Evaluator templates could not be loaded.
+    </Text>
+  );
+}
+
+function EvaluatorDetailsSkeleton() {
+  return <Skeleton width="100%" height={360} animation="wave" />;
+}
+
+function EvaluatorDetailsError() {
+  return (
+    <Text size="S" color="text-500">
+      Evaluator details could not be loaded.
     </Text>
   );
 }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -307,46 +307,59 @@ function EvaluatorGallery() {
   }, [requestedItemKeyToScroll, requestedSectionToScroll]);
 
   useEffect(() => {
-    const scrollRegion = galleryScrollRegionRef.current;
-    if (!scrollRegion) return undefined;
-    // Snapshot the mounted headings so observer entries can be mapped back to
-    // the category selection used by the sidebar and compact picker.
-    const headingsByElement = new Map<Element, GallerySection>(
-      sections
-        .map((section) => [headingRefs.current.get(section), section] as const)
-        .filter(
-          (entry): entry is [HTMLElement, GallerySection] => entry[0] != null
-        )
-    );
-    if (headingsByElement.size === 0) return undefined;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // More than one heading can occupy the active top band. The uppermost
-        // one represents the category the user is currently reading.
-        const topmostVisibleEntry = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
-          .at(0);
-        // The final heading cannot reach the top band when the scroll port is
-        // at its limit, so treat the bottom as belonging to the last category.
-        const isAtScrollEnd =
-          scrollRegion.scrollTop + scrollRegion.clientHeight >=
-          scrollRegion.scrollHeight - 1;
-        const section = isAtScrollEnd
-          ? sections.at(-1)
-          : topmostVisibleEntry
-            ? headingsByElement.get(topmostVisibleEntry.target)
-            : undefined;
-        if (section) {
-          setActiveSection(section);
-        }
-      },
-      { root: scrollRegion, rootMargin: SCROLL_SPY_ROOT_MARGIN }
-    );
-    // Observe every mounted category heading and release them together when
-    // the category collection changes or the gallery unmounts.
-    headingsByElement.forEach((_section, heading) => observer.observe(heading));
-    return () => observer.disconnect();
+    let observer: IntersectionObserver | undefined;
+    // Wait for React Aria to mount its collection headings before snapshotting
+    // the refs used by the scroll spy.
+    const animationFrameId = requestAnimationFrame(() => {
+      const scrollRegion = galleryScrollRegionRef.current;
+      if (!scrollRegion) return;
+      // Snapshot the mounted headings so observer entries can be mapped back to
+      // the category selection used by the sidebar and compact picker.
+      const headingsByElement = new Map<Element, GallerySection>(
+        sections
+          .map(
+            (section) => [headingRefs.current.get(section), section] as const
+          )
+          .filter(
+            (entry): entry is [HTMLElement, GallerySection] => entry[0] != null
+          )
+      );
+      if (headingsByElement.size === 0) return;
+      const createdObserver = new IntersectionObserver(
+        (entries) => {
+          // More than one heading can occupy the active top band. The uppermost
+          // one represents the category the user is currently reading.
+          const topmostVisibleEntry = entries
+            .filter((entry) => entry.isIntersecting)
+            .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+            .at(0);
+          // The final heading cannot reach the top band when the scroll port is
+          // at its limit, so treat the bottom as belonging to the last category.
+          const isAtScrollEnd =
+            scrollRegion.scrollTop + scrollRegion.clientHeight >=
+            scrollRegion.scrollHeight - 1;
+          const section = isAtScrollEnd
+            ? sections.at(-1)
+            : topmostVisibleEntry
+              ? headingsByElement.get(topmostVisibleEntry.target)
+              : undefined;
+          if (section) {
+            setActiveSection(section);
+          }
+        },
+        { root: scrollRegion, rootMargin: SCROLL_SPY_ROOT_MARGIN }
+      );
+      observer = createdObserver;
+      // Observe every mounted category heading and release them together when
+      // the category collection changes or the gallery unmounts.
+      headingsByElement.forEach((_section, heading) =>
+        createdObserver.observe(heading)
+      );
+    });
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      observer?.disconnect();
+    };
   }, [sections]);
 
   const setSelectedItem = (itemKey: string) => {
@@ -644,7 +657,10 @@ function EvaluatorGallery() {
 
       <aside className="project-evaluator-gallery__details" aria-live="polite">
         {selectedItem?.kind === "custom" ? (
-          <ErrorBoundary fallback={EvaluatorDetailsError}>
+          <ErrorBoundary
+            key={selectedItem.evaluator.id}
+            fallback={EvaluatorDetailsError}
+          >
             <Suspense fallback={<EvaluatorDetailsSkeleton />}>
               <CustomEvaluatorDetails
                 evaluator={selectedItem.evaluator}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -13,9 +13,8 @@ import {
 import {
   buildAttachCodeCreationMode,
   buildCopyLlmCreationMode,
-  isCodeProjectEvaluatorDetails,
-  isLlmProjectEvaluatorDetails,
   projectEvaluatorDetailsQueryNode,
+  readProjectEvaluatorDetails,
   UNSUPPORTED_PROMPT_TEMPLATE_ERROR,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
 import { ProjectEvaluatorSlideoverError } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSlideoverError";
@@ -62,7 +61,7 @@ function useSourceEvaluator() {
     { id: evaluatorId },
     { fetchPolicy: "store-or-network" }
   );
-  return data.evaluator;
+  return readProjectEvaluatorDetails(data.evaluator);
 }
 
 export function NewLlmProjectEvaluatorPage() {
@@ -132,7 +131,7 @@ export function CopyLlmProjectEvaluatorPage() {
   // changes). A new object each time would rebuild the evaluator store too.
   const built = useMemo(
     () =>
-      evaluator && isLlmProjectEvaluatorDetails(evaluator)
+      evaluator?.__typename === "LLMEvaluator"
         ? buildCopyLlmCreationMode(evaluator)
         : null,
     [evaluator]
@@ -174,7 +173,7 @@ export function AttachCodeProjectEvaluatorPage() {
   // source twice to extract its variables.
   const creationMode = useMemo(
     () =>
-      evaluator && isCodeProjectEvaluatorDetails(evaluator)
+      evaluator?.__typename === "CodeEvaluator"
         ? buildAttachCodeCreationMode(evaluator)
         : null,
     [evaluator]

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0b26ac4d73d8f15c0a464fcdd23c174e>>
+ * @generated SignedSource<<f40396fe2576a83a71f4af1a1b4341a4>>
  * @lightSyntaxTransform
  */
 
@@ -9,79 +9,13 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
-export type Language = "PYTHON" | "TYPESCRIPT";
-export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
-export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type projectEvaluatorDetailsQuery$variables = {
   id: string;
 };
 export type projectEvaluatorDetailsQuery$data = {
   readonly evaluator: {
     readonly __typename: string;
-    readonly description?: string | null;
-    readonly id?: string;
-    readonly kind?: EvaluatorKind;
-    readonly language?: Language;
-    readonly name?: string;
-    readonly outputConfigs?: ReadonlyArray<{
-      readonly __typename: "CategoricalAnnotationConfig";
-      readonly name: string;
-      readonly optimizationDirection: OptimizationDirection;
-      readonly values: ReadonlyArray<{
-        readonly label: string;
-        readonly score: number | null;
-      }>;
-    } | {
-      readonly __typename: "ContinuousAnnotationConfig";
-      readonly lowerBound: number | null;
-      readonly name: string;
-      readonly optimizationDirection: OptimizationDirection;
-      readonly upperBound: number | null;
-    } | {
-      readonly __typename: "FreeformAnnotationConfig";
-      readonly lowerBound: number | null;
-      readonly name: string;
-      readonly optimizationDirection: OptimizationDirection;
-      readonly threshold: number | null;
-      readonly upperBound: number | null;
-    } | {
-      // This will never be '%other', but we need some
-      // value in case none of the concrete values match.
-      readonly __typename: "%other";
-    }>;
-    readonly promptVersion?: {
-      readonly template: {
-        readonly __typename: "PromptChatTemplate";
-        readonly messages: ReadonlyArray<{
-          readonly " $fragmentSpreads": FragmentRefs<"promptUtils_promptMessages">;
-        }>;
-      } | {
-        readonly __typename: "PromptStringTemplate";
-        readonly template: string;
-      } | {
-        // This will never be '%other', but we need some
-        // value in case none of the concrete values match.
-        readonly __typename: "%other";
-      };
-      readonly templateFormat: PromptTemplateFormat;
-      readonly tools: {
-        readonly tools: ReadonlyArray<{
-          readonly __typename: "PromptToolFunction";
-          readonly function: {
-            readonly parameters: any;
-          };
-        } | {
-          readonly __typename: "PromptToolRaw";
-          readonly raw: any;
-        } | {
-          // This will never be '%other', but we need some
-          // value in case none of the concrete values match.
-          readonly __typename: "%other";
-        }>;
-      } | null;
-    };
-    readonly sourceCode?: string;
+    readonly " $fragmentSpreads": FragmentRefs<"projectEvaluatorOptions_codeEvaluatorDetails" | "projectEvaluatorOptions_llmEvaluatorDetails">;
   };
 };
 export type projectEvaluatorDetailsQuery = {
@@ -407,98 +341,113 @@ return {
         "selections": [
           (v2/*:: as any*/),
           {
-            "kind": "InlineFragment",
+            "kind": "InlineDataFragmentSpread",
+            "name": "projectEvaluatorOptions_llmEvaluatorDetails",
             "selections": [
-              (v3/*:: as any*/),
-              (v4/*:: as any*/),
-              (v5/*:: as any*/),
-              (v6/*:: as any*/)
-            ],
-            "type": "Evaluator",
-            "abstractKey": "__isEvaluator"
-          },
-          {
-            "kind": "InlineFragment",
-            "selections": [
-              (v13/*:: as any*/),
               {
-                "alias": null,
-                "args": null,
-                "concreteType": "PromptVersion",
-                "kind": "LinkedField",
-                "name": "promptVersion",
-                "plural": false,
+                "kind": "InlineFragment",
                 "selections": [
-                  (v14/*:: as any*/),
+                  (v2/*:: as any*/),
+                  (v3/*:: as any*/),
+                  (v4/*:: as any*/),
+                  (v5/*:: as any*/),
+                  (v6/*:: as any*/),
+                  (v13/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": null,
+                    "concreteType": "PromptVersion",
                     "kind": "LinkedField",
-                    "name": "template",
+                    "name": "promptVersion",
                     "plural": false,
                     "selections": [
-                      (v2/*:: as any*/),
+                      (v14/*:: as any*/),
                       {
-                        "kind": "InlineFragment",
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "template",
+                        "plural": false,
                         "selections": [
+                          (v2/*:: as any*/),
                           {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "PromptMessage",
-                            "kind": "LinkedField",
-                            "name": "messages",
-                            "plural": true,
+                            "kind": "InlineFragment",
                             "selections": [
                               {
-                                "kind": "InlineDataFragmentSpread",
-                                "name": "promptUtils_promptMessages",
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "PromptMessage",
+                                "kind": "LinkedField",
+                                "name": "messages",
+                                "plural": true,
                                 "selections": [
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": null,
-                                    "kind": "LinkedField",
-                                    "name": "content",
-                                    "plural": true,
+                                    "kind": "InlineDataFragmentSpread",
+                                    "name": "promptUtils_promptMessages",
                                     "selections": [
-                                      (v15/*:: as any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": null,
+                                        "kind": "LinkedField",
+                                        "name": "content",
+                                        "plural": true,
+                                        "selections": [
+                                          (v15/*:: as any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      (v16/*:: as any*/)
                                     ],
-                                    "storageKey": null
-                                  },
-                                  (v16/*:: as any*/)
+                                    "args": null,
+                                    "argumentDefinitions": []
+                                  }
                                 ],
-                                "args": null,
-                                "argumentDefinitions": []
+                                "storageKey": null
                               }
                             ],
-                            "storageKey": null
-                          }
+                            "type": "PromptChatTemplate",
+                            "abstractKey": null
+                          },
+                          (v17/*:: as any*/)
                         ],
-                        "type": "PromptChatTemplate",
-                        "abstractKey": null
+                        "storageKey": null
                       },
-                      (v17/*:: as any*/)
+                      (v18/*:: as any*/)
                     ],
                     "storageKey": null
-                  },
-                  (v18/*:: as any*/)
+                  }
                 ],
-                "storageKey": null
+                "type": "LLMEvaluator",
+                "abstractKey": null
               }
             ],
-            "type": "LLMEvaluator",
-            "abstractKey": null
+            "args": null,
+            "argumentDefinitions": []
           },
           {
-            "kind": "InlineFragment",
+            "kind": "InlineDataFragmentSpread",
+            "name": "projectEvaluatorOptions_codeEvaluatorDetails",
             "selections": [
-              (v13/*:: as any*/),
-              (v19/*:: as any*/),
-              (v20/*:: as any*/)
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v2/*:: as any*/),
+                  (v3/*:: as any*/),
+                  (v4/*:: as any*/),
+                  (v5/*:: as any*/),
+                  (v6/*:: as any*/),
+                  (v13/*:: as any*/),
+                  (v19/*:: as any*/),
+                  (v20/*:: as any*/)
+                ],
+                "type": "CodeEvaluator",
+                "abstractKey": null
+              }
             ],
-            "type": "CodeEvaluator",
-            "abstractKey": null
+            "args": null,
+            "argumentDefinitions": []
           }
         ],
         "storageKey": null
@@ -528,14 +477,7 @@ return {
             "selections": [
               (v4/*:: as any*/),
               (v5/*:: as any*/),
-              (v6/*:: as any*/)
-            ],
-            "type": "Evaluator",
-            "abstractKey": "__isEvaluator"
-          },
-          {
-            "kind": "InlineFragment",
-            "selections": [
+              (v6/*:: as any*/),
               (v21/*:: as any*/),
               {
                 "alias": null,
@@ -603,6 +545,9 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
+              (v4/*:: as any*/),
+              (v5/*:: as any*/),
+              (v6/*:: as any*/),
               (v21/*:: as any*/),
               (v19/*:: as any*/),
               (v20/*:: as any*/)
@@ -616,16 +561,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c28e93537bb65edc0592e1dd328c2426",
+    "cacheID": "cebb8eb6eb5a4934aa2f16f0993fdb74",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorDetailsQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorDetailsQuery(\n  $id: ID!\n) {\n  evaluator: node(id: $id) {\n    __typename\n    ... on Evaluator {\n      __isEvaluator: __typename\n      id\n      name\n      description\n      kind\n    }\n    ... on LLMEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      promptVersion {\n        templateFormat\n        template {\n          __typename\n          ... on PromptChatTemplate {\n            messages {\n              ...promptUtils_promptMessages\n            }\n          }\n          ... on PromptStringTemplate {\n            template\n          }\n        }\n        tools {\n          tools {\n            __typename\n            ... on PromptToolFunction {\n              function {\n                parameters\n              }\n            }\n            ... on PromptToolRaw {\n              raw\n            }\n          }\n        }\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      outputConfigs {\n        __typename\n        ... on CategoricalAnnotationConfig {\n          name\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          name\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      sourceCode\n      language\n    }\n    id\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
+    "text": "query projectEvaluatorDetailsQuery(\n  $id: ID!\n) {\n  evaluator: node(id: $id) {\n    __typename\n    ...projectEvaluatorOptions_llmEvaluatorDetails\n    ...projectEvaluatorOptions_codeEvaluatorDetails\n    id\n  }\n}\n\nfragment projectEvaluatorOptions_codeEvaluatorDetails on CodeEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  sourceCode\n  language\n}\n\nfragment projectEvaluatorOptions_llmEvaluatorDetails on LLMEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  promptVersion {\n    templateFormat\n    template {\n      __typename\n      ... on PromptChatTemplate {\n        messages {\n          ...promptUtils_promptMessages\n        }\n      }\n      ... on PromptStringTemplate {\n        template\n      }\n    }\n    tools {\n      tools {\n        __typename\n        ... on PromptToolFunction {\n          function {\n            parameters\n          }\n        }\n        ... on PromptToolRaw {\n          raw\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f024fbc74b4c1a8306536a2d98d2ab78";
+(node as any).hash = "54f77ca32506ba049155671c42aa80ce";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorGalleryPageQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorGalleryPageQuery.graphql.ts
@@ -1,0 +1,442 @@
+/**
+ * @generated SignedSource<<4c65a99ec6cba54ca38d8cd1367e5111>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type EvaluatorCategory = "AGENTS" | "GROUNDING_AND_RETRIEVAL" | "RESPONSE_QUALITY" | "SAFETY_AND_SECURITY" | "USER_EXPERIENCE";
+export type EvaluatorScope = "SESSION" | "SPAN" | "TRACE";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+export type projectEvaluatorGalleryPageQuery$variables = {
+  projectId: string;
+};
+export type projectEvaluatorGalleryPageQuery$data = {
+  readonly evaluatorGalleryConfigs: ReadonlyArray<{
+    readonly category: EvaluatorCategory | null;
+    readonly choices: any;
+    readonly description: string | null;
+    readonly details: string | null;
+    readonly messages: ReadonlyArray<{
+      readonly " $fragmentSpreads": FragmentRefs<"promptUtils_promptMessages">;
+    }>;
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly scope: EvaluatorScope | null;
+  }>;
+  readonly evaluators: {
+    readonly edges: ReadonlyArray<{
+      readonly evaluator: {
+        readonly __typename: string;
+        readonly description: string | null;
+        readonly id: string;
+        readonly name: string;
+      };
+    }>;
+  };
+};
+export type projectEvaluatorGalleryPageQuery = {
+  response: projectEvaluatorGalleryPageQuery$data;
+  variables: projectEvaluatorGalleryPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "choices",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "scope",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "category",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "details",
+  "storageKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "TextContentValue",
+      "kind": "LinkedField",
+      "name": "text",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "text",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "TextContentPart",
+  "abstractKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "role",
+  "storageKey": null
+},
+v10 = {
+  "kind": "Variable",
+  "name": "excludeProjectId",
+  "variableName": "projectId"
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v13 = {
+  "alias": "evaluator",
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "node",
+  "plural": false,
+  "selections": [
+    (v11/*:: as any*/),
+    (v12/*:: as any*/),
+    (v1/*:: as any*/),
+    (v2/*:: as any*/)
+  ],
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v16 = [
+  (v10/*:: as any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": {
+      "col": "updatedAt",
+      "dir": "desc"
+    }
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "projectEvaluatorGalleryPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ClassificationEvaluatorConfig",
+        "kind": "LinkedField",
+        "name": "evaluatorGalleryConfigs",
+        "plural": true,
+        "selections": [
+          (v1/*:: as any*/),
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          (v4/*:: as any*/),
+          (v5/*:: as any*/),
+          (v6/*:: as any*/),
+          (v7/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PromptMessage",
+            "kind": "LinkedField",
+            "name": "messages",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "InlineDataFragmentSpread",
+                "name": "promptUtils_promptMessages",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "content",
+                    "plural": true,
+                    "selections": [
+                      (v8/*:: as any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v9/*:: as any*/)
+                ],
+                "args": null,
+                "argumentDefinitions": []
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "evaluators",
+        "args": [
+          (v10/*:: as any*/)
+        ],
+        "concreteType": "EvaluatorConnection",
+        "kind": "LinkedField",
+        "name": "__ProjectEvaluatorGallery__evaluators_connection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EvaluatorEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              (v13/*:: as any*/),
+              (v14/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v11/*:: as any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v15/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "projectEvaluatorGalleryPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ClassificationEvaluatorConfig",
+        "kind": "LinkedField",
+        "name": "evaluatorGalleryConfigs",
+        "plural": true,
+        "selections": [
+          (v1/*:: as any*/),
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          (v4/*:: as any*/),
+          (v5/*:: as any*/),
+          (v6/*:: as any*/),
+          (v7/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PromptMessage",
+            "kind": "LinkedField",
+            "name": "messages",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "content",
+                "plural": true,
+                "selections": [
+                  (v11/*:: as any*/),
+                  (v8/*:: as any*/)
+                ],
+                "storageKey": null
+              },
+              (v9/*:: as any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v16/*:: as any*/),
+        "concreteType": "EvaluatorConnection",
+        "kind": "LinkedField",
+        "name": "evaluators",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EvaluatorEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              (v13/*:: as any*/),
+              (v14/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v11/*:: as any*/),
+                  (v12/*:: as any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v15/*:: as any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v16/*:: as any*/),
+        "filters": [
+          "excludeProjectId"
+        ],
+        "handle": "connection",
+        "key": "ProjectEvaluatorGallery__evaluators",
+        "kind": "LinkedHandle",
+        "name": "evaluators"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c65916cdaaa4447e7b4a926b4607e957",
+    "id": null,
+    "metadata": {
+      "connection": [
+        {
+          "count": null,
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "evaluators"
+          ]
+        }
+      ]
+    },
+    "name": "projectEvaluatorGalleryPageQuery",
+    "operationKind": "query",
+    "text": "query projectEvaluatorGalleryPageQuery(\n  $projectId: ID!\n) {\n  evaluatorGalleryConfigs {\n    name\n    description\n    choices\n    optimizationDirection\n    scope\n    category\n    details\n    messages {\n      ...promptUtils_promptMessages\n    }\n  }\n  evaluators(first: 100, sort: {col: updatedAt, dir: desc}, excludeProjectId: $projectId) {\n    edges {\n      evaluator: node {\n        __typename\n        id\n        name\n        description\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "28ad96fb28fca0f8f2afea73560b063e";
+
+export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql.ts
@@ -1,0 +1,63 @@
+/**
+ * @generated SignedSource<<7cc54066238328e00ed8a7f761135a8e>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderInlineDataFragment } from 'relay-runtime';
+export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type Language = "PYTHON" | "TYPESCRIPT";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type projectEvaluatorOptions_codeEvaluatorDetails$data = {
+  readonly __typename: "CodeEvaluator";
+  readonly description: string | null;
+  readonly id: string;
+  readonly kind: EvaluatorKind;
+  readonly language: Language;
+  readonly name: string;
+  readonly outputConfigs: ReadonlyArray<{
+    readonly __typename: "CategoricalAnnotationConfig";
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly values: ReadonlyArray<{
+      readonly label: string;
+      readonly score: number | null;
+    }>;
+  } | {
+    readonly __typename: "ContinuousAnnotationConfig";
+    readonly lowerBound: number | null;
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly upperBound: number | null;
+  } | {
+    readonly __typename: "FreeformAnnotationConfig";
+    readonly lowerBound: number | null;
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly threshold: number | null;
+    readonly upperBound: number | null;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  }>;
+  readonly sourceCode: string;
+  readonly " $fragmentType": "projectEvaluatorOptions_codeEvaluatorDetails";
+};
+export type projectEvaluatorOptions_codeEvaluatorDetails$key = {
+  readonly " $data"?: projectEvaluatorOptions_codeEvaluatorDetails$data;
+  readonly " $fragmentSpreads": FragmentRefs<"projectEvaluatorOptions_codeEvaluatorDetails">;
+};
+
+const node: ReaderInlineDataFragment = {
+  "kind": "InlineDataFragment",
+  "name": "projectEvaluatorOptions_codeEvaluatorDetails"
+};
+
+(node as any).hash = "9335d602204b26f5e830ed106d937640";
+
+export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<53b4844e90f6632cb246c0f7dc2d1067>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderInlineDataFragment } from 'relay-runtime';
+export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type projectEvaluatorOptions_llmEvaluatorDetails$data = {
+  readonly __typename: "LLMEvaluator";
+  readonly description: string | null;
+  readonly id: string;
+  readonly kind: EvaluatorKind;
+  readonly name: string;
+  readonly outputConfigs: ReadonlyArray<{
+    readonly __typename: "CategoricalAnnotationConfig";
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly values: ReadonlyArray<{
+      readonly label: string;
+      readonly score: number | null;
+    }>;
+  } | {
+    readonly __typename: "ContinuousAnnotationConfig";
+    readonly lowerBound: number | null;
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly upperBound: number | null;
+  } | {
+    readonly __typename: "FreeformAnnotationConfig";
+    readonly lowerBound: number | null;
+    readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
+    readonly threshold: number | null;
+    readonly upperBound: number | null;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  }>;
+  readonly promptVersion: {
+    readonly template: {
+      readonly __typename: "PromptChatTemplate";
+      readonly messages: ReadonlyArray<{
+        readonly " $fragmentSpreads": FragmentRefs<"promptUtils_promptMessages">;
+      }>;
+    } | {
+      readonly __typename: "PromptStringTemplate";
+      readonly template: string;
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    };
+    readonly templateFormat: PromptTemplateFormat;
+    readonly tools: {
+      readonly tools: ReadonlyArray<{
+        readonly __typename: "PromptToolFunction";
+        readonly function: {
+          readonly parameters: any;
+        };
+      } | {
+        readonly __typename: "PromptToolRaw";
+        readonly raw: any;
+      } | {
+        // This will never be '%other', but we need some
+        // value in case none of the concrete values match.
+        readonly __typename: "%other";
+      }>;
+    } | null;
+  };
+  readonly " $fragmentType": "projectEvaluatorOptions_llmEvaluatorDetails";
+};
+export type projectEvaluatorOptions_llmEvaluatorDetails$key = {
+  readonly " $data"?: projectEvaluatorOptions_llmEvaluatorDetails$data;
+  readonly " $fragmentSpreads": FragmentRefs<"projectEvaluatorOptions_llmEvaluatorDetails">;
+};
+
+const node: ReaderInlineDataFragment = {
+  "kind": "InlineDataFragment",
+  "name": "projectEvaluatorOptions_llmEvaluatorDetails"
+};
+
+(node as any).hash = "9f85a7ee11194d88d261c88f48464018";
+
+export default node;

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
@@ -55,7 +55,7 @@ describe("useProjectEvaluatorPaths", () => {
       root.render(
         <MemoryRouter
           initialEntries={[
-            "/projects/project-1/evaluators?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved",
+            "/projects/project-1/evaluators?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved",
           ]}
         >
           <Routes>
@@ -73,28 +73,28 @@ describe("useProjectEvaluatorPaths", () => {
       "/projects/project-1/evaluator-gallery?timeRangeKey=7d&proof=preserved"
     );
     expect(output?.getAttribute("data-list-new-llm")).toBe(
-      "/projects/project-1/evaluators/new/llm?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluators/new/llm?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-list-new-code")).toBe(
-      "/projects/project-1/evaluators/new/code?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluators/new/code?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-list-copy-llm")).toBe(
-      "/projects/project-1/evaluators/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluators/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-list-attach-code")).toBe(
-      "/projects/project-1/evaluators/new/attach/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluators/new/attach/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-new-llm")).toBe(
-      "/projects/project-1/evaluator-gallery/new/llm?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluator-gallery/new/llm?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-new-code")).toBe(
-      "/projects/project-1/evaluator-gallery/new/code?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluator-gallery/new/code?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-copy-llm")).toBe(
-      "/projects/project-1/evaluator-gallery/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluator-gallery/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-attach-code")).toBe(
-      "/projects/project-1/evaluator-gallery/new/attach/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluator-gallery/new/attach/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-response-quality-gallery")).toBe(
       "/projects/project-1/evaluator-gallery?timeRangeKey=7d&category=RESPONSE_QUALITY&proof=preserved"

--- a/js/app/src/pages/project/evaluators/projectEvaluatorGalleryConstants.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorGalleryConstants.ts
@@ -1,0 +1,2 @@
+export const PROJECT_EVALUATOR_GALLERY_CUSTOM_EVALUATORS_CONNECTION_KEY =
+  "ProjectEvaluatorGallery__evaluators";

--- a/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -131,17 +131,17 @@ export const projectEvaluatorDetailsQueryNode = graphql`
 export type ProjectEvaluatorOption =
   projectEvaluatorOptionsQuery$data["evaluators"]["edges"][number]["evaluator"];
 
-type ProjectEvaluatorDetails = NonNullable<
+export type ProjectEvaluatorDetails = NonNullable<
   projectEvaluatorDetailsQuery["response"]["evaluator"]
 >;
-type LlmProjectEvaluatorDetails = ProjectEvaluatorDetails & {
+export type LlmProjectEvaluatorDetails = ProjectEvaluatorDetails & {
   readonly __typename: "LLMEvaluator";
   readonly id: string;
   readonly name: string;
   readonly description: string | null;
   readonly outputConfigs: NonNullable<ProjectEvaluatorDetails["outputConfigs"]>;
 };
-type CodeProjectEvaluatorDetails = ProjectEvaluatorDetails & {
+export type CodeProjectEvaluatorDetails = ProjectEvaluatorDetails & {
   readonly __typename: "CodeEvaluator";
   readonly id: string;
   readonly name: string;

--- a/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -1,4 +1,4 @@
-import { graphql } from "react-relay";
+import { graphql, readInlineData } from "react-relay";
 
 import {
   extractCodeEvaluatorVariables,
@@ -6,11 +6,18 @@ import {
 } from "@phoenix/components/evaluators/codeEvaluatorUtils";
 import { inferIncludeExplanationFromPrompt } from "@phoenix/components/evaluators/utils";
 import type { projectEvaluatorDetailsQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql";
+import type {
+  projectEvaluatorOptions_codeEvaluatorDetails$data,
+  projectEvaluatorOptions_codeEvaluatorDetails$key,
+} from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql";
+import type {
+  projectEvaluatorOptions_llmEvaluatorDetails$data,
+  projectEvaluatorOptions_llmEvaluatorDetails$key,
+} from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql";
 import type { projectEvaluatorOptionsQuery$data } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorOptionsQuery.graphql";
 import type { ProjectEvaluatorCreationMode } from "@phoenix/pages/project/evaluators/CreateProjectEvaluatorSlideover";
 import { generateMessageId } from "@phoenix/store";
 import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
-import type { CodeEvaluatorLanguage } from "@phoenix/types";
 import { isStringKeyedObject } from "@phoenix/typeUtils";
 import { convertPromptVersionMessagesToPlaygroundInstanceMessages } from "@phoenix/utils/promptUtils";
 
@@ -33,97 +40,110 @@ export const projectEvaluatorOptionsQuery = graphql`
   }
 `;
 
+const llmProjectEvaluatorDetailsFragment = graphql`
+  fragment projectEvaluatorOptions_llmEvaluatorDetails on LLMEvaluator @inline {
+    __typename
+    id
+    name
+    description
+    kind
+    outputConfigs {
+      __typename
+      ... on CategoricalAnnotationConfig {
+        name
+        optimizationDirection
+        values {
+          label
+          score
+        }
+      }
+      ... on ContinuousAnnotationConfig {
+        name
+        optimizationDirection
+        lowerBound
+        upperBound
+      }
+      ... on FreeformAnnotationConfig {
+        name
+        optimizationDirection
+        threshold
+        lowerBound
+        upperBound
+      }
+    }
+    promptVersion {
+      templateFormat
+      template {
+        __typename
+        ... on PromptChatTemplate {
+          messages {
+            ...promptUtils_promptMessages
+          }
+        }
+        ... on PromptStringTemplate {
+          template
+        }
+      }
+      tools {
+        tools {
+          __typename
+          ... on PromptToolFunction {
+            function {
+              parameters
+            }
+          }
+          ... on PromptToolRaw {
+            raw
+          }
+        }
+      }
+    }
+  }
+`;
+
+const codeProjectEvaluatorDetailsFragment = graphql`
+  fragment projectEvaluatorOptions_codeEvaluatorDetails on CodeEvaluator
+  @inline {
+    __typename
+    id
+    name
+    description
+    kind
+    outputConfigs {
+      __typename
+      ... on CategoricalAnnotationConfig {
+        name
+        optimizationDirection
+        values {
+          label
+          score
+        }
+      }
+      ... on ContinuousAnnotationConfig {
+        name
+        optimizationDirection
+        lowerBound
+        upperBound
+      }
+      ... on FreeformAnnotationConfig {
+        name
+        optimizationDirection
+        threshold
+        lowerBound
+        upperBound
+      }
+    }
+    sourceCode
+    language
+  }
+`;
+
 export const projectEvaluatorDetailsQueryNode = graphql`
   query projectEvaluatorDetailsQuery($id: ID!) {
     evaluator: node(id: $id) {
       __typename
-      ... on Evaluator {
-        id
-        name
-        description
-        kind
-      }
-      ... on LLMEvaluator {
-        outputConfigs {
-          __typename
-          ... on CategoricalAnnotationConfig {
-            name
-            optimizationDirection
-            values {
-              label
-              score
-            }
-          }
-          ... on ContinuousAnnotationConfig {
-            name
-            optimizationDirection
-            lowerBound
-            upperBound
-          }
-          ... on FreeformAnnotationConfig {
-            name
-            optimizationDirection
-            threshold
-            lowerBound
-            upperBound
-          }
-        }
-        promptVersion {
-          templateFormat
-          template {
-            __typename
-            ... on PromptChatTemplate {
-              messages {
-                ...promptUtils_promptMessages
-              }
-            }
-            ... on PromptStringTemplate {
-              template
-            }
-          }
-          tools {
-            tools {
-              __typename
-              ... on PromptToolFunction {
-                function {
-                  parameters
-                }
-              }
-              ... on PromptToolRaw {
-                raw
-              }
-            }
-          }
-        }
-      }
-      ... on CodeEvaluator {
-        outputConfigs {
-          __typename
-          ... on CategoricalAnnotationConfig {
-            name
-            optimizationDirection
-            values {
-              label
-              score
-            }
-          }
-          ... on ContinuousAnnotationConfig {
-            name
-            optimizationDirection
-            lowerBound
-            upperBound
-          }
-          ... on FreeformAnnotationConfig {
-            name
-            optimizationDirection
-            threshold
-            lowerBound
-            upperBound
-          }
-        }
-        sourceCode
-        language
-      }
+      ...projectEvaluatorOptions_llmEvaluatorDetails
+      ...projectEvaluatorOptions_codeEvaluatorDetails
     }
   }
 `;
@@ -131,48 +151,34 @@ export const projectEvaluatorDetailsQueryNode = graphql`
 export type ProjectEvaluatorOption =
   projectEvaluatorOptionsQuery$data["evaluators"]["edges"][number]["evaluator"];
 
-export type ProjectEvaluatorDetails = NonNullable<
+type ProjectEvaluatorDetailsNode = NonNullable<
   projectEvaluatorDetailsQuery["response"]["evaluator"]
 >;
-export type LlmProjectEvaluatorDetails = ProjectEvaluatorDetails & {
-  readonly __typename: "LLMEvaluator";
-  readonly id: string;
-  readonly name: string;
-  readonly description: string | null;
-  readonly outputConfigs: NonNullable<ProjectEvaluatorDetails["outputConfigs"]>;
-};
-export type CodeProjectEvaluatorDetails = ProjectEvaluatorDetails & {
-  readonly __typename: "CodeEvaluator";
-  readonly id: string;
-  readonly name: string;
-  readonly description: string | null;
-  readonly language: NonNullable<ProjectEvaluatorDetails["language"]>;
-  readonly sourceCode: string;
-  readonly outputConfigs: NonNullable<ProjectEvaluatorDetails["outputConfigs"]>;
-};
 
-export function isLlmProjectEvaluatorDetails(
-  evaluator: ProjectEvaluatorDetails
-): evaluator is LlmProjectEvaluatorDetails {
-  return (
-    evaluator.__typename === "LLMEvaluator" &&
-    typeof evaluator.id === "string" &&
-    typeof evaluator.name === "string" &&
-    Array.isArray(evaluator.outputConfigs)
-  );
-}
+export type LlmProjectEvaluatorDetails =
+  projectEvaluatorOptions_llmEvaluatorDetails$data;
+export type CodeProjectEvaluatorDetails =
+  projectEvaluatorOptions_codeEvaluatorDetails$data;
+export type ProjectEvaluatorDetails =
+  | LlmProjectEvaluatorDetails
+  | CodeProjectEvaluatorDetails;
 
-export function isCodeProjectEvaluatorDetails(
-  evaluator: ProjectEvaluatorDetails
-): evaluator is CodeProjectEvaluatorDetails {
-  return (
-    evaluator.__typename === "CodeEvaluator" &&
-    typeof evaluator.id === "string" &&
-    typeof evaluator.name === "string" &&
-    typeof evaluator.language === "string" &&
-    typeof evaluator.sourceCode === "string" &&
-    Array.isArray(evaluator.outputConfigs)
-  );
+export function readProjectEvaluatorDetails(
+  evaluator: ProjectEvaluatorDetailsNode | null
+): ProjectEvaluatorDetails | null {
+  if (evaluator?.__typename === "LLMEvaluator") {
+    return readInlineData<projectEvaluatorOptions_llmEvaluatorDetails$key>(
+      llmProjectEvaluatorDetailsFragment,
+      evaluator
+    );
+  }
+  if (evaluator?.__typename === "CodeEvaluator") {
+    return readInlineData<projectEvaluatorOptions_codeEvaluatorDetails$key>(
+      codeProjectEvaluatorDetailsFragment,
+      evaluator
+    );
+  }
+  return null;
 }
 
 export type BuildCopyLlmCreationModeResult =
@@ -214,7 +220,7 @@ export function buildCopyLlmCreationMode(
         name: evaluator.name,
         description: evaluator.description ?? "",
         outputConfigs: convertProjectEvaluatorOutputConfigs(
-          evaluator.outputConfigs ?? []
+          evaluator.outputConfigs
         ),
         defaultMessages,
         templateFormat: evaluator.promptVersion?.templateFormat ?? "MUSTACHE",
@@ -230,12 +236,12 @@ export function buildAttachCodeCreationMode(
   evaluator: CodeProjectEvaluatorDetails
 ): ProjectEvaluatorCreationMode {
   const variables = extractCodeEvaluatorVariables({
-    language: evaluator.language as CodeEvaluatorLanguage,
-    sourceCode: evaluator.sourceCode ?? "",
+    language: evaluator.language,
+    sourceCode: evaluator.sourceCode,
   });
   const requiredVariables = extractRequiredCodeEvaluatorVariables({
-    language: evaluator.language as CodeEvaluatorLanguage,
-    sourceCode: evaluator.sourceCode ?? "",
+    language: evaluator.language,
+    sourceCode: evaluator.sourceCode,
   });
   return {
     kind: "code",
@@ -243,7 +249,7 @@ export function buildAttachCodeCreationMode(
     name: evaluator.name,
     description: evaluator.description ?? "",
     outputConfigs: convertProjectEvaluatorOutputConfigs(
-      evaluator.outputConfigs ?? []
+      evaluator.outputConfigs
     ),
     variables,
     requiredVariables,

--- a/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -3,6 +3,7 @@ import { useLocation } from "react-router";
 
 import {
   PROJECT_EVALUATOR_CATEGORY_PARAM,
+  PROJECT_EVALUATOR_PARAM,
   PROJECT_EVALUATOR_TEMPLATE_PARAM,
 } from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
@@ -70,6 +71,7 @@ export function useProjectEvaluatorPaths() {
     // project-page state in the query string.
     const defaultGallerySearch = withSearchParams(search, (searchParams) => {
       searchParams.delete(PROJECT_EVALUATOR_CATEGORY_PARAM);
+      searchParams.delete(PROJECT_EVALUATOR_PARAM);
       searchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
     });
     return {
@@ -78,6 +80,7 @@ export function useProjectEvaluatorPaths() {
       galleryCategory: (category: EvaluatorCategory) =>
         `${gallery}${withSearchParams(search, (searchParams) => {
           searchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);
+          searchParams.delete(PROJECT_EVALUATOR_PARAM);
           searchParams.delete(PROJECT_EVALUATOR_TEMPLATE_PARAM);
         })}`,
       galleryTemplate: ({
@@ -89,6 +92,7 @@ export function useProjectEvaluatorPaths() {
       }) =>
         `${gallery}${withSearchParams(search, (searchParams) => {
           searchParams.set(PROJECT_EVALUATOR_CATEGORY_PARAM, category);
+          searchParams.delete(PROJECT_EVALUATOR_PARAM);
           searchParams.set(PROJECT_EVALUATOR_TEMPLATE_PARAM, templateName);
         })}`,
       listCreation: buildCreationPaths(list),

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1470,6 +1470,7 @@ class Query:
         before: Optional[CursorString] = UNSET,
         sort: Optional[EvaluatorSort] = UNSET,
         filter: Optional[EvaluatorFilter] = UNSET,
+        exclude_project_id: Optional[GlobalID] = UNSET,
     ) -> Connection[Evaluator]:
         args = ConnectionArgs(
             first=first,
@@ -1497,6 +1498,16 @@ class Query:
                 has_dataset_association,
             )
         )
+
+        if isinstance(exclude_project_id, GlobalID):
+            project_rowid = from_global_id_with_expected_type(exclude_project_id, Project.__name__)
+            has_project_association = exists(
+                select(models.ProjectEvaluator.id).where(
+                    models.ProjectEvaluator.evaluator_id == PolymorphicEvaluator.id,
+                    models.ProjectEvaluator.project_id == project_rowid,
+                )
+            )
+            query = query.where(~has_project_association)
 
         if filter:
             if filter.col.value == "name":

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -2722,6 +2722,62 @@ class TestEvaluatorsQuery:
         assert not response.errors
         assert response.data == {"evaluators": {"edges": []}}
 
+    async def test_evaluators_excludes_project_associations_before_pagination(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        evaluators_for_querying: Any,
+    ) -> None:
+        from sqlalchemy import select
+
+        async with db() as session:
+            llm_evaluator = await session.scalar(
+                select(models.LLMEvaluator).where(
+                    models.LLMEvaluator.name == Identifier(root="llm_eval")
+                )
+            )
+            assert llm_evaluator is not None
+            project = models.Project(name="project-with-evaluator")
+            trace_project = models.Project(name="project-with-evaluator-traces")
+            session.add_all([project, trace_project])
+            await session.flush()
+            session.add(
+                models.ProjectEvaluator(
+                    project_id=project.id,
+                    evaluator_id=llm_evaluator.id,
+                    trace_project_id=trace_project.id,
+                    name=Identifier(root="llm-online"),
+                    filter_condition="",
+                    evaluation_target="SPAN",
+                    sampling_rate=1.0,
+                )
+            )
+            await session.flush()
+            project_id = str(GlobalID("Project", str(project.id)))
+
+        query = """
+          query ($excludeProjectId: ID) {
+            evaluators(
+              first: 1
+              sort: { col: name, dir: desc }
+              excludeProjectId: $excludeProjectId
+            ) {
+              edges {
+                evaluator: node {
+                  name
+                }
+              }
+            }
+          }
+        """
+        response = await gql_client.execute(
+            query=query,
+            variables={"excludeProjectId": project_id},
+        )
+
+        assert not response.errors
+        assert response.data == {"evaluators": {"edges": [{"evaluator": {"name": "contains"}}]}}
+
     async def test_evaluators_sort_by_name(
         self,
         gql_client: AsyncGraphQLClient,


### PR DESCRIPTION
## Summary

- add a Custom evaluators section above the template categories in the shared gallery scroll region
- fetch up to 100 evaluators while excluding evaluators already attached to the current project
- show template-like details for reusable LLM and code evaluators, including annotation values, optimization direction, prompts, and source code
- route LLM evaluators through the duplicate flow and code evaluators through the existing attach flow
- remove a newly attached code evaluator from the gallery connection without requiring a refresh

## Screenshot

![Custom evaluators in the evaluator gallery](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15771-custom-evaluators-gallery.png)

## Test plan

- `make test-frontend` — 2,378 passed, 12 skipped
- `make typecheck-frontend`
- `make lint-frontend`
- `make typecheck-python`
- `make lint-python`
- `uv run pytest tests/unit/server/api/test_queries.py -k 'evaluators_excludes_project_associations_before_pagination'` — 1 passed, 1 PostgreSQL variant skipped by the SQLite test environment
- browser-verified the shared scrolling list, current-project exclusion, LLM duplication flow, code attachment flow, compact and wide layouts, and expandable long prompt/code previews

Stacked on #13989.
