### PR TITLE
fix: preserve evaluator submit button emphasis

### DIFF
--- a/js/app/src/components/evaluators/EvaluatorFormDialogContent.tsx
+++ b/js/app/src/components/evaluators/EvaluatorFormDialogContent.tsx
@@ -86,7 +86,7 @@ export const EvaluatorFormDialogContent = ({
         </Button>
         <Button
           {...submitButtonProps}
-          variant={submitHint ? "default" : "primary"}
+          variant="primary"
           isPending={isSubmitting}
           isDisabled={isSubmitting || isSubmitDisabled}
           onPress={onSubmit}


### PR DESCRIPTION
## Summary

- keep evaluator form submit actions visually primary when validation hints are shown
- preserve the existing disabled and pending behavior across evaluator create and edit flows
- keep Cancel visually secondary to the submit action

## Validation

- `make format-frontend`
- `make lint-frontend`
- `make typecheck-frontend`
- `make test-frontend` (2,379 passed, 12 skipped)
- browser-verified hint, valid, disabled, pending, and 1024×768 footer states

## Screenshot

The validation hint remains visible while Cancel stays secondary and Create retains primary emphasis in its disabled state.

![Evaluator form footer with a validation hint and distinct Cancel and Create actions](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15819-evaluator-submit-emphasis.png)

Resolves #15295
