### PR TITLE
fix(agents): harden GitHub token handling and subagent write access

### DIFF
--- a/js/app/src/components/nav/AccountMenu.tsx
+++ b/js/app/src/components/nav/AccountMenu.tsx
@@ -18,6 +18,7 @@ import {
 } from "@phoenix/components";
 import { UserPicture } from "@phoenix/components/user/UserPicture";
 import { useViewer } from "@phoenix/contexts";
+import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { classNames } from "@phoenix/utils/classNames";
 import { prependBasename } from "@phoenix/utils/routingUtils";
@@ -42,6 +43,7 @@ const identityCSS = css`
 export function AccountMenu({ isExpanded }: { isExpanded: boolean }) {
   const navigate = useNavigate();
   const { viewer } = useViewer();
+  const agentStore = useAgentStore();
   const { authenticationEnabled } = useFunctionality();
   const displayName = viewer?.username || "Account";
   const managementUrl =
@@ -115,9 +117,14 @@ export function AccountMenu({ isExpanded }: { isExpanded: boolean }) {
             ) : null}
             {authenticationEnabled ? (
               <MenuItem
-                onAction={() =>
-                  window.location.replace(prependBasename("/auth/logout"))
-                }
+                onAction={() => {
+                  // Integration credentials (e.g. a personal GitHub PAT) are
+                  // persisted per deployment, not per user — purge them so the
+                  // next user of this browser cannot inherit them. The persist
+                  // middleware writes to local storage synchronously.
+                  agentStore.getState().clearIntegrationCredentials();
+                  window.location.replace(prependBasename("/auth/logout"));
+                }}
                 leadingContent={<Icon svg={<Icons.LogOut />} />}
               >
                 Log Out

--- a/js/app/src/store/agentStore.ts
+++ b/js/app/src/store/agentStore.ts
@@ -409,6 +409,13 @@ export interface AgentState extends AgentProps {
     key: string;
     value: string | null;
   }) => void;
+  /**
+   * Drops every client-held integration credential. Called on logout so a
+   * later user of the same browser cannot inherit (and silently send) the
+   * previous user's tokens — the persisted store is scoped per deployment,
+   * not per user.
+   */
+  clearIntegrationCredentials: () => void;
 
   // -- Elicitation (ephemeral, not persisted) --
 
@@ -913,6 +920,11 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         false,
         { type: "setIntegrationCredential" }
       );
+    },
+    clearIntegrationCredentials: () => {
+      set({ integrationCredentials: {} }, false, {
+        type: "clearIntegrationCredentials",
+      });
     },
 
     // -- Elicitation (ephemeral) --

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -161,13 +161,14 @@ def build_agent(
         # transport auth. Writes share `writes_permitted` with GraphQL
         # mutations: a headless run has nobody to answer an approval request,
         # so unless edit permission is "bypass" the write tools are filtered
-        # out entirely (subagents therefore get read/search only — duplicate
-        # checking is delegable, filing stays in the main thread).
+        # out entirely. Subagents get read/search only regardless of edit
+        # permission — duplicate checking is delegable, filing stays in the
+        # main thread — so a "bypass" run cannot file issues from a subagent.
         capabilities.append(
             build_github_mcp_capability(
                 github_mcp_config,
                 instructions=resolved_prompts.github_tools,
-                allow_writes=writes_permitted,
+                allow_writes=writes_permitted and not is_subagent,
                 require_write_approval=require_mutation_approval,
             )
         )

--- a/src/phoenix/server/agents/capabilities/github_mcp.py
+++ b/src/phoenix/server/agents/capabilities/github_mcp.py
@@ -99,7 +99,19 @@ class GitHubMCPToolset(MCPToolset[AgentDepsT]):
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, Any]:
         if self._unavailable:
             return {}
-        return await super().get_tools(ctx)
+        try:
+            return await super().get_tools(ctx)
+        except Exception as exc:
+            # Same degrade-and-sanitize policy as __aenter__: a tools/list
+            # failure after a successful init must not fail the turn, and the
+            # raw exception text can echo request headers, including the auth
+            # header, so only the failure class is logged.
+            logger.warning(
+                "GitHub MCP tool listing failed (%s); continuing the turn without GitHub tools",
+                type(exc).__name__,
+            )
+            self._unavailable = True
+            return {}
 
 
 async def _call_tool_with_sanitized_errors(

--- a/tests/unit/server/agents/capabilities/test_github_mcp.py
+++ b/tests/unit/server/agents/capabilities/test_github_mcp.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 from pydantic import SecretStr
 from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets import ApprovalRequiredToolset, FilteredToolset
 
@@ -118,6 +119,22 @@ class TestDegradeOnConnectFailure:
         # A second enter after failure stays degraded and still does not raise.
         async with toolset:
             assert await toolset.get_tools(Mock()) == {}
+
+    async def test_tool_listing_failure_degrades_instead_of_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A transport failure AFTER a successful init (tools/list is its own
+        # RPC) must also degrade to no tools rather than fail the turn with a
+        # potentially header-echoing exception.
+        toolset: GitHubMCPToolset[Any] = GitHubMCPToolset(_config())
+
+        async def raise_transport_error(self: Any, ctx: Any) -> Any:
+            raise httpx.ConnectError(f"listing failed, headers: Bearer {_TOKEN}")
+
+        monkeypatch.setattr(MCPToolset, "get_tools", raise_transport_error)
+        assert await toolset.get_tools(Mock()) == {}
+        # The toolset stays degraded for the rest of the run.
+        assert await toolset.get_tools(Mock()) == {}
 
 
 class TestErrorSanitization:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -1329,3 +1329,22 @@ class TestGitHubMCPCapabilityRegistration:
         ]
         assert len(matches) == 1
         assert not self._write_tools_visible(matches[0])
+
+    def test_subagent_stays_read_only_under_bypass(self, model: TestModel) -> None:
+        # "bypass" removes the approval gate for the main thread, but filing
+        # still stays in the main thread: the subagent must not see write tools.
+        agent = build_agent(
+            model=model,
+            enable_subagents=True,
+            edit_permission="bypass",
+            github_mcp_config=self._github_config(),
+        )
+        call_subagent = _find_capability(agent, CallSubAgentCapability)
+        subagent = call_subagent.subagent.wrapped
+        matches = [
+            capability
+            for capability in _iter_capabilities(subagent.root_capability)
+            if isinstance(capability, GitHubMCPCapability)
+        ]
+        assert len(matches) == 1
+        assert not self._write_tools_visible(matches[0])


### PR DESCRIPTION
Code-review follow-ups to the GitHub tools shipped in #15780, split out of #15801 so the security-relevant fixes don't wait on the settings-UI review.

- **Subagents stay read-only.** `allow_writes` now also requires `not is_subagent`, so even a `bypass` edit-approval run cannot file issues from a subagent — duplicate checking is delegable, filing stays in the main thread where the approval flow lives.
- **MCP tool-listing failures degrade instead of failing the turn.** A `tools/list` failure after a successful init previously raised through the run; raw transport exception text can echo request headers, including the bearer token. `get_tools` now logs only the failure class, marks the toolset unavailable, and lets the turn continue without GitHub tools — the same degrade-and-sanitize policy `__aenter__` already applied to connect failures.
- **Browser-stored integration credentials are purged on logout.** The persisted agent store is scoped per deployment, not per user, so a personal GitHub PAT saved in the browser would survive into the next user's session on a shared machine. Logging out now clears `integrationCredentials` before redirecting.

Unit tests cover the subagent write gate and the sanitized degrade paths (connect failure, tool-listing failure, HTTP status / transport errors reduced to class name or status code).

The companion path-string updates (GitHub tool instructions and PXI docs pointing at the new settings tab locations) remain in #15801, since those paths only exist once the topical tabs land.
