### PR TITLE
ci: bump setup-uv to v10.0.1 and read the uv version from pyproject.toml

### DIFF
--- a/.github/workflows/check-dependabot-uv-version.yml
+++ b/.github/workflows/check-dependabot-uv-version.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install target uv version
         if: steps.dependabot.outputs.version != steps.repo.outputs.version && steps.existing_pr.outputs.count == '0'
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: ${{ steps.dependabot.outputs.version }}
 
@@ -122,7 +122,7 @@ jobs:
             Bump the pinned uv CLI version across this repo from `${{ steps.repo.outputs.version }}` to `${{ steps.dependabot.outputs.version }}` so it matches the version Dependabot supports.
 
             Steps:
-            1. Use `git grep` (or ripgrep) to find every reference to `${{ steps.repo.outputs.version }}` that pins the uv CLI. Likely locations: `pyproject.toml` (`[tool.uv] required-version`), `Dockerfile` and other Dockerfiles (`ghcr.io/astral-sh/uv:` image tags, `pip install uv==`), and `.github/workflows/*.yml|*.yaml` (`astral-sh/setup-uv` `version:` inputs). Do NOT change unrelated occurrences of the same version string (e.g., CHANGELOG entries, unrelated dependency pins, lockfile-internal version metadata for other packages).
+            1. Use `git grep` (or ripgrep) to find every reference to `${{ steps.repo.outputs.version }}` that pins the uv CLI. Likely locations: `pyproject.toml` (`[tool.uv] required-version`), `Dockerfile` and other Dockerfiles (`ghcr.io/astral-sh/uv:` image tags, `pip install uv==`), and `.github/workflows/*.yml|*.yaml` (`astral-sh/setup-uv` `version:` inputs and any `UV_VERSION` env var feeding one). Most workflow steps use `version-file: "pyproject.toml"` and derive the version from `[tool.uv] required-version`, so they need no edit. Do NOT change unrelated occurrences of the same version string (e.g., CHANGELOG entries, unrelated dependency pins, lockfile-internal version metadata for other packages).
             2. Update each genuine uv pin to `${{ steps.dependabot.outputs.version }}`.
             3. After editing, run `git grep '${{ steps.repo.outputs.version }}'` and confirm any remaining matches are NOT uv pins (CHANGELOG entries, etc.). If any uv pin is left behind, fix it.
             4. Run `uv lock` to regenerate the lockfile against the new uv version.

--- a/.github/workflows/claude-weekly-deps-upgrade.yml
+++ b/.github/workflows/claude-weekly-deps-upgrade.yml
@@ -29,9 +29,9 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
 
       - name: Install PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/cost-sync.yml
+++ b/.github/workflows/cost-sync.yml
@@ -21,9 +21,9 @@ jobs:
       
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Sync model cost manifest with LiteLLM

--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -23,7 +23,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version-file: "pyproject.toml"
 
       - name: Generate sitemap
         run: uv run scripts/generate_sitemap.py

--- a/.github/workflows/harbor-evals.yml
+++ b/.github/workflows/harbor-evals.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      UV_VERSION: "0.12.7"
       HARBOR_ENV: daytona
       # Two attempts, gated on the mean: a one-off agent slip passes while a
       # consistent regression still fails.
@@ -31,9 +30,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: ${{ env.UV_VERSION }}
+          version-file: "pyproject.toml"
 
       - name: Build the Phoenix wheel and stage the Harbor task environments
         run: make harbor-stage-environments

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -38,9 +38,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
           python-version: "3.14"
 
       - name: Run Helm chart tests

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -95,9 +95,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Install dependencies
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
         run: uv sync --extra container

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -107,10 +107,10 @@ jobs:
       - name: Build frontend
         working-directory: ./js
         run: pnpm install --frozen-lockfile && pnpm --filter 'phoenix-ui...' run build
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.10"
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Build distribution
         run: rm -rf dist && uv build
       - name: Verify bundled UI assets in wheel
@@ -215,11 +215,11 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ steps.ref.outputs.ref }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uv build
         if: steps.check.outputs.needed == 'true'
         working-directory: ${{ matrix.path }}
@@ -541,10 +541,10 @@ jobs:
       - name: Build frontend
         working-directory: ./js
         run: pnpm install --frozen-lockfile && pnpm --filter 'phoenix-ui...' run build
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.10"
-          version: "0.12.7"
+          version-file: "pyproject.toml"
           enable-cache: false
       - name: Stamp dev version
         env:
@@ -612,11 +612,11 @@ jobs:
           # Pin to the exact commit detected by preview-changes (see preview-phoenix).
           ref: ${{ needs.preview-changes.outputs.sha }}
           persist-credentials: false
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         if: steps.check.outputs.needed == 'true'
         with:
           python-version: "3.10"
-          version: "0.12.7"
+          version-file: "pyproject.toml"
           enable-cache: false
       - name: Stamp dev version
         if: steps.check.outputs.needed == 'true'

--- a/.github/workflows/pxi-evals.yml
+++ b/.github/workflows/pxi-evals.yml
@@ -47,9 +47,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Check Phoenix connectivity

--- a/.github/workflows/pxi-online-evals.yml
+++ b/.github/workflows/pxi-online-evals.yml
@@ -43,9 +43,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --frozen

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -39,6 +39,9 @@ jobs:
             verify_latest: false
     env:
       PYTHON_VERSION: "3.12"
+      # Literal pin: this job never checks out the repository, so there is no
+      # pyproject.toml for setup-uv to read `required-version` from. Keep in
+      # sync with [tool.uv] required-version in pyproject.toml.
       UV_VERSION: "0.12.7"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PHOENIX_HOST: "127.0.0.1"
@@ -48,7 +51,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -130,9 +130,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals:
@@ -154,9 +154,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
@@ -177,9 +177,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   test-json-canonicalization-schema:
@@ -213,9 +213,9 @@ jobs:
             packages/
             .jcs-test-data/
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Install make (Windows)
         if: runner.os == 'Windows'
         run: choco install make --no-progress -y
@@ -247,9 +247,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Clean Jupyter notebooks
         run: make clean-notebooks
       - run: git diff --exit-code
@@ -273,9 +273,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Build GraphQL schema
         run: make schema-graphql
       - run: git diff --exit-code
@@ -306,9 +306,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Check UI filter DSL snippets against the Python filters
         run: make check-filter-dsl-snippets
 
@@ -331,9 +331,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Run doctests
         run: make doctest
 
@@ -356,9 +356,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Build OpenAPI schema
         run: make schema-openapi
       - run: git diff --exit-code
@@ -382,9 +382,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Create virtual environment
         # `make schema-ddl` installs its dependencies with `uv pip install`,
         # which requires an existing environment.
@@ -412,9 +412,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Compile Prompts
         run: make codegen-prompts
       - name: Check for changes
@@ -440,9 +440,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Check lockfile is up to date
         run: uv lock --check
 
@@ -464,9 +464,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Run formatter and linter
         run: |
           make format-python
@@ -501,9 +501,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Sync dependencies
         run: uv sync --frozen
       - name: Type check all Python code
@@ -540,9 +540,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql'
         # The floor version from the PGDG repository, not whatever the
@@ -614,9 +614,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 16
@@ -653,8 +653,12 @@ jobs:
         with:
           python-version: 3.14
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
+          # Literal pin: this job installs Phoenix from PyPI and only checks out
+          # the repository afterwards, so there is no pyproject.toml for setup-uv
+          # to read `required-version` from. Keep in sync with [tool.uv]
+          # required-version in pyproject.toml.
           version: "0.12.7"
       - name: Install arize-phoenix and database dependencies
         run: |
@@ -726,9 +730,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Run canary tests for ${{ matrix.pkg }}
         run: uvx tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
 

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -102,9 +102,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Install PostgreSQL (product floor)
         if: matrix.db == 'postgresql' && runner.os == 'Linux'
         # Floor version from PGDG; see the note in python-CI.yml. The macOS
@@ -182,9 +182,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - name: Run integration tests
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
@@ -211,9 +211,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uvx tox run -e phoenix_client -- -ra -x
 
   phoenix-evals-non-linux:
@@ -237,9 +237,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uvx tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel-non-linux:
@@ -263,9 +263,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
       - run: uvx tox run -e phoenix_otel -- -ra -x
 
   slack-notification:

--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -21,9 +21,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.7"
+          version-file: "pyproject.toml"
           enable-cache: false
 
       - name: Update lockfile


### PR DESCRIPTION
## What

Moves `astral-sh/setup-uv` from v7.6.0 (`37802ad`) to v10.0.1 (`20cfd1b`) across all 38 call sites, and replaces the literal `version: "0.12.7"` with `version-file: "pyproject.toml"` at 35 of them.

## Why the literal pin was redundant

`pyproject.toml` already carries `[tool.uv] required-version = "==0.12.7"`, which makes uv refuse to run at any other version. Repeating the number at every call site only created more places for it to drift.

Verified against setup-uv's source at the pinned SHA:

- `getVersionFile` resolves the input as `path.resolve(working-directory, "pyproject.toml")`, and `working-directory` defaults to `${{ github.workspace }}`.
- The pyproject parser returns `tool.uv.required-version`, which is `"==0.12.7"`.
- `normalizeVersionSpecifier` strips the `==` prefix, giving `"0.12.7"`.
- `parseVersionSpecifier` sees `tc.isExplicitVersion` return true and marks it `kind: "exact"`.
- `ExactVersionResolver` returns that string directly, with no manifest fetch and no range arithmetic.

`version-file` is also the fail-loud path. `VersionFileVersionResolver` throws when the file is missing, whereas omitting `version:` falls through to `latest` with only a log line.

## The three steps that keep an explicit version

| Step | Reason |
| --- | --- |
| `pypi-smoke-test.yml` | Never checks out the repository and installs Phoenix from PyPI, so there is no `pyproject.toml` to read. |
| `python-CI.yml` → `test-migrations` | Runs `setup-uv` before any checkout: it installs Phoenix from PyPI, runs migrations against the installed package, and clones the repo afterwards. |
| `check-dependabot-uv-version.yml` | Installs the bump target by design. |

Both checkout-less sites now carry a comment explaining why the literal stays. The bump automation's prompt was updated to match the new layout so it still finds them.

## Behavior changes from crossing v8 through v10

- **v9.0.0** flips the `prune-cache` default to `false`. About 30 jobs use the default `enable-cache: auto`, so their cache entries now hold the unpruned uv cache. The thing to watch is eviction churn against the 10GB repo cache cap; `prune-cache: true` restores the old behavior.
- **v10.0.0** makes `enable-cache: auto` disable the cache for `pull_request_target`, `workflow_run`, `release`, and tag pushes. Only `pypi-smoke-test.yml` matches, via `workflow_run`, and it has no checkout to cache.
- **v8.0.0**'s breaking changes do not apply here: `manifest-file` is unused, and we pin SHAs rather than major tags.

## Side effects checked

Populating `versionFile` feeds two other code paths that previously received an empty string and returned early.

- `getPythonVersion` calls `getPythonVersionFromToolVersions(versionFile)` when `python-version` is unset. Its `getToolVersions` helper guards on `filePath.endsWith(".tool-versions")` and returns `undefined` otherwise, so no `UV_PYTHON` is exported and the matrix interpreters from `actions/setup-python` are untouched.
- `getCacheDirFromConfig` now reads `cache-dir` from `pyproject.toml`. Our `[tool.uv]` block does not set one, so cache-path resolution is unchanged.

Also confirmed that no `actions/checkout` step in the repo uses a `path:` input, so every checkout lands at the workspace root where `version-file` looks.
