### PR TITLE
docs: add Railway marketplace template description

### DIFF
--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -1,0 +1,54 @@
+# Deploy and Host arize-phoenix on Railway
+
+Phoenix is an open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. It ingests OpenTelemetry traces from your LLM and agent applications, then adds LLM-as-a-judge evaluations, versioned datasets, experiments, a prompt playground, and prompt management — all in one UI. Phoenix is vendor and language agnostic, with out-of-the-box support for popular frameworks and LLM providers.
+
+## About Hosting arize-phoenix
+
+Phoenix ships as a prebuilt image on [Docker Hub](https://hub.docker.com/r/arizephoenix/phoenix), so Railway deploys it without a build step. The container serves the UI and REST API on port `6006` and accepts OTLP/gRPC spans on `4317`, binding to `0.0.0.0` by default. Railway's filesystem is ephemeral, so attach a Postgres service and point `PHOENIX_SQL_DATABASE_URL` at it — Phoenix runs its own migrations on startup. Enable authentication with `PHOENIX_ENABLE_AUTH` and a `PHOENIX_SECRET` of at least 32 characters containing a digit and a lowercase letter. Span-heavy queries want memory, so avoid the smallest instance sizes.
+
+## Common Use Cases
+
+- Tracing LLM and agent applications in development and production, with a searchable span view for debugging latency, token spend, and tool-call failures
+- Running evaluations over real traffic — LLM-as-a-judge evals on traced spans, then building a failure taxonomy from what you find
+- Prompt engineering and regression testing — iterate in the playground, version prompts, and run experiments against versioned datasets
+
+## Dependencies for arize-phoenix Hosting
+
+- A PostgreSQL database for durable storage (Railway's Postgres works out of the box). Without one, Phoenix falls back to SQLite on the container's ephemeral disk and your traces disappear on redeploy.
+- The public `arizephoenix/phoenix` Docker image — no source build or private registry required.
+- OpenTelemetry instrumentation in your application to send spans, via [OpenInference](https://github.com/Arize-ai/openinference) or any OTLP-compatible exporter.
+- An LLM provider API key (for example `OPENAI_API_KEY`), only if you plan to use evals, the playground, or PXI.
+
+## Implementation Details
+
+Phoenix reads its own `PHOENIX_PORT` rather than Railway's injected `PORT`, so set it explicitly and match Railway's target port to it.
+
+| Variable | Value | Notes |
+| --- | --- | --- |
+| `PHOENIX_PORT` | `6006` | HTTP port for the UI and REST API |
+| `PHOENIX_SQL_DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | Reference the Postgres service so data survives redeploys |
+| `PHOENIX_ENABLE_AUTH` | `true` | Requires a login for the UI and API |
+| `PHOENIX_SECRET` | 32+ chars, ≥1 digit, ≥1 lowercase | Signs auth tokens; the container refuses to start on an invalid value |
+| `PHOENIX_USE_SECURE_COOKIES` | `true` | Recommended — Railway serves over HTTPS |
+
+Use `/healthz` as the healthcheck path. The first login uses `admin@localhost` with password `admin` unless you set `PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD`; either way you are required to change it on first login.
+
+Point your application at the deployment:
+
+```python
+from phoenix.otel import register
+
+tracer_provider = register(
+    project_name="my-app",
+    endpoint="https://<your-app>.up.railway.app/v1/traces",
+    auto_instrument=True,
+)
+```
+
+With auth enabled, create an API key in the UI and export it as `PHOENIX_API_KEY` so the exporter can authenticate. See the [self-hosting documentation](https://arize.com/docs/phoenix/self-hosting) for the full configuration reference.
+
+## Why Deploy arize-phoenix on Railway?
+
+Railway is a singular platform to deploy your infrastructure stack. Railway will host your infrastructure so you don't have to deal with configuration, while allowing you to vertically and horizontally scale it.
+
+By deploying arize-phoenix on Railway, you are one step closer to supporting a complete full-stack application with minimal burden. Host your servers, databases, AI agents, and more on Railway.

--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -26,7 +26,7 @@ Phoenix runs from a prebuilt Docker image, so Railway deploys it with no build s
 | `PHOENIX_ENABLE_AUTH` | `true` |
 | `PHOENIX_SECRET` | 32+ chars, with a digit and a lowercase letter |
 
-Use `/healthz` as the healthcheck path. The first login is `admin@localhost` / `admin`, and you are required to change it. Point your application at the deployment:
+Use `/healthz` as the healthcheck path, and set the service restart policy to **On Failure** — Railway deploys services in parallel, and Phoenix exits if Postgres isn't accepting connections yet, so it comes up on a restart once the database is ready. The first login is `admin@localhost` / `admin`, and you are required to change it. Point your application at the deployment:
 
 ```python
 from phoenix.otel import register

--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -1,51 +1,43 @@
 # Deploy and Host arize-phoenix on Railway
 
-Phoenix is an open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. It ingests OpenTelemetry traces from your LLM and agent applications, then adds LLM-as-a-judge evaluations, versioned datasets, experiments, a prompt playground, and prompt management — all in one UI. Phoenix is vendor and language agnostic, with out-of-the-box support for popular frameworks and LLM providers.
+Phoenix is an open-source AI observability platform for tracing, evaluating, and troubleshooting LLM and agent applications. It ingests OpenTelemetry traces, then adds LLM-as-a-judge evals, versioned datasets, experiments, and a prompt playground in one UI. Phoenix is vendor and language agnostic, working with any OTLP-compatible framework or provider.
 
 ## About Hosting arize-phoenix
 
-Phoenix ships as a prebuilt image on [Docker Hub](https://hub.docker.com/r/arizephoenix/phoenix), so Railway deploys it without a build step. The container serves the UI and REST API on port `6006` and accepts OTLP/gRPC spans on `4317`, binding to `0.0.0.0` by default. Railway's filesystem is ephemeral, so attach a Postgres service and point `PHOENIX_SQL_DATABASE_URL` at it — Phoenix runs its own migrations on startup. Enable authentication with `PHOENIX_ENABLE_AUTH` and a `PHOENIX_SECRET` of at least 32 characters containing a digit and a lowercase letter. Span-heavy queries want memory, so avoid the smallest instance sizes.
+Phoenix runs from a prebuilt Docker image, so Railway deploys it with no build step. The container serves its UI and API on port 6006 and accepts OTLP/gRPC spans on 4317. Set `PHOENIX_PORT` explicitly — Phoenix reads it rather than Railway's injected `PORT`. Railway's filesystem is ephemeral, so attach a Postgres service and point `PHOENIX_SQL_DATABASE_URL` at it; Phoenix migrates on startup. Enable authentication with `PHOENIX_ENABLE_AUTH` and a `PHOENIX_SECRET` of at least 32 characters including a digit and a lowercase letter.
 
 ## Common Use Cases
 
-- Tracing LLM and agent applications in development and production, with a searchable span view for debugging latency, token spend, and tool-call failures
-- Running evaluations over real traffic — LLM-as-a-judge evals on traced spans, then building a failure taxonomy from what you find
-- Prompt engineering and regression testing — iterate in the playground, version prompts, and run experiments against versioned datasets
+- Tracing LLM and agent applications to debug latency, token spend, and tool-call failures
+- Running evals over real traffic to find where an application actually goes wrong
+- Iterating on prompts in the playground and testing changes against versioned datasets
 
 ## Dependencies for arize-phoenix Hosting
 
-- A PostgreSQL database for durable storage (Railway's Postgres works out of the box). Without one, Phoenix falls back to SQLite on the container's ephemeral disk and your traces disappear on redeploy.
-- The public `arizephoenix/phoenix` Docker image — no source build or private registry required.
-- OpenTelemetry instrumentation in your application to send spans, via [OpenInference](https://github.com/Arize-ai/openinference) or any OTLP-compatible exporter.
-- An LLM provider API key (for example `OPENAI_API_KEY`), only if you plan to use evals, the playground, or PXI.
+- A PostgreSQL database for durable storage — without one, Phoenix uses SQLite on the ephemeral disk and loses data on redeploy
+- OpenTelemetry instrumentation in your application to send spans, via [OpenInference](https://github.com/Arize-ai/openinference) or any OTLP exporter
 
 ## Implementation Details
 
-Phoenix reads its own `PHOENIX_PORT` rather than Railway's injected `PORT`, so set it explicitly and match Railway's target port to it.
+| Variable | Value |
+| --- | --- |
+| `PHOENIX_PORT` | `6006` |
+| `PHOENIX_SQL_DATABASE_URL` | `${{Postgres.DATABASE_URL}}` |
+| `PHOENIX_ENABLE_AUTH` | `true` |
+| `PHOENIX_SECRET` | 32+ chars, with a digit and a lowercase letter |
 
-| Variable | Value | Notes |
-| --- | --- | --- |
-| `PHOENIX_PORT` | `6006` | HTTP port for the UI and REST API |
-| `PHOENIX_SQL_DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | Reference the Postgres service so data survives redeploys |
-| `PHOENIX_ENABLE_AUTH` | `true` | Requires a login for the UI and API |
-| `PHOENIX_SECRET` | 32+ chars, ≥1 digit, ≥1 lowercase | Signs auth tokens; the container refuses to start on an invalid value |
-| `PHOENIX_USE_SECURE_COOKIES` | `true` | Recommended — Railway serves over HTTPS |
-
-Use `/healthz` as the healthcheck path. The first login uses `admin@localhost` with password `admin` unless you set `PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD`; either way you are required to change it on first login.
-
-Point your application at the deployment:
+Use `/healthz` as the healthcheck path. The first login is `admin@localhost` / `admin`, and you are required to change it. Point your application at the deployment:
 
 ```python
 from phoenix.otel import register
 
 tracer_provider = register(
-    project_name="my-app",
     endpoint="https://<your-app>.up.railway.app/v1/traces",
     auto_instrument=True,
 )
 ```
 
-With auth enabled, create an API key in the UI and export it as `PHOENIX_API_KEY` so the exporter can authenticate. See the [self-hosting documentation](https://arize.com/docs/phoenix/self-hosting) for the full configuration reference.
+See the [self-hosting documentation](https://arize.com/docs/phoenix/self-hosting) for the full configuration reference.
 
 ## Why Deploy arize-phoenix on Railway?
 


### PR DESCRIPTION
Adds `RAILWAY.md` at the repo root — the marketplace listing copy for the Railway template the README already links (`railway.app/template/PTHRoq`). It sits alongside the other deploy manifests (`app.json`, `render.yaml`, `azuredeploy.json`).

Docs only. No code, config, or existing files changed — the README and its deploy buttons are untouched, and no `railway.json` is added.

The deployment details are taken from the repo rather than written generically, since a few are easy to get wrong on Railway specifically:

- **`PHOENIX_PORT`, not `PORT`.** `get_env_port` (`src/phoenix/config.py:3280`) reads only `PHOENIX_PORT`, so Railway's injected `PORT` is ignored and the variable has to be set explicitly with the target port matched to it. This is why `render.yaml` sets both.
- **`PHOENIX_SECRET` rules.** 32+ characters with at least one digit and one lowercase letter, per `REQUIREMENTS_FOR_PHOENIX_SECRET` (`src/phoenix/auth.py:303`) and `DEFAULT_SECRET_LENGTH` (`src/phoenix/auth.py:280`). Validation runs in `get_env_phoenix_secret`, so an invalid value fails at startup rather than at first use.
- **Postgres is required for durable storage.** Railway's filesystem is ephemeral, so without `PHOENIX_SQL_DATABASE_URL` Phoenix falls back to SQLite on disk and traces are lost on redeploy.
- Host `0.0.0.0` (`src/phoenix/config.py:3076`), ports 6006 (HTTP/REST) and 4317 (OTLP/gRPC), `/healthz` for the healthcheck, and the `admin@localhost` first-login flow from `app.json`.

Structure and section headings follow the format Railway asks for in marketplace submissions; prose style follows the top-level README.

One thing worth a reviewer's eye: the Postgres reference is written as `${{Postgres.DATABASE_URL}}`, which assumes the template's Postgres service keeps Railway's default name. Worth confirming against the live template.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CL7k1T8KwySj3dDqCp6oyU)_