### PR TITLE
feat(project-evals): cache mean score aggregates with stable open-ended windows

### DIFF
--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -3402,9 +3402,9 @@ type ProjectEvaluator implements Node {
   runSummary: ProjectEvaluatorRunSummary!
 
   """
-  Score aggregates for each annotation this evaluator writes on the evaluated project: totals over the requested time range, totals over the equal-length window immediately before it, and a binned mean-score series. Loading is batched across the project's evaluators, so requesting this for a page of evaluators costs a fixed number of queries.
+  Score aggregates for each annotation this evaluator writes on the evaluated project: totals over the requested time range, totals over the previous window, and a binned mean-score series. An open-ended time range means "up to now" and requires an explicit previousTimeRange, since an open window has no duration to mirror backward; a closed range derives the previous window as the equal-length range before it when previousTimeRange is omitted. Loading is batched across the project's evaluators, so requesting this for a page of evaluators costs a fixed number of queries.
   """
-  annotationScoreMetrics(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): [EvaluatorAnnotationScoreMetrics!]!
+  annotationScoreMetrics(timeRange: TimeRange!, timeBinConfig: TimeBinConfig, previousTimeRange: TimeRange): [EvaluatorAnnotationScoreMetrics!]!
 
   """
   Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New project evaluators store the default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation. Only SESSION scheduling honors this value: a SPAN evaluator cannot set one, and TRACE evaluators are not scheduled.

--- a/js/app/src/components/datetime/utils.ts
+++ b/js/app/src/components/datetime/utils.ts
@@ -115,6 +115,21 @@ export function getMillisecondsUntilNextLastNTimeRangeRefresh(
 export function isLastNTimeRangeKey(key: unknown): key is LastNTimeRangeKey {
   return parseLastNTimeRangeKey(key) !== null;
 }
+
+/**
+ * The exact duration a last-N key denotes (e.g. "7d" -> seven days in
+ * milliseconds), independent of any resolved window. Useful for deriving a
+ * stable "previous window" without resolving "now".
+ */
+export function getDurationMsFromLastNTimeRangeKey(
+  key: LastNTimeRangeKey
+): number {
+  const parsed = parseLastNTimeRangeKey(key);
+  if (!parsed) {
+    throw new Error(`Invalid last N time range key: ${key}`);
+  }
+  return getLastNTimeRangeDurationMs(parsed);
+}
 /**
  * Type guard for the time range key
  */

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -66,7 +66,10 @@ import {
 } from "@phoenix/pages/project/evaluators/ProjectEvaluatorMeanScoreCell";
 import { useProjectEvaluatorPaths } from "@phoenix/pages/project/evaluators/projectEvaluatorPaths";
 import type { EvaluatorScoreWindow } from "@phoenix/pages/project/evaluators/projectEvaluatorScoreWindow";
-import { getEvaluatorScoreWindow } from "@phoenix/pages/project/evaluators/projectEvaluatorScoreWindow";
+import {
+  getEvaluatorScoreWindow,
+  isSameEvaluatorScoreWindow,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorScoreWindow";
 import { ProjectEvaluatorsEmptyState } from "@phoenix/pages/project/evaluators/ProjectEvaluatorsEmptyState";
 import { ProjectEvaluatorStatusCell } from "@phoenix/pages/project/evaluators/ProjectEvaluatorStatusCell";
 import {
@@ -343,11 +346,10 @@ export function ProjectEvaluatorsTable({
       const hasInitialTimeRange =
         timeRange.start === initialTimeRange.start &&
         timeRange.end === initialTimeRange.end;
-      const hasInitialScoreWindow =
-        scoreWindow.timeRange.start === initialScoreWindow.timeRange.start &&
-        scoreWindow.timeRange.end === initialScoreWindow.timeRange.end &&
-        scoreWindow.timeBinConfig.scale ===
-          initialScoreWindow.timeBinConfig.scale;
+      const hasInitialScoreWindow = isSameEvaluatorScoreWindow(
+        scoreWindow,
+        initialScoreWindow
+      );
       const hasInitialIncludeMeanScore =
         includeMeanScore === initialIncludeMeanScore;
       // Avoid a duplicate request only when the rows supplied by the owner

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorsTable.tsx
@@ -208,11 +208,13 @@ const readRow = (
       @inline
       @argumentDefinitions(
         scoreTimeRange: { type: "TimeRange!" }
+        scorePreviousTimeRange: { type: "TimeRange!" }
         scoreTimeBinConfig: { type: "TimeBinConfig!" }
         includeMeanScore: { type: "Boolean!" }
       ) {
         annotationScoreMetrics(
           timeRange: $scoreTimeRange
+          previousTimeRange: $scorePreviousTimeRange
           timeBinConfig: $scoreTimeBinConfig
         ) @include(if: $includeMeanScore) {
           annotationName
@@ -286,6 +288,7 @@ export function ProjectEvaluatorsTable({
         filter: { type: "ProjectEvaluatorFilter", defaultValue: null }
         timeRange: { type: "TimeRange!" }
         scoreTimeRange: { type: "TimeRange!" }
+        scorePreviousTimeRange: { type: "TimeRange!" }
         scoreTimeBinConfig: { type: "TimeBinConfig!" }
         includeMeanScore: { type: "Boolean!" }
       ) {
@@ -298,6 +301,7 @@ export function ProjectEvaluatorsTable({
               ...ProjectEvaluatorsTable_scores
                 @arguments(
                   scoreTimeRange: $scoreTimeRange
+                  scorePreviousTimeRange: $scorePreviousTimeRange
                   scoreTimeBinConfig: $scoreTimeBinConfig
                   includeMeanScore: $includeMeanScore
                 )
@@ -365,6 +369,7 @@ export function ProjectEvaluatorsTable({
           filter: trimmedFilter ? { col: "name", value: trimmedFilter } : null,
           timeRange,
           scoreTimeRange: scoreWindow.timeRange,
+          scorePreviousTimeRange: scoreWindow.previousTimeRange,
           scoreTimeBinConfig: scoreWindow.timeBinConfig,
           includeMeanScore,
         },
@@ -388,6 +393,7 @@ export function ProjectEvaluatorsTable({
         filter: trimmedFilter ? { col: "name", value: trimmedFilter } : null,
         timeRange,
         scoreTimeRange: scoreWindow.timeRange,
+        scorePreviousTimeRange: scoreWindow.previousTimeRange,
         scoreTimeBinConfig: scoreWindow.timeBinConfig,
         includeMeanScore,
       },

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTablePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d251e62f1ab7519286b618826c458151>>
+ * @generated SignedSource<<8e97dc69ffdf197a360a8e8388ef769c>>
  * @lightSyntaxTransform
  */
 
@@ -15,13 +15,13 @@ export type ProjectEvaluatorFilter = {
   col: ProjectEvaluatorFilterColumn;
   value: string;
 };
-export type TimeBinConfig = {
-  scale?: TimeBinScale;
-  utcOffsetMinutes?: number;
-};
 export type TimeRange = {
   end?: string | null;
   start?: string | null;
+};
+export type TimeBinConfig = {
+  scale?: TimeBinScale;
+  utcOffsetMinutes?: number;
 };
 export type ProjectEvaluatorsTablePaginationQuery$variables = {
   after?: string | null;
@@ -29,6 +29,7 @@ export type ProjectEvaluatorsTablePaginationQuery$variables = {
   first?: number | null;
   id: string;
   includeMeanScore: boolean;
+  scorePreviousTimeRange: TimeRange;
   scoreTimeBinConfig: TimeBinConfig;
   scoreTimeRange: TimeRange;
   timeRange: TimeRange;
@@ -72,103 +73,108 @@ v4 = {
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scoreTimeBinConfig"
+  "name": "scorePreviousTimeRange"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scoreTimeRange"
+  "name": "scoreTimeBinConfig"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "scoreTimeRange"
+},
+v8 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v8 = [
+v9 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "after",
   "variableName": "after"
 },
-v10 = {
+v11 = {
   "kind": "Variable",
   "name": "filter",
   "variableName": "filter"
 },
-v11 = {
+v12 = {
   "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v12 = {
+v13 = {
   "kind": "Variable",
   "name": "timeRange",
   "variableName": "timeRange"
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v15 = [
-  (v9/*:: as any*/),
+v16 = [
   (v10/*:: as any*/),
-  (v11/*:: as any*/)
+  (v11/*:: as any*/),
+  (v12/*:: as any*/)
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v21 = [
-  (v12/*:: as any*/)
-],
 v22 = [
+  (v13/*:: as any*/)
+],
+v23 = [
   {
     "alias": null,
     "args": null,
@@ -177,14 +183,14 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "meanScore",
   "storageKey": null
 },
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -201,7 +207,8 @@ return {
       (v4/*:: as any*/),
       (v5/*:: as any*/),
       (v6/*:: as any*/),
-      (v7/*:: as any*/)
+      (v7/*:: as any*/),
+      (v8/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -209,7 +216,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v8/*:: as any*/),
+        "args": (v9/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -217,13 +224,18 @@ return {
         "selections": [
           {
             "args": [
-              (v9/*:: as any*/),
               (v10/*:: as any*/),
               (v11/*:: as any*/),
+              (v12/*:: as any*/),
               {
                 "kind": "Variable",
                 "name": "includeMeanScore",
                 "variableName": "includeMeanScore"
+              },
+              {
+                "kind": "Variable",
+                "name": "scorePreviousTimeRange",
+                "variableName": "scorePreviousTimeRange"
               },
               {
                 "kind": "Variable",
@@ -235,7 +247,7 @@ return {
                 "name": "scoreTimeRange",
                 "variableName": "scoreTimeRange"
               },
-              (v12/*:: as any*/)
+              (v13/*:: as any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ProjectEvaluatorsTable_project"
@@ -257,6 +269,7 @@ return {
       (v5/*:: as any*/),
       (v6/*:: as any*/),
       (v7/*:: as any*/),
+      (v8/*:: as any*/),
       (v3/*:: as any*/)
     ],
     "kind": "Operation",
@@ -264,20 +277,20 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v8/*:: as any*/),
+        "args": (v9/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v13/*:: as any*/),
           (v14/*:: as any*/),
+          (v15/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v15/*:: as any*/),
+                "args": (v16/*:: as any*/),
                 "concreteType": "ProjectEvaluatorConnection",
                 "kind": "LinkedField",
                 "name": "evaluators",
@@ -299,8 +312,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v14/*:: as any*/),
-                          (v16/*:: as any*/),
+                          (v15/*:: as any*/),
+                          (v17/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -404,7 +417,7 @@ return {
                             "name": "evaluator",
                             "plural": false,
                             "selections": [
-                              (v13/*:: as any*/),
+                              (v14/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -420,11 +433,11 @@ return {
                                 "name": "outputConfigs",
                                 "plural": true,
                                 "selections": [
-                                  (v13/*:: as any*/),
+                                  (v14/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v16/*:: as any*/),
+                                      (v17/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -439,7 +452,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v17/*:: as any*/),
+                                      (v18/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -448,7 +461,7 @@ return {
                                         "name": "values",
                                         "plural": true,
                                         "selections": [
-                                          (v18/*:: as any*/),
+                                          (v19/*:: as any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -466,9 +479,9 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v17/*:: as any*/),
-                                      (v19/*:: as any*/),
-                                      (v20/*:: as any*/)
+                                      (v18/*:: as any*/),
+                                      (v20/*:: as any*/),
+                                      (v21/*:: as any*/)
                                     ],
                                     "type": "ContinuousAnnotationConfig",
                                     "abstractKey": null
@@ -476,7 +489,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v17/*:: as any*/),
+                                      (v18/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -484,8 +497,8 @@ return {
                                         "name": "threshold",
                                         "storageKey": null
                                       },
-                                      (v19/*:: as any*/),
-                                      (v20/*:: as any*/)
+                                      (v20/*:: as any*/),
+                                      (v21/*:: as any*/)
                                     ],
                                     "type": "FreeformAnnotationConfig",
                                     "abstractKey": null
@@ -493,7 +506,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v14/*:: as any*/)
+                                      (v15/*:: as any*/)
                                     ],
                                     "type": "Node",
                                     "abstractKey": "__isNode"
@@ -512,8 +525,8 @@ return {
                                     "name": "prompt",
                                     "plural": false,
                                     "selections": [
-                                      (v14/*:: as any*/),
-                                      (v16/*:: as any*/)
+                                      (v15/*:: as any*/),
+                                      (v17/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -525,8 +538,8 @@ return {
                                     "name": "promptVersionTag",
                                     "plural": false,
                                     "selections": [
-                                      (v16/*:: as any*/),
-                                      (v14/*:: as any*/)
+                                      (v17/*:: as any*/),
+                                      (v15/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -552,7 +565,7 @@ return {
                                         "name": "modelProvider",
                                         "storageKey": null
                                       },
-                                      (v14/*:: as any*/)
+                                      (v15/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -578,8 +591,8 @@ return {
                                     "name": "sandboxConfig",
                                     "plural": false,
                                     "selections": [
-                                      (v14/*:: as any*/),
-                                      (v16/*:: as any*/),
+                                      (v15/*:: as any*/),
+                                      (v17/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -595,7 +608,7 @@ return {
                                             "name": "backendType",
                                             "storageKey": null
                                           },
-                                          (v14/*:: as any*/)
+                                          (v15/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -606,7 +619,7 @@ return {
                                 "type": "CodeEvaluator",
                                 "abstractKey": null
                               },
-                              (v14/*:: as any*/)
+                              (v15/*:: as any*/)
                             ],
                             "storageKey": null
                           },
@@ -618,17 +631,17 @@ return {
                             "name": "traceProject",
                             "plural": false,
                             "selections": [
-                              (v14/*:: as any*/),
+                              (v15/*:: as any*/),
                               {
                                 "alias": null,
-                                "args": (v21/*:: as any*/),
+                                "args": (v22/*:: as any*/),
                                 "kind": "ScalarField",
                                 "name": "traceCount",
                                 "storageKey": null
                               },
                               {
                                 "alias": null,
-                                "args": (v21/*:: as any*/),
+                                "args": (v22/*:: as any*/),
                                 "concreteType": "SpanCostSummary",
                                 "kind": "LinkedField",
                                 "name": "costSummary",
@@ -641,7 +654,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "total",
                                     "plural": false,
-                                    "selections": (v22/*:: as any*/),
+                                    "selections": (v23/*:: as any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -651,7 +664,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "prompt",
                                     "plural": false,
-                                    "selections": (v22/*:: as any*/),
+                                    "selections": (v23/*:: as any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -661,7 +674,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "completion",
                                     "plural": false,
-                                    "selections": (v22/*:: as any*/),
+                                    "selections": (v23/*:: as any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -678,6 +691,11 @@ return {
                               {
                                 "alias": null,
                                 "args": [
+                                  {
+                                    "kind": "Variable",
+                                    "name": "previousTimeRange",
+                                    "variableName": "scorePreviousTimeRange"
+                                  },
                                   {
                                     "kind": "Variable",
                                     "name": "timeBinConfig",
@@ -709,8 +727,8 @@ return {
                                     "name": "summary",
                                     "plural": false,
                                     "selections": [
-                                      (v23/*:: as any*/),
                                       (v24/*:: as any*/),
+                                      (v25/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -733,7 +751,7 @@ return {
                                         "name": "labelFractions",
                                         "plural": true,
                                         "selections": [
-                                          (v18/*:: as any*/),
+                                          (v19/*:: as any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -755,7 +773,7 @@ return {
                                     "name": "previousSummary",
                                     "plural": false,
                                     "selections": [
-                                      (v23/*:: as any*/)
+                                      (v24/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -774,8 +792,8 @@ return {
                                         "name": "timestamp",
                                         "storageKey": null
                                       },
-                                      (v23/*:: as any*/),
-                                      (v24/*:: as any*/)
+                                      (v24/*:: as any*/),
+                                      (v25/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -784,7 +802,7 @@ return {
                               }
                             ]
                           },
-                          (v13/*:: as any*/)
+                          (v14/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -828,7 +846,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v15/*:: as any*/),
+                "args": (v16/*:: as any*/),
                 "filters": [
                   "filter"
                 ],
@@ -847,16 +865,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "59ab8fb5d25ef66ad3052c26c40d7f23",
+    "cacheID": "a1c9c21c6abf8d79b8d0648757ba6883",
     "id": null,
     "metadata": {},
     "name": "ProjectEvaluatorsTablePaginationQuery",
     "operationKind": "query",
-    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $includeMeanScore: Boolean!\n  $scoreTimeBinConfig: TimeBinConfig!\n  $scoreTimeRange: TimeRange!\n  $timeRange: TimeRange!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_1TlaaZ\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_costs_3E0ZE6 on ProjectEvaluator {\n  traceProject {\n    id\n    traceCount(timeRange: $timeRange)\n    costSummary(timeRange: $timeRange) {\n      total {\n        cost\n      }\n      prompt {\n        cost\n      }\n      completion {\n        cost\n      }\n    }\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_1TlaaZ on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        ...ProjectEvaluatorsTable_costs_3E0ZE6\n        ...ProjectEvaluatorsTable_scores_3clT2T\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  schedulabilityReason\n  runSummary {\n    status\n    lastRunAt\n    queuedCount\n    evaluatedCount\n    failedCount\n  }\n  evaluator {\n    __typename\n    kind\n    outputConfigs {\n      __typename\n      ... on AnnotationConfigBase {\n        __isAnnotationConfigBase: __typename\n        name\n        annotationType\n      }\n      ... on CategoricalAnnotationConfig {\n        optimizationDirection\n        values {\n          label\n          score\n        }\n      }\n      ... on ContinuousAnnotationConfig {\n        optimizationDirection\n        lowerBound\n        upperBound\n      }\n      ... on FreeformAnnotationConfig {\n        optimizationDirection\n        threshold\n        lowerBound\n        upperBound\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_scores_3clT2T on ProjectEvaluator {\n  annotationScoreMetrics(timeRange: $scoreTimeRange, timeBinConfig: $scoreTimeBinConfig) @include(if: $includeMeanScore) {\n    annotationName\n    summary {\n      meanScore\n      count\n      scoreCount\n      labelCount\n      labelFractions {\n        label\n        fraction\n      }\n    }\n    previousSummary {\n      meanScore\n    }\n    series {\n      timestamp\n      meanScore\n      count\n    }\n  }\n}\n"
+    "text": "query ProjectEvaluatorsTablePaginationQuery(\n  $after: String = null\n  $filter: ProjectEvaluatorFilter = null\n  $first: Int = 30\n  $includeMeanScore: Boolean!\n  $scorePreviousTimeRange: TimeRange!\n  $scoreTimeBinConfig: TimeBinConfig!\n  $scoreTimeRange: TimeRange!\n  $timeRange: TimeRange!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectEvaluatorsTable_project_3PAQ0g\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_costs_3E0ZE6 on ProjectEvaluator {\n  traceProject {\n    id\n    traceCount(timeRange: $timeRange)\n    costSummary(timeRange: $timeRange) {\n      total {\n        cost\n      }\n      prompt {\n        cost\n      }\n      completion {\n        cost\n      }\n    }\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_3PAQ0g on Project {\n  evaluators(first: $first, after: $after, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        ...ProjectEvaluatorsTable_costs_3E0ZE6\n        ...ProjectEvaluatorsTable_scores_1qAmj3\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  schedulabilityReason\n  runSummary {\n    status\n    lastRunAt\n    queuedCount\n    evaluatedCount\n    failedCount\n  }\n  evaluator {\n    __typename\n    kind\n    outputConfigs {\n      __typename\n      ... on AnnotationConfigBase {\n        __isAnnotationConfigBase: __typename\n        name\n        annotationType\n      }\n      ... on CategoricalAnnotationConfig {\n        optimizationDirection\n        values {\n          label\n          score\n        }\n      }\n      ... on ContinuousAnnotationConfig {\n        optimizationDirection\n        lowerBound\n        upperBound\n      }\n      ... on FreeformAnnotationConfig {\n        optimizationDirection\n        threshold\n        lowerBound\n        upperBound\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_scores_1qAmj3 on ProjectEvaluator {\n  annotationScoreMetrics(timeRange: $scoreTimeRange, previousTimeRange: $scorePreviousTimeRange, timeBinConfig: $scoreTimeBinConfig) @include(if: $includeMeanScore) {\n    annotationName\n    summary {\n      meanScore\n      count\n      scoreCount\n      labelCount\n      labelFractions {\n        label\n        fraction\n      }\n    }\n    previousSummary {\n      meanScore\n    }\n    series {\n      timestamp\n      meanScore\n      count\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9da07562d1eee40e3d6d2471a3630ed9";
+(node as any).hash = "927402af67eed497b895297f1a6b88c1";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_project.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f4542454a7cda1de7ba57f507f31f16e>>
+ * @generated SignedSource<<6fe5749ba807f335b128c2ba0160b9ef>>
  * @lightSyntaxTransform
  */
 
@@ -36,71 +36,76 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scoreTimeBinConfig"
+  "name": "scorePreviousTimeRange"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scoreTimeRange"
+  "name": "scoreTimeBinConfig"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "scoreTimeRange"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v4 = [
+v5 = [
   "evaluators"
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "kind": "Variable",
     "name": "timeRange",
     "variableName": "timeRange"
   }
 ],
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -109,14 +114,14 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "meanScore",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -143,7 +148,8 @@ return {
     (v0/*:: as any*/),
     (v1/*:: as any*/),
     (v2/*:: as any*/),
-    (v3/*:: as any*/)
+    (v3/*:: as any*/),
+    (v4/*:: as any*/)
   ],
   "kind": "Fragment",
   "metadata": {
@@ -152,7 +158,7 @@ return {
         "count": "first",
         "cursor": "after",
         "direction": "forward",
-        "path": (v4/*:: as any*/)
+        "path": (v5/*:: as any*/)
       }
     ],
     "refetch": {
@@ -162,7 +168,7 @@ return {
           "cursor": "after"
         },
         "backward": null,
-        "path": (v4/*:: as any*/)
+        "path": (v5/*:: as any*/)
       },
       "fragmentPathInResult": [
         "node"
@@ -210,8 +216,8 @@ return {
                   "kind": "InlineDataFragmentSpread",
                   "name": "ProjectEvaluatorsTable_row",
                   "selections": [
-                    (v5/*:: as any*/),
                     (v6/*:: as any*/),
+                    (v7/*:: as any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -333,7 +339,7 @@ return {
                             {
                               "kind": "InlineFragment",
                               "selections": [
-                                (v6/*:: as any*/),
+                                (v7/*:: as any*/),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -348,7 +354,7 @@ return {
                             {
                               "kind": "InlineFragment",
                               "selections": [
-                                (v7/*:: as any*/),
+                                (v8/*:: as any*/),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -357,7 +363,7 @@ return {
                                   "name": "values",
                                   "plural": true,
                                   "selections": [
-                                    (v8/*:: as any*/),
+                                    (v9/*:: as any*/),
                                     {
                                       "alias": null,
                                       "args": null,
@@ -375,9 +381,9 @@ return {
                             {
                               "kind": "InlineFragment",
                               "selections": [
-                                (v7/*:: as any*/),
-                                (v9/*:: as any*/),
-                                (v10/*:: as any*/)
+                                (v8/*:: as any*/),
+                                (v10/*:: as any*/),
+                                (v11/*:: as any*/)
                               ],
                               "type": "ContinuousAnnotationConfig",
                               "abstractKey": null
@@ -385,7 +391,7 @@ return {
                             {
                               "kind": "InlineFragment",
                               "selections": [
-                                (v7/*:: as any*/),
+                                (v8/*:: as any*/),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -393,8 +399,8 @@ return {
                                   "name": "threshold",
                                   "storageKey": null
                                 },
-                                (v9/*:: as any*/),
-                                (v10/*:: as any*/)
+                                (v10/*:: as any*/),
+                                (v11/*:: as any*/)
                               ],
                               "type": "FreeformAnnotationConfig",
                               "abstractKey": null
@@ -413,8 +419,8 @@ return {
                               "name": "prompt",
                               "plural": false,
                               "selections": [
-                                (v5/*:: as any*/),
-                                (v6/*:: as any*/)
+                                (v6/*:: as any*/),
+                                (v7/*:: as any*/)
                               ],
                               "storageKey": null
                             },
@@ -426,7 +432,7 @@ return {
                               "name": "promptVersionTag",
                               "plural": false,
                               "selections": [
-                                (v6/*:: as any*/)
+                                (v7/*:: as any*/)
                               ],
                               "storageKey": null
                             },
@@ -477,8 +483,8 @@ return {
                               "name": "sandboxConfig",
                               "plural": false,
                               "selections": [
-                                (v5/*:: as any*/),
                                 (v6/*:: as any*/),
+                                (v7/*:: as any*/),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -523,17 +529,17 @@ return {
                       "name": "traceProject",
                       "plural": false,
                       "selections": [
-                        (v5/*:: as any*/),
+                        (v6/*:: as any*/),
                         {
                           "alias": null,
-                          "args": (v11/*:: as any*/),
+                          "args": (v12/*:: as any*/),
                           "kind": "ScalarField",
                           "name": "traceCount",
                           "storageKey": null
                         },
                         {
                           "alias": null,
-                          "args": (v11/*:: as any*/),
+                          "args": (v12/*:: as any*/),
                           "concreteType": "SpanCostSummary",
                           "kind": "LinkedField",
                           "name": "costSummary",
@@ -546,7 +552,7 @@ return {
                               "kind": "LinkedField",
                               "name": "total",
                               "plural": false,
-                              "selections": (v12/*:: as any*/),
+                              "selections": (v13/*:: as any*/),
                               "storageKey": null
                             },
                             {
@@ -556,7 +562,7 @@ return {
                               "kind": "LinkedField",
                               "name": "prompt",
                               "plural": false,
-                              "selections": (v12/*:: as any*/),
+                              "selections": (v13/*:: as any*/),
                               "storageKey": null
                             },
                             {
@@ -566,7 +572,7 @@ return {
                               "kind": "LinkedField",
                               "name": "completion",
                               "plural": false,
-                              "selections": (v12/*:: as any*/),
+                              "selections": (v13/*:: as any*/),
                               "storageKey": null
                             }
                           ],
@@ -576,9 +582,9 @@ return {
                       "storageKey": null
                     }
                   ],
-                  "args": (v11/*:: as any*/),
+                  "args": (v12/*:: as any*/),
                   "argumentDefinitions": [
-                    (v3/*:: as any*/)
+                    (v4/*:: as any*/)
                   ]
                 },
                 {
@@ -593,6 +599,11 @@ return {
                         {
                           "alias": null,
                           "args": [
+                            {
+                              "kind": "Variable",
+                              "name": "previousTimeRange",
+                              "variableName": "scorePreviousTimeRange"
+                            },
                             {
                               "kind": "Variable",
                               "name": "timeBinConfig",
@@ -624,8 +635,8 @@ return {
                               "name": "summary",
                               "plural": false,
                               "selections": [
-                                (v13/*:: as any*/),
                                 (v14/*:: as any*/),
+                                (v15/*:: as any*/),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -648,7 +659,7 @@ return {
                                   "name": "labelFractions",
                                   "plural": true,
                                   "selections": [
-                                    (v8/*:: as any*/),
+                                    (v9/*:: as any*/),
                                     {
                                       "alias": null,
                                       "args": null,
@@ -670,7 +681,7 @@ return {
                               "name": "previousSummary",
                               "plural": false,
                               "selections": [
-                                (v13/*:: as any*/)
+                                (v14/*:: as any*/)
                               ],
                               "storageKey": null
                             },
@@ -689,8 +700,8 @@ return {
                                   "name": "timestamp",
                                   "storageKey": null
                                 },
-                                (v13/*:: as any*/),
-                                (v14/*:: as any*/)
+                                (v14/*:: as any*/),
+                                (v15/*:: as any*/)
                               ],
                               "storageKey": null
                             }
@@ -708,6 +719,11 @@ return {
                     },
                     {
                       "kind": "Variable",
+                      "name": "scorePreviousTimeRange",
+                      "variableName": "scorePreviousTimeRange"
+                    },
+                    {
+                      "kind": "Variable",
                       "name": "scoreTimeBinConfig",
                       "variableName": "scoreTimeBinConfig"
                     },
@@ -720,7 +736,8 @@ return {
                   "argumentDefinitions": [
                     (v0/*:: as any*/),
                     (v1/*:: as any*/),
-                    (v2/*:: as any*/)
+                    (v2/*:: as any*/),
+                    (v3/*:: as any*/)
                   ]
                 },
                 {
@@ -771,13 +788,13 @@ return {
       ],
       "storageKey": null
     },
-    (v5/*:: as any*/)
+    (v6/*:: as any*/)
   ],
   "type": "Project",
   "abstractKey": null
 };
 })();
 
-(node as any).hash = "9da07562d1eee40e3d6d2471a3630ed9";
+(node as any).hash = "927402af67eed497b895297f1a6b88c1";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_scores.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/ProjectEvaluatorsTable_scores.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aec4bce969aefc0ad3b2bac45404b46d>>
+ * @generated SignedSource<<00a8d5c8486e2e9e2334e9cb87b0d1fc>>
  * @lightSyntaxTransform
  */
 
@@ -43,6 +43,6 @@ const node: ReaderInlineDataFragment = {
   "name": "ProjectEvaluatorsTable_scores"
 };
 
-(node as any).hash = "188203191ee48eb89828a31b7d0b7e6f";
+(node as any).hash = "7bf924cc54d101ff545f898d1bad907b";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorsLoaderQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1c8d2e1b30da24a10c2bf76b01c69f3e>>
+ * @generated SignedSource<<a68447682fc97b4da4355d58cd7a6953>>
  * @lightSyntaxTransform
  */
 
@@ -27,6 +27,7 @@ export type projectEvaluatorsLoaderQuery$variables = {
   filter?: ProjectEvaluatorFilter | null;
   includeMeanScore: boolean;
   projectId: string;
+  scorePreviousTimeRange: TimeRange;
   scoreTimeBinConfig: TimeBinConfig;
   scoreTimeRange: TimeRange;
   timeRange: TimeRange;
@@ -61,103 +62,108 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scoreTimeBinConfig"
+  "name": "scorePreviousTimeRange"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scoreTimeRange"
+  "name": "scoreTimeBinConfig"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "scoreTimeRange"
+},
+v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v6 = [
+v7 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "projectId"
   }
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "evaluatorCount",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "Variable",
   "name": "filter",
   "variableName": "filter"
 },
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "timeRange",
   "variableName": "timeRange"
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = [
-  (v8/*:: as any*/),
+v13 = [
+  (v9/*:: as any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v18 = [
-  (v9/*:: as any*/)
-],
 v19 = [
+  (v10/*:: as any*/)
+],
+v20 = [
   {
     "alias": null,
     "args": null,
@@ -166,14 +172,14 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "meanScore",
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -188,7 +194,8 @@ return {
       (v2/*:: as any*/),
       (v3/*:: as any*/),
       (v4/*:: as any*/),
-      (v5/*:: as any*/)
+      (v5/*:: as any*/),
+      (v6/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -196,7 +203,7 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v6/*:: as any*/),
+        "args": (v7/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -205,14 +212,19 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
-              (v7/*:: as any*/),
+              (v8/*:: as any*/),
               {
                 "args": [
-                  (v8/*:: as any*/),
+                  (v9/*:: as any*/),
                   {
                     "kind": "Variable",
                     "name": "includeMeanScore",
                     "variableName": "includeMeanScore"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "scorePreviousTimeRange",
+                    "variableName": "scorePreviousTimeRange"
                   },
                   {
                     "kind": "Variable",
@@ -224,7 +236,7 @@ return {
                     "name": "scoreTimeRange",
                     "variableName": "scoreTimeRange"
                   },
-                  (v9/*:: as any*/)
+                  (v10/*:: as any*/)
                 ],
                 "kind": "FragmentSpread",
                 "name": "ProjectEvaluatorsTable_project"
@@ -245,9 +257,10 @@ return {
     "argumentDefinitions": [
       (v2/*:: as any*/),
       (v0/*:: as any*/),
+      (v6/*:: as any*/),
       (v5/*:: as any*/),
-      (v4/*:: as any*/),
       (v3/*:: as any*/),
+      (v4/*:: as any*/),
       (v1/*:: as any*/)
     ],
     "kind": "Operation",
@@ -255,21 +268,21 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v6/*:: as any*/),
+        "args": (v7/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v10/*:: as any*/),
           (v11/*:: as any*/),
+          (v12/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v7/*:: as any*/),
+              (v8/*:: as any*/),
               {
                 "alias": null,
-                "args": (v12/*:: as any*/),
+                "args": (v13/*:: as any*/),
                 "concreteType": "ProjectEvaluatorConnection",
                 "kind": "LinkedField",
                 "name": "evaluators",
@@ -291,8 +304,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v11/*:: as any*/),
-                          (v13/*:: as any*/),
+                          (v12/*:: as any*/),
+                          (v14/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -396,7 +409,7 @@ return {
                             "name": "evaluator",
                             "plural": false,
                             "selections": [
-                              (v10/*:: as any*/),
+                              (v11/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -412,11 +425,11 @@ return {
                                 "name": "outputConfigs",
                                 "plural": true,
                                 "selections": [
-                                  (v10/*:: as any*/),
+                                  (v11/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v13/*:: as any*/),
+                                      (v14/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -431,7 +444,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v14/*:: as any*/),
+                                      (v15/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -440,7 +453,7 @@ return {
                                         "name": "values",
                                         "plural": true,
                                         "selections": [
-                                          (v15/*:: as any*/),
+                                          (v16/*:: as any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -458,9 +471,9 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v14/*:: as any*/),
-                                      (v16/*:: as any*/),
-                                      (v17/*:: as any*/)
+                                      (v15/*:: as any*/),
+                                      (v17/*:: as any*/),
+                                      (v18/*:: as any*/)
                                     ],
                                     "type": "ContinuousAnnotationConfig",
                                     "abstractKey": null
@@ -468,7 +481,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v14/*:: as any*/),
+                                      (v15/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -476,8 +489,8 @@ return {
                                         "name": "threshold",
                                         "storageKey": null
                                       },
-                                      (v16/*:: as any*/),
-                                      (v17/*:: as any*/)
+                                      (v17/*:: as any*/),
+                                      (v18/*:: as any*/)
                                     ],
                                     "type": "FreeformAnnotationConfig",
                                     "abstractKey": null
@@ -485,7 +498,7 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v11/*:: as any*/)
+                                      (v12/*:: as any*/)
                                     ],
                                     "type": "Node",
                                     "abstractKey": "__isNode"
@@ -504,8 +517,8 @@ return {
                                     "name": "prompt",
                                     "plural": false,
                                     "selections": [
-                                      (v11/*:: as any*/),
-                                      (v13/*:: as any*/)
+                                      (v12/*:: as any*/),
+                                      (v14/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -517,8 +530,8 @@ return {
                                     "name": "promptVersionTag",
                                     "plural": false,
                                     "selections": [
-                                      (v13/*:: as any*/),
-                                      (v11/*:: as any*/)
+                                      (v14/*:: as any*/),
+                                      (v12/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -544,7 +557,7 @@ return {
                                         "name": "modelProvider",
                                         "storageKey": null
                                       },
-                                      (v11/*:: as any*/)
+                                      (v12/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -570,8 +583,8 @@ return {
                                     "name": "sandboxConfig",
                                     "plural": false,
                                     "selections": [
-                                      (v11/*:: as any*/),
-                                      (v13/*:: as any*/),
+                                      (v12/*:: as any*/),
+                                      (v14/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -587,7 +600,7 @@ return {
                                             "name": "backendType",
                                             "storageKey": null
                                           },
-                                          (v11/*:: as any*/)
+                                          (v12/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -598,7 +611,7 @@ return {
                                 "type": "CodeEvaluator",
                                 "abstractKey": null
                               },
-                              (v11/*:: as any*/)
+                              (v12/*:: as any*/)
                             ],
                             "storageKey": null
                           },
@@ -610,17 +623,17 @@ return {
                             "name": "traceProject",
                             "plural": false,
                             "selections": [
-                              (v11/*:: as any*/),
+                              (v12/*:: as any*/),
                               {
                                 "alias": null,
-                                "args": (v18/*:: as any*/),
+                                "args": (v19/*:: as any*/),
                                 "kind": "ScalarField",
                                 "name": "traceCount",
                                 "storageKey": null
                               },
                               {
                                 "alias": null,
-                                "args": (v18/*:: as any*/),
+                                "args": (v19/*:: as any*/),
                                 "concreteType": "SpanCostSummary",
                                 "kind": "LinkedField",
                                 "name": "costSummary",
@@ -633,7 +646,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "total",
                                     "plural": false,
-                                    "selections": (v19/*:: as any*/),
+                                    "selections": (v20/*:: as any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -643,7 +656,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "prompt",
                                     "plural": false,
-                                    "selections": (v19/*:: as any*/),
+                                    "selections": (v20/*:: as any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -653,7 +666,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "completion",
                                     "plural": false,
-                                    "selections": (v19/*:: as any*/),
+                                    "selections": (v20/*:: as any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -670,6 +683,11 @@ return {
                               {
                                 "alias": null,
                                 "args": [
+                                  {
+                                    "kind": "Variable",
+                                    "name": "previousTimeRange",
+                                    "variableName": "scorePreviousTimeRange"
+                                  },
                                   {
                                     "kind": "Variable",
                                     "name": "timeBinConfig",
@@ -701,8 +719,8 @@ return {
                                     "name": "summary",
                                     "plural": false,
                                     "selections": [
-                                      (v20/*:: as any*/),
                                       (v21/*:: as any*/),
+                                      (v22/*:: as any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -725,7 +743,7 @@ return {
                                         "name": "labelFractions",
                                         "plural": true,
                                         "selections": [
-                                          (v15/*:: as any*/),
+                                          (v16/*:: as any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -747,7 +765,7 @@ return {
                                     "name": "previousSummary",
                                     "plural": false,
                                     "selections": [
-                                      (v20/*:: as any*/)
+                                      (v21/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -766,8 +784,8 @@ return {
                                         "name": "timestamp",
                                         "storageKey": null
                                       },
-                                      (v20/*:: as any*/),
-                                      (v21/*:: as any*/)
+                                      (v21/*:: as any*/),
+                                      (v22/*:: as any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -776,7 +794,7 @@ return {
                               }
                             ]
                           },
-                          (v10/*:: as any*/)
+                          (v11/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -820,7 +838,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v12/*:: as any*/),
+                "args": (v13/*:: as any*/),
                 "filters": [
                   "filter"
                 ],
@@ -839,16 +857,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1aaa82e0fa13dc48e79569ca13a0f9c9",
+    "cacheID": "16bc7b9ca833b35544c5d4ea8c36815d",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorsLoaderQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorsLoaderQuery(\n  $projectId: ID!\n  $filter: ProjectEvaluatorFilter\n  $timeRange: TimeRange!\n  $scoreTimeRange: TimeRange!\n  $scoreTimeBinConfig: TimeBinConfig!\n  $includeMeanScore: Boolean!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      ...ProjectEvaluatorsTable_project_A8ZRX\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_costs_3E0ZE6 on ProjectEvaluator {\n  traceProject {\n    id\n    traceCount(timeRange: $timeRange)\n    costSummary(timeRange: $timeRange) {\n      total {\n        cost\n      }\n      prompt {\n        cost\n      }\n      completion {\n        cost\n      }\n    }\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_A8ZRX on Project {\n  evaluators(first: 30, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        ...ProjectEvaluatorsTable_costs_3E0ZE6\n        ...ProjectEvaluatorsTable_scores_3clT2T\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  schedulabilityReason\n  runSummary {\n    status\n    lastRunAt\n    queuedCount\n    evaluatedCount\n    failedCount\n  }\n  evaluator {\n    __typename\n    kind\n    outputConfigs {\n      __typename\n      ... on AnnotationConfigBase {\n        __isAnnotationConfigBase: __typename\n        name\n        annotationType\n      }\n      ... on CategoricalAnnotationConfig {\n        optimizationDirection\n        values {\n          label\n          score\n        }\n      }\n      ... on ContinuousAnnotationConfig {\n        optimizationDirection\n        lowerBound\n        upperBound\n      }\n      ... on FreeformAnnotationConfig {\n        optimizationDirection\n        threshold\n        lowerBound\n        upperBound\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_scores_3clT2T on ProjectEvaluator {\n  annotationScoreMetrics(timeRange: $scoreTimeRange, timeBinConfig: $scoreTimeBinConfig) @include(if: $includeMeanScore) {\n    annotationName\n    summary {\n      meanScore\n      count\n      scoreCount\n      labelCount\n      labelFractions {\n        label\n        fraction\n      }\n    }\n    previousSummary {\n      meanScore\n    }\n    series {\n      timestamp\n      meanScore\n      count\n    }\n  }\n}\n"
+    "text": "query projectEvaluatorsLoaderQuery(\n  $projectId: ID!\n  $filter: ProjectEvaluatorFilter\n  $timeRange: TimeRange!\n  $scoreTimeRange: TimeRange!\n  $scorePreviousTimeRange: TimeRange!\n  $scoreTimeBinConfig: TimeBinConfig!\n  $includeMeanScore: Boolean!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      evaluatorCount\n      ...ProjectEvaluatorsTable_project_13VVNU\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_costs_3E0ZE6 on ProjectEvaluator {\n  traceProject {\n    id\n    traceCount(timeRange: $timeRange)\n    costSummary(timeRange: $timeRange) {\n      total {\n        cost\n      }\n      prompt {\n        cost\n      }\n      completion {\n        cost\n      }\n    }\n  }\n}\n\nfragment ProjectEvaluatorsTable_project_13VVNU on Project {\n  evaluators(first: 30, filter: $filter) {\n    edges {\n      node {\n        ...ProjectEvaluatorsTable_row\n        ...ProjectEvaluatorsTable_costs_3E0ZE6\n        ...ProjectEvaluatorsTable_scores_1qAmj3\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment ProjectEvaluatorsTable_row on ProjectEvaluator {\n  id\n  name\n  evaluationTarget\n  filterCondition\n  samplingRate\n  schedulabilityStatus\n  enabled\n  updatedAt\n  schedulabilityReason\n  runSummary {\n    status\n    lastRunAt\n    queuedCount\n    evaluatedCount\n    failedCount\n  }\n  evaluator {\n    __typename\n    kind\n    outputConfigs {\n      __typename\n      ... on AnnotationConfigBase {\n        __isAnnotationConfigBase: __typename\n        name\n        annotationType\n      }\n      ... on CategoricalAnnotationConfig {\n        optimizationDirection\n        values {\n          label\n          score\n        }\n      }\n      ... on ContinuousAnnotationConfig {\n        optimizationDirection\n        lowerBound\n        upperBound\n      }\n      ... on FreeformAnnotationConfig {\n        optimizationDirection\n        threshold\n        lowerBound\n        upperBound\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    ... on LLMEvaluator {\n      prompt {\n        id\n        name\n      }\n      promptVersionTag {\n        name\n        id\n      }\n      promptVersion {\n        modelName\n        modelProvider\n        id\n      }\n    }\n    ... on CodeEvaluator {\n      language\n      sandboxConfig {\n        id\n        name\n        provider {\n          backendType\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectEvaluatorsTable_scores_1qAmj3 on ProjectEvaluator {\n  annotationScoreMetrics(timeRange: $scoreTimeRange, previousTimeRange: $scorePreviousTimeRange, timeBinConfig: $scoreTimeBinConfig) @include(if: $includeMeanScore) {\n    annotationName\n    summary {\n      meanScore\n      count\n      scoreCount\n      labelCount\n      labelFractions {\n        label\n        fraction\n      }\n    }\n    previousSummary {\n      meanScore\n    }\n    series {\n      timestamp\n      meanScore\n      count\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "96c0079c947e594876aa6a4e0d371783";
+(node as any).hash = "f508212a756e44775bfde9b353b4b50b";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorScoreWindow.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorScoreWindow.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { getEvaluatorScoreWindow } from "../projectEvaluatorScoreWindow";
+
+const UTC_OFFSET_MINUTES = 0;
+const now = new Date("2026-06-09T12:34:56.789Z");
+
+describe("getEvaluatorScoreWindow", () => {
+  it("keeps a live last-N window open-ended and independent of now", () => {
+    // The provider hands a snapped start with no end for live ranges
+    const start = new Date("2026-06-02T12:00:00.000Z");
+    const timeRange = { timeRangeKey: "7d" as const, start, end: null };
+    const window = getEvaluatorScoreWindow({
+      timeRange,
+      utcOffsetMinutes: UTC_OFFSET_MINUTES,
+      now,
+    });
+    expect(window.timeRange).toEqual({ start: start.toISOString() });
+    // The previous window mirrors the key's exact duration backward
+    expect(window.previousTimeRange).toEqual({
+      start: "2026-05-26T12:00:00.000Z",
+      end: start.toISOString(),
+    });
+    expect(window.windowKey).toBe("7d");
+    // Nothing depends on "now": a different clock yields identical variables
+    const later = getEvaluatorScoreWindow({
+      timeRange,
+      utcOffsetMinutes: UTC_OFFSET_MINUTES,
+      now: new Date("2026-06-09T12:59:59.999Z"),
+    });
+    expect(later).toEqual(window);
+  });
+
+  it("keeps a custom range closed with a mirrored previous window", () => {
+    const window = getEvaluatorScoreWindow({
+      timeRange: {
+        timeRangeKey: "custom",
+        start: new Date("2026-06-01T00:00:00.000Z"),
+        end: new Date("2026-06-03T00:00:00.000Z"),
+      },
+      utcOffsetMinutes: UTC_OFFSET_MINUTES,
+      now,
+    });
+    expect(window.timeRange).toEqual({
+      start: "2026-06-01T00:00:00.000Z",
+      end: "2026-06-03T00:00:00.000Z",
+    });
+    expect(window.previousTimeRange).toEqual({
+      start: "2026-05-30T00:00:00.000Z",
+      end: "2026-06-01T00:00:00.000Z",
+    });
+    expect(window.windowKey).toBe("2d");
+  });
+
+  it("clamps a live range over the cap to its trailing 30 days, hour-snapped", () => {
+    const window = getEvaluatorScoreWindow({
+      timeRange: {
+        timeRangeKey: "90d",
+        start: new Date("2026-03-11T12:00:00.000Z"),
+        end: null,
+      },
+      utcOffsetMinutes: UTC_OFFSET_MINUTES,
+      now,
+    });
+    // Resolved "now" snaps to the hour so repeated derivations stay stable
+    expect(window.timeRange).toEqual({
+      start: "2026-05-10T12:00:00.000Z",
+      end: "2026-06-09T12:00:00.000Z",
+    });
+    expect(window.previousTimeRange).toEqual({
+      start: "2026-04-10T12:00:00.000Z",
+      end: "2026-05-10T12:00:00.000Z",
+    });
+    expect(window.windowKey).toBe("30d");
+  });
+
+  it("chooses the bin scale from the window duration", () => {
+    const day = getEvaluatorScoreWindow({
+      timeRange: {
+        timeRangeKey: "7d",
+        start: new Date("2026-06-02T12:00:00.000Z"),
+        end: null,
+      },
+      utcOffsetMinutes: UTC_OFFSET_MINUTES,
+      now,
+    });
+    expect(day.timeBinConfig).toEqual({ scale: "DAY", utcOffsetMinutes: 0 });
+    const minute = getEvaluatorScoreWindow({
+      timeRange: {
+        timeRangeKey: "1h",
+        start: new Date("2026-06-09T11:34:00.000Z"),
+        end: null,
+      },
+      utcOffsetMinutes: UTC_OFFSET_MINUTES,
+      now,
+    });
+    expect(minute.timeRange).toEqual({ start: "2026-06-09T11:34:00.000Z" });
+    expect(minute.timeBinConfig.scale).toBe("MINUTE");
+    expect(minute.windowKey).toBe("1h");
+  });
+});

--- a/js/app/src/pages/project/evaluators/projectEvaluatorScoreWindow.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorScoreWindow.ts
@@ -37,6 +37,26 @@ export type EvaluatorScoreWindow = {
 };
 
 /**
+ * Whether two score windows would produce identical query variables. Compares
+ * every field so the table's initial-fetch guard can't silently drift from
+ * whatever the loader derived.
+ */
+export function isSameEvaluatorScoreWindow(
+  a: EvaluatorScoreWindow,
+  b: EvaluatorScoreWindow
+): boolean {
+  return (
+    a.timeRange.start === b.timeRange.start &&
+    a.timeRange.end === b.timeRange.end &&
+    a.previousTimeRange.start === b.previousTimeRange.start &&
+    a.previousTimeRange.end === b.previousTimeRange.end &&
+    a.timeBinConfig.scale === b.timeBinConfig.scale &&
+    a.timeBinConfig.utcOffsetMinutes === b.timeBinConfig.utcOffsetMinutes &&
+    a.windowKey === b.windowKey
+  );
+}
+
+/**
  * Resolves the page time range into the mean score column's clamped window.
  * Everything derives from the range's snapped bounds and its last-N key —
  * never from "now" — so the loader and the table produce identical query

--- a/js/app/src/pages/project/evaluators/projectEvaluatorScoreWindow.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorScoreWindow.ts
@@ -1,7 +1,11 @@
+import { startOfHour } from "date-fns";
+
 import type { OpenTimeRangeWithKey } from "@phoenix/components/datetime";
 import {
   clampTimeRangeToMaxDuration,
+  getDurationMsFromLastNTimeRangeKey,
   getLastNTimeRangeKeyFromDurationMs,
+  isLastNTimeRangeKey,
 } from "@phoenix/components/datetime/utils";
 import { ONE_DAY_MS } from "@phoenix/constants/timeConstants";
 import { getTimeBinScale } from "@phoenix/hooks/useTimeBin";
@@ -18,18 +22,27 @@ export const MAX_SCORE_WINDOW_MS = 30 * ONE_DAY_MS;
  * which must agree exactly so a fresh mount reuses the loader's response.
  */
 export type EvaluatorScoreWindow = {
-  /** The page time range clamped to the score window cap, as ISO strings. */
-  timeRange: { start: string; end: string };
+  /**
+   * The window the scores cover, as ISO strings. A live page range leaves the
+   * end open ("up to now", resolved by the server) so the query variables —
+   * and with them the server's dataloader cache keys — stay stable between
+   * the range's snap boundaries instead of changing every render.
+   */
+  timeRange: { start: string; end?: string };
+  /** The equal-length window immediately before, for the delta. */
+  previousTimeRange: { start: string; end: string };
   timeBinConfig: { scale: TimeBinScale; utcOffsetMinutes: number };
   /** Compact label of the window length, e.g. "7d". */
   windowKey: string;
 };
 
 /**
- * Resolves the page time range into the mean score column's closed, clamped
- * window. Everything derives from the range's snapped bounds so the loader
- * and the table produce identical query variables (see the loader's note on
- * snapping).
+ * Resolves the page time range into the mean score column's clamped window.
+ * Everything derives from the range's snapped bounds and its last-N key —
+ * never from "now" — so the loader and the table produce identical query
+ * variables and repeated derivations stay cache-friendly. The one exception
+ * is a live range longer than the cap, whose trailing window must resolve
+ * "now"; it snaps to the hour so it, too, holds still between snaps.
  */
 export function getEvaluatorScoreWindow({
   timeRange,
@@ -41,31 +54,62 @@ export function getEvaluatorScoreWindow({
   /** Reference "now" for resolving open-ended ranges. Defaults to the current time. */
   now?: Date;
 }): EvaluatorScoreWindow {
+  const { timeRangeKey } = timeRange;
+  const keyDurationMs = isLastNTimeRangeKey(timeRangeKey)
+    ? getDurationMsFromLastNTimeRangeKey(timeRangeKey)
+    : null;
+  if (
+    keyDurationMs != null &&
+    keyDurationMs <= MAX_SCORE_WINDOW_MS &&
+    timeRange.start != null &&
+    timeRange.end == null
+  ) {
+    // A live last-N range within the cap: keep the end open and mirror the
+    // key's exact duration backward for the previous window. The start is
+    // already snapped by the provider, so no field here depends on "now" —
+    // including the bin scale, derived from the key's duration.
+    const startIso = timeRange.start.toISOString();
+    return {
+      timeRange: { start: startIso },
+      previousTimeRange: {
+        start: new Date(
+          timeRange.start.getTime() - keyDurationMs
+        ).toISOString(),
+        end: startIso,
+      },
+      timeBinConfig: {
+        scale: getTimeBinScale({
+          timeRange: {
+            start: timeRange.start,
+            end: new Date(timeRange.start.getTime() + keyDurationMs),
+          },
+        }),
+        utcOffsetMinutes,
+      },
+      windowKey: timeRangeKey,
+    };
+  }
+  // Custom ranges are closed by nature; a live range over the cap clamps to
+  // its trailing 30 days, resolving "now" snapped to the hour for stability.
   const clamped = clampTimeRangeToMaxDuration({
     value: timeRange,
     maxDurationMs: MAX_SCORE_WINDOW_MS,
-    now,
+    now: startOfHour(now),
   });
   const durationMs = clamped.end.getTime() - clamped.start.getTime();
-  // An unclamped last-N range echoes its own key ("1d"), since the resolved
-  // duration overshoots the label a little (last-N starts snap backward) and
-  // would otherwise format as e.g. "25h". Clamped and custom ranges derive
-  // the label from the actual window.
-  const isClamped =
-    timeRange.start == null ||
-    clamped.start.getTime() > timeRange.start.getTime();
   return {
     timeRange: {
       start: clamped.start.toISOString(),
       end: clamped.end.toISOString(),
     },
+    previousTimeRange: {
+      start: new Date(clamped.start.getTime() - durationMs).toISOString(),
+      end: clamped.start.toISOString(),
+    },
     timeBinConfig: {
       scale: getTimeBinScale({ timeRange: clamped }),
       utcOffsetMinutes,
     },
-    windowKey:
-      !isClamped && timeRange.timeRangeKey !== "custom"
-        ? timeRange.timeRangeKey
-        : getLastNTimeRangeKeyFromDurationMs(durationMs),
+    windowKey: getLastNTimeRangeKeyFromDurationMs(durationMs),
   };
 }

--- a/js/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorsLoader.ts
@@ -37,6 +37,7 @@ export const projectEvaluatorsLoaderGQL = graphql`
     $filter: ProjectEvaluatorFilter
     $timeRange: TimeRange!
     $scoreTimeRange: TimeRange!
+    $scorePreviousTimeRange: TimeRange!
     $scoreTimeBinConfig: TimeBinConfig!
     $includeMeanScore: Boolean!
   ) {
@@ -48,6 +49,7 @@ export const projectEvaluatorsLoaderGQL = graphql`
             filter: $filter
             timeRange: $timeRange
             scoreTimeRange: $scoreTimeRange
+            scorePreviousTimeRange: $scorePreviousTimeRange
             scoreTimeBinConfig: $scoreTimeBinConfig
             includeMeanScore: $includeMeanScore
           )
@@ -185,6 +187,7 @@ export function projectEvaluatorsLoader(
         filter: filter ? { col: "name", value: filter } : null,
         timeRange,
         scoreTimeRange: scoreWindow.timeRange,
+        scorePreviousTimeRange: scoreWindow.previousTimeRange,
         scoreTimeBinConfig: scoreWindow.timeBinConfig,
         includeMeanScore,
       },

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -10,7 +10,10 @@ from phoenix.server.types import DbSessionFactory
 
 from .agent_session_message_text import AgentSessionMessageTextDataLoader
 from .annotation_configs_by_project import AnnotationConfigsByProjectDataLoader
-from .annotation_mean_score_time_series import AnnotationMeanScoreTimeSeriesDataLoader
+from .annotation_mean_score_time_series import (
+    AnnotationMeanScoreTimeSeriesCache,
+    AnnotationMeanScoreTimeSeriesDataLoader,
+)
 from .annotation_summaries import AnnotationSummaryCache, AnnotationSummaryDataLoader
 from .average_experiment_repeated_run_group_latency import (
     AverageExperimentRepeatedRunGroupLatencyDataLoader,
@@ -137,6 +140,9 @@ class CacheForDataLoaders:
     )
     annotation_summary: AnnotationSummaryCache = field(
         default_factory=AnnotationSummaryCache,
+    )
+    annotation_mean_score_time_series: AnnotationMeanScoreTimeSeriesCache = field(
+        default_factory=AnnotationMeanScoreTimeSeriesCache,
     )
     latency_ms_quantile: LatencyMsQuantileCache = field(
         default_factory=LatencyMsQuantileCache,
@@ -316,7 +322,14 @@ def build_data_loaders(
         agent_session_first_inputs=AgentSessionMessageTextDataLoader(db, "first_input"),
         agent_session_latest_outputs=AgentSessionMessageTextDataLoader(db, "latest_output"),
         annotation_configs_by_project=AnnotationConfigsByProjectDataLoader(db),
-        annotation_mean_score_time_series=AnnotationMeanScoreTimeSeriesDataLoader(db),
+        annotation_mean_score_time_series=AnnotationMeanScoreTimeSeriesDataLoader(
+            db,
+            cache_map=(
+                cache_for_dataloaders.annotation_mean_score_time_series
+                if cache_for_dataloaders
+                else None
+            ),
+        ),
         average_experiment_repeated_run_group_latency=AverageExperimentRepeatedRunGroupLatencyDataLoader(
             db
         ),

--- a/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
+++ b/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Literal, NamedTuple, Optional, Type, Union
 
-from cachetools import LFUCache, TTLCache
+from cachetools import LRUCache, TTLCache
 from sqlalchemy import Select, or_, select
 from strawberry.dataloader import AbstractCache, DataLoader
 from typing_extensions import TypeAlias, assert_never
@@ -68,8 +68,12 @@ class AnnotationMeanScoreTimeSeriesCache(
             # TTL=3600 (1-hour) because window starts snap to the hour, so an
             # entry older than that no longer matches any live window anyway.
             main_cache=TTLCache(maxsize=64 * 32 * 2, ttl=3600),
-            # A couple of windows times a couple of bin scales per section.
-            sub_cache_factory=lambda: LFUCache(maxsize=2 * 2),
+            # LRU, not LFU: a user hops between a handful of windows, and
+            # under LFU a fresh window's key enters at frequency 1 — the
+            # immediate eviction victim while stale high-frequency windows
+            # squat, so new windows never cache. LRU keeps the recently
+            # viewed windows, which is the actual access pattern.
+            sub_cache_factory=lambda: LRUCache(maxsize=2 * 2),
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:

--- a/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
+++ b/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
@@ -59,14 +59,16 @@ class AnnotationMeanScoreTimeSeriesCache(
 ):
     """Sections match AnnotationSummaryCache's `(project, name, kind)`, so the
     same annotation-write events invalidate both caches. Live windows are sent
-    open-ended with hour-snapped starts, so sub-keys stay stable between snap
-    boundaries and entries stay useful for the whole main-cache TTL.
+    open-ended with snapped starts (to the hour for day-scale keys, finer for
+    shorter ones), so sub-keys hold still between snap boundaries and
+    day-scale entries stay useful for the whole main-cache TTL.
     """
 
     def __init__(self) -> None:
         super().__init__(
-            # TTL=3600 (1-hour) because window starts snap to the hour, so an
-            # entry older than that no longer matches any live window anyway.
+            # TTL=3600 (1-hour): day-scale window starts snap to the hour, so
+            # an entry older than that no longer matches any live window;
+            # shorter windows snap finer and churn their sub-keys sooner.
             main_cache=TTLCache(maxsize=64 * 32 * 2, ttl=3600),
             # LRU, not LFU: a user hops between a handful of windows, and
             # under LFU a fresh window's key enters at frequency 1 — the
@@ -80,9 +82,7 @@ class AnnotationMeanScoreTimeSeriesCache(
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:
-        for section in self._cache.keys():
-            if section[0] == project_rowid:
-                del self._cache[section]
+        self.invalidate_matching(lambda section: section[0] == project_rowid)
 
     def _cache_key(self, key: Key) -> tuple[_Section, _SubKey]:
         (

--- a/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
+++ b/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
@@ -73,7 +73,10 @@ class AnnotationMeanScoreTimeSeriesCache(
             # immediate eviction victim while stale high-frequency windows
             # squat, so new windows never cache. LRU keeps the recently
             # viewed windows, which is the actual access pattern.
-            sub_cache_factory=lambda: LRUCache(maxsize=2 * 2),
+            # Each viewed window costs two sub-keys (the window and its
+            # previous-window comparison), so eight entries retain the four
+            # most recently viewed windows.
+            sub_cache_factory=lambda: LRUCache(maxsize=2 * 4),
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:

--- a/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
+++ b/src/phoenix/server/api/dataloaders/annotation_mean_score_time_series.py
@@ -7,21 +7,23 @@ its score series in a single query.
 
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Literal, NamedTuple, Type, Union
+from typing import Any, Literal, NamedTuple, Optional, Type, Union
 
+from cachetools import LFUCache, TTLCache
 from sqlalchemy import Select, or_, select
-from strawberry.dataloader import DataLoader
+from strawberry.dataloader import AbstractCache, DataLoader
 from typing_extensions import TypeAlias, assert_never
 
 from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import date_trunc
 from phoenix.server.api.annotation_metrics import build_entity_weighted_annotation_metrics_stmt
+from phoenix.server.api.dataloaders.cache import TwoTierCache
 from phoenix.server.types import DbSessionFactory
 
 Kind: TypeAlias = Literal["span", "trace", "session"]
 ProjectRowId: TypeAlias = int
-TimeInterval: TypeAlias = tuple[datetime, datetime]
+TimeInterval: TypeAlias = tuple[datetime, Optional[datetime]]
 Stride: TypeAlias = Literal["minute", "hour", "day", "week", "month", "year"]
 UtcOffsetMinutes: TypeAlias = int
 AnnotationName: TypeAlias = str
@@ -48,13 +50,52 @@ def _segment(key: Key) -> tuple[Segment, AnnotationName]:
     return (kind, project_rowid, interval, stride, utc_offset_minutes), annotation_name
 
 
+_Section: TypeAlias = tuple[ProjectRowId, AnnotationName, Kind]
+_SubKey: TypeAlias = tuple[TimeInterval, Stride, UtcOffsetMinutes]
+
+
+class AnnotationMeanScoreTimeSeriesCache(
+    TwoTierCache[Key, Result, _Section, _SubKey],
+):
+    """Sections match AnnotationSummaryCache's `(project, name, kind)`, so the
+    same annotation-write events invalidate both caches. Live windows are sent
+    open-ended with hour-snapped starts, so sub-keys stay stable between snap
+    boundaries and entries stay useful for the whole main-cache TTL.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            # TTL=3600 (1-hour) because window starts snap to the hour, so an
+            # entry older than that no longer matches any live window anyway.
+            main_cache=TTLCache(maxsize=64 * 32 * 2, ttl=3600),
+            # A couple of windows times a couple of bin scales per section.
+            sub_cache_factory=lambda: LFUCache(maxsize=2 * 2),
+        )
+
+    def invalidate_project(self, project_rowid: ProjectRowId) -> None:
+        for section in self._cache.keys():
+            if section[0] == project_rowid:
+                del self._cache[section]
+
+    def _cache_key(self, key: Key) -> tuple[_Section, _SubKey]:
+        (
+            (kind, project_rowid, interval, stride, utc_offset_minutes),
+            annotation_name,
+        ) = _segment(key)
+        return (project_rowid, annotation_name, kind), (interval, stride, utc_offset_minutes)
+
+
 class AnnotationMeanScoreTimeSeriesDataLoader(DataLoader[Key, Result]):
     """Loads `{bucket: (mean_score, scored_entity_count)}` for one annotation
     name; empty buckets are absent and left for the caller to fill along its
     time axis."""
 
-    def __init__(self, db: DbSessionFactory) -> None:
-        super().__init__(load_fn=self._load_fn)
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        cache_map: Optional[AbstractCache[Key, Result]] = None,
+    ) -> None:
+        super().__init__(load_fn=self._load_fn, cache_map=cache_map)
         self._db = db
 
     async def _load_fn(self, keys: list[Key]) -> list[Result]:
@@ -174,7 +215,10 @@ class AnnotationMeanScoreTimeSeriesDataLoader(DataLoader[Key, Result]):
         )
         stmt = stmt.where(annotation_model.name.in_(annotation_names))
         stmt = stmt.where(start_time <= bucket_time_column)
-        stmt = stmt.where(bucket_time_column < end_time)
+        if end_time is not None:
+            # An absent end means "up to now": leaving the range open keeps
+            # the cache key stable while writes invalidate stale entries.
+            stmt = stmt.where(bucket_time_column < end_time)
         return build_entity_weighted_annotation_metrics_stmt(stmt)
 
 

--- a/src/phoenix/server/api/dataloaders/annotation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/annotation_summaries.py
@@ -88,7 +88,10 @@ class AnnotationSummaryCache(
             # victim while stale high-frequency windows squat, so switching
             # ranges could permanently miss. LRU keeps the recently viewed
             # windows, which is the actual access pattern.
-            sub_cache_factory=lambda: LRUCache(maxsize=2 * 2),
+            # Each viewed window costs two sub-keys (the window and its
+            # previous-window comparison), so eight entries retain the four
+            # most recently viewed windows.
+            sub_cache_factory=lambda: LRUCache(maxsize=2 * 4),
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:

--- a/src/phoenix/server/api/dataloaders/annotation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/annotation_summaries.py
@@ -82,12 +82,10 @@ class AnnotationSummaryCache(
             # interval endpoints are rounded down to the hour by the UI, so anything
             # older than an hour most likely won't be a cache-hit anyway.
             main_cache=TTLCache(maxsize=64 * 32 * 2, ttl=3600),
-            # LRU, not LFU: each viewed window contributes two sub-keys (the
-            # window and its previous-window comparison), and under LFU a
-            # fresh window enters at frequency 1 — the immediate eviction
-            # victim while stale high-frequency windows squat, so switching
-            # ranges could permanently miss. LRU keeps the recently viewed
-            # windows, which is the actual access pattern.
+            # LRU, not LFU: under LFU a fresh window enters at frequency 1 —
+            # the immediate eviction victim while stale high-frequency windows
+            # squat, so switching ranges could permanently miss. LRU keeps the
+            # recently viewed windows, which is the actual access pattern.
             # Each viewed window costs two sub-keys (the window and its
             # previous-window comparison), so eight entries retain the four
             # most recently viewed windows.
@@ -95,9 +93,7 @@ class AnnotationSummaryCache(
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:
-        for section in self._cache.keys():
-            if section[0] == project_rowid:
-                del self._cache[section]
+        self.invalidate_matching(lambda section: section[0] == project_rowid)
 
     def _cache_key(self, key: Key) -> tuple[_Section, _SubKey]:
         (

--- a/src/phoenix/server/api/dataloaders/annotation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/annotation_summaries.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, Optional, Type, Union
 
 import pandas as pd
 from aioitertools.itertools import groupby
-from cachetools import LFUCache, TTLCache
+from cachetools import LRUCache, TTLCache
 from sqlalchemy import Select, and_, case, distinct, func, or_, select
 from sqlalchemy.orm import InstrumentedAttribute
 from strawberry.dataloader import AbstractCache, DataLoader
@@ -82,7 +82,13 @@ class AnnotationSummaryCache(
             # interval endpoints are rounded down to the hour by the UI, so anything
             # older than an hour most likely won't be a cache-hit anyway.
             main_cache=TTLCache(maxsize=64 * 32 * 2, ttl=3600),
-            sub_cache_factory=lambda: LFUCache(maxsize=2 * 2),
+            # LRU, not LFU: each viewed window contributes two sub-keys (the
+            # window and its previous-window comparison), and under LFU a
+            # fresh window enters at frequency 1 — the immediate eviction
+            # victim while stale high-frequency windows squat, so switching
+            # ranges could permanently miss. LRU keeps the recently viewed
+            # windows, which is the actual access pattern.
+            sub_cache_factory=lambda: LRUCache(maxsize=2 * 2),
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:

--- a/src/phoenix/server/api/dataloaders/cache/two_tier_cache.py
+++ b/src/phoenix/server/api/dataloaders/cache/two_tier_cache.py
@@ -44,6 +44,15 @@ class TwoTierCache(
         if sub_cache := self._cache.get(section):
             sub_cache.clear()
 
+    def invalidate_matching(self, predicate: Callable[[_Section], bool]) -> None:
+        """Drop every section the predicate matches, e.g. all of one project's.
+
+        The matching sections are collected before any deletion so correctness
+        doesn't depend on the cache's delete-during-iteration semantics.
+        """
+        for section in [s for s in self._cache.keys() if predicate(s)]:
+            del self._cache[section]
+
     def get(self, key: _Key) -> Optional["Future[_Result]"]:
         section, sub_key = self._cache_key(key)
         if not (sub_cache := self._cache.get(section)):

--- a/src/phoenix/server/api/dataloaders/document_evaluation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/document_evaluation_summaries.py
@@ -57,9 +57,7 @@ class DocumentEvaluationSummaryCache(
         )
 
     def invalidate_project(self, project_rowid: ProjectRowId) -> None:
-        for section in self._cache.keys():
-            if section[0] == project_rowid:
-                del self._cache[section]
+        self.invalidate_matching(lambda section: section[0] == project_rowid)
 
     def _cache_key(self, key: Key) -> tuple[_Section, _SubKey]:
         (project_rowid, interval, filter_condition), eval_name = _cache_key_fn(key)

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1,6 +1,6 @@
 import asyncio
 import zlib
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Sequence, Union
 
@@ -1366,10 +1366,13 @@ class ProjectEvaluator(Node):
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Score aggregates for each annotation this evaluator writes on the evaluated "
-            "project: totals over the requested time range, totals over the equal-length "
-            "window immediately before it, and a binned mean-score series. Loading is "
-            "batched across the project's evaluators, so requesting this for a page of "
-            "evaluators costs a fixed number of queries."
+            "project: totals over the requested time range, totals over the previous "
+            "window, and a binned mean-score series. An open-ended time range means "
+            '"up to now" and requires an explicit previousTimeRange, since an open '
+            "window has no duration to mirror backward; a closed range derives the "
+            "previous window as the equal-length range before it when previousTimeRange "
+            "is omitted. Loading is batched across the project's evaluators, so "
+            "requesting this for a page of evaluators costs a fixed number of queries."
         )
     )
     async def annotation_score_metrics(
@@ -1377,9 +1380,10 @@ class ProjectEvaluator(Node):
         info: Info[Context, None],
         time_range: TimeRange,
         time_bin_config: Optional[TimeBinConfig] = UNSET,
+        previous_time_range: Optional[TimeRange] = UNSET,
     ) -> list[EvaluatorAnnotationScoreMetrics]:
-        if time_range.start is None or time_range.end is None:
-            raise BadRequest("time_range must have both a start and an end")
+        if time_range.start is None:
+            raise BadRequest("time_range must have a start")
         window_start, window_end = time_range.start, time_range.end
         record = await self._get_record(info)
         kind = _ANNOTATION_KIND_BY_TARGET.get(record.evaluation_target)
@@ -1394,10 +1398,19 @@ class ProjectEvaluator(Node):
             utc_offset_minutes = time_bin_config.utc_offset_minutes
         else:
             stride, utc_offset_minutes = "hour", 0
-        previous_time_range = TimeRange(
-            start=window_start - (window_end - window_start),
-            end=window_start,
-        )
+        if isinstance(previous_time_range, TimeRange):
+            if previous_time_range.start is None or previous_time_range.end is None:
+                raise BadRequest("previous_time_range must have both a start and an end")
+            previous_window = previous_time_range
+        elif window_end is not None:
+            previous_window = TimeRange(
+                start=window_start - (window_end - window_start),
+                end=window_start,
+            )
+        else:
+            # An open-ended window carries no duration to mirror backward, so
+            # the caller must say what "the previous window" means.
+            raise BadRequest("previous_time_range is required when time_range has no end")
         loaders = info.context.data_loaders
         project_rowid = record.project_id
 
@@ -1407,7 +1420,7 @@ class ProjectEvaluator(Node):
                     (kind, project_rowid, time_range, None, None, annotation_name)
                 ),
                 loaders.annotation_summaries.load(
-                    (kind, project_rowid, previous_time_range, None, None, annotation_name)
+                    (kind, project_rowid, previous_window, None, None, annotation_name)
                 ),
                 loaders.annotation_mean_score_time_series.load(
                     (
@@ -1427,7 +1440,12 @@ class ProjectEvaluator(Node):
                     count=mean_bin.scored_entity_count if mean_bin is not None else 0,
                 )
                 for timestamp in get_timestamp_range(
-                    window_start, window_end, stride, utc_offset_minutes
+                    window_start,
+                    # An open end means "up to now"; the loader's cached bins
+                    # stay valid while the axis keeps growing between writes.
+                    window_end if window_end is not None else datetime.now(timezone.utc),
+                    stride,
+                    utc_offset_minutes,
                 )
                 for mean_bin in (mean_scores_by_bucket.get(timestamp),)
             ]

--- a/src/phoenix/server/dml_event_handler.py
+++ b/src/phoenix/server/dml_event_handler.py
@@ -136,6 +136,7 @@ class _SpanDeleteEventHandler(_SpanDmlEventHandler):
 
         # Then invalidate annotation-specific caches
         cache.annotation_summary.invalidate_project(project_id)
+        cache.annotation_mean_score_time_series.invalidate_project(project_id)
         cache.document_evaluation_summary.invalidate_project(project_id)
 
 
@@ -197,6 +198,7 @@ class _SpanAnnotationDmlEventHandler(_AnnotationDmlEventHandler[SpanAnnotationDm
     @staticmethod
     def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
         cache.annotation_summary.invalidate((project_id, name, "span"))
+        cache.annotation_mean_score_time_series.invalidate((project_id, name, "span"))
 
 
 class _TraceAnnotationDmlEventHandler(_AnnotationDmlEventHandler[TraceAnnotationDmlEvent]):
@@ -209,6 +211,7 @@ class _TraceAnnotationDmlEventHandler(_AnnotationDmlEventHandler[TraceAnnotation
     @staticmethod
     def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
         cache.annotation_summary.invalidate((project_id, name, "trace"))
+        cache.annotation_mean_score_time_series.invalidate((project_id, name, "trace"))
 
 
 class _DocumentAnnotationDmlEventHandler(_AnnotationDmlEventHandler[DocumentAnnotationDmlEvent]):
@@ -238,6 +241,7 @@ class _ProjectSessionAnnotationDmlEventHandler(
     @staticmethod
     def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
         cache.annotation_summary.invalidate((project_id, name, "session"))
+        cache.annotation_mean_score_time_series.invalidate((project_id, name, "session"))
 
 
 class DmlEventHandler:

--- a/tests/unit/server/api/dataloaders/test_annotation_mean_score_time_series.py
+++ b/tests/unit/server/api/dataloaders/test_annotation_mean_score_time_series.py
@@ -1,3 +1,4 @@
+import asyncio
 from asyncio import Future
 from datetime import datetime, timezone
 
@@ -18,13 +19,15 @@ def _key(
 
 
 def _entry() -> "Future[dict[datetime, float]]":
-    future: "Future[dict[datetime, float]]" = Future()
+    # Created via the running loop: bare Future() requires a current event
+    # loop, which pytest-xdist workers do not guarantee at import time.
+    future = asyncio.get_running_loop().create_future()
     future.set_result({})
     return future
 
 
 class TestAnnotationMeanScoreTimeSeriesCache:
-    def test_round_trips_by_full_key(self) -> None:
+    async def test_round_trips_by_full_key(self) -> None:
         cache = AnnotationMeanScoreTimeSeriesCache()
         entry = _entry()
         cache.set(_key(), entry)
@@ -32,7 +35,7 @@ class TestAnnotationMeanScoreTimeSeriesCache:
         # A different bin scale is a different sub-key within the same section
         assert cache.get(_key(stride="hour")) is None
 
-    def test_invalidate_clears_one_annotation_kind_section(self) -> None:
+    async def test_invalidate_clears_one_annotation_kind_section(self) -> None:
         cache = AnnotationMeanScoreTimeSeriesCache()
         cache.set(_key(kind="span"), _entry())
         cache.set(_key(kind="trace"), _entry())
@@ -43,7 +46,7 @@ class TestAnnotationMeanScoreTimeSeriesCache:
         assert cache.get(_key(kind="trace")) is not None
         assert cache.get(_key(annotation_name="other")) is not None
 
-    def test_invalidate_project_clears_every_section_of_the_project(self) -> None:
+    async def test_invalidate_project_clears_every_section_of_the_project(self) -> None:
         cache = AnnotationMeanScoreTimeSeriesCache()
         cache.set(_key(project_rowid=1), _entry())
         cache.set(_key(project_rowid=1, annotation_name="other"), _entry())

--- a/tests/unit/server/api/dataloaders/test_annotation_mean_score_time_series.py
+++ b/tests/unit/server/api/dataloaders/test_annotation_mean_score_time_series.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from phoenix.server.api.dataloaders.annotation_mean_score_time_series import (
     AnnotationMeanScoreTimeSeriesCache,
     Key,
+    Result,
 )
 
 
@@ -18,7 +19,7 @@ def _key(
     return (kind, project_rowid, interval, stride, 0, annotation_name)  # type: ignore[return-value]
 
 
-def _entry() -> "Future[dict[datetime, float]]":
+def _entry() -> "Future[Result]":
     # Created via the running loop: bare Future() requires a current event
     # loop, which pytest-xdist workers do not guarantee at import time.
     future = asyncio.get_running_loop().create_future()

--- a/tests/unit/server/api/dataloaders/test_annotation_mean_score_time_series.py
+++ b/tests/unit/server/api/dataloaders/test_annotation_mean_score_time_series.py
@@ -1,0 +1,54 @@
+from asyncio import Future
+from datetime import datetime, timezone
+
+from phoenix.server.api.dataloaders.annotation_mean_score_time_series import (
+    AnnotationMeanScoreTimeSeriesCache,
+    Key,
+)
+
+
+def _key(
+    kind: str = "span",
+    project_rowid: int = 1,
+    annotation_name: str = "quality",
+    stride: str = "day",
+) -> Key:
+    interval = (datetime(2024, 6, 10, tzinfo=timezone.utc), None)
+    return (kind, project_rowid, interval, stride, 0, annotation_name)  # type: ignore[return-value]
+
+
+def _entry() -> "Future[dict[datetime, float]]":
+    future: "Future[dict[datetime, float]]" = Future()
+    future.set_result({})
+    return future
+
+
+class TestAnnotationMeanScoreTimeSeriesCache:
+    def test_round_trips_by_full_key(self) -> None:
+        cache = AnnotationMeanScoreTimeSeriesCache()
+        entry = _entry()
+        cache.set(_key(), entry)
+        assert cache.get(_key()) is entry
+        # A different bin scale is a different sub-key within the same section
+        assert cache.get(_key(stride="hour")) is None
+
+    def test_invalidate_clears_one_annotation_kind_section(self) -> None:
+        cache = AnnotationMeanScoreTimeSeriesCache()
+        cache.set(_key(kind="span"), _entry())
+        cache.set(_key(kind="trace"), _entry())
+        cache.set(_key(annotation_name="other"), _entry())
+        # The same section tuple the annotation DML handlers pass
+        cache.invalidate((1, "quality", "span"))
+        assert cache.get(_key(kind="span")) is None
+        assert cache.get(_key(kind="trace")) is not None
+        assert cache.get(_key(annotation_name="other")) is not None
+
+    def test_invalidate_project_clears_every_section_of_the_project(self) -> None:
+        cache = AnnotationMeanScoreTimeSeriesCache()
+        cache.set(_key(project_rowid=1), _entry())
+        cache.set(_key(project_rowid=1, annotation_name="other"), _entry())
+        cache.set(_key(project_rowid=2), _entry())
+        cache.invalidate_project(1)
+        assert cache.get(_key(project_rowid=1)) is None
+        assert cache.get(_key(project_rowid=1, annotation_name="other")) is None
+        assert cache.get(_key(project_rowid=2)) is not None

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -2098,10 +2098,19 @@ async def test_project_evaluator_trace_project_spans_are_scoped_to_the_evaluator
 class TestProjectEvaluatorAnnotationScoreMetrics:
     """Tests for ProjectEvaluator.annotationScoreMetrics."""
 
-    _QUERY = """query ($id: ID!, $timeRange: TimeRange!, $timeBinConfig: TimeBinConfig!) {
+    _QUERY = """query (
+        $id: ID!
+        $timeRange: TimeRange!
+        $timeBinConfig: TimeBinConfig!
+        $previousTimeRange: TimeRange
+    ) {
         node(id: $id) {
             ... on ProjectEvaluator {
-                annotationScoreMetrics(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {
+                annotationScoreMetrics(
+                    timeRange: $timeRange
+                    timeBinConfig: $timeBinConfig
+                    previousTimeRange: $previousTimeRange
+                ) {
                     annotationName
                     summary { meanScore count scoreCount labelFractions { label fraction } }
                     previousSummary { meanScore }
@@ -2278,7 +2287,7 @@ class TestProjectEvaluatorAnnotationScoreMetrics:
         ]
         assert [bin["count"] for bin in metrics["series"]] == [4, 2, 0, 0]
 
-    async def test_open_time_range_is_rejected(
+    async def test_open_end_requires_an_explicit_previous_window(
         self, _test_data: dict[str, Any], gql_client: AsyncGraphQLClient
     ) -> None:
         resp = await gql_client.execute(
@@ -2290,7 +2299,39 @@ class TestProjectEvaluatorAnnotationScoreMetrics:
             },
         )
         assert resp.errors
-        assert "start and an end" in resp.errors[0].message
+        assert "previous_time_range is required" in resp.errors[0].message
+
+    async def test_open_ended_window_covers_up_to_now(
+        self, _test_data: dict[str, Any], gql_client: AsyncGraphQLClient
+    ) -> None:
+        """A live window: open end plus an explicit previous window. YEAR bins
+        keep the axis small (the fixture's 2024 data through the present)."""
+        window_start = _test_data["window_start"]
+        resp = await gql_client.execute(
+            self._QUERY,
+            variables={
+                "id": str(GlobalID("ProjectEvaluator", str(_test_data["project_evaluator"]))),
+                "timeRange": {"start": window_start.isoformat()},
+                "previousTimeRange": {
+                    "start": (window_start - timedelta(days=2)).isoformat(),
+                    "end": window_start.isoformat(),
+                },
+                "timeBinConfig": {"scale": "YEAR", "utcOffsetMinutes": 0},
+            },
+        )
+        assert not resp.errors
+        assert resp.data is not None
+        (metrics,) = resp.data["node"]["annotationScoreMetrics"]
+        summary = metrics["summary"]
+        # Everything from the window start onward: 6 annotations, mean 0.5
+        assert summary["count"] == 6
+        assert summary["meanScore"] == pytest.approx(0.5)
+        assert metrics["previousSummary"]["meanScore"] == pytest.approx(1.0)
+        series = metrics["series"]
+        # The axis runs to "now": the 2024 bucket holds the data, later years none
+        assert len(series) >= 2
+        assert series[0]["meanScore"] == pytest.approx(0.5)
+        assert all(bin["meanScore"] is None for bin in series[1:])
 
 
 class TestProjectEvaluatorAnnotationScoreMetricsMultiOutput:


### PR DESCRIPTION
Stacked on #15805 (stack #15844).

Makes the mean score column cheap to reload. The first visit runs the aggregate queries. Later visits to the same time range are served from cache until an annotation is written.

## Why nothing cached before

For a live range like "last 7 days", the client resolved the window's end to the current millisecond on every render. That end time was part of the query variables, and the variables are the cache key. So every request had a brand-new key, and even the existing summary cache never hit on this page.

## What changed

**1. The query variables hold still.** A live range now sends only its start, which the time range provider already snaps. The server reads the missing end as "up to now". Custom ranges stay closed as before. Because an open window has no length to mirror backward, the client also sends the previous window explicitly, via a new optional `previousTimeRange` argument on `annotationScoreMetrics`. Closed windows still derive it the old way, so existing callers are unaffected.

**2. The sparkline series is cached.** A new dataloader cache for the binned series sits beside the existing summary cache, with the same `(project, annotation name, kind)` sections. The annotation-write events that already invalidate the summary cache now invalidate this one too. One-hour TTL, SQLite deployments only, like the other dataloader caches.

**3. Eviction is by recency.** The per-section caches were LFU, which meant a range you had just switched to was the first thing evicted while stale ranges kept their high counts. Both caches are now LRU and keep the four most recently viewed windows.

## Effect

Measured on 176k annotations and a 30-row page.

| Scenario | Before | After |
|---|---|---|
| Warm page load, slowest request | 769 ms | 28 ms |
| Return to a recently viewed range | ~900 ms | ~28 ms |
| Write one annotation, reload | everything recomputes | only that annotation's rows recompute |

Tests cover the cache's invalidation, the open-window contract, and that live-window variables do not depend on the clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
