### PR TITLE
feat(project-evals): persist the evaluators search filter in the URL

### DIFF
--- a/js/app/src/constants/searchParams.ts
+++ b/js/app/src/constants/searchParams.ts
@@ -63,7 +63,7 @@ export const LABEL_ID_PARAM = "labelId";
  * empty one. Persisting to the URL makes the search shareable and lets the
  * route loader preload the already-filtered first page.
  */
-export const EVALUATOR_FILTER_PARAM = "evaluatorFilter";
+export const EVALUATOR_FILTER_PARAM = "evaluatorsFilter";
 
 export const CREATE_CODE_EVALUATOR_PARAM = "createCodeEvaluator";
 

--- a/js/app/src/constants/searchParams.ts
+++ b/js/app/src/constants/searchParams.ts
@@ -57,6 +57,14 @@ export const TIME_RANGE_END_PARAM = "timeRangeEnd";
  */
 export const LABEL_ID_PARAM = "labelId";
 
+/**
+ * The evaluator name search applied to an evaluators list. Absent means
+ * unfiltered — a cleared search removes the param rather than writing an
+ * empty one. Persisting to the URL makes the search shareable and lets the
+ * route loader preload the already-filtered first page.
+ */
+export const EVALUATOR_FILTER_PARAM = "evaluatorFilter";
+
 export const CREATE_CODE_EVALUATOR_PARAM = "createCodeEvaluator";
 
 export const CREATE_LLM_EVALUATOR_PARAM = "createLlmEvaluator";

--- a/js/app/src/hooks/__tests__/useFilterSearchParam.test.tsx
+++ b/js/app/src/hooks/__tests__/useFilterSearchParam.test.tsx
@@ -1,0 +1,131 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+import { useFilterSearchParam } from "../useFilterSearchParam";
+
+const FILTER_PARAM = "evaluatorFilter";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+/**
+ * Renders the hook under a memory router and collects every setter identity
+ * the hook returns, so tests can read the value, drive writes, and assert the
+ * setter stays reference-stable across the URL changes those writes cause.
+ */
+function renderFilterParam({
+  initialEntries,
+  initialIndex,
+}: {
+  initialEntries: string[];
+  initialIndex?: number;
+}) {
+  const setters: Array<(value: string) => void> = [];
+  function TestFilterParam() {
+    const [value, setValue] = useFilterSearchParam(FILTER_PARAM);
+    setters.push(setValue);
+    return <output>{value}</output>;
+  }
+  const router = createMemoryRouter(
+    [{ path: "*", element: <TestFilterParam /> }],
+    { initialEntries, initialIndex }
+  );
+  act(() => {
+    root.render(<RouterProvider router={router} />);
+  });
+  const setFilterValue = (value: string) => {
+    const setValue = setters.at(-1);
+    if (!setValue) {
+      throw new Error("the hook has not rendered");
+    }
+    act(() => {
+      setValue(value);
+    });
+  };
+  return { router, setters, setFilterValue };
+}
+
+describe("useFilterSearchParam", () => {
+  it("seeds from the URL param and falls back to an empty string", () => {
+    renderFilterParam({ initialEntries: ["/?evaluatorFilter=foo"] });
+    expect(container.textContent).toBe("foo");
+
+    act(() => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    renderFilterParam({ initialEntries: ["/"] });
+    expect(container.textContent).toBe("");
+  });
+
+  it("writes the trimmed value and preserves unrelated params", () => {
+    const { router, setFilterValue } = renderFilterParam({
+      initialEntries: ["/?other=1"],
+    });
+
+    setFilterValue("  foo  ");
+
+    const params = new URLSearchParams(router.state.location.search);
+    expect(params.get(FILTER_PARAM)).toBe("foo");
+    expect(params.get("other")).toBe("1");
+    expect(container.textContent).toBe("foo");
+  });
+
+  it("removes the param when the value is empty or whitespace", () => {
+    const { router, setFilterValue } = renderFilterParam({
+      initialEntries: ["/?evaluatorFilter=foo&other=1"],
+    });
+
+    setFilterValue("   ");
+
+    const params = new URLSearchParams(router.state.location.search);
+    expect(params.has(FILTER_PARAM)).toBe(false);
+    expect(params.get("other")).toBe("1");
+    expect(container.textContent).toBe("");
+  });
+
+  it("replaces the current history entry instead of pushing", () => {
+    const { router, setFilterValue } = renderFilterParam({
+      initialEntries: ["/start", "/list"],
+      initialIndex: 1,
+    });
+
+    setFilterValue("foo");
+    setFilterValue("bar");
+
+    // Both writes replaced the /list entry, so one step back is /start; a
+    // pushed write would have put an intermediate filter state there.
+    act(() => {
+      router.navigate(-1);
+    });
+    expect(router.state.location.pathname).toBe("/start");
+  });
+
+  it("keeps the setter reference-stable across its own URL writes", () => {
+    const { setters, setFilterValue } = renderFilterParam({
+      initialEntries: ["/"],
+    });
+
+    setFilterValue("foo");
+    setFilterValue("bar");
+    setFilterValue("");
+
+    expect(setters.length).toBeGreaterThan(1);
+    expect(new Set(setters).size).toBe(1);
+  });
+});

--- a/js/app/src/hooks/index.ts
+++ b/js/app/src/hooks/index.ts
@@ -17,4 +17,5 @@ export * from "./useLatestPhoenixVersion";
 export * from "./usePersistedState";
 export * from "./useOwnedPreloadedQuery";
 export * from "./useLabelFilterSearchParams";
+export * from "./useFilterSearchParam";
 export * from "./useMediaQuery";

--- a/js/app/src/hooks/useFilterSearchParam.ts
+++ b/js/app/src/hooks/useFilterSearchParam.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useSearchParams } from "react-router";
+
+/**
+ * Backs a free-text filter with a URL search param so the filter is
+ * shareable, survives reloads, and lets a route loader preload
+ * already-filtered data.
+ *
+ * Returns a `[value, setValue]` tuple. The value is the param's current
+ * value, or "" when absent. The setter persists the trimmed value with
+ * replace-history (so typing does not spam history) while preserving
+ * unrelated params. An empty or whitespace-only value removes the param:
+ * absent already means unfiltered — there is no default to distinguish a
+ * deliberate clear from.
+ *
+ * Unlike react-router's own `setSearchParams` — which is recreated whenever
+ * `location.search` changes, including this hook's own writes — the returned
+ * setter is reference-stable across URL changes. Consumers hand it to
+ * debounced controls (see `useDebouncedChange`) that rebuild on
+ * identity change, abandoning the pending call mid-typing; the latest router
+ * setter is kept behind a ref so the returned setter's identity survives.
+ *
+ * @param paramName - the search param that carries the filter
+ */
+export function useFilterSearchParam(
+  paramName: string
+): [string, (value: string) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const value = searchParams.get(paramName) ?? "";
+  const setSearchParamsRef = useRef(setSearchParams);
+  useEffect(() => {
+    setSearchParamsRef.current = setSearchParams;
+  }, [setSearchParams]);
+  const setValue = useCallback(
+    (nextValue: string) => {
+      const trimmedValue = nextValue.trim();
+      setSearchParamsRef.current(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (trimmedValue) {
+            next.set(paramName, trimmedValue);
+          } else {
+            next.delete(paramName);
+          }
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [paramName]
+  );
+  return [value, setValue];
+}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -1,12 +1,13 @@
 import { css } from "@emotion/react";
-import { Suspense, useState } from "react";
+import { Suspense, useCallback, useState } from "react";
 import { Outlet, useLoaderData, useParams } from "react-router";
 import invariant from "tiny-invariant";
 
 import { Flex, Loading, Text, View } from "@phoenix/components";
 import { useTimeRange } from "@phoenix/components/datetime";
+import { EVALUATOR_FILTER_PARAM } from "@phoenix/constants/searchParams";
 import { ProjectEvaluatorsTableProvider } from "@phoenix/contexts/ProjectEvaluatorsTableContext";
-import { useOwnedPreloadedQuery } from "@phoenix/hooks";
+import { useFilterSearchParam, useOwnedPreloadedQuery } from "@phoenix/hooks";
 import type { projectEvaluatorsLoaderQuery } from "@phoenix/pages/project/evaluators/__generated__/projectEvaluatorsLoaderQuery.graphql";
 import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
@@ -18,7 +19,21 @@ import { ProjectEvaluatorsToolbar } from "@phoenix/pages/project/evaluators/Proj
 export function ProjectEvaluatorsPage() {
   const { projectId } = useParams();
   invariant(projectId, "projectId is required");
-  const [filter, setFilter] = useState("");
+  const [urlFilter, setUrlFilter] = useFilterSearchParam(
+    EVALUATOR_FILTER_PARAM
+  );
+  // The raw text drives the table live while the hook lands the trimmed
+  // value in the URL (debounced by the toolbar's search field). Seeded from
+  // the URL so a shared or reloaded link restores the search; the route
+  // loader preloads the first page with the same param.
+  const [filter, setFilter] = useState(urlFilter);
+  const handleFilterChange = useCallback(
+    (nextFilter: string) => {
+      setFilter(nextFilter);
+      setUrlFilter(nextFilter);
+    },
+    [setUrlFilter]
+  );
   return (
     <main
       css={css`
@@ -33,7 +48,7 @@ export function ProjectEvaluatorsPage() {
           <ProjectEvaluatorsPageContent
             projectId={projectId}
             filter={filter}
-            onFilterChange={setFilter}
+            onFilterChange={handleFilterChange}
           />
         </ProjectEvaluatorsTableProvider>
       </Suspense>
@@ -57,7 +72,7 @@ function ProjectEvaluatorsPageContent({
   onFilterChange: (filter: string) => void;
 }) {
   const { timeRangeISOStrings } = useTimeRange();
-  // The route loader preloads the owner query (unfiltered, with the time
+  // The route loader preloads the owner query (with the filter and time
   // range resolved from the URL). Subsequent toolbar, live, or user-selected
   // changes refetch the pagination fragment in ProjectEvaluatorsTable without
   // reloading this query.
@@ -110,7 +125,7 @@ function ProjectEvaluatorsPageContent({
         projectId={projectId}
         filter={filter}
         timeRange={timeRangeISOStrings}
-        initialFilter=""
+        initialFilter={loaderData.filter}
         initialTimeRange={initialTimeRange}
         initialScoreWindow={loaderData.scoreWindow}
         initialIncludeMeanScore={loaderData.includeMeanScore}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -22,10 +22,10 @@ export function ProjectEvaluatorsPage() {
   const [urlFilter, setUrlFilter] = useFilterSearchParam(
     EVALUATOR_FILTER_PARAM
   );
-  // The raw text drives the table live while the hook lands the trimmed
-  // value in the URL (debounced by the toolbar's search field). Seeded from
-  // the URL so a shared or reloaded link restores the search; the route
-  // loader preloads the first page with the same param.
+  // One debounced onChange feeds both: the raw text drives the table while
+  // the hook lands the trimmed value in the URL. Seeded from the URL so a
+  // shared or reloaded link restores the search; the route loader preloads
+  // the first page with the same param.
   const [filter, setFilter] = useState(urlFilter);
   const handleFilterChange = useCallback(
     (nextFilter: string) => {

--- a/js/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
@@ -13,6 +13,7 @@ import {
 import {
   CREATE_CODE_EVALUATOR_PARAM,
   CREATE_LLM_EVALUATOR_PARAM,
+  EVALUATOR_FILTER_PARAM,
 } from "@phoenix/constants/searchParams";
 import { PROJECT_EVALUATORS_TABLE_STORAGE_KEY } from "@phoenix/contexts/ProjectEvaluatorsTableContext";
 import { getUTCOffsetMinutes } from "@phoenix/hooks/useUTCOffsetMinutes";
@@ -115,6 +116,8 @@ function getStoredIncludeMeanScore(): boolean {
 
 export type ProjectEvaluatorsLoaderData = {
   queryRef: ReturnType<typeof loadQuery<projectEvaluatorsLoaderQuery>>;
+  /** The normalized (trimmed) name search the query was loaded with. */
+  filter: string;
   /** The exact time range the query was loaded with. */
   timeRange: TimeRangeISOStrings;
   /** The exact score window the query was loaded with. */
@@ -168,15 +171,18 @@ export function projectEvaluatorsLoader(
     utcOffsetMinutes: getUTCOffsetMinutes(),
   });
   const includeMeanScore = getStoredIncludeMeanScore();
+  // The toolbar search lives in the URL, so the loader preloads the
+  // already-filtered first page; the table refetches as the user types.
+  // Trimmed the same way the table normalizes its variables, so the mount
+  // guard's comparison sees the exact filter the rows were fetched with.
+  const filter = url.searchParams.get(EVALUATOR_FILTER_PARAM)?.trim() ?? "";
   return {
     queryRef: loadQuery<projectEvaluatorsLoaderQuery>(
       RelayEnvironment,
       projectEvaluatorsLoaderGQL,
-      // The toolbar search always starts empty on a fresh mount, so the
-      // loader fetches unfiltered; the table refetches when the user types.
       {
         projectId,
-        filter: null,
+        filter: filter ? { col: "name", value: filter } : null,
         timeRange,
         scoreTimeRange: scoreWindow.timeRange,
         scoreTimeBinConfig: scoreWindow.timeBinConfig,
@@ -184,6 +190,7 @@ export function projectEvaluatorsLoader(
       },
       { fetchPolicy: "store-and-network" }
     ),
+    filter,
     timeRange,
     scoreWindow,
     includeMeanScore,


### PR DESCRIPTION
Stacked on #15765.

Moves the evaluators tab's name search into a `?evaluatorFilter=` URL param (mirroring the spans page's `filterCondition`), so the search is shareable, survives reloads, and the route loader can preload the first page already filtered.

- New `useFilterSearchParam(param)` hook, modeled on `useLabelFilterSearchParams`: a `[value, setValue]` tuple over one search param with replace-history writes, trimmed values, and removal of the param when cleared. The returned setter is reference-stable across URL changes so debounced inputs don't rebuild (and drop a pending call) mid-typing.
- The loader reads the param, fetches with `filter: { col: "name", value }`, and returns the value it used; the table's initial-fetch guard compares against that instead of a hardcoded empty string.
- The legacy `?createLlmEvaluator`/`?createCodeEvaluator` redirects preserve the param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)