### PR TITLE
feat(playground): add support for claude-fable-5-1

### DIFF
--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -338,7 +338,7 @@ call. Models that are weak at tool use produce broken sessions even if they
 handle free-form chat well. Pick one of these validated models unless you have a
 specific reason not to:
 
-- **Anthropic** — `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`
+- **Anthropic** — `claude-fable-5-1`, `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`
 - **OpenAI** — `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`
 - **Google** — `gemini-3.7-flash`, `gemini-3.1-pro-preview`
 

--- a/js/.changeset/spicy-berries-dream.md
+++ b/js/.changeset/spicy-berries-dream.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": patch
+---
+
+recommend claude-fable-5-1 for PXI sessions

--- a/js/app/src/components/agent/agentCuratedModels.ts
+++ b/js/app/src/components/agent/agentCuratedModels.ts
@@ -13,6 +13,7 @@ export type AgentPlaygroundModel = {
 
 export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[] =
   [
+    { provider: "ANTHROPIC", modelName: "claude-fable-5-1" },
     { provider: "ANTHROPIC", modelName: "claude-fable-5" },
     { provider: "ANTHROPIC", modelName: "claude-opus-5" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },

--- a/js/app/stories/ModelMenu.stories.tsx
+++ b/js/app/stories/ModelMenu.stories.tsx
@@ -43,7 +43,15 @@ export default meta;
 
 const MODELS_BY_PROVIDER = new Map<string, string[]>([
   ["OPENAI", ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.4-mini"]],
-  ["ANTHROPIC", ["claude-fable-5", "claude-sonnet-4-6", "claude-haiku-4-5"]],
+  [
+    "ANTHROPIC",
+    [
+      "claude-fable-5-1",
+      "claude-fable-5",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+    ],
+  ],
   ["AZURE_OPENAI", ["gpt-5.6-luna", "gpt-5.4-mini"]],
   [
     "AWS",

--- a/js/packages/phoenix-cli/src/pxi/preflight.ts
+++ b/js/packages/phoenix-cli/src/pxi/preflight.ts
@@ -95,6 +95,7 @@ export type PxiModelPreflightData = {
 };
 
 const RECOMMENDED_PXI_MODELS = [
+  { provider: "ANTHROPIC", modelName: "claude-fable-5-1" },
   { provider: "ANTHROPIC", modelName: "claude-fable-5" },
   { provider: "ANTHROPIC", modelName: "claude-opus-5" },
   { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },

--- a/js/packages/phoenix-cli/test/pxiPreflight.test.ts
+++ b/js/packages/phoenix-cli/test/pxiPreflight.test.ts
@@ -334,12 +334,18 @@ describe("PXI model preflight", () => {
           { providerKey: "GOOGLE", name: "gemini-3.5-flash" },
           { providerKey: "OPENAI", name: "unrecommended-model" },
           { providerKey: "OPENAI", name: "gpt-5.4" },
+          { providerKey: "ANTHROPIC", name: "claude-fable-5-1" },
           { providerKey: "ANTHROPIC", name: "claude-opus-4-8" },
         ],
       }),
     });
 
     expect(models).toEqual([
+      {
+        providerType: "builtin",
+        provider: "ANTHROPIC",
+        modelName: "claude-fable-5-1",
+      },
       {
         providerType: "builtin",
         provider: "ANTHROPIC",

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1404,6 +1404,7 @@ class TogetherClient(OpenAICompatibleClient):
     provider_key=GenerativeProviderKey.AWS,
     model_names=[
         PROVIDER_DEFAULT,
+        "anthropic.claude-fable-5-1",
         "anthropic.claude-fable-5",
         "anthropic.claude-opus-5",
         "anthropic.claude-opus-4-8",
@@ -2099,6 +2100,7 @@ _ANTHROPIC_SAMPLING_PARAM_KEYS = frozenset(("temperature", "top_p"))
 # (`thinking: {"type": "enabled", "budget_tokens": N}`) from their request
 # surface; sending any of them returns a 400.
 ANTHROPIC_ADAPTIVE_THINKING_MODELS = [
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4-8",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -204,6 +204,33 @@
       ]
     },
     {
+      "name": "claude-fable-5-1",
+      "name_pattern": "claude-fable-5-1",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 0.00001,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00005,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 2.5e-7,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 0.0000125,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
       "name": "claude-haiku-4-5",
       "name_pattern": "claude-haiku-4-5",
       "source": "litellm",


### PR DESCRIPTION
Adds Claude Fable 5.1 ([what's new](https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1)) across the playground, cost tracking, and the curated model lists, following the pattern of the claude-fable-5 (#13684) and gemini-3.7-flash (#15520) additions.

## Changes

- **Playground registration** — `claude-fable-5-1` joins `ANTHROPIC_ADAPTIVE_THINKING_MODELS` (Fable 5.1 keeps always-on adaptive thinking and rejects sampling parameters, same request surface as Fable 5) and `anthropic.claude-fable-5-1` joins the Bedrock model list.
- **Cost manifest** — new entry with the same rates as `claude-fable-5` ($10/MTok input, $50/MTok output, $12.50/MTok cache write) except cache reads at **$0.25/MTok** instead of $1.00/MTok — the one price that changed in 5.1. The cost lookup ranks name patterns by literal-length specificity, so `claude-fable-5-1` spans resolve to the new entry rather than the `claude-fable-5` substring match.
- **Curated/recommended lists** — added first (keeping `claude-fable-5`) in the agent curated models, the PXI preflight recommendations (with a patch changeset for `@arizeai/phoenix-cli`), the ModelMenu storybook data, and the PXI docs.
- **Test** — the preflight recommendation test now covers the new model.

## Notes

- No `claude-mythos-5-1` manifest entry: the LiteLLM sync should pick it up; until then mythos-5-1 spans fall back to the mythos-5 entry and overprice cache reads 4×.
- Fable 5.1 newly rejects forced `tool_choice` (`"any"`/`"tool"`) with a 400. Phoenix doesn't gate unsupported invocation parameters per model anywhere (temperature on fable-5 behaves the same way), so no gating is added here — the provider error surfaces to the user.

## Verification

- Manifest JSON parses with the new entry exactly once; `tests/unit/server/cost_tracking/test_model_cost_manifest.py` passes (10/10).
- `pxiPreflight.test.ts` 23/23 and `agentCuratedModels.test.ts` 4/4 pass; oxfmt check clean.