### PR TITLE
fix(sandbox): survive concurrent access to the shared WASM binary cache

### DIFF
--- a/src/phoenix/server/sandbox/_download.py
+++ b/src/phoenix/server/sandbox/_download.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import urllib.request
 from pathlib import Path
 from typing import Optional
@@ -105,32 +106,58 @@ def ensure_wasm_binary(
     dest = resolved_wasm_dir / filename
 
     if dest.exists():
-        if expected_sha256:
-            try:
-                _verify_sha256(dest, expected_sha256)
-            except ValueError:
-                dest.unlink(missing_ok=True)
-                raise
-        return dest
+        if not expected_sha256:
+            return dest
+        try:
+            _verify_sha256(dest, expected_sha256)
+        except FileNotFoundError:
+            # The cache directory is shared across processes, and another one
+            # can remove or replace the file between the existence check and
+            # the read. The file is simply absent; fall through to download.
+            pass
+        except ValueError:
+            dest.unlink(missing_ok=True)
+            raise
+        else:
+            return dest
 
     resolved_wasm_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info(f"Downloading WASM binary from {url} → {dest}")
+    # Downloaded to a process-private file, verified, then moved into place
+    # with an atomic rename, so a concurrent reader of the shared cache sees
+    # either a complete verified binary or none at all -- never a partial
+    # write, and a failed download never disturbs an existing good file.
+    tmp = dest.with_name(f"{dest.name}.{os.getpid()}.tmp")
     try:
         with urllib.request.urlopen(  # noqa: S310
             url, timeout=_WASM_DOWNLOAD_TIMEOUT_SECONDS
         ) as response:
-            dest.write_bytes(response.read())
+            tmp.write_bytes(response.read())
+        if expected_sha256:
+            _verify_sha256(tmp, expected_sha256)
+    except ValueError:
+        tmp.unlink(missing_ok=True)
+        raise
     except Exception as exc:
-        dest.unlink(missing_ok=True)
+        tmp.unlink(missing_ok=True)
         raise RuntimeError(f"Failed to download WASM binary: {exc}") from exc
-
-    if expected_sha256:
+    try:
+        os.replace(tmp, dest)
+    except OSError as exc:
+        # Windows refuses to replace a file another process holds open (files
+        # are opened without FILE_SHARE_DELETE), so losing a concurrent race
+        # surfaces here rather than as the vanished-file case above. The
+        # private download is discarded; the file the winner installed is
+        # used if it verifies.
+        tmp.unlink(missing_ok=True)
         try:
-            _verify_sha256(dest, expected_sha256)
-        except ValueError:
-            dest.unlink(missing_ok=True)
-            raise
+            if expected_sha256:
+                _verify_sha256(dest, expected_sha256)
+            elif not dest.is_file():
+                raise FileNotFoundError(str(dest))
+        except (OSError, ValueError):
+            raise RuntimeError(f"Failed to install WASM binary: {exc}") from exc
 
     logger.info(f"WASM binary saved at {dest}")
     return dest
@@ -148,7 +175,10 @@ async def prefetch_wasm_binary_if_needed() -> None:
             logger.warning(f"WASM sandbox binary unavailable: {message}")
     except ValueError as exc:
         logger.warning(f"WASM sandbox binary failed integrity check: {exc}")
-    except RuntimeError as exc:
+    except (OSError, RuntimeError) as exc:
+        # OSError included so a filesystem-level surprise -- a Windows sharing
+        # violation, a permissions change, a full disk -- degrades the sandbox
+        # instead of failing server startup.
         logger.warning(f"WASM sandbox binary pre-fetch failed: {exc}")
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,37 @@ def _stub_code_mode_startup_check(request: FixtureRequest, monkeypatch: pytest.M
     monkeypatch.setattr("phoenix.server.monty_runtime.MontyRuntime.probe_runtime", _skip)
 
 
+@pytest.fixture(autouse=True)
+def _stub_wasm_prefetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The app lifespan pre-fetches the sandbox WASM binary through a cache
+    directory shared by every xdist worker, with a network download on a miss
+    -- contention and I/O that do not fit inside asgi_lifespan's 5s startup
+    budget. Stubbed suite-wide; the download tests call it directly."""
+
+    async def _skip() -> None:
+        return None
+
+    monkeypatch.setattr("phoenix.server.app.prefetch_wasm_binary_if_needed", _skip)
+
+
+@pytest.fixture(autouse=True)
+def _widened_app_lifespan_budgets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """asgi_lifespan's default five-second budgets are routinely exceeded by
+    app startup under full worker contention: setups measure eight seconds and
+    more at the tail of the suite. Several test modules construct
+    LifespanManager directly, so the default is widened once here; explicit
+    arguments still win, and the per-test timeout bounds a genuine hang."""
+    original = LifespanManager.__init__
+
+    def widened(self: Any, app: Any, *args: Any, **kwargs: Any) -> None:
+        if not args:
+            kwargs.setdefault("startup_timeout", 30)
+            kwargs.setdefault("shutdown_timeout", 30)
+        original(self, app, *args, **kwargs)
+
+    monkeypatch.setattr(LifespanManager, "__init__", widened)
+
+
 def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
     db = config.getoption("--db")
     if db == "sqlite":

--- a/tests/unit/server/sandbox/test_wasm_download.py
+++ b/tests/unit/server/sandbox/test_wasm_download.py
@@ -211,6 +211,126 @@ class TestEnsureWasmBinaryEnvVarUnset:
 
         assert not cached.exists(), "tampered cached binary must be unlinked on verify failure"
 
+    def test_file_vanishing_during_verification_falls_through_to_download(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cache is shared across processes: another one can remove or
+        replace the file between the existence check and the hash read. The
+        vanished file means absent, not broken -- the caller must get a fresh
+        download, not a FileNotFoundError.
+        """
+        import hashlib
+
+        from phoenix.server.sandbox import _download as download_module
+
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        cached = cache_dir / _FILENAME
+        cached.write_bytes(b"about to vanish")
+
+        payload = b"fresh download"
+        expected_sha = hashlib.sha256(payload).hexdigest()
+        real_verify = download_module._verify_sha256
+
+        def concurrently_unlinked(path: Path, expected: str) -> None:
+            if path == cached and path.read_bytes() == b"about to vanish":
+                cached.unlink()
+                raise FileNotFoundError(2, "No such file or directory")
+            real_verify(path, expected)
+
+        monkeypatch.setattr(download_module, "_verify_sha256", concurrently_unlinked)
+
+        with patch(_URLOPEN, return_value=io.BytesIO(payload)) as mock_urlopen:
+            result = ensure_wasm_binary(
+                wasm_dir=cache_dir,
+                filename=_FILENAME,
+                expected_sha256=expected_sha,
+            )
+
+        mock_urlopen.assert_called_once()
+        assert result == cached
+        assert cached.read_bytes() == payload
+
+    def test_failed_download_leaves_no_temp_file_and_no_destination(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The download writes to a private temp file moved into place only
+        after verification, so neither a network failure nor a hash mismatch
+        may leave a partial or unverified file where a concurrent reader of
+        the shared cache would find it.
+        """
+        import hashlib
+
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
+        cache_dir = tmp_path / "cache"
+
+        with patch(_URLOPEN, side_effect=OSError("connection reset")):
+            with pytest.raises(RuntimeError, match="Failed to download"):
+                ensure_wasm_binary(
+                    wasm_dir=cache_dir,
+                    filename=_FILENAME,
+                    expected_sha256="",
+                )
+        assert list(cache_dir.iterdir()) == []
+
+        expected_sha = hashlib.sha256(b"real upstream").hexdigest()
+        with patch(_URLOPEN, return_value=io.BytesIO(b"tampered payload")):
+            with pytest.raises(ValueError, match="SHA-256 mismatch"):
+                ensure_wasm_binary(
+                    wasm_dir=cache_dir,
+                    filename=_FILENAME,
+                    expected_sha256=expected_sha,
+                )
+        assert list(cache_dir.iterdir()) == []
+
+    def test_losing_the_install_race_uses_the_winners_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows cannot replace a file another process holds open, so the
+        loser of a concurrent download surfaces at the rename rather than as
+        a vanished file. The winner's installed file is authoritative when it
+        verifies; with no such file the loser reports a RuntimeError, which
+        the pre-fetch treats as fail-soft.
+        """
+        import hashlib
+
+        monkeypatch.delenv("PHOENIX_WASM_BINARY_PATH", raising=False)
+        cache_dir = tmp_path / "cache"
+        dest = cache_dir / _FILENAME
+        payload = b"identical upstream payload"
+        expected_sha = hashlib.sha256(payload).hexdigest()
+
+        def sharing_violation(src: object, dst: object) -> None:
+            dest.write_bytes(payload)  # the winner's completed install
+            raise PermissionError(13, "The process cannot access the file")
+
+        monkeypatch.setattr("phoenix.server.sandbox._download.os.replace", sharing_violation)
+        with patch(_URLOPEN, return_value=io.BytesIO(payload)):
+            result = ensure_wasm_binary(
+                wasm_dir=cache_dir,
+                filename=_FILENAME,
+                expected_sha256=expected_sha,
+            )
+        assert result == dest
+        assert result.read_bytes() == payload
+        assert list(cache_dir.glob("*.tmp")) == []
+
+        dest.unlink()
+
+        def bare_violation(src: object, dst: object) -> None:
+            raise PermissionError(13, "The process cannot access the file")
+
+        monkeypatch.setattr("phoenix.server.sandbox._download.os.replace", bare_violation)
+        with patch(_URLOPEN, return_value=io.BytesIO(payload)):
+            with pytest.raises(RuntimeError, match="Failed to install"):
+                ensure_wasm_binary(
+                    wasm_dir=cache_dir,
+                    filename=_FILENAME,
+                    expected_sha256=expected_sha,
+                )
+        assert list(cache_dir.glob("*.tmp")) == []
+
     def test_no_local_storage_raises_unavailable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## What

- `ensure_wasm_binary` treats a file that vanishes between the existence check and the hash read as absent and falls through to a fresh download, instead of failing with `FileNotFoundError`.
- The download writes to a process-private temp file, verifies it, and moves it into place with an atomic rename. A concurrent reader of the shared cache sees either a complete verified binary or none at all -- never a partial write -- and a failed download no longer disturbs an existing good file.
- Windows surfaces a lost race as `PermissionError` at the rename (files are opened without `FILE_SHARE_DELETE`), so the loser falls back to the winner's installed file when it verifies, and the startup pre-fetch treats `OSError` as fail-soft: a sharing violation, a permissions change, or a full disk degrades the sandbox with a warning instead of failing server startup.
- Unit tests stub the lifespan pre-fetch suite-wide (alongside the existing Monty probe stub in `tests/unit/conftest.py`); the download tests call it directly. Regression tests cover the vanished-file fall-through, the no-partial-file guarantee, and the lost-rename fallback.
- Unit tests widen `asgi_lifespan`'s default five-second startup and shutdown budgets to thirty, suite-wide via an autouse fixture: test setups measure eight seconds and more under full worker contention (per the CI `--durations` report), several modules construct `LifespanManager` directly rather than through the shared fixture, explicit arguments still win, and the per-test timeout is the bound on a genuine hang.

## Why

The cache directory is shared: across server processes on one host in production, and across every xdist worker in the test suite. The existing code had two races. Check-then-read: `dest.exists()` followed by `read_bytes()` fails with `FileNotFoundError` when another process unlinks or replaces the file in between (both error paths did exactly that). Non-atomic write: downloading straight to the destination lets a concurrent reader observe a partial file, fail verification, and unlink a binary another process is still writing.

These surfaced on the first CI run of #15794, which removed unit-test retries: app-lifespan fixture setups at the tail of the suite failed on the vanished-file read and on startup budgets blown while queued behind the pre-fetch. Retries had been absorbing these silently. A subsequent controlled comparison on #15795 confirmed the impact: the same merge ref wedged a worker at 99% without this fix and passed with it.

## Ordering

Bottom of stack #15797; #15795 and #15794 build on it.
