### PR TITLE
feat(evals): support Anthropic native structured output

### DIFF
--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "typing-extensions>=4.5, <5",
   "pystache",
   "pydantic>=2.0.0",
+  "jsonschema",
   "jsonpath_ng",
   "openinference-semantic-conventions>=0.1.19",
   "openinference-instrumentation>=0.1.20",
@@ -57,6 +58,7 @@ test = [
   "respx",
   "nest_asyncio",
   "pandas-stubs==2.0.3.230814",
+  "types-jsonschema",
   "types-tqdm",
 ]
 

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/anthropic/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/anthropic/adapter.py
@@ -1,5 +1,8 @@
+import json
 import logging
 from typing import Any, Dict, List, Type, cast
+
+import jsonschema
 
 from ...prompts import (
     Message,
@@ -51,6 +54,7 @@ class AnthropicAdapter(BaseLLMAdapter):
         super().__init__(client, model)
         self._validate_client()
         self._is_async = self._check_if_async_client()
+        self._preferred_method: ObjectGenerationMethod | None = None
 
     @classmethod
     def client_name(cls) -> str:
@@ -143,15 +147,35 @@ class AnthropicAdapter(BaseLLMAdapter):
         kwargs = {**required_kwargs, **kwargs}
 
         if method == ObjectGenerationMethod.STRUCTURED_OUTPUT:
-            raise ValueError(
-                "Anthropic does not support native structured output. Use TOOL_CALLING or AUTO."
-            )
+            return self._generate_with_structured_output(prompt, schema, **kwargs)
 
         elif method == ObjectGenerationMethod.TOOL_CALLING:
             return self._generate_with_tool_calling(prompt, schema, **kwargs)
 
         elif method == ObjectGenerationMethod.AUTO:
-            return self._generate_with_tool_calling(prompt, schema, **kwargs)
+            if self._preferred_method == ObjectGenerationMethod.STRUCTURED_OUTPUT:
+                return self._generate_with_structured_output(prompt, schema, **kwargs)
+            if self._preferred_method == ObjectGenerationMethod.TOOL_CALLING:
+                return self._generate_with_tool_calling(prompt, schema, **kwargs)
+
+            from anthropic import BadRequestError as _AnthropicBadRequestError
+
+            try:
+                result = self._generate_with_structured_output(prompt, schema, **kwargs)
+                self._preferred_method = ObjectGenerationMethod.STRUCTURED_OUTPUT
+                return result
+            except _AnthropicBadRequestError as structured_error:
+                if not self._is_unsupported_structured_output_error(structured_error):
+                    raise
+                logger.debug(
+                    "Native structured output rejected as unsupported by %s; "
+                    "falling back to tool calling: %s",
+                    self.model,
+                    structured_error,
+                )
+                result = self._generate_with_tool_calling(prompt, schema, **kwargs)
+                self._preferred_method = ObjectGenerationMethod.TOOL_CALLING
+                return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -173,13 +197,79 @@ class AnthropicAdapter(BaseLLMAdapter):
         kwargs = {**required_kwargs, **kwargs}
 
         if method == ObjectGenerationMethod.STRUCTURED_OUTPUT:
-            raise ValueError(
-                "Anthropic does not support native structured output. Use TOOL_CALLING or AUTO."
-            )
+            return await self._async_generate_with_structured_output(prompt, schema, **kwargs)
         elif method == ObjectGenerationMethod.TOOL_CALLING:
             return await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
         elif method == ObjectGenerationMethod.AUTO:
-            return await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
+            if self._preferred_method == ObjectGenerationMethod.STRUCTURED_OUTPUT:
+                return await self._async_generate_with_structured_output(prompt, schema, **kwargs)
+            if self._preferred_method == ObjectGenerationMethod.TOOL_CALLING:
+                return await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
+
+            from anthropic import BadRequestError as _AnthropicBadRequestError
+
+            try:
+                result = await self._async_generate_with_structured_output(prompt, schema, **kwargs)
+                self._preferred_method = ObjectGenerationMethod.STRUCTURED_OUTPUT
+                return result
+            except _AnthropicBadRequestError as structured_error:
+                if not self._is_unsupported_structured_output_error(structured_error):
+                    raise
+                logger.debug(
+                    "Native structured output rejected as unsupported by %s; "
+                    "falling back to tool calling: %s",
+                    self.model,
+                    structured_error,
+                )
+                result = await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
+                self._preferred_method = ObjectGenerationMethod.TOOL_CALLING
+                return result
+        else:
+            raise ValueError(f"Unsupported object generation method: {method}")
+
+    def _generate_with_structured_output(
+        self,
+        prompt: PromptLike,
+        schema: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        messages, system = self._build_messages(prompt)
+        if system:
+            kwargs["system"] = system
+        kwargs["output_config"] = {
+            "format": {
+                "type": "json_schema",
+                "schema": schema,
+            }
+        }
+        response = self.client.messages.create(
+            model=self.model,
+            messages=messages,
+            **kwargs,
+        )
+        return self._parse_structured_output_response(response, schema)
+
+    async def _async_generate_with_structured_output(
+        self,
+        prompt: PromptLike,
+        schema: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        messages, system = self._build_messages(prompt)
+        if system:
+            kwargs["system"] = system
+        kwargs["output_config"] = {
+            "format": {
+                "type": "json_schema",
+                "schema": schema,
+            }
+        }
+        response = await self.client.messages.create(
+            model=self.model,
+            messages=messages,
+            **kwargs,
+        )
+        return self._parse_structured_output_response(response, schema)
 
     def _generate_with_tool_calling(
         self,
@@ -198,15 +288,25 @@ class AnthropicAdapter(BaseLLMAdapter):
             model=self.model,
             messages=messages,
             tools=[tool_definition],
-            tool_choice={"type": "tool", "name": "extract_structured_data"},
+            tool_choice={
+                "type": "tool",
+                "name": "extract_structured_data",
+                "disable_parallel_tool_use": True,
+            },
             **kwargs,
         )
 
+        self._raise_for_incomplete_response(response)
         for content_block in response.content:
-            if hasattr(content_block, "type") and content_block.type == "tool_use":
-                return cast(Dict[str, Any], content_block.input)
+            if (
+                getattr(content_block, "type", None) == "tool_use"
+                and getattr(content_block, "name", None) == "extract_structured_data"
+            ):
+                result = cast(Dict[str, Any], content_block.input)
+                self._validate_result(result, schema)
+                return result
 
-        raise ValueError("No tool use in response")
+        raise ValueError("Anthropic returned no matching tool use in response")
 
     async def _async_generate_with_tool_calling(
         self,
@@ -225,15 +325,93 @@ class AnthropicAdapter(BaseLLMAdapter):
             model=self.model,
             messages=messages,
             tools=[tool_definition],
-            tool_choice={"type": "tool", "name": "extract_structured_data"},
+            tool_choice={
+                "type": "tool",
+                "name": "extract_structured_data",
+                "disable_parallel_tool_use": True,
+            },
             **kwargs,
         )
 
+        self._raise_for_incomplete_response(response)
         for content_block in response.content:
-            if hasattr(content_block, "type") and content_block.type == "tool_use":
-                return cast(Dict[str, Any], content_block.input)
+            if (
+                getattr(content_block, "type", None) == "tool_use"
+                and getattr(content_block, "name", None) == "extract_structured_data"
+            ):
+                result = cast(Dict[str, Any], content_block.input)
+                self._validate_result(result, schema)
+                return result
 
-        raise ValueError("No tool use in response")
+        raise ValueError("Anthropic returned no matching tool use in response")
+
+    def _parse_structured_output_response(
+        self,
+        response: Any,
+        schema: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        self._raise_for_incomplete_response(response)
+        text_blocks = [
+            text
+            for block in response.content
+            if getattr(block, "type", None) == "text"
+            and isinstance((text := getattr(block, "text", None)), str)
+        ]
+        if not text_blocks:
+            raise ValueError("Anthropic structured output returned no text content")
+        try:
+            result = json.loads("".join(text_blocks))
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"Anthropic structured output returned malformed JSON: {error}"
+            ) from error
+        if not isinstance(result, dict):
+            raise ValueError("Anthropic structured output must be a JSON object")
+        self._validate_result(result, schema)
+        return cast(Dict[str, Any], result)
+
+    def _raise_for_incomplete_response(self, response: Any) -> None:
+        stop_reason = getattr(response, "stop_reason", None)
+        if stop_reason == "refusal" or any(
+            getattr(block, "type", None) == "refusal" for block in getattr(response, "content", [])
+        ):
+            raise ValueError("Anthropic refused to generate structured output")
+        if stop_reason == "max_tokens":
+            raise ValueError(
+                "Anthropic structured output was truncated because max_tokens was reached"
+            )
+
+    def _validate_result(self, result: Any, schema: Dict[str, Any]) -> None:
+        try:
+            jsonschema.validate(instance=result, schema=schema)
+        except jsonschema.ValidationError as error:
+            raise ValueError(
+                f"Anthropic structured output does not match the requested schema: {error.message}"
+            ) from error
+
+    def _is_unsupported_structured_output_error(self, error: Exception) -> bool:
+        body = getattr(error, "body", None)
+        details = f"{error} {json.dumps(body, default=str) if body is not None else ''}".lower()
+        feature_markers = (
+            "output_config",
+            "output config",
+            "output format",
+            "json_schema",
+            "json schema",
+            "json output",
+            "structured output",
+        )
+        unsupported_markers = (
+            "not supported",
+            "does not support",
+            "unsupported",
+            "unknown parameter",
+            "unrecognized",
+            "not available",
+        )
+        return any(marker in details for marker in feature_markers) and any(
+            marker in details for marker in unsupported_markers
+        )
 
     def _schema_to_tool(self, schema: Dict[str, Any]) -> Dict[str, Any]:
         description = schema.get("description", "Respond in a format matching the provided schema")

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/test_adapter.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/test_adapter.py
@@ -1,0 +1,237 @@
+"""Tests for Anthropic native structured output and AUTO fallback behavior."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import anthropic
+import pytest
+
+from phoenix.evals.llm.adapters.anthropic.adapter import AnthropicAdapter
+from phoenix.evals.llm.types import ObjectGenerationMethod
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {"label": {"type": "string", "enum": ["yes", "no"]}},
+    "required": ["label"],
+    "additionalProperties": False,
+}
+
+
+class FakeBadRequestError(Exception):
+    def __init__(self, message: str, body: object = None) -> None:
+        super().__init__(message)
+        self.body = body
+
+
+def _make_sync_adapter() -> tuple[MagicMock, AnthropicAdapter]:
+    client = MagicMock()
+    client.__module__ = "anthropic"
+    client.__class__.__name__ = "Anthropic"
+    client.messages.create = MagicMock()
+    return client, AnthropicAdapter(client, "claude-test")
+
+
+def _make_async_adapter() -> tuple[MagicMock, AnthropicAdapter]:
+    client, adapter = _make_sync_adapter()
+    adapter._is_async = True
+    client.messages.create = AsyncMock()
+    return client, adapter
+
+
+def _text_response(
+    value: object = None,
+    *,
+    raw_text: str | None = None,
+    stop_reason: str = "end_turn",
+) -> SimpleNamespace:
+    text = raw_text if raw_text is not None else json.dumps(value or {"label": "yes"})
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        content=[SimpleNamespace(type="text", text=text)],
+    )
+
+
+def _tool_response(value: object = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        stop_reason="tool_use",
+        content=[
+            SimpleNamespace(
+                type="tool_use",
+                name="extract_structured_data",
+                input=value or {"label": "no"},
+            )
+        ],
+    )
+
+
+def test_structured_output_uses_output_config_format_and_parses_json() -> None:
+    client, adapter = _make_sync_adapter()
+    client.messages.create.return_value = _text_response({"label": "yes"})
+
+    result = adapter.generate_object(
+        "classify",
+        SIMPLE_SCHEMA,
+        method=ObjectGenerationMethod.STRUCTURED_OUTPUT,
+    )
+
+    assert result == {"label": "yes"}
+    assert client.messages.create.call_args.kwargs["output_config"] == {
+        "format": {
+            "type": "json_schema",
+            "schema": SIMPLE_SCHEMA,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_structured_output_uses_output_config_format_and_parses_json() -> None:
+    client, adapter = _make_async_adapter()
+    client.messages.create.return_value = _text_response({"label": "yes"})
+
+    result = await adapter.async_generate_object(
+        "classify",
+        SIMPLE_SCHEMA,
+        method=ObjectGenerationMethod.STRUCTURED_OUTPUT,
+    )
+
+    assert result == {"label": "yes"}
+    assert client.messages.create.call_args.kwargs["output_config"] == {
+        "format": {
+            "type": "json_schema",
+            "schema": SIMPLE_SCHEMA,
+        }
+    }
+
+
+def test_auto_falls_back_only_for_unsupported_output_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(anthropic, "BadRequestError", FakeBadRequestError)
+    client, adapter = _make_sync_adapter()
+    client.messages.create.side_effect = [
+        FakeBadRequestError(
+            "output_config.format is not supported for this model",
+            body={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "output_config.format is not supported for this model",
+                },
+            },
+        ),
+        _tool_response({"label": "no"}),
+    ]
+
+    result = adapter.generate_object("classify", SIMPLE_SCHEMA)
+
+    assert result == {"label": "no"}
+    assert client.messages.create.call_count == 2
+    fallback_kwargs = client.messages.create.call_args.kwargs
+    assert fallback_kwargs["tools"] == [
+        {
+            "name": "extract_structured_data",
+            "description": "Respond in a format matching the provided schema",
+            "input_schema": SIMPLE_SCHEMA,
+        }
+    ]
+    assert fallback_kwargs["tool_choice"] == {
+        "type": "tool",
+        "name": "extract_structured_data",
+        "disable_parallel_tool_use": True,
+    }
+
+
+def test_auto_propagates_unrelated_bad_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(anthropic, "BadRequestError", FakeBadRequestError)
+    client, adapter = _make_sync_adapter()
+    error = FakeBadRequestError(
+        "Invalid schema: required property is missing",
+        body={"error": {"type": "invalid_request_error", "message": "Invalid schema"}},
+    )
+    client.messages.create.side_effect = error
+
+    with pytest.raises(FakeBadRequestError) as exc_info:
+        adapter.generate_object("classify", SIMPLE_SCHEMA)
+
+    assert exc_info.value is error
+    assert client.messages.create.call_count == 1
+
+
+def test_auto_falls_back_for_does_not_support_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(anthropic, "BadRequestError", FakeBadRequestError)
+    client, adapter = _make_sync_adapter()
+    client.messages.create.side_effect = [
+        FakeBadRequestError("This model does not support json_schema output"),
+        _tool_response({"label": "no"}),
+    ]
+
+    assert adapter.generate_object("classify", SIMPLE_SCHEMA) == {"label": "no"}
+
+
+@pytest.mark.asyncio
+async def test_async_auto_falls_back_for_unsupported_output_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(anthropic, "BadRequestError", FakeBadRequestError)
+    client, adapter = _make_async_adapter()
+    client.messages.create.side_effect = [
+        FakeBadRequestError("unknown parameter: output_config.format"),
+        _tool_response({"label": "no"}),
+    ]
+
+    result = await adapter.async_generate_object("classify", SIMPLE_SCHEMA)
+
+    assert result == {"label": "no"}
+    assert client.messages.create.call_count == 2
+    assert (
+        client.messages.create.call_args.kwargs["tool_choice"]["disable_parallel_tool_use"] is True
+    )
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        (_text_response(stop_reason="refusal"), "refused"),
+        (_text_response(stop_reason="max_tokens"), "max_tokens"),
+        (SimpleNamespace(stop_reason="end_turn", content=[]), "no text content"),
+        (
+            SimpleNamespace(
+                stop_reason="end_turn",
+                content=[SimpleNamespace(type="thinking", thinking="...")],
+            ),
+            "no text content",
+        ),
+        (_text_response(raw_text="{not-json"), "malformed JSON"),
+        (_text_response({"label": "maybe"}), "does not match the requested schema"),
+    ],
+)
+def test_structured_output_rejects_invalid_responses(
+    response: SimpleNamespace,
+    message: str,
+) -> None:
+    client, adapter = _make_sync_adapter()
+    client.messages.create.return_value = response
+
+    with pytest.raises(ValueError, match=message):
+        adapter.generate_object(
+            "classify",
+            SIMPLE_SCHEMA,
+            method=ObjectGenerationMethod.STRUCTURED_OUTPUT,
+        )
+
+
+def test_tool_output_is_validated_against_schema() -> None:
+    client, adapter = _make_sync_adapter()
+    client.messages.create.return_value = _tool_response({"label": "maybe"})
+
+    with pytest.raises(ValueError, match="does not match the requested schema"):
+        adapter.generate_object(
+            "classify",
+            SIMPLE_SCHEMA,
+            method=ObjectGenerationMethod.TOOL_CALLING,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -937,6 +937,7 @@ version = "3.5.1"
 source = { editable = "packages/phoenix-evals" }
 dependencies = [
     { name = "jsonpath-ng" },
+    { name = "jsonschema" },
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
     { name = "opentelemetry-api" },
@@ -965,6 +966,7 @@ test = [
     { name = "pandas-stubs" },
     { name = "respx" },
     { name = "tqdm" },
+    { name = "types-jsonschema" },
     { name = "types-tqdm" },
     { name = "typing-extensions" },
 ]
@@ -976,6 +978,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'test'" },
     { name = "jsonpath-ng" },
+    { name = "jsonschema" },
     { name = "litellm", marker = "python_full_version < '3.14' and extra == 'dev'", specifier = ">=1.83.14" },
     { name = "litellm", marker = "python_full_version < '3.14' and extra == 'test'", specifier = ">=1.83.14" },
     { name = "nest-asyncio", marker = "extra == 'test'" },
@@ -993,6 +996,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'test'" },
     { name = "tqdm" },
     { name = "tqdm", marker = "extra == 'test'" },
+    { name = "types-jsonschema", marker = "extra == 'test'" },
     { name = "types-tqdm", marker = "extra == 'test'" },
     { name = "typing-extensions", specifier = ">=4.5,<5" },
     { name = "typing-extensions", marker = "extra == 'test'", specifier = ">=4.5,<5" },


### PR DESCRIPTION
resolves #15645

## Summary
- Anthropic 1.x `output_config.format` 同步与异步路径均已对齐，`AUTO` 模式仅在明确不支持的能力上回退为 `BadRequest`。
- 单命名工具 + `disable_parallel_tool_use` 路径已明确。
- 按输入 JSON Schema 验证输出结构。

## Failure handling
- 拒绝（refusal）、token 耗尽（max_tokens）、空/非文本响应、畸形 JSON、schema mismatch 均已覆盖。

## Tests
- `llm/adapters` 整包：164 passed, 1 skipped。
- Ruff、mypy、uv lock、diff check 均通过。

## Scope note
- Draft，pending maintainer confirmation on issue。

## AI Assistance Disclosure
- AI assisted investigation/implementation/test drafting; author reviewed code and independently reran validation。