### PR TITLE
ci: remove unit-test retries and bound hung tests

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -557,11 +557,11 @@ jobs:
       - name: Run SQLite tests
         if: matrix.db == 'sqlite'
         timeout-minutes: 60
-        run: uvx tox run -e unit_tests -- -ra --reruns 5 -n 16 --dist loadscope
+        run: uvx tox run -e unit_tests -- -ra --durations=20 --timeout 360 -n 16 --dist loadscope
       - name: Run PostgreSQL tests
         if: matrix.db == 'postgresql'
         timeout-minutes: 60
-        run: uvx tox run -e unit_tests -- -ra --reruns 5 --db postgresql -n 16 --dist loadscope --postgresql-exec /usr/lib/postgresql/14/bin/pg_ctl
+        run: uvx tox run -e unit_tests -- -ra --durations=20 --timeout 360 --db postgresql -n 16 --dist loadscope --postgresql-exec /usr/lib/postgresql/14/bin/pg_ctl
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -116,12 +116,12 @@ jobs:
           sudo apt-get -yqq install postgresql-14
       - name: Run SQLite tests
         if: matrix.db == 'sqlite'
-        timeout-minutes: 60
-        run: uvx tox run -e unit_tests -- -ra --reruns 5 -n 4 --dist loadscope
+        timeout-minutes: 90
+        run: uvx tox run -e unit_tests -- -ra --durations=20 --timeout 360 -n 4 --dist loadscope
       - name: Run PostgreSQL tests
         if: matrix.db == 'postgresql'
-        timeout-minutes: 60
-        run: uvx tox run -e unit_tests -- -ra --reruns 5 --db postgresql -n 4 --dist loadscope ${{ runner.os == 'Linux' && '--postgresql-exec /usr/lib/postgresql/14/bin/pg_ctl' || '' }}
+        timeout-minutes: 90
+        run: uvx tox run -e unit_tests -- -ra --durations=20 --timeout 360 --db postgresql -n 4 --dist loadscope ${{ runner.os == 'Linux' && '--postgresql-exec /usr/lib/postgresql/14/bin/pg_ctl' || '' }}
 
   integration-tests:
     name: Integration Tests (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.db }}, ${{ matrix.py }})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,8 @@ artifacts = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope="function"
+faulthandler_timeout = 300.0
+faulthandler_exit_on_timeout = false
 addopts = [
   "-rA",
   "--import-mode=importlib",

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,6 +8,7 @@ pydantic>=1.0,!=2.0.*,<3
 pyright[nodejs]==1.1.394
 pytest-randomly
 pytest-rerunfailures
+pytest-timeout
 deepdiff==8.6.2
 anthropic>=1,<2
 openai>=3.1.0,<4


### PR DESCRIPTION
## What

- Remove `--reruns 5` from the unit-test invocations in `python-CI.yml` and `python-all-platforms.yml`. Integration tests keep their retries.
- Add a per-test timeout to the unit-test invocations (`--timeout 360` via `pytest-timeout`, added to `requirements/ci.txt`) and set `faulthandler_timeout = 300.0` with `faulthandler_exit_on_timeout = false` (the pytest default, pinned explicitly) in `[tool.pytest.ini_options]`.
- Add `--durations=20` to the unit-test invocations so every run reports its slowest tests.
- Raise the nightly all-platforms unit-test legs from `timeout-minutes: 60` to `90`.

## Why

**Retries.** `--reruns 5` was a suite-wide policy that any unit-test failure may be retried until it passes. It absorbed every new flaky test silently: `-ra` prints only a rerun count, so a test that failed and passed on retry left no name behind. It also hid the early symptoms of shared-state contamination. During the CI incident of 2026-08-31, the `unit-tests (postgresql)` job wedged at 99% on several pull requests and sat silent until the 60-minute kill, and the only advance warning -- clusters of rerun markers immediately before the hang -- had been disappearing into green runs all day. Unit tests are expected to be deterministic. A genuinely timing-bound test can carry a per-test flaky marker, where the exception is visible and reviewed, instead of a suite-wide default that nobody re-approves. Integration tests keep their retries because their failures can be environmental: real network, containers, service startup.

**Timeouts.** No per-test timeout existed, so one hung await consumed the whole job budget anonymously and the log ended in a truncated progress line with no test name. `pytest-timeout` now fails a hung test after six minutes, and pytest's faulthandler dumps every thread's stack one minute earlier, so a hang names itself and shows its exact await in the log before anything is killed. The dump-before-kill ordering is deliberate and safe: with `faulthandler_exit_on_timeout = false` -- pytest's default, pinned explicitly -- the faulthandler dump is diagnostic only and never terminates anything; `--timeout 360` owns termination. The 360-second value is deliberately generous: the suite contains tests that legitimately wait out 30-second statement deadlines, and wall clock inflates severalfold under worker contention on the slowest runners. `--durations=20` collects the data to tighten it later: once a few weeks of runs establish the true slow tail, the timeout can drop to a small multiple of the observed maximum.

**Nightly budget.** The macOS legs of the nightly all-platforms workflow need roughly 50 minutes when healthy (`-n 4` on the slowest hosted runners) and have been hitting the 60-minute kill since at least 2026-08-20. Those failures were slowness, not defects; the budget now reflects the measured healthy duration.

## Rollout note

The root cause of the 2026-08-31 hangs -- a permit leak in the analytics SQL execution semaphore, reachable only under the test harness -- is fixed in a separate pull request. Until that merges, a pull request that hits the leak will fail with a named six-minute timeout and stack dumps instead of a 60-minute anonymous job kill. That is the intended behavior of this change: the failure becomes diagnosable instead of silent.
