### PR TITLE
perf(traces): correlate and scope filtered trace query lowering

### DIFF
--- a/internal_docs/specs/trace-filter-dsl.md
+++ b/internal_docs/specs/trace-filter-dsl.md
@@ -111,11 +111,20 @@ another trace cannot leak elements into a predicate.
 Both `Project.spans` query paths use probe lowering: the trace-start-time paginator and the
 general span listing are limited page queries, so correlated predicates can stop after
 satisfying the limit. Aggregate subqueries remain bounded by the candidate project, time
-range, and trace IDs. Scan-lowered comprehension subqueries use the same bounds. `all()` keeps
-its correlated `NOT EXISTS` shape under both lowerings because an uncorrelated `NOT IN` must
-materialize every counterexample and cannot be planned as an anti-join efficiently. Scan lowering
-remains the helper default for future unbounded analytical callers; both lowerings must agree with
-the Python reference evaluator.
+range, and trace IDs. Scan-lowered reduction subqueries (`len`, `sum`, `max`, …) use the same
+bounds. Quantifiers — `any()`, `all()`, and their negations — keep their correlated `EXISTS` /
+`NOT EXISTS` shape under both lowerings, so no spelling reaches an uncorrelated `NOT IN`.
+That shape is avoided because PostgreSQL does not convert an uncorrelated `NOT IN` into an
+anti-join at all — `NOT IN`'s NULL semantics forbid it — leaving a hashed `SubPlan` when the
+estimated anti-set fits `work_mem × hash_mem_multiplier` and a per-outer-row `SubPlan` when it
+does not. Scan lowering remains the helper default for future unbounded analytical callers;
+both lowerings must agree with the Python reference evaluator. The scan bounds are a pruning
+hint rather than a semantic filter, and the correlated probes carry no bounds of their own
+(the outer statement's scope already bounds the anti-join, and repeating it inside `NOT EXISTS`
+measured slower), so the two lowerings agree only when the outer statement already selects the
+same trace universe — the same projects, the same `Trace.start_time` window, the same candidate
+IDs. Callers that pass the bounds must bound the outer statement identically; the trace page
+does so on `Trace.start_time`.
 
 Filtering composes with the existing trace paginator before representative-root selection.
 It therefore preserves one edge per trace, trace-start-time window semantics, cursor behavior,

--- a/internal_docs/specs/trace-filter-dsl.md
+++ b/internal_docs/specs/trace-filter-dsl.md
@@ -111,8 +111,11 @@ another trace cannot leak elements into a predicate.
 Both `Project.spans` query paths use probe lowering: the trace-start-time paginator and the
 general span listing are limited page queries, so correlated predicates can stop after
 satisfying the limit. Aggregate subqueries remain bounded by the candidate project, time
-range, and trace IDs. Scan lowering remains the helper default for future unbounded analytical
-callers; both lowerings must agree with the Python reference evaluator.
+range, and trace IDs. Scan-lowered comprehension subqueries use the same bounds. `all()` keeps
+its correlated `NOT EXISTS` shape under both lowerings because an uncorrelated `NOT IN` must
+materialize every counterexample and cannot be planned as an anti-join efficiently. Scan lowering
+remains the helper default for future unbounded analytical callers; both lowerings must agree with
+the Python reference evaluator.
 
 Filtering composes with the existing trace paginator before representative-root selection.
 It therefore preserves one edge per trace, trace-start-time window semantics, cursor behavior,

--- a/scripts/perf/session_filter_perf.py
+++ b/scripts/perf/session_filter_perf.py
@@ -124,10 +124,19 @@ def _skewed_num_traces(rng: random.Random) -> int:
     return rng.randint(20, 60)
 
 
-def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
+def seed(
+    engine: Engine,
+    n_sessions: int,
+    rng: random.Random,
+    *,
+    reset: bool = True,
+    project_name: str = "perf",
+    id_prefix: str = "",
+) -> dict[str, Any]:
     """Bulk-seed one project with ``n_sessions`` skewed sessions; return counts + rowids."""
-    models.Base.metadata.drop_all(engine)
-    models.Base.metadata.create_all(engine)
+    if reset:
+        models.Base.metadata.drop_all(engine)
+        models.Base.metadata.create_all(engine)
     trace_rows: list[dict[str, Any]] = []
     span_rows: list[dict[str, Any]] = []
     cost_rows: list[dict[str, Any]] = []
@@ -139,14 +148,14 @@ def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
             conn.exec_driver_sql("PRAGMA synchronous=OFF")
             conn.exec_driver_sql("PRAGMA journal_mode=MEMORY")
         project_id = conn.execute(
-            models.Project.__table__.insert().values(name="perf").returning(models.Project.id)
+            models.Project.__table__.insert().values(name=project_name).returning(models.Project.id)
         ).scalar_one()
 
         for _ in range(n_sessions):
             start = _EPOCH + timedelta(seconds=rng.randint(0, 10_000_000))
             session_rows.append(
                 {
-                    "session_id": f"s{rng.getrandbits(48):x}",
+                    "session_id": f"{id_prefix}s{rng.getrandbits(48):x}",
                     "project_id": project_id,
                     "start_time": start,
                     "end_time": start + timedelta(seconds=rng.randint(1, 600)),
@@ -177,7 +186,7 @@ def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
                 trace_start = base + timedelta(seconds=trace_index)
                 trace_rows.append(
                     {
-                        "trace_id": f"t{trace_counter:x}",
+                        "trace_id": f"{id_prefix}t{trace_counter:x}",
                         "project_rowid": project_id,
                         "project_session_rowid": session_rowid,
                         "start_time": trace_start,
@@ -213,7 +222,7 @@ def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
         annotated_span_ids: list[str] = []
         for trace_id, session_rowid in trace_ids:
             spans_in_trace = rng.randint(8, 16)
-            root_span_id = f"sp{span_counter:x}"
+            root_span_id = f"{id_prefix}sp{span_counter:x}"
             root_start = _EPOCH + timedelta(seconds=rng.randint(0, 10_000_000))
             model = rng.choice(_MODELS)
             attributes: dict[str, Any] = {"input": {"value": rng.choice(_INPUTS)}}
@@ -240,7 +249,7 @@ def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
                 else:
                     kind = "TOOL" if rng.random() < 0.5 else "LLM"
                 errored = session_rowid in erroring_sessions and rng.random() < 0.2
-                span_id = f"sp{span_counter:x}"
+                span_id = f"{id_prefix}sp{span_counter:x}"
                 span_rows.append(
                     _span_row(
                         span_id,
@@ -259,7 +268,9 @@ def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
         span_rowids = dict(
             conn.execute(
                 select(models.Span.span_id, models.Span.id).where(
-                    models.Span.trace_rowid.in_(select(models.Trace.id))
+                    models.Span.trace_rowid.in_(
+                        select(models.Trace.id).where(models.Trace.project_rowid == project_id)
+                    )
                 )
             ).all()
         )
@@ -280,7 +291,15 @@ def seed(engine: Engine, n_sessions: int, rng: random.Random) -> dict[str, Any]:
                 ],
             )
 
-        cost_ids = list(conn.execute(select(models.SpanCost.id)).scalars())
+        cost_ids = list(
+            conn.execute(
+                select(models.SpanCost.id).where(
+                    models.SpanCost.trace_rowid.in_(
+                        select(models.Trace.id).where(models.Trace.project_rowid == project_id)
+                    )
+                )
+            ).scalars()
+        )
         detail_rows = [
             {
                 "span_cost_id": cost_id,

--- a/src/phoenix/db/trace_aggregates.py
+++ b/src/phoenix/db/trace_aggregates.py
@@ -20,6 +20,7 @@ __all__ = [
     "TRACE_ROWID",
     "SPAN_ROWID",
     "TraceAggregate",
+    "apply_trace_scope",
     "cost_summary_by_trace",
     "error_count_by_trace",
     "num_spans_by_trace",
@@ -60,7 +61,7 @@ class TraceAggregate:
         stmt = self._base((self.group_key.label(TRACE_ROWID), *projected))
         if keys is not None:
             stmt = stmt.where(self.group_key.in_(keys))
-        stmt = _apply_scope(stmt, self.group_key, project_rowids, start_time, end_time)
+        stmt = apply_trace_scope(stmt, self.group_key, project_rowids, start_time, end_time)
         return stmt.group_by(self.group_key)
 
     def as_correlated_scalar(
@@ -74,7 +75,7 @@ class TraceAggregate:
         """Return one aggregate value correlated to ``trace_col``."""
         column = self.values[0] if value is None else self._value(value)
         stmt = self._base((column,)).where(self.group_key == trace_col)
-        stmt = _apply_scope(stmt, self.group_key, project_rowids, start_time, end_time)
+        stmt = apply_trace_scope(stmt, self.group_key, project_rowids, start_time, end_time)
         return stmt.scalar_subquery()
 
     def _value(self, name: str) -> KeyedColumnElement[Any]:
@@ -173,7 +174,9 @@ def representative_root_span_by_trace(
     ).where(root_predicate)
     if keys is not None:
         ranked = ranked.where(models.Span.trace_rowid.in_(keys))
-    ranked = _apply_scope(ranked, models.Span.trace_rowid, project_rowids, start_time, end_time)
+    ranked = apply_trace_scope(
+        ranked, models.Span.trace_rowid, project_rowids, start_time, end_time
+    )
     ranked_subquery = ranked.subquery()
     return select(
         ranked_subquery.c[TRACE_ROWID],
@@ -181,13 +184,19 @@ def representative_root_span_by_trace(
     ).where(ranked_subquery.c[_ROOT_SPAN_RANK] == 1)
 
 
-def _apply_scope(
+def apply_trace_scope(
     stmt: Select[Any],
     trace_key: Any,
     project_rowids: Optional[Collection[int]],
     start_time: Optional[Any],
     end_time: Optional[Any],
 ) -> Select[Any]:
+    """Bound a span-grain statement to the traces in ``project_rowids`` that start inside
+    ``[start_time, end_time)``, joining ``traces`` as ``trace_scope`` on ``trace_key``.
+
+    A no-op when no bound is given. Shared by the trace aggregates and the trace filter's
+    scan-lowered comprehension subqueries so both emit one scoping shape.
+    """
     if project_rowids is None and start_time is None and end_time is None:
         return stmt
     trace_scope = models.Trace.__table__.alias("trace_scope")

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -137,9 +137,9 @@ async def _get_results(
         if filter_condition:
             sf = SpanFilter(filter_condition)
             stmt = stmt.where(
-                models.Trace.id.in_(
-                    sf(select(models.Span.trace_rowid).distinct()).scalar_subquery()
-                )
+                sf(select(1).where(models.Span.trace_rowid == models.Trace.id))
+                .correlate(models.Trace)
+                .exists()
             )
     elif kind == "span":
         latency_column = cast(FloatCol, models.Span.latency_ms)

--- a/src/phoenix/trace/dsl/query.py
+++ b/src/phoenix/trace/dsl/query.py
@@ -13,7 +13,7 @@ import pandas as pd
 from openinference.semconv.trace import SpanAttributes
 from sqlalchemy import JSON, Column, Label, Select, SQLColumnExpression, and_, func, or_, select
 from sqlalchemy.dialects.postgresql import aggregate_order_by
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 from typing_extensions import assert_never
 
 from phoenix.config import DEFAULT_PROJECT_NAME
@@ -612,9 +612,12 @@ class SpanQuery(_HasTmpSuffix):
             # (a span whose parent_id references a span that doesn't exist in the database)
             if orphan_span_as_root_span:
                 # Include both types of root spans:
-                parent_spans = select(models.Span.span_id).alias("parent_spans")
+                parent_spans = aliased(models.Span, name="parent_spans")
                 stmt = stmt.where(
-                    ~select(1).where(models.Span.parent_id == parent_spans.c.span_id).exists(),
+                    ~select(1)
+                    .where(models.Span.parent_id == parent_spans.span_id)
+                    .correlate(models.Span)
+                    .exists(),
                     # Note: We avoid using an OR clause with Span.parent_id.is_(None) here
                     # because it significantly degraded PostgreSQL performance (>10x worse)
                     # during testing.
@@ -849,13 +852,14 @@ def _get_spans_dataframe(
         # (a span whose parent_id references a span that doesn't exist in the database)
         if orphan_span_as_root_span:
             # Include both types of root spans
-            parent_spans = select(models.Span.span_id).alias("parent_spans")
+            parent_spans = aliased(models.Span, name="parent_spans")
             candidate_spans = stmt.cte("candidate_spans")
             stmt = select(candidate_spans).where(
                 or_(
                     candidate_spans.c.parent_id.is_(None),
                     ~select(1)
-                    .where(candidate_spans.c.parent_id == parent_spans.c.span_id)
+                    .where(candidate_spans.c.parent_id == parent_spans.span_id)
+                    .correlate(candidate_spans)
                     .exists(),
                 ),
             )

--- a/src/phoenix/trace/dsl/session_filter.py
+++ b/src/phoenix/trace/dsl/session_filter.py
@@ -613,11 +613,10 @@ def _comprehension_bindings(
         return stmt.scalar_subquery()
 
     def build_scan(spec: ComprehensionSpec) -> typing.Any:
-        """The outermost comprehension as one uncorrelated pass over the element table.
+        """The outermost reduction as one uncorrelated, grouped pass over the element table.
 
-        `any` becomes a semi-join on the session rowid; reductions become a grouped subquery
-        the caller LEFT JOINs. `all` never takes this shape — see the dispatch below — and
-        nested comprehensions keep the correlated shape.
+        The caller LEFT JOINs the result on the session rowid. Quantifiers never take this
+        shape — see the dispatch below — and nested comprehensions keep the correlated shape.
         """
         iterable, element, element_globals, predicate = element_scope(spec)
         session_key = iterable.session_key(element)
@@ -639,8 +638,6 @@ def _comprehension_bindings(
                 stmt = stmt.where(eval(spec.condition, element_globals))
             return stmt
 
-        if spec.kind == "any":
-            return models.ProjectSession.id.in_(scan(session_key).where(predicate))
         value = func.count() if spec.kind == "len" else _REDUCTION_FUNCTIONS[spec.kind](predicate)
         return scan(session_key.label(SESSION_ROWID), value.label(VALUE)).group_by(session_key)
 
@@ -651,23 +648,25 @@ def _comprehension_bindings(
             continue
         if lowering != "scan":
             raise ValueError(f"Unknown filter lowering: {lowering}")
-        if spec.kind == "all":
-            # `all` keeps the correlated NOT EXISTS shape under both lowerings. The uncorrelated
-            # alternative — `id NOT IN (SELECT session_key … WHERE predicate IS NOT TRUE)` — puts
-            # every element that fails the test in the anti-set, which is most of the element
-            # table whenever the predicate is selective (i.e. whenever someone is actually
-            # filtering), and `NOT IN` over a set that size degrades past statement timeouts
-            # where the correlated form plans as a per-session anti-join probe. Measured on a
-            # 3M-span corpus: >90 s uncorrelated vs. under a second correlated. The correlated
-            # shape is also immune to the `NOT IN` NULL trap (a nullable session key never
-            # matches the correlation, where one NULL in a `NOT IN` set empties the result).
+        if spec.kind in QUANTIFIER_NAMES:
+            # Quantifiers keep the correlated EXISTS / NOT EXISTS shape under both lowerings.
+            # The uncorrelated alternatives are `id IN (SELECT session_key … WHERE predicate)`
+            # for `any` and `id NOT IN (…)` for `all` and for a negated `any`. The anti-set holds
+            # every element that fails (or, negated, passes) the test — most of the element table
+            # whenever the predicate is selective, i.e. whenever someone is actually filtering —
+            # and PostgreSQL never plans an uncorrelated `NOT IN` as an anti-join: it hashes the
+            # set when the row *estimate* fits work_mem and otherwise re-scans it per outer row.
+            # Measured: `all` on a 3M-span corpus >90 s uncorrelated vs. under a second
+            # correlated; `not any` on the session statistics path over 8.8M spans at the default
+            # work_mem >30 s (timeout) uncorrelated vs. 0.1–1.7 s correlated — the uncorrelated
+            # form finishes at all only when work_mem is large enough to hash the anti-set. The
+            # correlated shape is also immune to the `NOT IN` NULL
+            # trap: `traces.project_session_rowid` is nullable, so one session-less trace in the
+            # anti-set empties a `NOT IN` result, where a NULL key simply never matches the
+            # correlation.
             bindings_map[spec.name] = build(spec)
             continue
-        lowered = build_scan(spec)
-        if spec.kind in QUANTIFIER_NAMES:
-            bindings_map[spec.name] = lowered
-            continue
-        subquery = lowered.subquery()
+        subquery = build_scan(spec).subquery()
         stmt = stmt.outerjoin(subquery, models.ProjectSession.id == subquery.c[SESSION_ROWID])
         column = subquery.c[VALUE]
         # `max`/`min` over nothing is SQL NULL, which reads as missing and fails every comparison.

--- a/src/phoenix/trace/dsl/trace_filter.py
+++ b/src/phoenix/trace/dsl/trace_filter.py
@@ -19,6 +19,7 @@ from phoenix.db.trace_aggregates import (
     TRACE_ROWID,
     VALUE,
     TraceAggregate,
+    apply_trace_scope,
     cost_summary_by_trace,
     error_count_by_trace,
     num_spans_by_trace,
@@ -658,7 +659,14 @@ def _comprehension_bindings(
             return func.coalesce(element_stmt.scalar_subquery(), 0)
         return element_stmt.scalar_subquery()
 
-    def build_scan(spec: ComprehensionSpec) -> typing.Any:
+    def build_scan(spec: ComprehensionSpec) -> Select[typing.Any]:
+        """The outermost reduction as one uncorrelated, grouped pass over the element table.
+
+        The caller LEFT JOINs the result on the trace rowid. Quantifiers never take this shape
+        (see the dispatch below), and nested comprehensions keep the correlated shape. The
+        candidate, project, and time bounds are a pruning hint: they are sound only when the
+        outer statement already selects the same trace universe.
+        """
         iterable, scope, element_globals, predicate = element_scope(spec, ())
         element_trace_key = trace_key(iterable, scope)
 
@@ -666,21 +674,13 @@ def _comprehension_bindings(
             element_stmt = apply_joins(select(*columns).select_from(scope.element), iterable, scope)
             if candidate_trace_rowids is not None:
                 element_stmt = element_stmt.where(element_trace_key.in_(candidate_trace_rowids))
-            if project_rowids is not None or start_time is not None or end_time is not None:
-                trace_scope = aliased(models.Trace, name="trace_scope")
-                element_stmt = element_stmt.join(trace_scope, trace_scope.id == element_trace_key)
-                if project_rowids is not None:
-                    element_stmt = element_stmt.where(trace_scope.project_rowid.in_(project_rowids))
-                if start_time is not None:
-                    element_stmt = element_stmt.where(trace_scope.start_time >= start_time)
-                if end_time is not None:
-                    element_stmt = element_stmt.where(trace_scope.start_time < end_time)
+            element_stmt = apply_trace_scope(
+                element_stmt, element_trace_key, project_rowids, start_time, end_time
+            )
             if spec.condition is not None:
                 element_stmt = element_stmt.where(eval(spec.condition, element_globals))
             return element_stmt
 
-        if spec.kind == "any":
-            return models.Trace.id.in_(scan(element_trace_key).where(predicate))
         value = func.count() if spec.kind == "len" else _REDUCTION_FUNCTIONS[spec.kind](predicate)
         return scan(element_trace_key.label(TRACE_ROWID), value.label(VALUE)).group_by(
             element_trace_key
@@ -693,15 +693,17 @@ def _comprehension_bindings(
             continue
         if lowering != "scan":
             raise ValueError(f"Unknown filter lowering: {lowering}")
-        if spec.kind == "all":
-            # `all` keeps the correlated NOT EXISTS shape under both lowerings.
+        if spec.kind in QUANTIFIER_NAMES:
+            # Quantifiers keep the correlated EXISTS / NOT EXISTS shape under both lowerings,
+            # which PostgreSQL decorrelates into semi- and anti-joins. The uncorrelated
+            # alternatives are `traces.id IN (SELECT trace_rowid …)` for `any` and
+            # `traces.id NOT IN (…)` for `all` and for a negated `any` — and PostgreSQL never
+            # plans an uncorrelated `NOT IN` as an anti-join: it hashes the set when the row
+            # *estimate* fits work_mem and otherwise re-scans it per outer row, past statement
+            # timeouts once the anti-set is large. Only reductions take the scan shape.
             bindings_map[spec.name] = build(spec)
             continue
-        lowered = build_scan(spec)
-        if spec.kind in QUANTIFIER_NAMES:
-            bindings_map[spec.name] = lowered
-            continue
-        subquery = lowered.subquery()
+        subquery = build_scan(spec).subquery()
         stmt = stmt.outerjoin(subquery, models.Trace.id == subquery.c[TRACE_ROWID])
         column = subquery.c[VALUE]
         bindings_map[spec.name] = (

--- a/src/phoenix/trace/dsl/trace_filter.py
+++ b/src/phoenix/trace/dsl/trace_filter.py
@@ -515,6 +515,10 @@ _REDUCTION_FUNCTIONS: typing.Mapping[str, typing.Any] = MappingProxyType(
 def _comprehension_bindings(
     stmt: Select[typing.Any],
     specs: typing.Iterable[ComprehensionSpec],
+    candidate_trace_rowids: typing.Optional[typing.Collection[int]],
+    project_rowids: typing.Optional[typing.Sequence[int]],
+    start_time: typing.Optional[typing.Any],
+    end_time: typing.Optional[typing.Any],
     lowering: FilterLowering,
 ) -> tuple[Select[typing.Any], dict[str, typing.Any]]:
     aliases = count()
@@ -660,15 +664,23 @@ def _comprehension_bindings(
 
         def scan(*columns: typing.Any) -> Select[typing.Any]:
             element_stmt = apply_joins(select(*columns).select_from(scope.element), iterable, scope)
+            if candidate_trace_rowids is not None:
+                element_stmt = element_stmt.where(element_trace_key.in_(candidate_trace_rowids))
+            if project_rowids is not None or start_time is not None or end_time is not None:
+                trace_scope = aliased(models.Trace, name="trace_scope")
+                element_stmt = element_stmt.join(trace_scope, trace_scope.id == element_trace_key)
+                if project_rowids is not None:
+                    element_stmt = element_stmt.where(trace_scope.project_rowid.in_(project_rowids))
+                if start_time is not None:
+                    element_stmt = element_stmt.where(trace_scope.start_time >= start_time)
+                if end_time is not None:
+                    element_stmt = element_stmt.where(trace_scope.start_time < end_time)
             if spec.condition is not None:
                 element_stmt = element_stmt.where(eval(spec.condition, element_globals))
             return element_stmt
 
         if spec.kind == "any":
             return models.Trace.id.in_(scan(element_trace_key).where(predicate))
-        if spec.kind == "all":
-            # Every trace correlation key is non-null, so no nullable-key guard is needed.
-            return models.Trace.id.not_in(scan(element_trace_key).where(predicate.is_not(True)))
         value = func.count() if spec.kind == "len" else _REDUCTION_FUNCTIONS[spec.kind](predicate)
         return scan(element_trace_key.label(TRACE_ROWID), value.label(VALUE)).group_by(
             element_trace_key
@@ -681,6 +693,10 @@ def _comprehension_bindings(
             continue
         if lowering != "scan":
             raise ValueError(f"Unknown filter lowering: {lowering}")
+        if spec.kind == "all":
+            # `all` keeps the correlated NOT EXISTS shape under both lowerings.
+            bindings_map[spec.name] = build(spec)
+            continue
         lowered = build_scan(spec)
         if spec.kind in QUANTIFIER_NAMES:
             bindings_map[spec.name] = lowered
@@ -783,7 +799,11 @@ class TraceFilter:
         stmt, comprehension_bindings = _comprehension_bindings(
             stmt,
             self._comprehensions,
-            lowering,
+            candidate_trace_rowids=candidate_trace_rowids,
+            project_rowids=project_rowids,
+            start_time=start_time,
+            end_time=end_time,
+            lowering=lowering,
         )
         extra_bindings = {
             **self._literal_bindings,

--- a/tests/unit/server/api/dataloaders/test_latency_ms_quantiles.py
+++ b/tests/unit/server/api/dataloaders/test_latency_ms_quantiles.py
@@ -1,15 +1,23 @@
+from collections.abc import AsyncIterator
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal, cast
 
 import numpy as np
 import pandas as pd
 import pytest
-from sqlalchemy import select
+from sqlalchemy import Select, select
+from sqlalchemy.dialects import postgresql, sqlite
+from sqlalchemy.engine.interfaces import Dialect
 
 from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.server.api.dataloaders import latency_ms_quantile
 from phoenix.server.api.dataloaders.latency_ms_quantile import Key, LatencyMsQuantileDataLoader
 from phoenix.server.api.input_types.TimeRange import TimeRange
 from phoenix.server.types import DbSessionFactory
+
+_SQLITE_DIALECT = cast(Dialect, sqlite.dialect())
+_POSTGRESQL_DIALECT = cast(Dialect, postgresql.dialect())  # type: ignore[no-untyped-call]
 
 
 async def test_latency_ms_quantiles_p25_p50_p75(
@@ -65,3 +73,51 @@ async def test_latency_ms_quantiles_p25_p50_p75(
     ]
     actual = await LatencyMsQuantileDataLoader(db)._load_fn(keys)
     assert actual == pytest.approx(expected, 1e-7)
+
+
+@pytest.mark.parametrize(
+    "dialect",
+    [_SQLITE_DIALECT, _POSTGRESQL_DIALECT],
+)
+async def test_trace_filter_compiles_to_correlated_span_exists(
+    dialect: Dialect,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statements: list[Select[Any]] = []
+
+    async def capture_statement(
+        session: Any,
+        base_stmt: Select[Any],
+        latency_column: Any,
+        params: Any,
+    ) -> AsyncIterator[tuple[int, float]]:
+        statements.append(base_stmt)
+        if False:
+            yield 0, 0.0
+
+    monkeypatch.setattr(latency_ms_quantile, "_get_results_sqlite", capture_statement)
+    segment: latency_ms_quantile.Segment = (
+        "trace",
+        (None, None),
+        'status_code == "ERROR"',
+        None,
+    )
+    params = {(7, 0.5): [0]}
+    assert not [
+        result
+        async for result in latency_ms_quantile._get_results(
+            SupportedSQLDialect.SQLITE,
+            cast(Any, None),
+            segment,
+            params,
+        )
+    ]
+
+    assert len(statements) == 1
+    sql = str(
+        statements[0].compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    ).lower()
+    assert "exists (select 1" in sql
+    assert "spans.trace_rowid = traces.id" in sql
+    assert "traces.id in (select" not in sql
+    assert "select distinct spans.trace_rowid" not in sql

--- a/tests/unit/server/api/dataloaders/test_latency_ms_quantiles.py
+++ b/tests/unit/server/api/dataloaders/test_latency_ms_quantiles.py
@@ -117,7 +117,11 @@ async def test_trace_filter_compiles_to_correlated_span_exists(
     sql = str(
         statements[0].compile(dialect=dialect, compile_kwargs={"literal_binds": True})
     ).lower()
-    assert "exists (select 1" in sql
+    # Pin the inner FROM as well: an uncorrelated `exists (select 1 from spans, traces where
+    # spans.trace_rowid = traces.id …)` would satisfy both fragments below on their own and
+    # match every trace with any matching span anywhere.
+    normalized = " ".join(sql.split())
+    assert "exists (select 1 from spans where" in normalized
     assert "spans.trace_rowid = traces.id" in sql
     assert "traces.id in (select" not in sql
     assert "select distinct spans.trace_rowid" not in sql

--- a/tests/unit/trace/dsl/test_trace_filter.py
+++ b/tests/unit/trace/dsl/test_trace_filter.py
@@ -150,6 +150,52 @@ async def _matched_rowids(
 
 
 @pytest.mark.parametrize("lowering", ["scan", "probe"])
+async def test_scoped_trace_filter_agrees_with_reference_evaluator(
+    db: DbSessionFactory,
+    lowering: FilterLowering,
+) -> None:
+    """The candidate/project/time bounds are a pruning hint for the scan-lowered reduction
+    subqueries. They are sound only when the outer statement already selects the same trace
+    universe — which this test's outer statement does — and under that precondition both
+    lowerings must still agree with the reference evaluator on every differential condition."""
+    window_start = FIXTURE_TRACES[0].start_time
+    window_end = window_start + timedelta(minutes=2)
+    in_window = [f for f in FIXTURE_TRACES if window_start <= f.start_time < window_end]
+    assert 1 < len(in_window) < len(FIXTURE_TRACES)
+    # Drop one in-window trace from the candidates so every bound prunes something.
+    selected = in_window[:1] + in_window[2:]
+    async with db() as session:
+        project = await _add_project(session)
+        rowids = {
+            fixture.trace_id: (await _seed_reference_trace(session, project, fixture)).id
+            for fixture in FIXTURE_TRACES
+        }
+        candidates = [rowids[fixture.trace_id] for fixture in selected]
+        base_stmt = (
+            select(models.Trace.id)
+            .where(models.Trace.project_rowid == project.id)
+            .where(models.Trace.start_time >= window_start)
+            .where(models.Trace.start_time < window_end)
+            .where(models.Trace.id.in_(candidates))
+        )
+        for condition in DIFFERENTIAL_CONDITIONS:
+            stmt = TraceFilter(condition)(
+                base_stmt,
+                candidate_trace_rowids=candidates,
+                project_rowids=[project.id],
+                start_time=window_start,
+                end_time=window_end,
+                lowering=lowering,
+            )
+            stmt.compile(dialect=_SQLITE_DIALECT)
+            stmt.compile(dialect=_POSTGRESQL_DIALECT)
+            expected = {
+                rowids[fixture.trace_id] for fixture in selected if matches(condition, fixture)
+            }
+            assert set(await session.scalars(stmt)) == expected, condition
+
+
+@pytest.mark.parametrize("lowering", ["scan", "probe"])
 async def test_trace_filter_agrees_with_reference_evaluator(
     db: DbSessionFactory,
     lowering: FilterLowering,
@@ -395,19 +441,30 @@ def test_scan_aggregate_subquery_is_scoped_to_candidates_project_and_time() -> N
 
 
 @pytest.mark.parametrize("dialect", [_SQLITE_DIALECT, _POSTGRESQL_DIALECT])
-def test_trace_filter_all_keeps_correlated_shape_under_scan_lowering(
+@pytest.mark.parametrize(
+    "condition,shape",
+    [
+        ('all(s.status_code == "OK" for s in spans)', "not (exists (select 1"),
+        ('not any(s.status_code == "ERROR" for s in spans)', "not (exists (select 1"),
+        ('any(s.status_code == "ERROR" for s in spans)', "exists (select 1"),
+    ],
+)
+def test_trace_filter_quantifiers_keep_correlated_shape_under_scan_lowering(
     dialect: Dialect,
+    condition: str,
+    shape: str,
 ) -> None:
+    """No quantifier spelling reaches an uncorrelated `IN` / `NOT IN` anti-set under scan."""
     sql = str(
-        TraceFilter('all(s.status_code == "OK" for s in spans)')(
+        TraceFilter(condition)(
             select(models.Trace.id),
             project_rowids=[7],
             lowering="scan",
         ).compile(dialect=dialect, compile_kwargs={"literal_binds": True})
     ).lower()
 
-    assert "not (exists" in sql
-    assert "not in (select" not in sql
+    assert shape in sql
+    assert "in (select" not in sql
     assert "spans_0.trace_rowid = traces.id" in sql
 
 
@@ -430,11 +487,16 @@ def test_scan_comprehension_subqueries_are_scoped_to_candidates_project_and_time
         ).compile(dialect=dialect, compile_kwargs={"literal_binds": True})
     ).lower()
 
-    assert sql.count("join traces as trace_scope") == 2
-    assert sql.count("trace_scope.project_rowid in (7)") == 2
-    assert sql.count("trace_scope.start_time >=") == 2
-    assert sql.count("trace_scope.start_time <") == 2
-    assert sql.count("trace_rowid in (11, 12)") == 2
+    # Only the `len` reduction takes the scan shape and carries the bounds; the quantifier
+    # stays a correlated probe against the trace's own spans.
+    assert sql.count("join traces as trace_scope") == 1
+    assert sql.count("trace_scope.project_rowid in (7)") == 1
+    assert sql.count("trace_scope.start_time >=") == 1
+    assert sql.count("trace_scope.start_time <") == 1
+    assert sql.count("trace_rowid in (11, 12)") == 1
+    assert "traces.id in (select" not in sql
+    assert "exists (select 1" in sql
+    assert "from spans as spans_0 where spans_0.trace_rowid = traces.id" in " ".join(sql.split())
 
 
 def test_trace_page_filter_uses_probe_lowering() -> None:

--- a/tests/unit/trace/dsl/test_trace_filter.py
+++ b/tests/unit/trace/dsl/test_trace_filter.py
@@ -394,6 +394,49 @@ def test_scan_aggregate_subquery_is_scoped_to_candidates_project_and_time() -> N
     assert "trace_scope.start_time <" in sql
 
 
+@pytest.mark.parametrize("dialect", [_SQLITE_DIALECT, _POSTGRESQL_DIALECT])
+def test_trace_filter_all_keeps_correlated_shape_under_scan_lowering(
+    dialect: Dialect,
+) -> None:
+    sql = str(
+        TraceFilter('all(s.status_code == "OK" for s in spans)')(
+            select(models.Trace.id),
+            project_rowids=[7],
+            lowering="scan",
+        ).compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    ).lower()
+
+    assert "not (exists" in sql
+    assert "not in (select" not in sql
+    assert "spans_0.trace_rowid = traces.id" in sql
+
+
+@pytest.mark.parametrize("dialect", [_SQLITE_DIALECT, _POSTGRESQL_DIALECT])
+def test_scan_comprehension_subqueries_are_scoped_to_candidates_project_and_time(
+    dialect: Dialect,
+) -> None:
+    start_time = FIXTURE_TRACES[0].start_time
+    sql = str(
+        TraceFilter(
+            'any(s.status_code == "ERROR" for s in spans) '
+            "and len([s for s in spans if s.span_kind == 'LLM']) > 0"
+        )(
+            select(models.Trace.id),
+            candidate_trace_rowids=[11, 12],
+            project_rowids=[7],
+            start_time=start_time,
+            end_time=start_time + timedelta(hours=1),
+            lowering="scan",
+        ).compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    ).lower()
+
+    assert sql.count("join traces as trace_scope") == 2
+    assert sql.count("trace_scope.project_rowid in (7)") == 2
+    assert sql.count("trace_scope.start_time >=") == 2
+    assert sql.count("trace_scope.start_time <") == 2
+    assert sql.count("trace_rowid in (11, 12)") == 2
+
+
 def test_trace_page_filter_uses_probe_lowering() -> None:
     sql = str(
         apply_trace_filter_to_page(


### PR DESCRIPTION
Fixes #15427

Filtered trace and session queries could scan the entire span table — across all projects — or materialize an uncorrelated `NOT IN` anti-set that PostgreSQL never plans as an anti-join, instead of probing only the traces or sessions under consideration. This PR moves the affected query shapes to correlated, scoped forms on both grains. Queries and tests only: no schema changes, no new parameters or configuration.

## Performance impact

Measured on PostgreSQL 17.11 with a 7.0M-span corpus (8.8M spans in the two-project variant); full methodology and tables below.

| Query shape | Before | After |
|---|---|---|
| Session statistics with a `not any(...)` filter, scan lowering (the production path for session-filtered aside statistics) | **Timed out at 30 s** at PostgreSQL's default `work_mem` (uncorrelated `NOT IN` anti-set, per-row `SubPlan`); 1.46 s only when `work_mem` is large enough to hash the 3.97M-row estimate | **1.75 s** (large project) / **111 ms** (small project) — correlated `NOT EXISTS`, planned as an anti-join |
| Trace filter `all(...)`, scan lowering | **Timed out at 30 s in 5/5 runs** (uncorrelated `NOT IN` anti-set) | **1.3 s** — hash right anti-join, within 1% of the probe lowering |
| Filtered trace latency quantile on a multi-project instance | **1,254 ms** — scans and deduplicates **all 8.77M spans in the database**, regardless of which project is queried | **199 ms (6.3×)** — indexed probes over only the queried project's traces |

The quantile improvement is the load-bearing one for the trace grain, and the ratio understates it: the old shape's cost grows with the *whole instance's* span count, while the new shape's cost tracks only the queried project. At the measured 4:1 project-size ratio that is 6.3×; on a busier multi-tenant instance where the queried project is a small fraction of total spans, the gap keeps widening — the 199 ms side stays flat.

On the trace grain, no caller *executes* the scan lowering today: the two executing callers (the span listing and the trace page) select the probe lowering, and `validateTraceFilterCondition` selects scan but only compiles. Scan is still the helper default, so the first analytical trace caller added would have inherited the timeout. On the session grain the scan lowering *is* the production path for session-filtered statistics, and `not any(...)` still reached the anti-set there. This PR removes the uncorrelated `IN` / `NOT IN` shape for every quantifier spelling — `any(...)`, `all(...)`, `not any(...)` — on both grains, rather than relying on every future caller to keep opting out.

## Changes

1. **`latency_ms_quantile` (trace kind + span filter)** — the span filter was applied as an uncorrelated `Trace.id IN (SELECT DISTINCT spans.trace_rowid …)` with no project or time scope on the inner select. It now compiles as a correlated `EXISTS` probe against each candidate trace's own spans.
2. **Trace and session filter DSLs: quantifiers keep the correlated shape under both lowerings** — previously, scan lowering compiled `any(...)` to `id IN (<set>)` and `all(...)` to `id NOT IN (<anti-set>)`; the session compiler had already carved `all(...)` out (#14101), but a negated `any(...)` renders the same `NOT IN` on both grains. Every quantifier now lowers to a correlated `EXISTS` / `NOT EXISTS`, which PostgreSQL decorrelates into semi- and anti-joins regardless of the anti-set's row estimate or `work_mem`. Only reductions (`len`, `sum`, `max`, …) take the scan shape. On the session grain this also removes a latent correctness bug: `traces.project_session_rowid` is nullable, so one session-less trace in the anti-set would have emptied a `NOT IN` result on a request with no time range.
3. **Trace filter DSL: scan reduction subqueries are scoped** — scan-lowered reduction subqueries carried no candidate/project/time bounds and aggregated spans across every project. They now inherit the outer statement's scope through `apply_trace_scope` (promoted from `trace_aggregates._apply_scope`), so the filter and the aggregates emit one scoping shape.
4. **`SpanQuery(root_spans_only=True)`** — the parent-existence probe now uses a plain table alias instead of a derived table, the shape already used by the span filter's `parent_span` predicate. Plan-identical on PostgreSQL (measured below); the table alias avoids relying on subquery flattening, which is more conservative on SQLite.
5. **`scripts/perf/session_filter_perf.py`** — `seed()` gains keyword-only `reset`, `project_name`, and `id_prefix` arguments so a multi-project corpus can be built by seeding twice. Defaults are unchanged.

`internal_docs/specs/trace-filter-dsl.md` is updated to document the lowering behavior: which spellings correlate (all quantifiers), why `NOT IN` is avoided (PostgreSQL does not convert an uncorrelated `NOT IN` into an anti-join at all), and the precondition on the scope arguments (a pruning hint, sound only when the outer statement selects the same trace universe).

## Why this closes #15427

The issue reported session-filter statistics timing out under the scan lowering with `all(...)` conditions. #14101 carved `all(...)` out, and re-measurement on current `main` confirms the `all(...)` spelling no longer times out (medians of 1.05–1.71 s across `count` and 1,000-candidate `sweep` patterns). But `all(...)` is one spelling of the anti-set, not the only one: `not any(...)` still rendered the same uncorrelated `NOT IN` on the session grain, and the session statistics statement with a `not any(...)` filter still exceeded a 30 s timeout on this corpus. This PR routes every quantifier through the correlated builder on both grains, so no spelling reaches `NOT IN`; the trace-side anti-set and the unscoped quantile scan are fixed alongside.

## Measurements

PostgreSQL 17.11, parallelism and JIT disabled, 30 s statement timeout, `EXPLAIN (ANALYZE, BUFFERS, SETTINGS)`, one warmup then five measured runs per query in randomized order; medians and nearest-rank p95. Corpus built with `scripts/perf/session_filter_perf.py` using the `seed()` extension committed here: the single-project corpus is one `seed(engine, 100_000, rng)` call; the two-project corpus adds `seed(engine, 25_000, rng, reset=False, project_name="small", id_prefix="b")` on top of it (the first project is named `large`).

<details>
<summary>Corpus shape</summary>

| Corpus | Project | Sessions | Traces | Spans |
|---|---:|---:|---:|---:|
| Single-project | large | 100,000 | 584,822 | 7,019,036 |
| Multi-project | large | 100,000 | 584,822 | 7,019,036 |
| Multi-project | small (queried) | 25,000 | 145,908 | 1,750,634 |
| Multi-project total | 2 projects | 125,000 | 730,730 | 8,769,670 |

`fsync`/`synchronous_commit` were off during corpus construction and measurement.
</details>

### Session statistics with `not any(...)` under scan lowering

`not any(s.span_kind == "LLM" for s in spans)` on the two-project corpus, `count` (an exact filtered session count) and 1,000-candidate `sweep`, one warmup then three measured runs, medians. `any(...)` is included as the no-regression check.

All four pre-change statements plan the anti-set as a per-outer-row `SubPlan` at PostgreSQL's default `work_mem` (4 MB) — the estimate is 3.97M rows for the large project — and are cancelled at 30 s. The same statements finish only when `work_mem` is raised far enough to hash the set (at this instance's configured 64 MB: 1,456 ms large / 1,075 ms small as a `hashed SubPlan`), which is the plan flip the spec now describes. The correlated shape plans as an anti-join at either setting.

| Project | Access | Before: `NOT IN` anti-set (work_mem 4 MB) | After: correlated `NOT EXISTS` | `any(...)` before → after |
|---|---|---|---|---|
| large | count | **>30,000 ms, timeout**; per-row `SubPlan` | **1,747 ms**; hash right anti join | 1,767 → 1,838 ms |
| large | sweep | **>30,000 ms, timeout**; per-row `SubPlan` | **1,716 ms**; hash right anti join | 1,783 → 1,816 ms |
| small | count | **>30,000 ms, timeout**; per-row `SubPlan` | **111 ms**; nested-loop anti join | 110 → 119 ms |
| small | sweep | **>30,000 ms, timeout**; per-row `SubPlan` | **106 ms**; nested-loop anti join | 15 → 14 ms |

`any(...)` is included as the no-regression check: its correlated `EXISTS` decorrelates to the same semi-join the old `IN (SELECT …)` produced.

### Trace `all(...)` under scan lowering

Selective: `all(s.span_kind == "LLM" for s in spans)` (29,296 matching traces). Nonselective: `all(s.status_code == "OK" for s in spans)` (559,660 matching traces).

| Predicate | Baseline scan | Fixed scan | Fixed probe (reference) |
|---|---|---|---|
| Selective | **>30,000 ms; 5/5 timeouts**; materialized `NOT IN` SubPlan | **1,324.3 / 1,334.4 ms**; hash right anti-join | 1,311.3 / 1,320.0 ms |
| Nonselective | **>30,000 ms; 5/5 timeouts**; materialized `NOT IN` SubPlan | **1,255.9 / 1,279.2 ms**; hash right anti-join | 1,246.5 / 1,250.4 ms |

The baseline `NOT IN` shape never finishes inside the 30 s timeout at this corpus size. The fixed scan shape matches probe within 1%.

### Trace latency quantile with a span filter

The win case — querying the small project of a multi-project instance with a frequently matching filter (`span_kind == "LLM"`):

| Corpus | Before median / p95 | Before plan | After median / p95 | After plan |
|---|---:|---|---:|---|
| Multi-project, small project | 1,253.9 / 1,256.9 ms | Scans all 8.77M spans, deduplicates 730,730 trace IDs, hash join | **198.9 / 207.6 ms** | Nested-loop semi-join, `spans.trace_rowid` index probes over 145,908 candidate traces |

The correlated form lets the planner probe only the queried project's traces instead of paying for every project's spans on every quantile load.

<details>
<summary>Null results (measured and kept deliberately)</summary>

| Case | Before → After | Why unchanged | Why the change is kept |
|---|---|---|---|
| Quantile, single-project, frequent/rare | 1,279→1,296 ms / 622→621 ms | PostgreSQL decorrelates the `EXISTS` back to the equivalent hash-join plan | The correlated SQL *enables* project-local probes; single-project instances have no foreign spans to skip |
| Quantile, rare/zero-match on multi-project | ~710/~490 ms both sides | The planner still prefers a global span scan at these selectivities | No regression; the fix permits better plans, it doesn't force worse ones |
| Scan `any` + `len` reduction scoping | 2,296→2,313 ms (noise) | Planner keeps a global span scan at the 4:1 project-size ratio | Bounds the materialized groups (730,730 → 145,908) — a correctness-of-scale bound that pays off at higher skew |
| `root_spans_only` alias | 74.2→75.5 ms | PostgreSQL flattens the derived table into the identical index-only probe (`uq_spans_span_id`, 10,866 probes both sides) | Shape alignment with the span filter's existing predicate; SQLite's subquery flattening is more conservative |

</details>

### Session `all(...)` on current `main` (issue premise re-checked)

`all(s.span_kind == "LLM" for s in spans)` and mixed `any(...) and all(...)`, default scan lowering, `count` and 1,000-candidate `sweep`: medians 1,050–1,711 ms, zero timeouts. The `all(...)` spelling was already correlated by #14101; the `not any(...)` spelling above was not.

## Testing

- Shape-pinning tests, asserted against both SQLite and PostgreSQL compilation: scan-lowered trace `any(...)`, `all(...)`, and `not any(...)` compile with no `IN (SELECT` / `NOT IN (SELECT`; only the reduction subquery carries the project/time/candidate scope while the quantifier stays a correlated probe; the rewritten quantile statement correlates to `traces.id` with its inner `FROM` pinned to `spans` alone.
- Trace DSL differential reference tests (spec-grammar oracle vs compiled SQL) pass under both lowerings, including a new scoped variant that passes `candidate_trace_rowids`/`project_rowids`/`start_time`/`end_time` alongside an identically bounded outer statement.
- Session filter DSL, session/trace filter helper, trace aggregate, and `Project` session-filter suites pass with the mirrored carve-out; no test churn on the session side.
- `make format-python`, `lint-python`, `typecheck-python` clean.

https://claude.ai/code/session_01NwGZkfC5HZJ1eL1QezFyLZ
