### PR TITLE
feat(ui): duplicate code evaluators

### DIFF
--- a/js/app/src/Routes.tsx
+++ b/js/app/src/Routes.tsx
@@ -67,6 +67,7 @@ import {
   AttachCodeProjectEvaluatorPage,
   AuthenticatedRoot,
   authenticatedRootLoader,
+  CopyCodeProjectEvaluatorPage,
   CopyLlmProjectEvaluatorPage,
   dashboardsLoader,
   DashboardsEmptyPage,
@@ -540,6 +541,17 @@ export const appRouteObjects = createRoutesFromElements(
                   }}
                 />
                 <Route
+                  path="new/copy-code/:evaluatorId"
+                  element={<CopyCodeProjectEvaluatorPage />}
+                  handle={{
+                    agentRoute: {
+                      label: "Duplicate Code Evaluator Into Project",
+                      description:
+                        "Create and attach a new project code evaluator seeded from an existing code evaluator. The evaluatorId route param uses the GraphQL Evaluator.id Relay node ID of the evaluator being duplicated.",
+                    },
+                  }}
+                />
+                <Route
                   path="new/attach/:evaluatorId"
                   element={<AttachCodeProjectEvaluatorPage />}
                   handle={{
@@ -609,6 +621,17 @@ export const appRouteObjects = createRoutesFromElements(
                     label: "Copy LLM Evaluator Into Project From Gallery",
                     description:
                       "Create a project evaluator seeded from an existing LLM evaluator while browsing the evaluator gallery. The evaluatorId route param uses the GraphQL Evaluator.id Relay node ID of the evaluator being copied.",
+                  },
+                }}
+              />
+              <Route
+                path="new/copy-code/:evaluatorId"
+                element={<CopyCodeProjectEvaluatorPage />}
+                handle={{
+                  agentRoute: {
+                    label: "Duplicate Code Evaluator Into Project From Gallery",
+                    description:
+                      "Create and attach a new project code evaluator seeded from an existing code evaluator while browsing the evaluator gallery. The evaluatorId route param uses the GraphQL Evaluator.id Relay node ID of the evaluator being duplicated.",
                   },
                 }}
               />

--- a/js/app/src/Routes.tsx
+++ b/js/app/src/Routes.tsx
@@ -530,7 +530,7 @@ export const appRouteObjects = createRoutesFromElements(
                   }}
                 />
                 <Route
-                  path="new/copy/:evaluatorId"
+                  path="new/copy-llm/:evaluatorId"
                   element={<CopyLlmProjectEvaluatorPage />}
                   handle={{
                     agentRoute: {
@@ -614,7 +614,7 @@ export const appRouteObjects = createRoutesFromElements(
                 }}
               />
               <Route
-                path="new/copy/:evaluatorId"
+                path="new/copy-llm/:evaluatorId"
                 element={<CopyLlmProjectEvaluatorPage />}
                 handle={{
                   agentRoute: {

--- a/js/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
+++ b/js/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
@@ -195,6 +195,14 @@ function ProjectEvaluatorMenuItems({
               navigate(creationPaths.attachCode(evaluatorId))
             }
           />
+          <EvaluatorSubmenu
+            label="Duplicate existing code evaluator"
+            icon={<Icons.Duplicate />}
+            evaluators={codeEvaluators}
+            onAction={(evaluatorId) =>
+              navigate(creationPaths.copyCode(evaluatorId))
+            }
+          />
         </MenuSection>
       </Menu>
       {hasMoreEvaluators ? (

--- a/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -257,7 +257,9 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
               code evaluator.
             </Alert>
           ) : null}
-          {isInitialSandboxUnavailable && !hasNoSandboxConfigs ? (
+          {isInitialSandboxUnavailable &&
+          selectedSandboxConfigId == null &&
+          !hasNoSandboxConfigs ? (
             <Alert variant="warning" banner>
               The original evaluator&apos;s sandbox is unavailable. Select a
               sandbox before creating this evaluator.

--- a/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -40,12 +40,18 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
   scope,
   onScopeChange,
   onSuccess,
+  initialValues,
 }: {
   title: string;
   projectId: string;
   scope: ProjectEvaluatorScope;
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
   onSuccess: () => void;
+  initialValues?: {
+    language: CodeEvaluatorLanguage;
+    sourceCode: string;
+    sandboxConfigId: string | null;
+  };
 }) => {
   const store = useEvaluatorStoreInstance();
   const environment = useRelayEnvironment();
@@ -93,11 +99,15 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
     data.sandboxBackends
   );
 
-  const [language, setLanguage] = useState<CodeEvaluatorLanguage>("PYTHON");
-  const [sourceCode, setSourceCode] = useState(() =>
-    getDefaultCodeEvaluatorSource("PYTHON")
+  const [language, setLanguage] = useState<CodeEvaluatorLanguage>(
+    initialValues?.language ?? "PYTHON"
   );
-  const [sandboxConfigId, setSandboxConfigId] = useState<string | null>(null);
+  const [sourceCode, setSourceCode] = useState(
+    () => initialValues?.sourceCode ?? getDefaultCodeEvaluatorSource("PYTHON")
+  );
+  const [sandboxConfigId, setSandboxConfigId] = useState<string | null>(
+    initialValues?.sandboxConfigId ?? null
+  );
   const [error, setError] = useState<string | undefined>();
   const [validationMessage, setValidationMessage] = useState<
     string | undefined
@@ -117,6 +127,13 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
     ? sandboxConfigId
     : null;
   const hasNoSandboxConfigs = sandboxConfigs.length === 0;
+  const isInitialSandboxUnavailable =
+    initialValues?.sandboxConfigId != null &&
+    !sandboxConfigs.some(
+      (config) =>
+        config.id === initialValues.sandboxConfigId &&
+        config.language === initialValues.language
+    );
 
   const [createEvaluator, isCreating] =
     useMutation<CreateProjectCodeEvaluatorDialogContentMutation>(graphql`
@@ -238,6 +255,12 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
             >
               No sandboxes configured. Configure a sandbox before creating a
               code evaluator.
+            </Alert>
+          ) : null}
+          {isInitialSandboxUnavailable && !hasNoSandboxConfigs ? (
+            <Alert variant="warning" banner>
+              The original evaluator&apos;s sandbox is unavailable. Select a
+              sandbox before creating this evaluator.
             </Alert>
           ) : null}
           {validationMessage ? (

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -56,6 +56,10 @@ import {
   type AnnotationConfig,
   type EvaluatorStoreProps,
 } from "@phoenix/store/evaluatorStore";
+import type {
+  CodeEvaluatorLanguage,
+  EvaluatorInputMapping,
+} from "@phoenix/types";
 
 type SeededLlmEvaluatorInitialState = {
   name: string;
@@ -70,12 +74,27 @@ type TemplateLlmEvaluatorInitialState = SeededLlmEvaluatorInitialState & {
   targetType: ProjectEvaluatorTarget;
 };
 
+type SeededCodeEvaluatorInitialState = {
+  name: string;
+  copyName: string;
+  description: string;
+  outputConfigs: AnnotationConfig[];
+  language: CodeEvaluatorLanguage;
+  sourceCode: string;
+  sandboxConfigId: string | null;
+  inputMapping: EvaluatorInputMapping;
+};
+
 export type ProjectEvaluatorCreationMode =
   | { kind: "scratch" }
   | { kind: "newCode" }
   | {
       kind: "copy";
       initialState: SeededLlmEvaluatorInitialState;
+    }
+  | {
+      kind: "copyCode";
+      initialState: SeededCodeEvaluatorInitialState;
     }
   | {
       kind: "template";
@@ -103,6 +122,9 @@ function getProjectEvaluatorCreationTitle(
   }
   if (creationMode.kind === "copy") {
     return `Copy LLM evaluator “${creationMode.initialState.name}”`;
+  }
+  if (creationMode.kind === "copyCode") {
+    return `Duplicate code evaluator “${creationMode.initialState.name}”`;
   }
   if (creationMode.kind === "template") {
     return `Create “${creationMode.initialState.name}” evaluator`;
@@ -186,17 +208,24 @@ const CreateProjectEvaluatorDialog = ({
   });
 
   const initialState = (() => {
-    if (creationMode.kind === "newCode") {
+    if (creationMode.kind === "newCode" || creationMode.kind === "copyCode") {
+      const copiedState =
+        creationMode.kind === "copyCode" ? creationMode.initialState : null;
       return {
         ...DEFAULT_LLM_EVALUATOR_STORE_VALUES,
         evaluator: {
           ...DEFAULT_LLM_EVALUATOR_STORE_VALUES.evaluator,
-          globalName: "",
-          description: "",
-          inputMapping: { pathMapping: {}, literalMapping: {} },
+          globalName: copiedState?.copyName ?? "",
+          description: copiedState?.description ?? "",
+          inputMapping: copiedState?.inputMapping ?? {
+            pathMapping: {},
+            literalMapping: {},
+          },
           kind: "CODE",
         },
-        outputConfigs: [createDefaultFreeformOutputConfig("")],
+        outputConfigs: copiedState?.outputConfigs ?? [
+          createDefaultFreeformOutputConfig(""),
+        ],
         evaluatorMappingSource: defaultEvaluatorMappingSourceState(
           toEvaluatorMappingSourceGrain(scope.targetType)
         ),
@@ -259,7 +288,7 @@ const CreateProjectEvaluatorDialog = ({
 
   return (
     <EvaluatorStoreProvider initialState={initialState}>
-      {creationMode.kind === "newCode" ? (
+      {creationMode.kind === "newCode" || creationMode.kind === "copyCode" ? (
         <CreateNewCodeProjectEvaluatorDialog
           title={title}
           projectId={projectId}
@@ -267,6 +296,15 @@ const CreateProjectEvaluatorDialog = ({
           onScopeChange={setScope}
           onSuccess={finishCreation}
           registerDirtyCheck={registerDirtyCheck}
+          initialValues={
+            creationMode.kind === "copyCode"
+              ? {
+                  language: creationMode.initialState.language,
+                  sourceCode: creationMode.initialState.sourceCode,
+                  sandboxConfigId: creationMode.initialState.sandboxConfigId,
+                }
+              : undefined
+          }
         />
       ) : creationMode.kind === "code" ? (
         <AttachCodeProjectEvaluatorDialog
@@ -300,6 +338,7 @@ function CreateNewCodeProjectEvaluatorDialog({
   onScopeChange,
   onSuccess,
   registerDirtyCheck,
+  initialValues,
 }: {
   title: string;
   projectId: string;
@@ -307,6 +346,11 @@ function CreateNewCodeProjectEvaluatorDialog({
   onScopeChange: (scope: ProjectEvaluatorScope) => void;
   onSuccess: () => void;
   registerDirtyCheck: (check: EvaluatorFormDirtyCheck) => void;
+  initialValues?: {
+    language: CodeEvaluatorLanguage;
+    sourceCode: string;
+    sandboxConfigId: string | null;
+  };
 }) {
   const store = useEvaluatorStoreInstance();
   const trackStoreForDirtyCheck = useEvaluatorFormDirtyCheck({
@@ -322,6 +366,7 @@ function CreateNewCodeProjectEvaluatorDialog({
       scope={scope}
       onScopeChange={onScopeChange}
       onSuccess={onSuccess}
+      initialValues={initialValues}
     />
   );
 }

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -89,7 +89,7 @@ export type ProjectEvaluatorCreationMode =
   | { kind: "scratch" }
   | { kind: "newCode" }
   | {
-      kind: "copy";
+      kind: "copyLlm";
       initialState: SeededLlmEvaluatorInitialState;
     }
   | {
@@ -120,7 +120,7 @@ function getProjectEvaluatorCreationTitle(
   if (creationMode.kind === "newCode") {
     return "Create new code evaluator";
   }
-  if (creationMode.kind === "copy") {
+  if (creationMode.kind === "copyLlm") {
     return `Copy LLM evaluator “${creationMode.initialState.name}”`;
   }
   if (creationMode.kind === "copyCode") {
@@ -161,7 +161,7 @@ function CreateProjectEvaluatorDialogForMode(
   const { creationMode } = props;
   if (
     creationMode.kind === "scratch" ||
-    creationMode.kind === "copy" ||
+    creationMode.kind === "copyLlm" ||
     creationMode.kind === "template"
   ) {
     const defaultMessages =
@@ -232,11 +232,11 @@ const CreateProjectEvaluatorDialog = ({
       } satisfies EvaluatorStoreProps;
     }
     const seededState =
-      creationMode.kind === "copy" || creationMode.kind === "template"
+      creationMode.kind === "copyLlm" || creationMode.kind === "template"
         ? creationMode.initialState
         : undefined;
     const defaultEvaluatorName =
-      creationMode.kind === "copy"
+      creationMode.kind === "copyLlm"
         ? creationMode.initialState.name
           ? `${creationMode.initialState.name} copy`
           : DEFAULT_LLM_EVALUATOR_STORE_VALUES.evaluator.globalName

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -698,6 +698,11 @@ function EvaluatorGallery() {
                         )
                   )
                 }
+                onDuplicateEvaluator={() =>
+                  navigate(
+                    paths.galleryCreation.copyCode(selectedItem.evaluator.id)
+                  )
+                }
               />
             </Suspense>
           </ErrorBoundary>
@@ -782,9 +787,11 @@ function EvaluatorTemplateCardFooter({
 function CustomEvaluatorDetails({
   evaluator: evaluatorSummary,
   onUseEvaluator,
+  onDuplicateEvaluator,
 }: {
   evaluator: CustomEvaluator;
   onUseEvaluator: () => void;
+  onDuplicateEvaluator: () => void;
 }) {
   const data = useLazyLoadQuery<ProjectEvaluatorDetailsQueryType>(
     projectEvaluatorDetailsQueryNode,
@@ -808,6 +815,7 @@ function CustomEvaluatorDetails({
       <CodeCustomEvaluatorDetails
         evaluator={evaluator}
         onUseEvaluator={onUseEvaluator}
+        onDuplicateEvaluator={onDuplicateEvaluator}
       />
     );
   }
@@ -972,9 +980,11 @@ function LlmCustomEvaluatorDetails({
 function CodeCustomEvaluatorDetails({
   evaluator,
   onUseEvaluator,
+  onDuplicateEvaluator,
 }: {
   evaluator: CodeProjectEvaluatorDetails;
   onUseEvaluator: () => void;
+  onDuplicateEvaluator: () => void;
 }) {
   return (
     <Flex direction="column" gap="size-200" height="100%">
@@ -1010,7 +1020,13 @@ function CodeCustomEvaluatorDetails({
           </ExpandableContent>
         </div>
       </Flex>
-      <EvaluatorDetailsAction onPress={onUseEvaluator}>
+      <EvaluatorDetailsAction
+        onPress={onUseEvaluator}
+        secondaryAction={{
+          label: "Duplicate this evaluator",
+          onPress: onDuplicateEvaluator,
+        }}
+      >
         Use this evaluator
       </EvaluatorDetailsAction>
     </Flex>
@@ -1055,15 +1071,25 @@ function EvaluatorPromptPreview({
 function EvaluatorDetailsAction({
   children,
   onPress,
+  secondaryAction,
 }: {
   children: string;
   onPress: () => void;
+  secondaryAction?: {
+    label: string;
+    onPress: () => void;
+  };
 }) {
   return (
-    <Flex direction="column" css={stickyUseTemplateFooterCSS}>
+    <Flex direction="column" gap="size-100" css={stickyUseTemplateFooterCSS}>
       <Button variant="primary" onPress={onPress}>
         {children}
       </Button>
+      {secondaryAction ? (
+        <Button onPress={secondaryAction.onPress}>
+          {secondaryAction.label}
+        </Button>
+      ) : null}
     </Flex>
   );
 }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -689,18 +689,18 @@ function EvaluatorGallery() {
             <Suspense fallback={<EvaluatorDetailsSkeleton />}>
               <CustomEvaluatorDetails
                 evaluator={selectedItem.evaluator}
-                onUseEvaluator={() =>
+                onAttachCodeEvaluator={() =>
                   navigate(
-                    getCustomEvaluatorKind(selectedItem.evaluator) === "LLM"
-                      ? paths.galleryCreation.copyLlm(selectedItem.evaluator.id)
-                      : paths.galleryCreation.attachCode(
-                          selectedItem.evaluator.id
-                        )
+                    paths.galleryCreation.attachCode(selectedItem.evaluator.id)
                   )
                 }
                 onDuplicateEvaluator={() =>
                   navigate(
-                    paths.galleryCreation.copyCode(selectedItem.evaluator.id)
+                    getCustomEvaluatorKind(selectedItem.evaluator) === "LLM"
+                      ? paths.galleryCreation.copyLlm(selectedItem.evaluator.id)
+                      : paths.galleryCreation.copyCode(
+                          selectedItem.evaluator.id
+                        )
                   )
                 }
               />
@@ -786,11 +786,11 @@ function EvaluatorTemplateCardFooter({
 
 function CustomEvaluatorDetails({
   evaluator: evaluatorSummary,
-  onUseEvaluator,
+  onAttachCodeEvaluator,
   onDuplicateEvaluator,
 }: {
   evaluator: CustomEvaluator;
-  onUseEvaluator: () => void;
+  onAttachCodeEvaluator: () => void;
   onDuplicateEvaluator: () => void;
 }) {
   const data = useLazyLoadQuery<ProjectEvaluatorDetailsQueryType>(
@@ -806,7 +806,7 @@ function CustomEvaluatorDetails({
     return (
       <LlmCustomEvaluatorDetails
         evaluator={evaluator}
-        onUseEvaluator={onUseEvaluator}
+        onDuplicateEvaluator={onDuplicateEvaluator}
       />
     );
   }
@@ -814,7 +814,7 @@ function CustomEvaluatorDetails({
     return (
       <CodeCustomEvaluatorDetails
         evaluator={evaluator}
-        onUseEvaluator={onUseEvaluator}
+        onAttachCodeEvaluator={onAttachCodeEvaluator}
         onDuplicateEvaluator={onDuplicateEvaluator}
       />
     );
@@ -945,10 +945,10 @@ function AnnotationValues({
 
 function LlmCustomEvaluatorDetails({
   evaluator,
-  onUseEvaluator,
+  onDuplicateEvaluator,
 }: {
   evaluator: LlmProjectEvaluatorDetails;
-  onUseEvaluator: () => void;
+  onDuplicateEvaluator: () => void;
 }) {
   const promptTemplate = evaluator.promptVersion?.template;
   const messages: PlaygroundChatTemplate["messages"] =
@@ -970,7 +970,7 @@ function LlmCustomEvaluatorDetails({
       <CustomEvaluatorDetailsHeader evaluator={evaluator} />
       <EvaluatorOutputSummary outputConfigs={evaluator.outputConfigs} />
       <EvaluatorPromptPreview messages={messages} />
-      <EvaluatorDetailsAction onPress={onUseEvaluator}>
+      <EvaluatorDetailsAction onPress={onDuplicateEvaluator}>
         Duplicate this evaluator
       </EvaluatorDetailsAction>
     </Flex>
@@ -979,11 +979,11 @@ function LlmCustomEvaluatorDetails({
 
 function CodeCustomEvaluatorDetails({
   evaluator,
-  onUseEvaluator,
+  onAttachCodeEvaluator,
   onDuplicateEvaluator,
 }: {
   evaluator: CodeProjectEvaluatorDetails;
-  onUseEvaluator: () => void;
+  onAttachCodeEvaluator: () => void;
   onDuplicateEvaluator: () => void;
 }) {
   return (
@@ -1021,7 +1021,7 @@ function CodeCustomEvaluatorDetails({
         </div>
       </Flex>
       <EvaluatorDetailsAction
-        onPress={onUseEvaluator}
+        onPress={onAttachCodeEvaluator}
         secondaryAction={{
           label: "Duplicate this evaluator",
           onPress: onDuplicateEvaluator,

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorSlideoverRoutes.tsx
@@ -12,6 +12,7 @@ import {
 } from "@phoenix/pages/project/evaluators/EditProjectEvaluatorSlideover";
 import {
   buildAttachCodeCreationMode,
+  buildCopyCodeCreationMode,
   buildCopyLlmCreationMode,
   projectEvaluatorDetailsQueryNode,
   readProjectEvaluatorDetails,
@@ -182,6 +183,33 @@ export function AttachCodeProjectEvaluatorPage() {
     return (
       <ProjectEvaluatorSlideoverError
         title="Cannot attach evaluator"
+        message="This link does not name a code evaluator."
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
+  return (
+    <CreateProjectEvaluatorSlideover
+      isOpen
+      onOpenChange={onOpenChange}
+      projectId={projectId}
+      creationMode={creationMode}
+    />
+  );
+}
+
+export function CopyCodeProjectEvaluatorPage() {
+  const projectId = useRouteProjectId();
+  const onOpenChange = useCloseSlideover();
+  const evaluator = useSourceEvaluator();
+  const creationMode =
+    evaluator?.__typename === "CodeEvaluator"
+      ? buildCopyCodeCreationMode(evaluator)
+      : null;
+  if (!creationMode) {
+    return (
+      <ProjectEvaluatorSlideoverError
+        title="Cannot duplicate evaluator"
         message="This link does not name a code evaluator."
         onOpenChange={onOpenChange}
       />

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f40396fe2576a83a71f4af1a1b4341a4>>
+ * @generated SignedSource<<2f1e71a04b535ac9e76732247443c3b9>>
  * @lightSyntaxTransform
  */
 
@@ -301,7 +301,45 @@ v20 = {
   "name": "language",
   "storageKey": null
 },
-v21 = {
+v21 = [
+  (v3/*:: as any*/)
+],
+v22 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SandboxConfig",
+  "kind": "LinkedField",
+  "name": "sandboxConfig",
+  "plural": false,
+  "selections": (v21/*:: as any*/),
+  "storageKey": null
+},
+v23 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EvaluatorInputMapping",
+  "kind": "LinkedField",
+  "name": "inputMapping",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "pathMapping",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "literalMapping",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -315,9 +353,7 @@ v21 = {
     (v12/*:: as any*/),
     {
       "kind": "InlineFragment",
-      "selections": [
-        (v3/*:: as any*/)
-      ],
+      "selections": (v21/*:: as any*/),
       "type": "Node",
       "abstractKey": "__isNode"
     }
@@ -440,7 +476,9 @@ return {
                   (v6/*:: as any*/),
                   (v13/*:: as any*/),
                   (v19/*:: as any*/),
-                  (v20/*:: as any*/)
+                  (v20/*:: as any*/),
+                  (v22/*:: as any*/),
+                  (v23/*:: as any*/)
                 ],
                 "type": "CodeEvaluator",
                 "abstractKey": null
@@ -478,7 +516,7 @@ return {
               (v4/*:: as any*/),
               (v5/*:: as any*/),
               (v6/*:: as any*/),
-              (v21/*:: as any*/),
+              (v24/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -548,9 +586,11 @@ return {
               (v4/*:: as any*/),
               (v5/*:: as any*/),
               (v6/*:: as any*/),
-              (v21/*:: as any*/),
+              (v24/*:: as any*/),
               (v19/*:: as any*/),
-              (v20/*:: as any*/)
+              (v20/*:: as any*/),
+              (v22/*:: as any*/),
+              (v23/*:: as any*/)
             ],
             "type": "CodeEvaluator",
             "abstractKey": null
@@ -561,12 +601,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cebb8eb6eb5a4934aa2f16f0993fdb74",
+    "cacheID": "9142867e7a26fc8cca78b4ace9c8f639",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorDetailsQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorDetailsQuery(\n  $id: ID!\n) {\n  evaluator: node(id: $id) {\n    __typename\n    ...projectEvaluatorOptions_llmEvaluatorDetails\n    ...projectEvaluatorOptions_codeEvaluatorDetails\n    id\n  }\n}\n\nfragment projectEvaluatorOptions_codeEvaluatorDetails on CodeEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  sourceCode\n  language\n}\n\nfragment projectEvaluatorOptions_llmEvaluatorDetails on LLMEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  promptVersion {\n    templateFormat\n    template {\n      __typename\n      ... on PromptChatTemplate {\n        messages {\n          ...promptUtils_promptMessages\n        }\n      }\n      ... on PromptStringTemplate {\n        template\n      }\n    }\n    tools {\n      tools {\n        __typename\n        ... on PromptToolFunction {\n          function {\n            parameters\n          }\n        }\n        ... on PromptToolRaw {\n          raw\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
+    "text": "query projectEvaluatorDetailsQuery(\n  $id: ID!\n) {\n  evaluator: node(id: $id) {\n    __typename\n    ...projectEvaluatorOptions_llmEvaluatorDetails\n    ...projectEvaluatorOptions_codeEvaluatorDetails\n    id\n  }\n}\n\nfragment projectEvaluatorOptions_codeEvaluatorDetails on CodeEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  sourceCode\n  language\n  sandboxConfig {\n    id\n  }\n  inputMapping {\n    pathMapping\n    literalMapping\n  }\n}\n\nfragment projectEvaluatorOptions_llmEvaluatorDetails on LLMEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  promptVersion {\n    templateFormat\n    template {\n      __typename\n      ... on PromptChatTemplate {\n        messages {\n          ...promptUtils_promptMessages\n        }\n      }\n      ... on PromptStringTemplate {\n        template\n      }\n    }\n    tools {\n      tools {\n        __typename\n        ... on PromptToolFunction {\n          function {\n            parameters\n          }\n        }\n        ... on PromptToolRaw {\n          raw\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
   }
 };
 })();

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7cc54066238328e00ed8a7f761135a8e>>
+ * @generated SignedSource<<71bb70f9ed8db0416e5d7ab1671e0719>>
  * @lightSyntaxTransform
  */
 
@@ -16,6 +16,10 @@ export type projectEvaluatorOptions_codeEvaluatorDetails$data = {
   readonly __typename: "CodeEvaluator";
   readonly description: string | null;
   readonly id: string;
+  readonly inputMapping: {
+    readonly literalMapping: any;
+    readonly pathMapping: any;
+  };
   readonly kind: EvaluatorKind;
   readonly language: Language;
   readonly name: string;
@@ -45,6 +49,9 @@ export type projectEvaluatorOptions_codeEvaluatorDetails$data = {
     // value in case none of the concrete values match.
     readonly __typename: "%other";
   }>;
+  readonly sandboxConfig: {
+    readonly id: string;
+  } | null;
   readonly sourceCode: string;
   readonly " $fragmentType": "projectEvaluatorOptions_codeEvaluatorDetails";
 };
@@ -58,6 +65,6 @@ const node: ReaderInlineDataFragment = {
   "name": "projectEvaluatorOptions_codeEvaluatorDetails"
 };
 
-(node as any).hash = "9335d602204b26f5e830ed106d937640";
+(node as any).hash = "909a71aa9d157eb5cff56e368fc79cc2";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts
@@ -1,0 +1,67 @@
+import {
+  buildCopyCodeCreationMode,
+  type CodeProjectEvaluatorDetails,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
+
+const codeEvaluator = {
+  __typename: "CodeEvaluator",
+  id: "CodeEvaluator:1",
+  name: "checks-output",
+  description: "Checks the final answer",
+  kind: "CODE",
+  language: "TYPESCRIPT",
+  sourceCode: "function evaluate(output: string) { return output.length; }",
+  sandboxConfig: { id: "SandboxConfig:1" },
+  inputMapping: {
+    pathMapping: { output: "output.value" },
+    literalMapping: { threshold: 5 },
+  },
+  outputConfigs: [
+    {
+      __typename: "ContinuousAnnotationConfig",
+      name: "length",
+      optimizationDirection: "MAXIMIZE",
+      lowerBound: 0,
+      upperBound: null,
+    },
+  ],
+  " $fragmentType": "projectEvaluatorOptions_codeEvaluatorDetails",
+} satisfies CodeProjectEvaluatorDetails;
+
+describe("buildCopyCodeCreationMode", () => {
+  it("seeds a new code evaluator from the source definition", () => {
+    expect(buildCopyCodeCreationMode(codeEvaluator)).toEqual({
+      kind: "copyCode",
+      initialState: {
+        name: "checks-output",
+        copyName: "checks-output-copy",
+        description: "Checks the final answer",
+        language: "TYPESCRIPT",
+        sourceCode:
+          "function evaluate(output: string) { return output.length; }",
+        sandboxConfigId: "SandboxConfig:1",
+        inputMapping: {
+          pathMapping: { output: "output.value" },
+          literalMapping: { threshold: 5 },
+        },
+        outputConfigs: [
+          {
+            name: "length",
+            optimizationDirection: "MAXIMIZE",
+            lowerBound: 0,
+            upperBound: null,
+          },
+        ],
+      },
+    });
+  });
+
+  it("allows the duplicate form to require a replacement sandbox", () => {
+    expect(
+      buildCopyCodeCreationMode({
+        ...codeEvaluator,
+        sandboxConfig: null,
+      }).initialState.sandboxConfigId
+    ).toBeNull();
+  });
+});

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
@@ -83,7 +83,7 @@ describe("useProjectEvaluatorPaths", () => {
       "/projects/project-1/evaluators/new/code?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-list-copy-llm")).toBe(
-      "/projects/project-1/evaluators/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluators/new/copy-llm/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-list-copy-code")).toBe(
       "/projects/project-1/evaluators/new/copy-code/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
@@ -98,7 +98,7 @@ describe("useProjectEvaluatorPaths", () => {
       "/projects/project-1/evaluator-gallery/new/code?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-copy-llm")).toBe(
-      "/projects/project-1/evaluator-gallery/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
+      "/projects/project-1/evaluator-gallery/new/copy-llm/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-copy-code")).toBe(
       "/projects/project-1/evaluator-gallery/new/copy-code/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorPaths.test.tsx
@@ -29,6 +29,7 @@ function TestProjectEvaluatorPaths() {
       data-list-new-llm={paths.listCreation.newLlm}
       data-list-new-code={paths.listCreation.newCode}
       data-list-copy-llm={paths.listCreation.copyLlm("Evaluator:llm/source")}
+      data-list-copy-code={paths.listCreation.copyCode("Evaluator:code/source")}
       data-list-attach-code={paths.listCreation.attachCode(
         "Evaluator:code/source"
       )}
@@ -36,6 +37,9 @@ function TestProjectEvaluatorPaths() {
       data-gallery-new-code={paths.galleryCreation.newCode}
       data-gallery-copy-llm={paths.galleryCreation.copyLlm(
         "Evaluator:llm/source"
+      )}
+      data-gallery-copy-code={paths.galleryCreation.copyCode(
+        "Evaluator:code/source"
       )}
       data-gallery-attach-code={paths.galleryCreation.attachCode(
         "Evaluator:code/source"
@@ -81,6 +85,9 @@ describe("useProjectEvaluatorPaths", () => {
     expect(output?.getAttribute("data-list-copy-llm")).toBe(
       "/projects/project-1/evaluators/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
+    expect(output?.getAttribute("data-list-copy-code")).toBe(
+      "/projects/project-1/evaluators/new/copy-code/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
+    );
     expect(output?.getAttribute("data-list-attach-code")).toBe(
       "/projects/project-1/evaluators/new/attach/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
@@ -92,6 +99,9 @@ describe("useProjectEvaluatorPaths", () => {
     );
     expect(output?.getAttribute("data-gallery-copy-llm")).toBe(
       "/projects/project-1/evaluator-gallery/new/copy/Evaluator%3Allm%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
+    );
+    expect(output?.getAttribute("data-gallery-copy-code")).toBe(
+      "/projects/project-1/evaluator-gallery/new/copy-code/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"
     );
     expect(output?.getAttribute("data-gallery-attach-code")).toBe(
       "/projects/project-1/evaluator-gallery/new/attach/Evaluator%3Acode%2Fsource?timeRangeKey=7d&category=AGENTS&evaluator=Evaluator%3Astale&template=Hallucination&proof=preserved"

--- a/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -222,7 +222,7 @@ export function buildCopyLlmCreationMode(
   return {
     ok: true,
     mode: {
-      kind: "copy",
+      kind: "copyLlm",
       initialState: {
         name: evaluator.name,
         description: evaluator.description ?? "",

--- a/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -135,6 +135,13 @@ const codeProjectEvaluatorDetailsFragment = graphql`
     }
     sourceCode
     language
+    sandboxConfig {
+      id
+    }
+    inputMapping {
+      pathMapping
+      literalMapping
+    }
   }
 `;
 
@@ -253,6 +260,29 @@ export function buildAttachCodeCreationMode(
     ),
     variables,
     requiredVariables,
+  };
+}
+
+export function buildCopyCodeCreationMode(
+  evaluator: CodeProjectEvaluatorDetails
+): Extract<ProjectEvaluatorCreationMode, { kind: "copyCode" }> {
+  return {
+    kind: "copyCode",
+    initialState: {
+      name: evaluator.name,
+      copyName: `${evaluator.name}-copy`,
+      description: evaluator.description ?? "",
+      outputConfigs: convertProjectEvaluatorOutputConfigs(
+        evaluator.outputConfigs
+      ),
+      language: evaluator.language,
+      sourceCode: evaluator.sourceCode,
+      sandboxConfigId: evaluator.sandboxConfig?.id ?? null,
+      inputMapping: {
+        pathMapping: { ...evaluator.inputMapping.pathMapping },
+        literalMapping: { ...evaluator.inputMapping.literalMapping },
+      },
+    },
   };
 }
 

--- a/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -61,7 +61,7 @@ export function useProjectEvaluatorPaths() {
       newCode: withCurrentSearch(`${parentPath}/new/code`),
       copyLlm: (evaluatorId: string) =>
         withCurrentSearch(
-          `${parentPath}/new/copy/${encodeURIComponent(evaluatorId)}`
+          `${parentPath}/new/copy-llm/${encodeURIComponent(evaluatorId)}`
         ),
       copyCode: (evaluatorId: string) =>
         withCurrentSearch(

--- a/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorPaths.ts
@@ -30,6 +30,7 @@ export type ProjectEvaluatorCreationPaths = {
   newLlm: string;
   newCode: string;
   copyLlm: (evaluatorId: string) => string;
+  copyCode: (evaluatorId: string) => string;
   attachCode: (evaluatorId: string) => string;
 };
 
@@ -61,6 +62,10 @@ export function useProjectEvaluatorPaths() {
       copyLlm: (evaluatorId: string) =>
         withCurrentSearch(
           `${parentPath}/new/copy/${encodeURIComponent(evaluatorId)}`
+        ),
+      copyCode: (evaluatorId: string) =>
+        withCurrentSearch(
+          `${parentPath}/new/copy-code/${encodeURIComponent(evaluatorId)}`
         ),
       attachCode: (evaluatorId: string) =>
         withCurrentSearch(


### PR DESCRIPTION
## Summary

- add a secondary `Duplicate this evaluator` action beneath the code evaluator gallery's existing attach action
- add a `Duplicate existing code evaluator` submenu beneath the existing-code action in the Add evaluator menu
- open the code evaluator creation dialog with the source evaluator's description, input mapping, output configs, language, source code, and sandbox pre-populated
- generate an identifier-safe copy name and require a replacement when the source sandbox is unavailable

## Screenshots

### Gallery action

![Code evaluator gallery with duplicate action](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15809-code-evaluator-gallery.png)

### Pre-populated duplicate dialog

![Pre-populated code evaluator duplicate dialog](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15809-code-evaluator-duplicate-dialog.png)

## Test plan

- `make relay-build`
- `make typecheck-frontend`
- `make lint-frontend`
- `make test-frontend` — 2,380 passed, 12 skipped
- `make build-frontend`
- browser-verified both duplicate entry points, the pre-populated form, successful duplicate creation, and 1440px and 1024px layouts

Stacked on #15771.
