### PR TITLE
fix(ui): show a neutral redirect state instead of the error boundary during login handoff

### DIFF
--- a/js/app/__tests__/authFetch.test.ts
+++ b/js/app/__tests__/authFetch.test.ts
@@ -1,4 +1,4 @@
-import { authFetch } from "@phoenix/authFetch";
+import { authFetch, isRedirectingToLoginError } from "@phoenix/authFetch";
 vi.mock("@phoenix/config");
 
 describe("authFetch", () => {
@@ -55,5 +55,23 @@ describe("authFetch", () => {
     expect(global.fetch.mock.calls[1][0]).toBe("http://localhost/auth/refresh");
     // @ts-expect-error mock global fetch
     expect(global.fetch.mock.calls[2][0]).toBe("/test");
+  });
+  it("rejects with a RedirectingToLoginError when the token refresh fails", async () => {
+    // Every request 401s: the original request triggers a refresh, and the
+    // refresh itself fails, so the browser is pointed at the login page.
+    // @ts-expect-error mock global fetch
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        status: 401,
+        ok: false,
+      })
+    );
+
+    await expect(authFetch("/test")).rejects.toSatisfy(
+      isRedirectingToLoginError
+    );
+
+    // @ts-expect-error mock global fetch
+    expect(global.fetch.mock.calls[1][0]).toBe("http://localhost/auth/refresh");
   });
 });

--- a/js/app/__tests__/authFetch.test.ts
+++ b/js/app/__tests__/authFetch.test.ts
@@ -56,7 +56,7 @@ describe("authFetch", () => {
     // @ts-expect-error mock global fetch
     expect(global.fetch.mock.calls[2][0]).toBe("/test");
   });
-  it("rejects with a RedirectingToLoginError when the token refresh fails", async () => {
+  it("rejects with a RedirectingToLoginError during the login handoff", async () => {
     // Every request 401s: the original request triggers a refresh, and the
     // refresh itself fails, so the browser is pointed at the login page.
     // @ts-expect-error mock global fetch
@@ -66,12 +66,23 @@ describe("authFetch", () => {
         ok: false,
       })
     );
-
     await expect(authFetch("/test")).rejects.toSatisfy(
       isRedirectingToLoginError
     );
-
     // @ts-expect-error mock global fetch
     expect(global.fetch.mock.calls[1][0]).toBe("http://localhost/auth/refresh");
+
+    // Fetches interrupted by the login navigation reject with a generic
+    // TypeError in some browsers (e.g. Firefox's "NetworkError when
+    // attempting to fetch resource."); during the handoff these must not
+    // surface as generic errors either.
+    global.fetch = vi.fn(() =>
+      Promise.reject(
+        new TypeError("NetworkError when attempting to fetch resource.")
+      )
+    );
+    await expect(authFetch("/test")).rejects.toSatisfy(
+      isRedirectingToLoginError
+    );
   });
 });

--- a/js/app/src/authFetch.ts
+++ b/js/app/src/authFetch.ts
@@ -1,5 +1,3 @@
-import invariant from "tiny-invariant";
-
 import { BASE_URL } from "@phoenix/config";
 
 import { createLoginRedirectUrl } from "./utils/routingUtils";
@@ -30,6 +28,35 @@ class RefreshTimeoutError extends Error {
   }
 }
 
+const REDIRECTING_TO_LOGIN_ERROR_NAME = "RedirectingToLoginError";
+
+/**
+ * Thrown after the browser has already been pointed at the login page
+ * (`window.location.href = createLoginRedirectUrl()`). Navigation via
+ * `window.location.href` is asynchronous — the current document keeps running
+ * until the login page's document replaces it — so the pending request still
+ * needs to reject to unblock its caller. Error surfaces (the router's
+ * errorElement, ErrorBoundary fallbacks) should treat this error as "redirect
+ * in progress" and render a neutral pending state rather than an error page.
+ */
+export class RedirectingToLoginError extends Error {
+  constructor(options?: ErrorOptions) {
+    super("Redirecting to log in", options);
+    this.name = REDIRECTING_TO_LOGIN_ERROR_NAME;
+  }
+}
+
+/**
+ * Detects a {@link RedirectingToLoginError}. Checks the error's name rather
+ * than using `instanceof` so the detection is robust to the class being
+ * duplicated across bundles.
+ */
+export function isRedirectingToLoginError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.name === REDIRECTING_TO_LOGIN_ERROR_NAME
+  );
+}
+
 /**
  * A wrapper around fetch that retries the request if the server returns a 401.
  */
@@ -48,12 +75,15 @@ export async function authFetch(
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       // If the server returns a 401, we should try to refresh the token
-      // If not successful, the user will be redirected to the login page
+      // If not successful, refreshTokens starts the login redirect and throws
+      // RedirectingToLoginError, which propagates out of this function.
+      // refreshTokens only resolves with an ok response, but guard
+      // defensively: a non-ok response here also means the session is gone.
       const response = await refreshTokens();
-      invariant(
-        response.ok,
-        `Failed to authenticate. Please visit ${createLoginRedirectUrl()} to login.`
-      );
+      if (!response.ok) {
+        window.location.href = createLoginRedirectUrl();
+        throw new RedirectingToLoginError();
+      }
       return fetch(input, init);
     }
     if (error instanceof Error && error.name === "AbortError") {
@@ -102,6 +132,10 @@ export async function refreshTokens(): Promise<Response> {
     return await refreshPromise;
   } catch (error) {
     window.location.href = createLoginRedirectUrl();
-    throw error;
+    // Navigation is already underway, but this document keeps running until
+    // the login page loads. Reject with a dedicated error so error surfaces
+    // can show a neutral "redirecting" state instead of flashing an error
+    // page during the handoff.
+    throw new RedirectingToLoginError({ cause: error });
   }
 }

--- a/js/app/src/authFetch.ts
+++ b/js/app/src/authFetch.ts
@@ -57,6 +57,25 @@ export function isRedirectingToLoginError(error: unknown): boolean {
   );
 }
 
+let redirectingToLogin = false;
+
+/**
+ * True once this document has been pointed at the login page. From that moment
+ * until the login page's document takes over, any error that surfaces is
+ * teardown noise — e.g. Firefox rejects fetches interrupted by the navigation
+ * with a TypeError rather than an AbortError — so error surfaces should render
+ * a neutral pending state instead of an error page.
+ */
+export function isRedirectingToLogin(): boolean {
+  return redirectingToLogin;
+}
+
+function startLoginRedirect(cause: unknown): RedirectingToLoginError {
+  redirectingToLogin = true;
+  window.location.href = createLoginRedirectUrl();
+  return new RedirectingToLoginError({ cause });
+}
+
 /**
  * A wrapper around fetch that retries the request if the server returns a 401.
  */
@@ -81,14 +100,18 @@ export async function authFetch(
       // defensively: a non-ok response here also means the session is gone.
       const response = await refreshTokens();
       if (!response.ok) {
-        window.location.href = createLoginRedirectUrl();
-        throw new RedirectingToLoginError();
+        throw startLoginRedirect(error);
       }
       return fetch(input, init);
     }
     if (error instanceof Error && error.name === "AbortError") {
       // This is triggered when the controller is aborted
       throw error;
+    }
+    if (redirectingToLogin) {
+      // The document is being torn down for the login handoff; a fetch
+      // interrupted by that navigation is not a real failure.
+      throw new RedirectingToLoginError({ cause: error });
     }
   }
   throw new Error("An unexpected error occurred while fetching data");
@@ -131,11 +154,10 @@ export async function refreshTokens(): Promise<Response> {
   try {
     return await refreshPromise;
   } catch (error) {
-    window.location.href = createLoginRedirectUrl();
-    // Navigation is already underway, but this document keeps running until
-    // the login page loads. Reject with a dedicated error so error surfaces
-    // can show a neutral "redirecting" state instead of flashing an error
-    // page during the handoff.
-    throw new RedirectingToLoginError({ cause: error });
+    // Navigation starts here, but this document keeps running until the login
+    // page loads. Reject with a dedicated error so error surfaces can show a
+    // neutral "redirecting" state instead of flashing an error page during
+    // the handoff.
+    throw startLoginRedirect(error);
   }
 }

--- a/js/app/src/components/exception/ErrorBoundary.tsx
+++ b/js/app/src/components/exception/ErrorBoundary.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
 import { Component } from "react";
 
+import { isRedirectingToLoginError } from "@phoenix/authFetch";
+
+import { Loading } from "../core/loading/Loading";
 import { BugReportErrorBoundaryFallback } from "./BugReportErrorBoundaryFallback";
 import type { ErrorBoundaryFallbackComponent } from "./types";
 type ErrorBoundaryProps = {
@@ -32,6 +35,11 @@ export class ErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError) {
+      if (isRedirectingToLoginError(this.state.error)) {
+        // The browser is already navigating to the login page; show a neutral
+        // pending state instead of an error while the handoff completes.
+        return <Loading />;
+      }
       const errorMessage: string | null =
         this.state.error instanceof Error ? this.state.error.message : null;
       return typeof this.props.fallback === "function" ? (

--- a/js/app/src/components/exception/ErrorBoundary.tsx
+++ b/js/app/src/components/exception/ErrorBoundary.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from "react";
 import { Component } from "react";
 
-import { isRedirectingToLoginError } from "@phoenix/authFetch";
+import {
+  isRedirectingToLogin,
+  isRedirectingToLoginError,
+} from "@phoenix/authFetch";
 
-import { Loading } from "../core/loading/Loading";
 import { BugReportErrorBoundaryFallback } from "./BugReportErrorBoundaryFallback";
 import type { ErrorBoundaryFallbackComponent } from "./types";
 type ErrorBoundaryProps = {
@@ -35,10 +37,16 @@ export class ErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError) {
-      if (isRedirectingToLoginError(this.state.error)) {
-        // The browser is already navigating to the login page; show a neutral
-        // pending state instead of an error while the handoff completes.
-        return <Loading />;
+      if (
+        isRedirectingToLoginError(this.state.error) ||
+        isRedirectingToLogin()
+      ) {
+        // The browser is already navigating to the login page; render nothing
+        // rather than an error while the handoff completes. The flag check
+        // also covers errors from fetches interrupted by that navigation,
+        // which some browsers reject with a generic error rather than an
+        // AbortError.
+        return null;
       }
       const errorMessage: string | null =
         this.state.error instanceof Error ? this.state.error.message : null;

--- a/js/app/src/pages/ErrorElement.tsx
+++ b/js/app/src/pages/ErrorElement.tsx
@@ -2,7 +2,8 @@ import { css } from "@emotion/react";
 import { useMemo } from "react";
 import { isRouteErrorResponse, useRouteError } from "react-router";
 
-import { Button, ExternalLink, Flex } from "@phoenix/components";
+import { isRedirectingToLoginError } from "@phoenix/authFetch";
+import { Button, ExternalLink, Flex, Loading } from "@phoenix/components";
 import { isConnectionTimeoutError } from "@phoenix/components/exception/isConnectionTimeoutError";
 
 import { NotFoundContent, ProjectOnboardingNotFound } from "./NotFound";
@@ -41,6 +42,21 @@ export function ErrorElement() {
     }
     return <ErrorContent error={error} />;
   }, [error, is404, notFoundData]);
+
+  if (isRedirectingToLoginError(error)) {
+    // The browser is already navigating to the login page; show a neutral
+    // pending state instead of an error page while the handoff completes.
+    return (
+      <main
+        css={css`
+          width: 100%;
+          height: 100%;
+        `}
+      >
+        <Loading message="Redirecting to log in" />
+      </main>
+    );
+  }
 
   if (notFoundData?.kind === "project-onboarding") {
     return (

--- a/js/app/src/pages/ErrorElement.tsx
+++ b/js/app/src/pages/ErrorElement.tsx
@@ -2,7 +2,10 @@ import { css } from "@emotion/react";
 import { useMemo } from "react";
 import { isRouteErrorResponse, useRouteError } from "react-router";
 
-import { isRedirectingToLoginError } from "@phoenix/authFetch";
+import {
+  isRedirectingToLogin,
+  isRedirectingToLoginError,
+} from "@phoenix/authFetch";
 import { Button, ExternalLink, Flex, Loading } from "@phoenix/components";
 import { isConnectionTimeoutError } from "@phoenix/components/exception/isConnectionTimeoutError";
 
@@ -43,19 +46,13 @@ export function ErrorElement() {
     return <ErrorContent error={error} />;
   }, [error, is404, notFoundData]);
 
-  if (isRedirectingToLoginError(error)) {
-    // The browser is already navigating to the login page; show a neutral
-    // pending state instead of an error page while the handoff completes.
-    return (
-      <main
-        css={css`
-          width: 100%;
-          height: 100%;
-        `}
-      >
-        <Loading message="Redirecting to log in" />
-      </main>
-    );
+  if (isRedirectingToLoginError(error) || isRedirectingToLogin()) {
+    // The browser is already navigating to the login page; show a single
+    // neutral pending state instead of an error page while the handoff
+    // completes. The flag check also covers errors from fetches interrupted
+    // by that navigation, which some browsers reject with a generic error
+    // rather than an AbortError.
+    return <Loading />;
   }
 
   if (notFoundData?.kind === "project-onboarding") {

--- a/js/app/tests/auth-refresh.spec.ts
+++ b/js/app/tests/auth-refresh.spec.ts
@@ -7,6 +7,58 @@ import { expect, test, type Page } from "@playwright/test";
 // without this, all tests take exponentially longer as they hit expiring auth sessions
 test.use({ storageState: { cookies: [], origins: [] } });
 
+/**
+ * Watches every document the page loads for the error boundary's
+ * "Something went wrong" surface, including transient flashes that an
+ * end-state assertion would miss (see #15774). Returns a handle whose
+ * `seen` flag flips if the error boundary ever painted.
+ */
+async function trackErrorBoundaryFlash(page: Page) {
+  const state = { seen: false };
+  await page.exposeFunction("__phoenixReportErrorBoundary__", () => {
+    state.seen = true;
+  });
+  await page.addInitScript(() => {
+    const report = () => {
+      if (document.body?.textContent?.includes("Something went wrong")) {
+        (
+          window as Window & { __phoenixReportErrorBoundary__?: () => void }
+        ).__phoenixReportErrorBoundary__?.();
+      }
+    };
+    const observe = () => {
+      report();
+      new MutationObserver(report).observe(document.body, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    };
+    if (document.body) {
+      observe();
+    } else {
+      document.addEventListener("DOMContentLoaded", observe);
+    }
+  });
+  return state;
+}
+
+/**
+ * Delays the login page's document response. `window.location.href` navigation
+ * is asynchronous — the current document keeps running (and rendering) until
+ * the login page's document replaces it. On localhost that handoff is nearly
+ * instant, which would mask the regression the flash assertions guard against:
+ * the error boundary painting during the gap (#15774).
+ */
+async function delayLoginDocument(page: Page) {
+  await page.route("**/login*", async (route) => {
+    if (route.request().resourceType() === "document") {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+    await route.continue();
+  });
+}
+
 async function loginAsMember(page: Page) {
   await page.goto("/login");
   await page.getByLabel("Email").fill("member@localhost.com");
@@ -58,10 +110,27 @@ test("recovers from an expired session by refreshing auth", async ({
   expect(graphqlFailures).toBe(1);
 });
 
+test("visiting unauthenticated redirects to login without flashing the error boundary", async ({
+  page,
+}) => {
+  const errorBoundary = await trackErrorBoundaryFlash(page);
+  await delayLoginDocument(page);
+
+  // With no cookies (storage state is cleared above), the app's first GraphQL
+  // request 401s, the token refresh fails, and the app must hand off to the
+  // login page without ever painting the error boundary.
+  await page.goto("/projects");
+  await page.waitForURL(/\/login\?returnUrl=%2Fprojects/);
+
+  expect(errorBoundary.seen).toBe(false);
+});
+
 test("redirects to login when session refresh fails", async ({ page }) => {
   let graphqlFailures = 0;
 
+  const errorBoundary = await trackErrorBoundaryFlash(page);
   await openProjectsPage(page);
+  await delayLoginDocument(page);
 
   await page.route("**/graphql", async (route) => {
     if (graphqlFailures === 0) {
@@ -88,6 +157,8 @@ test("redirects to login when session refresh fails", async ({ page }) => {
   // returnUrl round-trips the projects URL, which may carry a recreatable time
   // range (e.g. an encoded ?timeRangeKey=7d), so match the returnUrl prefix.
   await page.waitForURL(/\/login\?returnUrl=%2Fprojects/);
+
+  expect(errorBoundary.seen).toBe(false);
 });
 
 test("redirects to login when session refresh times out", async ({ page }) => {

--- a/js/app/tests/auth-refresh.spec.ts
+++ b/js/app/tests/auth-refresh.spec.ts
@@ -128,9 +128,7 @@ test("visiting unauthenticated redirects to login without flashing the error bou
 test("redirects to login when session refresh fails", async ({ page }) => {
   let graphqlFailures = 0;
 
-  const errorBoundary = await trackErrorBoundaryFlash(page);
   await openProjectsPage(page);
-  await delayLoginDocument(page);
 
   await page.route("**/graphql", async (route) => {
     if (graphqlFailures === 0) {
@@ -157,8 +155,6 @@ test("redirects to login when session refresh fails", async ({ page }) => {
   // returnUrl round-trips the projects URL, which may carry a recreatable time
   // range (e.g. an encoded ?timeRangeKey=7d), so match the returnUrl prefix.
   await page.waitForURL(/\/login\?returnUrl=%2Fprojects/);
-
-  expect(errorBoundary.seen).toBe(false);
 });
 
 test("redirects to login when session refresh times out", async ({ page }) => {


### PR DESCRIPTION
resolves #15774

Visiting Phoenix unauthenticated (auth enabled, no valid tokens) briefly flashed the error boundary ("Something went wrong") before the browser landed on `/login`. The failed token refresh set `window.location.href` and re-threw; since `window.location.href` navigation is asynchronous, the rejection surfaced through Relay/Suspense into the router's `errorElement` / `ErrorBoundary` fallback while the login document was still loading.

## Changes

- `refreshTokens()` now rejects with a dedicated `RedirectingToLoginError` (carrying the original failure as `cause`) after starting the login redirect, so error surfaces can distinguish "redirect in progress" from a real failure.
- `authFetch` tracks that a login redirect is underway (`isRedirectingToLogin()`); fetches interrupted by the in-progress navigation — which Firefox rejects with a generic `TypeError` rather than an `AbortError` — are also treated as redirect-in-progress instead of surfacing as generic errors.
- During the handoff, the route-level `ErrorElement` shows a single neutral loading state and nested `ErrorBoundary` fallbacks render nothing (no stacked spinners), instead of the error page.
- The `invariant(response.ok, ...)` in `authFetch` was dead in practice (`refreshTokens` only resolves with ok responses); it is replaced with the same defensive redirect-and-throw path.

## Testing

- Playwright regression test: an unauthenticated visit to `/projects` must reach `/login` without the error boundary ever painting. A `MutationObserver` installed via init script catches transient flashes, and the login *document* response is delayed so the old document stays visible during the handoff (on localhost the navigation is otherwise near-instant, masking the regression — verified the test fails against the pre-fix code and passes with the fix).
- Unit test: `authFetch` rejects with `RedirectingToLoginError` when the token refresh fails, and again for a fetch interrupted during the handoff.
- Verified in both Chromium and Firefox against a live server; `tests/auth-refresh.spec.ts` passes locally along with lint, typecheck, prettier, and unit tests.

Note: Firefox can also flash the error boundary in the *outgoing* document on any reload/navigation that interrupts in-flight fetches before a redirect starts — that behavior predates this change and is independent of the auth redirect path, so it's left out of scope.