### PR TITLE
refactor(mcp/sql): scope analytics SQL admission to the session factory

### DIFF
--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -39,6 +39,16 @@ class SupportedSQLDialect(Enum):
     SQLITE = "sqlite"
     POSTGRESQL = "postgresql"
 
+    @property
+    def name_literal(self) -> SupportedSQLDialectName:
+        """The member as the `Literal` type. `value` is typed `str`, which the
+        `Literal`-keyed consumers cannot accept under strict type checking."""
+        if self is SupportedSQLDialect.POSTGRESQL:
+            return "postgresql"
+        if self is SupportedSQLDialect.SQLITE:
+            return "sqlite"
+        assert_never(self)
+
     @classmethod
     def _missing_(cls, v: Any) -> "SupportedSQLDialect":
         if isinstance(v, str) and v and v.isascii() and not v.islower():

--- a/src/phoenix/server/mcp/sql/execute.py
+++ b/src/phoenix/server/mcp/sql/execute.py
@@ -21,7 +21,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.elements import TextClause
 
-from phoenix.db.helpers import SupportedSQLDialect, SupportedSQLDialectName
+from phoenix.db.helpers import SupportedSQLDialectName
 from phoenix.server.mcp.sql.allowlist import (
     PLAN_GATE_ALLOWED_FUNCTIONS,
     SQLITE_TABLE_VALUED_FUNCTIONS,
@@ -151,64 +151,49 @@ SQL_CONCURRENCY: dict[SupportedSQLDialectName, int] = {"postgresql": 4, "sqlite"
 
 
 @dataclass
-class ExecutionSemaphore:
-    _width_by_dialect: dict[SupportedSQLDialectName, int] = field(
-        default_factory=lambda: dict(SQL_CONCURRENCY)
-    )
-    _queue_size: int = 8
-    _locks: dict[SupportedSQLDialectName, asyncio.Semaphore] = field(default_factory=dict)
-    _waiting: dict[SupportedSQLDialectName, int] = field(
-        default_factory=lambda: {"postgresql": 0, "sqlite": 0}
-    )
-    _guard: asyncio.Lock = field(default_factory=asyncio.Lock)
+class StatementAdmissionController:
+    """Bounds concurrent analytics statements for one session factory.
 
-    async def acquire(self, dialect: SupportedSQLDialectName) -> None:
+    Callers past the width for the factory's dialect wait; waiters past the
+    queue bound are refused. Built from loop-bound asyncio primitives, so an
+    instance must not outlive the event loop its factory serves.
+    """
+
+    dialect: SupportedSQLDialectName
+    _queue_size: int = 8
+    _waiting: int = field(default=0, init=False)
+    _guard: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _permits: asyncio.Semaphore = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._permits = asyncio.Semaphore(SQL_CONCURRENCY[self.dialect])
+
+    async def acquire(self) -> None:
         async with self._guard:
-            if self._waiting[dialect] >= self._queue_size:
-                # Logged, not merely returned. Saturation is the one failure the
-                # caller cannot diagnose and the operator most needs to see: the
-                # caller is told to retry, while the reason -- that concurrent
-                # demand exceeded a deliberately narrow queue -- exists only
-                # here. Without this the condition leaves no server-side trace,
-                # so an operator grepping for it finds nothing and reads the
-                # absence as health.
-                logger.warning(
+            if self._waiting >= self._queue_size:
+                logger.debug(
                     "analytics sql: %s queue is full at %d waiting; request refused",
-                    dialect,
-                    self._waiting[dialect],
+                    self.dialect,
+                    self._waiting,
                 )
                 raise AnalyticsSqlError(
                     code=ErrorCode.QUEUE_FULL,
                     message="Too many analytics SQL requests are queued.",
                 )
-            self._waiting[dialect] += 1
-        lock = self._locks.setdefault(dialect, asyncio.Semaphore(self._width_by_dialect[dialect]))
+            self._waiting += 1
         try:
-            await lock.acquire()
+            await self._permits.acquire()
         finally:
-            # Decremented in a finally because a client disconnecting while
-            # queued cancels the await above. Without it the slot is never
-            # returned, and enough cancellations leave the queue permanently
-            # full for the life of the process.
-            #
-            # Deliberately *not* under `_guard`. Taking the lock here means
-            # awaiting inside a `finally` that a cancellation is already
-            # unwinding, and a second cancellation delivered during that await
-            # skips the decrement -- reintroducing the leak this block exists
-            # to prevent. Demonstrated: hold the guard, cancel twice, and the
-            # count stays at 1 forever. The guard is unnecessary anyway. It
-            # exists to make the read-compare-increment above indivisible; a
-            # bare decrement contains no await point, so no other coroutine can
-            # observe a torn value on a single-threaded loop.
-            self._waiting[dialect] -= 1
+            # A cancellation while queued unwinds through here; without the
+            # decrement the slot leaks until the queue refuses everything.
+            # Deliberately not under `_guard`: awaiting a lock inside a
+            # finally that a cancellation is unwinding can be skipped by a
+            # second cancellation, and the bare decrement needs no guard --
+            # it has no await point, so it is indivisible on the loop.
+            self._waiting -= 1
 
-    def release(self, dialect: SupportedSQLDialectName) -> None:
-        lock = self._locks.get(dialect)
-        if lock is not None:
-            lock.release()
-
-
-EXECUTION_SEMAPHORE = ExecutionSemaphore()
+    def release(self) -> None:
+        self._permits.release()
 
 
 @dataclass(frozen=True)
@@ -610,13 +595,11 @@ async def execute_analytics_sql(
     *,
     sqlite_db_path: Optional[str] = None,
 ) -> ExecuteResult:
-    dialect: SupportedSQLDialectName = (
-        "postgresql" if db.dialect is SupportedSQLDialect.POSTGRESQL else "sqlite"
-    )
+    dialect: SupportedSQLDialectName = db.dialect.name_literal
     call_id = _next_call_id()
-    semaphore = EXECUTION_SEMAPHORE
-    await semaphore.acquire(dialect)
-    release_semaphore = True
+    admission_controller = db.analytics_sql_admission
+    await admission_controller.acquire()
+    release_permit = True
     try:
         # Characters first. UTF-8 never encodes to fewer bytes than characters,
         # so an over-long string is refused without encoding it -- measuring by
@@ -735,9 +718,9 @@ async def execute_analytics_sql(
                 # after the caller disconnects. Keep SQLite's width-one permit
                 # until that cleanup has completed, while preserving prompt
                 # cancellation for the caller.
-                release_semaphore = False
+                release_permit = False
                 exc.worker.add_done_callback(
-                    lambda worker: _release_after_worker(worker, semaphore, "sqlite", call_id)
+                    lambda worker: _release_after_worker(worker, admission_controller, call_id)
                 )
                 raise
         if params.validate_only:
@@ -754,14 +737,14 @@ async def execute_analytics_sql(
         # The thread finishes its parse or rewrite whatever the caller does.
         # Holding the permit until it exits keeps concurrency bounded by the
         # work actually running rather than by the callers still waiting.
-        release_semaphore = False
+        release_permit = False
         exc.worker.add_done_callback(
-            lambda worker: _release_after_worker(worker, semaphore, dialect, call_id)
+            lambda worker: _release_after_worker(worker, admission_controller, call_id)
         )
         raise
     finally:
-        if release_semaphore:
-            semaphore.release(dialect)
+        if release_permit:
+            admission_controller.release()
 
 
 # SQLAlchemy's asyncpg dialect uses the `numeric_dollar` paramstyle, and its
@@ -1088,8 +1071,7 @@ class _SQLiteWorkerCancellation(asyncio.CancelledError):
 
 def _release_after_worker(
     worker: asyncio.Future[Any],
-    semaphore: ExecutionSemaphore,
-    dialect: SupportedSQLDialectName,
+    admission_controller: StatementAdmissionController,
     call_id: str,
 ) -> None:
     """Consume an abandoned worker result, then return its capacity.
@@ -1105,7 +1087,7 @@ def _release_after_worker(
     except BaseException:
         logger.exception("analytics sql: %s abandoned worker failed", call_id)
     finally:
-        semaphore.release(dialect)
+        admission_controller.release()
 
 
 class _OffloadedWorkerCancellation(asyncio.CancelledError):
@@ -1120,11 +1102,11 @@ class _OffloadedWorkerCancellation(asyncio.CancelledError):
         self.worker = worker
 
 
-#: Threads for the CPU-bound phases. Sized to the concurrency the semaphore
-#: already permits across both dialects, and separate from the default executor
-#: so caller SQL cannot occupy the pool the rest of the server shares. A permit
-#: is held before any work is submitted, so this should never queue; the
-#: queued-cancellation branch in `_offloaded` is the backstop if it ever does.
+#: Threads for the CPU-bound phases, separate from the default executor so
+#: caller SQL cannot occupy the pool the rest of the server shares. Width is
+#: the sum of SQL_CONCURRENCY, so permits bound submissions while one factory
+#: exists per process; more factories can oversubscribe the pool and make it
+#: queue, and the queued-cancellation branch in `_offloaded` is the backstop.
 _EXECUTOR_WIDTH = sum(SQL_CONCURRENCY.values())
 _executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _executor_guard = threading.Lock()
@@ -1204,7 +1186,7 @@ async def _execute_sqlite_file(
         # cancellation flag was not enough: that flag is set in the `finally`
         # below, which runs *after* execution returns, so it could never fire
         # during a long query. A costly statement could therefore run without
-        # limit, and since SQLite's semaphore width is 1, block every other
+        # limit, and since SQLite's admission width is 1, block every other
         # analytics query behind it.
         deadline = time.monotonic() + SQLITE_TIMEOUT_SECONDS
 

--- a/src/phoenix/server/types.py
+++ b/src/phoenix/server/types.py
@@ -8,7 +8,8 @@ from collections.abc import Callable, Iterator
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Generic, Optional, Protocol, TypeVar, final
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar, final
 
 from cachetools import LRUCache
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +19,9 @@ from phoenix.auth import CanReadToken, ClaimSet, Token, TokenAttributes
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.models import UserRoleName
+
+if TYPE_CHECKING:
+    from phoenix.server.mcp.sql.execute import StatementAdmissionController
 
 
 class CanSetLastUpdatedAt(Protocol):
@@ -45,6 +49,19 @@ class DbSessionFactory:
         usage returns to normal. Note that this flag does not preclude the actual execution of any
         insert or update operations.
         """
+
+    @cached_property
+    def analytics_sql_admission(self) -> StatementAdmissionController:
+        """Concurrency admission control for analytics SQL statements.
+
+        Scoped to the factory because the controller's asyncio primitives bind
+        to an event loop and a factory is expected to serve exactly one; a
+        wider scope can outlive the loop. The deferred import keeps factory
+        construction from importing the analytics module.
+        """
+        from phoenix.server.mcp.sql.execute import StatementAdmissionController
+
+        return StatementAdmissionController(self.dialect.name_literal)
 
     def __call__(self) -> AbstractAsyncContextManager[AsyncSession]:
         return self._db()

--- a/tests/unit/server/mcp/sql/test_execute.py
+++ b/tests/unit/server/mcp/sql/test_execute.py
@@ -1059,10 +1059,9 @@ async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
         return original(*args, **kwargs)
 
     monkeypatch.setattr(execute_module, "parse_sql", blocking)
-    # A private semaphore, so a regression that leaks the width-one permit
-    # fails this test alone instead of stalling every later execute test.
-    semaphore = execute_module.ExecutionSemaphore()
-    monkeypatch.setattr(execute_module, "EXECUTION_SEMAPHORE", semaphore)
+    # Installed before first use so the test holds the factory's admission controller.
+    controller = execute_module.StatementAdmissionController("sqlite")
+    db.analytics_sql_admission = controller
 
     call = asyncio.create_task(
         execute_analytics_sql(db, ExecuteParams(sql="SELECT id FROM spans"), sqlite_db_path=db_path)
@@ -1074,7 +1073,7 @@ async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
 
     # SQLite runs one statement at a time, so a second acquire completing here
     # would mean the permit came back while the thread still held it.
-    second = asyncio.create_task(semaphore.acquire("sqlite"))
+    second = asyncio.create_task(controller.acquire())
     try:
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(asyncio.shield(second), 0.25)
@@ -1086,7 +1085,7 @@ async def test_a_cancelled_call_keeps_its_permit_until_the_parse_thread_exits(
         # bury the failure that caused it.
         finish.set()
         if second.done() and not second.cancelled():
-            semaphore.release("sqlite")
+            controller.release()
         else:
             second.cancel()
 
@@ -1117,8 +1116,8 @@ async def test_a_call_cancelled_before_its_thread_starts_returns_its_permit_at_o
         return parse_sql(*args, **kwargs)
 
     monkeypatch.setattr(execute_module, "parse_sql", watched)
-    semaphore = execute_module.ExecutionSemaphore()
-    monkeypatch.setattr(execute_module, "EXECUTION_SEMAPHORE", semaphore)
+    controller = execute_module.StatementAdmissionController("sqlite")
+    db.analytics_sql_admission = controller
 
     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
@@ -1159,8 +1158,8 @@ async def test_a_call_cancelled_before_its_thread_starts_returns_its_permit_at_o
         assert submitted[0].cancelled(), "the queued job was not cancelled"
         # Free while the pool is still occupied, which it could not be if
         # release waited on the queue rather than on started work.
-        await asyncio.wait_for(semaphore.acquire("sqlite"), 1)
-        semaphore.release("sqlite")
+        await asyncio.wait_for(controller.acquire(), 1)
+        controller.release()
     finally:
         release_pool.set()
         pool.shutdown(wait=True)

--- a/tests/unit/server/mcp/sql/test_liveness.py
+++ b/tests/unit/server/mcp/sql/test_liveness.py
@@ -28,7 +28,7 @@ from sqlalchemy import text
 from phoenix.server.mcp.sql.errors import AnalyticsSqlError
 from phoenix.server.mcp.sql.execute import (
     ExecuteParams,
-    ExecutionSemaphore,
+    StatementAdmissionController,
     execute_analytics_sql,
 )
 from phoenix.server.mcp.sql.teaching import describe_sql_schema
@@ -428,24 +428,24 @@ async def test_queue_slot_is_returned_when_a_waiter_is_cancelled() -> None:
     """A client disconnecting while queued must not consume capacity forever.
 
     Acquisition happens before the caller's try/finally, so a cancellation while
-    waiting on the semaphore unwinds through code that would otherwise never
+    waiting on the controller unwinds through code that would otherwise never
     decrement the counter. Enough of those and every later request is refused as
     QUEUE_FULL until the process restarts -- a denial of service reachable by
     doing nothing but disconnecting.
     """
     import asyncio
 
-    from phoenix.server.mcp.sql.execute import ExecutionSemaphore
+    from phoenix.server.mcp.sql.execute import StatementAdmissionController
 
-    semaphore = ExecutionSemaphore()
-    await semaphore.acquire("sqlite")
-    waiters = [asyncio.create_task(semaphore.acquire("sqlite")) for _ in range(3)]
+    controller = StatementAdmissionController("sqlite")
+    await controller.acquire()
+    waiters = [asyncio.create_task(controller.acquire()) for _ in range(3)]
     await asyncio.sleep(0.05)
     for waiter in waiters:
         waiter.cancel()
     await asyncio.gather(*waiters, return_exceptions=True)
 
-    assert semaphore._waiting["sqlite"] == 0
+    assert controller._waiting == 0
 
 
 async def test_queue_slot_is_returned_when_a_waiter_is_cancelled_twice() -> None:
@@ -463,25 +463,25 @@ async def test_queue_slot_is_returned_when_a_waiter_is_cancelled_twice() -> None
     """
     import asyncio
 
-    from phoenix.server.mcp.sql.execute import ExecutionSemaphore
+    from phoenix.server.mcp.sql.execute import StatementAdmissionController
 
-    semaphore = ExecutionSemaphore()
-    await semaphore.acquire("sqlite")
-    waiter = asyncio.create_task(semaphore.acquire("sqlite"))
+    controller = StatementAdmissionController("sqlite")
+    await controller.acquire()
+    waiter = asyncio.create_task(controller.acquire())
     await asyncio.sleep(0.05)
-    assert semaphore._waiting["sqlite"] == 1
+    assert controller._waiting == 1
 
     # Hold the guard so anything taking it inside the unwind has to wait, then
     # cancel a second time while it is waiting.
-    await semaphore._guard.acquire()
+    await controller._guard.acquire()
     waiter.cancel()
     await asyncio.sleep(0.05)
     waiter.cancel()
     await asyncio.sleep(0.05)
-    semaphore._guard.release()
+    controller._guard.release()
     await asyncio.gather(waiter, return_exceptions=True)
 
-    assert semaphore._waiting["sqlite"] == 0
+    assert controller._waiting == 0
 
 
 async def test_row_limit_is_clamped(
@@ -769,8 +769,8 @@ async def test_cancelling_a_query_stops_the_worker(
     from phoenix.server.mcp.sql import execute as execute_module
 
     db, db_path = analytics_sqlite_db
-    semaphore = ExecutionSemaphore()
-    monkeypatch.setattr(execute_module, "EXECUTION_SEMAPHORE", semaphore)
+    controller = StatementAdmissionController("sqlite")
+    db.analytics_sql_admission = controller
     statement_started = threading.Event()
     close_started = threading.Event()
     allow_close = threading.Event()
@@ -850,9 +850,9 @@ async def test_cancelling_a_query_stops_the_worker(
 
         # Hold cleanup briefly so this assertion cannot race the worker's done
         # callback. The timeout and finally prevent a test failure from
-        # stranding a worker thread or its semaphore permit.
+        # stranding a worker thread or its admission permit.
         await wait_for_event(close_started)
-        assert semaphore._locks["sqlite"].locked()
+        assert controller._permits.locked()
     finally:
         allow_close.set()
         if not task.done():


### PR DESCRIPTION
## What

- The admission control for analytics SQL statements moves from a module-level singleton onto `DbSessionFactory`, as a `cached_property` named `analytics_sql_admission`.
- Per-dialect keying is retired: a factory has exactly one dialect, so each controller carries the single width for its dialect and `acquire()`/`release()` take no arguments. The width table remains as `SQL_CONCURRENCY`, which also sizes the analytics thread pool.
- `SupportedSQLDialect` gains `name_literal`, so the enum-to-`Literal` mapping lives in one place beside the two types it bridges, with `assert_never` making a future dialect fail loudly instead of misrouting.
- Renamed for the wider scope: the class `ExecutionSemaphore` is now `StatementAdmissionController`, holding `_permits`. "Semaphore" named only the width, not the bounded wait queue or the `QUEUE_FULL` refusal, and "Statement" distinguishes runtime concurrency admission from parse-time admission (`AdmissionOutcome` in `parse.py`).
- Queue-full refusals now log at DEBUG, matching the parse-time refusal logs in the same module; the line remains the only server-side trace of saturation.

## Why

The controller is built from event-loop-bound asyncio primitives. As a module global it carried an implicit invariant -- one event loop per process lifetime -- that every supported deployment satisfies and the test harness does not: pytest gives each test a function-scoped loop inside a long-lived xdist worker. A caller cancelled mid-parse returns its permit through a done-callback on a future bound to the caller's loop; when that loop closed before the worker thread finished, the permit leaked. Enough leaks exhausted the PostgreSQL width and the next analytics test awaited `acquire()` forever -- the CI hangs of 2026-08-31, where `unit-tests (postgresql)` jobs wedged at 99% and died at the 60-minute kill across several pull requests.

A factory serves exactly one event loop, so scoping the controller to the factory makes the hazard structurally unreachable: the object cannot outlive the loop its primitives bind to, a permit lost at a loop's death dies inside a dead instance, and each test's fresh factory carries its own limits, so any future leak fails the test that caused it. The `cached_property` defers the analytics import to first access, keeping the import graph acyclic and the cost off factories that never run analytics; as a non-data descriptor it is overridden by plain assignment, which is how tests install an instance they hold.

Production behavior is unchanged apart from the queue-full log level: one process holds one factory, so per-factory limits and the former per-process limits coincide. Typed `refactor` rather than `fix` deliberately: no released deployment ever experienced the defect, so it does not belong in the user-facing changelog.

## Verification

- Strict mypy clean on all touched files; the full `tests/unit/server/mcp/sql/` suite plus `test_mcp_sql_tools.py` green on SQLite (two random seeds) and on PostgreSQL 14, the CI-pinned floor.
- The leak was reproduced deterministically against the old code (caller cancelled mid-parse, its loop closed before the worker thread finished, permit never returned, next acquire waits forever) and does not reproduce against this change.

## Related

- #15794 adds the CI-side diagnostics (per-test timeouts, no unit-test retries). Until this PR merges, a run that hits the leak fails there as a named six-minute timeout instead of a 60-minute anonymous job kill.
