### PR TITLE
fix: handle deleted project gracefully in dashboards project menu

### DIFF
--- a/js/app/src/Routes.tsx
+++ b/js/app/src/Routes.tsx
@@ -153,15 +153,18 @@ const revalidateOnPathChange: ShouldRevalidateFunction = ({
   return defaultShouldRevalidate;
 };
 
-// For loaders that read no URL params at all: navigation can never change
-// their data, so only same-URL requests (useRevalidator, post-action
-// revalidation) defer to the router's default.
+// For loaders that read nothing from the URL: no navigation — path or search
+// param change alike — can change their data, so only genuinely same-URL
+// requests (useRevalidator, post-action revalidation) defer to the router's
+// default. Compares href, not pathname: the router's default revalidates on
+// search-param changes, which pages like dashboards trigger on every
+// time-range adjustment.
 const revalidateOnlyOnDemand: ShouldRevalidateFunction = ({
   currentUrl,
   nextUrl,
   defaultShouldRevalidate,
 }) => {
-  if (currentUrl.pathname === nextUrl.pathname) return defaultShouldRevalidate;
+  if (currentUrl.href === nextUrl.href) return defaultShouldRevalidate;
   return false;
 };
 

--- a/js/app/src/Routes.tsx
+++ b/js/app/src/Routes.tsx
@@ -153,6 +153,18 @@ const revalidateOnPathChange: ShouldRevalidateFunction = ({
   return defaultShouldRevalidate;
 };
 
+// For loaders that read no URL params at all: navigation can never change
+// their data, so only same-URL requests (useRevalidator, post-action
+// revalidation) defer to the router's default.
+const revalidateOnlyOnDemand: ShouldRevalidateFunction = ({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}) => {
+  if (currentUrl.pathname === nextUrl.pathname) return defaultShouldRevalidate;
+  return false;
+};
+
 // :projectId's loader depends only on its own param. Same-URL requests
 // (useRevalidator) defer to the router's default so manual revalidation works.
 export const revalidateOnProjectChange: ShouldRevalidateFunction = ({
@@ -494,7 +506,7 @@ export const appRouteObjects = createRoutesFromElements(
           }}
           element={<DashboardsRoot />}
           loader={dashboardsLoader}
-          shouldRevalidate={revalidateOnPathChange}
+          shouldRevalidate={revalidateOnlyOnDemand}
         >
           <Route index element={<DashboardsEmptyPage />} />
           <Route

--- a/js/app/src/components/project/ProjectMenu.tsx
+++ b/js/app/src/components/project/ProjectMenu.tsx
@@ -1,4 +1,12 @@
-import { startTransition, Suspense, useState } from "react";
+import {
+  startTransition,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay";
 
 import {
@@ -39,6 +47,13 @@ export type ProjectMenuProps = StylableProps & {
   query: ProjectMenu_projects$key;
   selectedProjectId?: string | null;
   onProjectChange: (projectId: string) => void;
+  /**
+   * Called when the selected project's name cannot be resolved (e.g. the
+   * project was deleted). The menu itself degrades to its placeholder; use
+   * this to clean up state that references the project, such as a remembered
+   * last-selected id.
+   */
+  onSelectedProjectError?: () => void;
   placeholder?: string;
   searchPlaceholder?: string;
   size?: MenuButtonProps["size"];
@@ -82,8 +97,12 @@ function ProjectMenuButton({
  */
 function SelectedProjectMenuButton({
   projectId,
+  fetchKey,
   ...buttonProps
-}: Omit<ProjectMenuButtonProps, "projectName"> & { projectId: string }) {
+}: Omit<ProjectMenuButtonProps, "projectName"> & {
+  projectId: string;
+  fetchKey: number;
+}) {
   const data = useLazyLoadQuery<ProjectMenuSelectedProjectQuery>(
     graphql`
       query ProjectMenuSelectedProjectQuery($id: ID!) {
@@ -97,7 +116,7 @@ function SelectedProjectMenuButton({
       }
     `,
     { id: projectId },
-    { fetchPolicy: "store-or-network" }
+    { fetchPolicy: "store-or-network", fetchKey }
   );
   const projectName =
     data.node?.__typename === "Project" && typeof data.node.name === "string"
@@ -106,10 +125,26 @@ function SelectedProjectMenuButton({
   return <ProjectMenuButton projectName={projectName} {...buttonProps} />;
 }
 
+/**
+ * Error fallback for the selected-project lookup. Renders the same
+ * placeholder button and reports the failure so the caller can react (e.g.
+ * clear a remembered project id) and the menu can retry on the next open.
+ */
+function SelectedProjectMenuButtonFallback({
+  onError,
+  ...buttonProps
+}: ProjectMenuButtonProps & { onError: () => void }) {
+  useEffect(() => {
+    onError();
+  }, [onError]);
+  return <ProjectMenuButton {...buttonProps} />;
+}
+
 export function ProjectMenu({
   query,
   selectedProjectId,
   onProjectChange,
+  onSelectedProjectError,
   placeholder = "Select project",
   searchPlaceholder = "Search projects...",
   size,
@@ -118,6 +153,14 @@ export function ProjectMenu({
   const [search, setSearch] = useState("");
   const [optimisticProject, setOptimisticProject] =
     useState<SelectedProject | null>(null);
+  // Bumped to retry the selected-project lookup after a failure; the ref
+  // remembers that the last attempt failed so a retry only happens then.
+  const [selectedProjectFetchKey, setSelectedProjectFetchKey] = useState(0);
+  const selectedProjectErrorRef = useRef(false);
+  const handleSelectedProjectError = useCallback(() => {
+    selectedProjectErrorRef.current = true;
+    onSelectedProjectError?.();
+  }, [onSelectedProjectError]);
   const { contains } = useFilter({ sensitivity: "base" });
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<ProjectMenuProjectsQuery, ProjectMenu_projects$key>(
@@ -145,9 +188,13 @@ export function ProjectMenu({
       query
     );
 
-  const projects = data.projects.edges.map((edge) => edge.project);
-  const selectedProject: SelectedProject | null =
-    projects.find((project) => project.id === selectedProjectId) ?? null;
+  const projects = useMemo(
+    () => data.projects.edges.map((edge) => edge.project),
+    [data.projects.edges]
+  );
+  const selectedProject = projects.find(
+    (project) => project.id === selectedProjectId
+  );
   const projectFilter = search ? { col: "name" as const, value: search } : null;
   const displayProjectName = selectedProjectId
     ? (selectedProject?.name ??
@@ -159,10 +206,7 @@ export function ProjectMenu({
   const onSearchChange = (value: string) => {
     setSearch(value);
     if (selectedProject) {
-      setOptimisticProject({
-        id: selectedProject.id,
-        name: selectedProject.name,
-      });
+      setOptimisticProject(selectedProject);
     }
     startTransition(() => {
       refetch(
@@ -193,55 +237,55 @@ export function ProjectMenu({
     });
   };
 
+  const buttonProps = {
+    css: propCSS,
+    placeholder,
+    size,
+  };
+
   return (
     <MenuTrigger
       onOpenChange={(isOpen) => {
-        if (!isOpen) {
+        if (isOpen) {
+          // Retry a previously failed selected-project lookup: a transient
+          // network error should not latch the placeholder for the rest of
+          // the session.
+          if (selectedProjectErrorRef.current) {
+            selectedProjectErrorRef.current = false;
+            setSelectedProjectFetchKey((key) => key + 1);
+          }
+        } else {
           resetSearch();
         }
       }}
     >
       {selectedProjectId && displayProjectName == null ? (
-        // The error boundary keeps a stale id (e.g. a deleted project) from
-        // crashing the page: the menu falls back to its placeholder so the
-        // user can pick a different project. Keyed so the boundary resets
-        // when the selection changes.
+        // The error boundary keeps a failed lookup (e.g. a stale id for a
+        // deleted project) from crashing the page: the menu falls back to its
+        // placeholder so the user can pick a different project. Keyed so the
+        // boundary resets when the selection changes or a retry is requested.
         <ErrorBoundary
-          key={selectedProjectId}
+          key={`${selectedProjectId}:${selectedProjectFetchKey}`}
           fallback={() => (
-            <ProjectMenuButton
-              css={propCSS}
-              placeholder={placeholder}
+            <SelectedProjectMenuButtonFallback
+              {...buttonProps}
               projectName={null}
-              size={size}
+              onError={handleSelectedProjectError}
             />
           )}
         >
           <Suspense
-            fallback={
-              <ProjectMenuButton
-                css={propCSS}
-                placeholder={placeholder}
-                projectName={null}
-                size={size}
-              />
-            }
+            fallback={<ProjectMenuButton {...buttonProps} projectName={null} />}
           >
             <SelectedProjectMenuButton
-              css={propCSS}
-              placeholder={placeholder}
+              {...buttonProps}
+              fetchKey={selectedProjectFetchKey}
               projectId={selectedProjectId}
-              size={size}
             />
           </Suspense>
         </ErrorBoundary>
       ) : (
-        <ProjectMenuButton
-          css={propCSS}
-          placeholder={placeholder}
-          projectName={displayProjectName}
-          size={size}
-        />
+        <ProjectMenuButton {...buttonProps} projectName={displayProjectName} />
       )}
       <MenuContainer placement="bottom start">
         <Autocomplete filter={contains}>

--- a/js/app/src/components/project/ProjectMenu.tsx
+++ b/js/app/src/components/project/ProjectMenu.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay";
@@ -38,22 +37,18 @@ import { ProjectItemContent } from "./ProjectItemContent";
 
 const PAGE_SIZE = 50;
 
-type SelectedProject = {
-  id: string;
-  name: string;
-};
-
 export type ProjectMenuProps = StylableProps & {
   query: ProjectMenu_projects$key;
   selectedProjectId?: string | null;
   onProjectChange: (projectId: string) => void;
   /**
-   * Called when the selected project's name cannot be resolved (e.g. the
-   * project was deleted). The menu itself degrades to its placeholder; use
-   * this to clean up state that references the project, such as a remembered
-   * last-selected id.
+   * Called when the selected project no longer exists (the lookup failed with
+   * a not-found error). The menu itself degrades to its placeholder; use this
+   * to clean up state that references the project, such as a remembered
+   * last-selected id. Transient failures (e.g. a network blip) do not trigger
+   * this — the menu retries those on its next open.
    */
-  onSelectedProjectError?: () => void;
+  onSelectedProjectNotFound?: () => void;
   placeholder?: string;
   searchPlaceholder?: string;
   size?: MenuButtonProps["size"];
@@ -128,15 +123,19 @@ function SelectedProjectMenuButton({
 /**
  * Error fallback for the selected-project lookup. Renders the same
  * placeholder button and reports the failure so the caller can react (e.g.
- * clear a remembered project id) and the menu can retry on the next open.
+ * clear a remembered project id) or retry on the next menu open.
  */
 function SelectedProjectMenuButtonFallback({
+  error,
   onError,
   ...buttonProps
-}: ProjectMenuButtonProps & { onError: () => void }) {
+}: ProjectMenuButtonProps & {
+  error?: string | null;
+  onError: (error: string | null) => void;
+}) {
   useEffect(() => {
-    onError();
-  }, [onError]);
+    onError(error ?? null);
+  }, [error, onError]);
   return <ProjectMenuButton {...buttonProps} />;
 }
 
@@ -144,23 +143,30 @@ export function ProjectMenu({
   query,
   selectedProjectId,
   onProjectChange,
-  onSelectedProjectError,
+  onSelectedProjectNotFound,
   placeholder = "Select project",
   searchPlaceholder = "Search projects...",
   size,
   css: propCSS,
 }: ProjectMenuProps) {
   const [search, setSearch] = useState("");
-  const [optimisticProject, setOptimisticProject] =
-    useState<SelectedProject | null>(null);
-  // Bumped to retry the selected-project lookup after a failure; the ref
-  // remembers that the last attempt failed so a retry only happens then.
+  // Bumped to retry the selected-project lookup after a transient failure;
+  // failedProjectId records which project's lookup failed so a retry only
+  // happens while that project is still the selection.
   const [selectedProjectFetchKey, setSelectedProjectFetchKey] = useState(0);
-  const selectedProjectErrorRef = useRef(false);
-  const handleSelectedProjectError = useCallback(() => {
-    selectedProjectErrorRef.current = true;
-    onSelectedProjectError?.();
-  }, [onSelectedProjectError]);
+  const [failedProjectId, setFailedProjectId] = useState<string | null>(null);
+  const handleSelectedProjectError = useCallback(
+    (error: string | null) => {
+      if (error != null && /not found/i.test(error)) {
+        // Permanent: the project no longer exists. Retrying cannot succeed,
+        // so let the caller clean up instead.
+        onSelectedProjectNotFound?.();
+      } else if (selectedProjectId) {
+        setFailedProjectId(selectedProjectId);
+      }
+    },
+    [onSelectedProjectNotFound, selectedProjectId]
+  );
   const { contains } = useFilter({ sensitivity: "base" });
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<ProjectMenuProjectsQuery, ProjectMenu_projects$key>(
@@ -196,18 +202,14 @@ export function ProjectMenu({
     (project) => project.id === selectedProjectId
   );
   const projectFilter = search ? { col: "name" as const, value: search } : null;
-  const displayProjectName = selectedProjectId
-    ? (selectedProject?.name ??
-      (optimisticProject?.id === selectedProjectId
-        ? optimisticProject.name
-        : null))
-    : null;
+  // When the selected project is not in the loaded pages of the connection
+  // (e.g. the connection is filtered by search), SelectedProjectMenuButton
+  // resolves the name — synchronously from the Relay store when the record
+  // was fetched before.
+  const displayProjectName = selectedProject?.name ?? null;
 
   const onSearchChange = (value: string) => {
     setSearch(value);
-    if (selectedProject) {
-      setOptimisticProject(selectedProject);
-    }
     startTransition(() => {
       refetch(
         {
@@ -237,11 +239,29 @@ export function ProjectMenu({
     });
   };
 
-  const buttonProps = {
-    css: propCSS,
-    placeholder,
-    size,
-  };
+  const buttonProps = useMemo(
+    () => ({
+      css: propCSS,
+      placeholder,
+      size,
+    }),
+    [propCSS, placeholder, size]
+  );
+
+  // Stable across re-renders: ErrorBoundary renders this as a component type,
+  // so a fresh identity per render would remount the fallback (and re-fire
+  // its onError effect) on every parent re-render.
+  const selectedProjectErrorFallback = useCallback(
+    ({ error }: { error?: string | null }) => (
+      <SelectedProjectMenuButtonFallback
+        {...buttonProps}
+        projectName={null}
+        error={error}
+        onError={handleSelectedProjectError}
+      />
+    ),
+    [buttonProps, handleSelectedProjectError]
+  );
 
   return (
     <MenuTrigger
@@ -249,9 +269,12 @@ export function ProjectMenu({
         if (isOpen) {
           // Retry a previously failed selected-project lookup: a transient
           // network error should not latch the placeholder for the rest of
-          // the session.
-          if (selectedProjectErrorRef.current) {
-            selectedProjectErrorRef.current = false;
+          // the session. Only retries the project that actually failed.
+          if (
+            failedProjectId != null &&
+            failedProjectId === selectedProjectId
+          ) {
+            setFailedProjectId(null);
             setSelectedProjectFetchKey((key) => key + 1);
           }
         } else {
@@ -266,13 +289,7 @@ export function ProjectMenu({
         // boundary resets when the selection changes or a retry is requested.
         <ErrorBoundary
           key={`${selectedProjectId}:${selectedProjectFetchKey}`}
-          fallback={() => (
-            <SelectedProjectMenuButtonFallback
-              {...buttonProps}
-              projectName={null}
-              onError={handleSelectedProjectError}
-            />
-          )}
+          fallback={selectedProjectErrorFallback}
         >
           <Suspense
             fallback={<ProjectMenuButton {...buttonProps} projectName={null} />}
@@ -315,10 +332,6 @@ export function ProjectMenu({
             selectionMode="single"
             onAction={(key) => {
               if (typeof key === "string") {
-                const project = projects.find((project) => project.id === key);
-                if (project) {
-                  setOptimisticProject(project);
-                }
                 onProjectChange(key);
               }
             }}

--- a/js/app/src/components/project/ProjectMenu.tsx
+++ b/js/app/src/components/project/ProjectMenu.tsx
@@ -21,6 +21,7 @@ import type { MenuButtonProps } from "@phoenix/components";
 import { CompactEmptyState } from "@phoenix/components/core/empty";
 import { SearchIcon } from "@phoenix/components/core/field";
 import type { StylableProps } from "@phoenix/components/core/types";
+import { ErrorBoundary } from "@phoenix/components/exception";
 
 import type { ProjectMenu_projects$key } from "./__generated__/ProjectMenu_projects.graphql";
 import type { ProjectMenuProjectsQuery } from "./__generated__/ProjectMenuProjectsQuery.graphql";
@@ -74,9 +75,10 @@ function ProjectMenuButton({
 
 /**
  * A menu button that resolves the selected project's name by id. Used when
- * the name is not available from data already fetched, e.g. when the route
- * was entered client-side (so the route loader never fetched the selected
- * project) and the project is not in the loaded pages of the connection.
+ * the name is not available from data already fetched, i.e. when the selected
+ * project is not in the loaded pages of the connection. Must be rendered
+ * inside an error boundary: the query fails when the selected project no
+ * longer exists (e.g. a stale id for a deleted project).
  */
 function SelectedProjectMenuButton({
   projectId,
@@ -126,17 +128,7 @@ export function ProjectMenu({
           after: { type: "String", defaultValue: null }
           first: { type: "Int", defaultValue: 50 }
           filter: { type: "ProjectFilter", defaultValue: null }
-          hasSelectedProject: { type: "Boolean!" }
-          selectedProjectId: { type: "ID!" }
         ) {
-          selectedProject: node(id: $selectedProjectId)
-            @include(if: $hasSelectedProject) {
-            __typename
-            id
-            ... on Project {
-              name
-            }
-          }
           projects(first: $first, after: $after, filter: $filter)
             @connection(key: "ProjectMenu_projects") {
             edges {
@@ -154,28 +146,8 @@ export function ProjectMenu({
     );
 
   const projects = data.projects.edges.map((edge) => edge.project);
-  const selectedProjectFromMenu = projects.find(
-    (project) => project.id === selectedProjectId
-  );
-  const selectedProjectFromRoute: SelectedProject | null =
-    data.selectedProject?.__typename === "Project" &&
-    data.selectedProject.id === selectedProjectId &&
-    typeof data.selectedProject.name === "string"
-      ? {
-          id: data.selectedProject.id,
-          name: data.selectedProject.name,
-        }
-      : null;
-  const selectedProject = selectedProjectFromMenu ?? selectedProjectFromRoute;
-  const selectedProjectVariables = selectedProjectId
-    ? {
-        hasSelectedProject: true,
-        selectedProjectId,
-      }
-    : {
-        hasSelectedProject: false,
-        selectedProjectId: "",
-      };
+  const selectedProject: SelectedProject | null =
+    projects.find((project) => project.id === selectedProjectId) ?? null;
   const projectFilter = search ? { col: "name" as const, value: search } : null;
   const displayProjectName = selectedProjectId
     ? (selectedProject?.name ??
@@ -198,7 +170,6 @@ export function ProjectMenu({
           after: null,
           first: PAGE_SIZE,
           filter: value ? { col: "name", value } : null,
-          ...selectedProjectVariables,
         },
         { fetchPolicy: "store-and-network" }
       );
@@ -216,7 +187,6 @@ export function ProjectMenu({
           after: null,
           first: PAGE_SIZE,
           filter: null,
-          ...selectedProjectVariables,
         },
         { fetchPolicy: "store-and-network" }
       );
@@ -232,23 +202,39 @@ export function ProjectMenu({
       }}
     >
       {selectedProjectId && displayProjectName == null ? (
-        <Suspense
-          fallback={
+        // The error boundary keeps a stale id (e.g. a deleted project) from
+        // crashing the page: the menu falls back to its placeholder so the
+        // user can pick a different project. Keyed so the boundary resets
+        // when the selection changes.
+        <ErrorBoundary
+          key={selectedProjectId}
+          fallback={() => (
             <ProjectMenuButton
               css={propCSS}
               placeholder={placeholder}
               projectName={null}
               size={size}
             />
-          }
+          )}
         >
-          <SelectedProjectMenuButton
-            css={propCSS}
-            placeholder={placeholder}
-            projectId={selectedProjectId}
-            size={size}
-          />
-        </Suspense>
+          <Suspense
+            fallback={
+              <ProjectMenuButton
+                css={propCSS}
+                placeholder={placeholder}
+                projectName={null}
+                size={size}
+              />
+            }
+          >
+            <SelectedProjectMenuButton
+              css={propCSS}
+              placeholder={placeholder}
+              projectId={selectedProjectId}
+              size={size}
+            />
+          </Suspense>
+        </ErrorBoundary>
       ) : (
         <ProjectMenuButton
           css={propCSS}
@@ -303,7 +289,6 @@ export function ProjectMenu({
                 loadNext(PAGE_SIZE, {
                   UNSTABLE_extraVariables: {
                     filter: projectFilter,
-                    ...selectedProjectVariables,
                   },
                 });
               }

--- a/js/app/src/components/project/__generated__/ProjectMenuProjectsQuery.graphql.ts
+++ b/js/app/src/components/project/__generated__/ProjectMenuProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f49ad99a4d41d61ba90a467654dd77ee>>
+ * @generated SignedSource<<6b373bb65bcc8442db12863cd9b8462f>>
  * @lightSyntaxTransform
  */
 
@@ -18,8 +18,6 @@ export type ProjectMenuProjectsQuery$variables = {
   after?: string | null;
   filter?: ProjectFilter | null;
   first?: number | null;
-  hasSelectedProject: boolean;
-  selectedProjectId: string;
 };
 export type ProjectMenuProjectsQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"ProjectMenu_projects">;
@@ -45,59 +43,32 @@ var v0 = [
     "defaultValue": 50,
     "kind": "LocalArgument",
     "name": "first"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "hasSelectedProject"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "selectedProjectId"
   }
 ],
-v1 = {
-  "kind": "Variable",
-  "name": "after",
-  "variableName": "after"
-},
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
 v2 = {
-  "kind": "Variable",
-  "name": "filter",
-  "variableName": "filter"
-},
-v3 = {
-  "kind": "Variable",
-  "name": "first",
-  "variableName": "first"
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v7 = [
-  (v1/*:: as any*/),
-  (v2/*:: as any*/),
-  (v3/*:: as any*/)
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*:: as any*/),
@@ -106,21 +77,7 @@ return {
     "name": "ProjectMenuProjectsQuery",
     "selections": [
       {
-        "args": [
-          (v1/*:: as any*/),
-          (v2/*:: as any*/),
-          (v3/*:: as any*/),
-          {
-            "kind": "Variable",
-            "name": "hasSelectedProject",
-            "variableName": "hasSelectedProject"
-          },
-          {
-            "kind": "Variable",
-            "name": "selectedProjectId",
-            "variableName": "selectedProjectId"
-          }
-        ],
+        "args": (v1/*:: as any*/),
         "kind": "FragmentSpread",
         "name": "ProjectMenu_projects"
       }
@@ -135,42 +92,8 @@ return {
     "name": "ProjectMenuProjectsQuery",
     "selections": [
       {
-        "condition": "hasSelectedProject",
-        "kind": "Condition",
-        "passingValue": true,
-        "selections": [
-          {
-            "alias": "selectedProject",
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "id",
-                "variableName": "selectedProjectId"
-              }
-            ],
-            "concreteType": null,
-            "kind": "LinkedField",
-            "name": "node",
-            "plural": false,
-            "selections": [
-              (v4/*:: as any*/),
-              (v5/*:: as any*/),
-              {
-                "kind": "InlineFragment",
-                "selections": [
-                  (v6/*:: as any*/)
-                ],
-                "type": "Project",
-                "abstractKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ]
-      },
-      {
         "alias": null,
-        "args": (v7/*:: as any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "ProjectConnection",
         "kind": "LinkedField",
         "name": "projects",
@@ -192,8 +115,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v5/*:: as any*/),
-                  (v6/*:: as any*/),
+                  (v2/*:: as any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
                   {
                     "alias": null,
                     "args": null,
@@ -226,8 +155,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v4/*:: as any*/),
-                  (v5/*:: as any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v2/*:: as any*/)
                 ],
                 "storageKey": null
               }
@@ -264,7 +199,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v7/*:: as any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "filter"
         ],
@@ -276,16 +211,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "08e2f2fe1f9ce2b75562419084fe3ceb",
+    "cacheID": "fd51befd29e493fba43cf04140b96804",
     "id": null,
     "metadata": {},
     "name": "ProjectMenuProjectsQuery",
     "operationKind": "query",
-    "text": "query ProjectMenuProjectsQuery(\n  $after: String = null\n  $filter: ProjectFilter = null\n  $first: Int = 50\n  $hasSelectedProject: Boolean!\n  $selectedProjectId: ID!\n) {\n  ...ProjectMenu_projects_27hoVN\n}\n\nfragment ProjectMenu_projects_27hoVN on Query {\n  selectedProject: node(id: $selectedProjectId) @include(if: $hasSelectedProject) {\n    __typename\n    id\n    ... on Project {\n      name\n    }\n  }\n  projects(first: $first, after: $after, filter: $filter) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ProjectMenuProjectsQuery(\n  $after: String = null\n  $filter: ProjectFilter = null\n  $first: Int = 50\n) {\n  ...ProjectMenu_projects_G9cLv\n}\n\nfragment ProjectMenu_projects_G9cLv on Query {\n  projects(first: $first, after: $after, filter: $filter) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "acf5af224c355e76f53d918b469f477c";
+(node as any).hash = "b352f700c90c5801783845b12c62096f";
 
 export default node;

--- a/js/app/src/components/project/__generated__/ProjectMenu_projects.graphql.ts
+++ b/js/app/src/components/project/__generated__/ProjectMenu_projects.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<33369ca95a80927220fb8f970e61284e>>
+ * @generated SignedSource<<7d6842e07a90d9c4243a639ca8d76155>>
  * @lightSyntaxTransform
  */
 
@@ -20,11 +20,6 @@ export type ProjectMenu_projects$data = {
       };
     }>;
   };
-  readonly selectedProject?: {
-    readonly __typename: string;
-    readonly id: string;
-    readonly name?: string;
-  };
   readonly " $fragmentType": "ProjectMenu_projects";
 };
 export type ProjectMenu_projects$key = {
@@ -37,28 +32,7 @@ import ProjectMenuProjectsQuery_graphql from './ProjectMenuProjectsQuery.graphql
 const node: ReaderFragment = (function(){
 var v0 = [
   "projects"
-],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-};
+];
 return {
   "argumentDefinitions": [
     {
@@ -75,16 +49,6 @@ return {
       "defaultValue": 50,
       "kind": "LocalArgument",
       "name": "first"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "hasSelectedProject"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "selectedProjectId"
     }
   ],
   "kind": "Fragment",
@@ -112,40 +76,6 @@ return {
   },
   "name": "ProjectMenu_projects",
   "selections": [
-    {
-      "condition": "hasSelectedProject",
-      "kind": "Condition",
-      "passingValue": true,
-      "selections": [
-        {
-          "alias": "selectedProject",
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "id",
-              "variableName": "selectedProjectId"
-            }
-          ],
-          "concreteType": null,
-          "kind": "LinkedField",
-          "name": "node",
-          "plural": false,
-          "selections": [
-            (v1/*:: as any*/),
-            (v2/*:: as any*/),
-            {
-              "kind": "InlineFragment",
-              "selections": [
-                (v3/*:: as any*/)
-              ],
-              "type": "Project",
-              "abstractKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ]
-    },
     {
       "alias": "projects",
       "args": [
@@ -176,8 +106,20 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v2/*:: as any*/),
-                (v3/*:: as any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
                 {
                   "alias": null,
                   "args": null,
@@ -210,7 +152,13 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v1/*:: as any*/)
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
               ],
               "storageKey": null
             }
@@ -251,6 +199,6 @@ return {
 };
 })();
 
-(node as any).hash = "acf5af224c355e76f53d918b469f477c";
+(node as any).hash = "b352f700c90c5801783845b12c62096f";
 
 export default node;

--- a/js/app/src/pages/dashboards/DashboardsPage.tsx
+++ b/js/app/src/pages/dashboards/DashboardsPage.tsx
@@ -66,9 +66,9 @@ export function DashboardsPage() {
   const setLastSelectedDashboardProjectId = usePreferencesContext(
     (state) => state.setLastSelectedDashboardProjectId
   );
-  const onSelectedProjectError = useCallback(() => {
-    // The remembered project can no longer be resolved (e.g. it was deleted).
-    // Forget it so the dashboards index stops redirecting back to it.
+  const onSelectedProjectNotFound = useCallback(() => {
+    // The remembered project no longer exists (it was deleted). Forget it so
+    // the dashboards index stops redirecting back to it.
     setLastSelectedDashboardProjectId(undefined);
   }, [setLastSelectedDashboardProjectId]);
   const data = useOwnedPreloadedQuery<DashboardsLoaderQuery>({
@@ -88,7 +88,7 @@ export function DashboardsPage() {
             setLastSelectedDashboardProjectId(projectId);
             navigate(`/dashboards/projects/${projectId}`);
           }}
-          onSelectedProjectError={onSelectedProjectError}
+          onSelectedProjectNotFound={onSelectedProjectNotFound}
         />
         <Flex direction="row" alignItems="center" gap="size-100">
           <ConnectedTimeRangeSelector size="S" />

--- a/js/app/src/pages/dashboards/DashboardsPage.tsx
+++ b/js/app/src/pages/dashboards/DashboardsPage.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Suspense } from "react";
+import { Suspense, useCallback } from "react";
 import {
   Navigate,
   Outlet,
@@ -66,6 +66,11 @@ export function DashboardsPage() {
   const setLastSelectedDashboardProjectId = usePreferencesContext(
     (state) => state.setLastSelectedDashboardProjectId
   );
+  const onSelectedProjectError = useCallback(() => {
+    // The remembered project can no longer be resolved (e.g. it was deleted).
+    // Forget it so the dashboards index stops redirecting back to it.
+    setLastSelectedDashboardProjectId(undefined);
+  }, [setLastSelectedDashboardProjectId]);
   const data = useOwnedPreloadedQuery<DashboardsLoaderQuery>({
     query: dashboardsLoaderQuery,
     queryRef: loaderData.queryRef,
@@ -83,6 +88,7 @@ export function DashboardsPage() {
             setLastSelectedDashboardProjectId(projectId);
             navigate(`/dashboards/projects/${projectId}`);
           }}
+          onSelectedProjectError={onSelectedProjectError}
         />
         <Flex direction="row" alignItems="center" gap="size-100">
           <ConnectedTimeRangeSelector size="S" />

--- a/js/app/src/pages/dashboards/__generated__/dashboardsLoaderQuery.graphql.ts
+++ b/js/app/src/pages/dashboards/__generated__/dashboardsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<80d394267fb7209519c5ed78472d0349>>
+ * @generated SignedSource<<5bc0e88c04bfd722a7eee3e0aa666ba5>>
  * @lightSyntaxTransform
  */
 
@@ -9,10 +9,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type dashboardsLoaderQuery$variables = {
-  hasSelectedProject: boolean;
-  projectId: string;
-};
+export type dashboardsLoaderQuery$variables = Record<PropertyKey, never>;
 export type dashboardsLoaderQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"ProjectMenu_projects">;
 };
@@ -24,64 +21,27 @@ export type dashboardsLoaderQuery = {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "hasSelectedProject"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "projectId"
+    "kind": "Literal",
+    "name": "first",
+    "value": 50
   }
 ],
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 50
-  }
-];
+};
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*:: as any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
     "name": "dashboardsLoaderQuery",
     "selections": [
       {
-        "args": [
-          {
-            "kind": "Variable",
-            "name": "hasSelectedProject",
-            "variableName": "hasSelectedProject"
-          },
-          {
-            "kind": "Variable",
-            "name": "selectedProjectId",
-            "variableName": "projectId"
-          }
-        ],
+        "args": null,
         "kind": "FragmentSpread",
         "name": "ProjectMenu_projects"
       }
@@ -91,47 +51,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*:: as any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
     "name": "dashboardsLoaderQuery",
     "selections": [
       {
-        "condition": "hasSelectedProject",
-        "kind": "Condition",
-        "passingValue": true,
-        "selections": [
-          {
-            "alias": "selectedProject",
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "id",
-                "variableName": "projectId"
-              }
-            ],
-            "concreteType": null,
-            "kind": "LinkedField",
-            "name": "node",
-            "plural": false,
-            "selections": [
-              (v1/*:: as any*/),
-              (v2/*:: as any*/),
-              {
-                "kind": "InlineFragment",
-                "selections": [
-                  (v3/*:: as any*/)
-                ],
-                "type": "Project",
-                "abstractKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ]
-      },
-      {
         "alias": null,
-        "args": (v4/*:: as any*/),
+        "args": (v0/*:: as any*/),
         "concreteType": "ProjectConnection",
         "kind": "LinkedField",
         "name": "projects",
@@ -153,8 +79,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*:: as any*/),
-                  (v3/*:: as any*/),
+                  (v1/*:: as any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
                   {
                     "alias": null,
                     "args": null,
@@ -187,8 +119,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v1/*:: as any*/),
-                  (v2/*:: as any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v1/*:: as any*/)
                 ],
                 "storageKey": null
               }
@@ -225,7 +163,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v4/*:: as any*/),
+        "args": (v0/*:: as any*/),
         "filters": [
           "filter"
         ],
@@ -237,16 +175,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5d463418de182761a57f32d91d2e4739",
+    "cacheID": "20432a5384336d073fc5b8b5c598ac9d",
     "id": null,
     "metadata": {},
     "name": "dashboardsLoaderQuery",
     "operationKind": "query",
-    "text": "query dashboardsLoaderQuery(\n  $hasSelectedProject: Boolean!\n  $projectId: ID!\n) {\n  ...ProjectMenu_projects_4wy0JP\n}\n\nfragment ProjectMenu_projects_4wy0JP on Query {\n  selectedProject: node(id: $projectId) @include(if: $hasSelectedProject) {\n    __typename\n    id\n    ... on Project {\n      name\n    }\n  }\n  projects(first: 50) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query dashboardsLoaderQuery {\n  ...ProjectMenu_projects\n}\n\nfragment ProjectMenu_projects on Query {\n  projects(first: 50) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6fe56c8cb343694b5f9427aa7eadacc7";
+(node as any).hash = "70ea87bf6213ad6bb7735fd77c22dfe5";
 
 export default node;

--- a/js/app/src/pages/dashboards/dashboardsLoader.tsx
+++ b/js/app/src/pages/dashboards/dashboardsLoader.tsx
@@ -1,5 +1,4 @@
 import { graphql, loadQuery } from "react-relay";
-import type { LoaderFunctionArgs } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 
@@ -7,29 +6,27 @@ import type { dashboardsLoaderQuery as DashboardsLoaderQuery } from "./__generat
 
 /**
  * The query for the dashboards loader.
+ *
+ * Note: the selected project (from the route params) is deliberately not
+ * fetched here. It may no longer exist (e.g. a stale URL or remembered id for
+ * a deleted project), and a failed lookup would fail the entire query and
+ * take down the page. The ProjectMenu resolves the selected project's name
+ * on its own and degrades gracefully when the project is not found.
  */
 export const dashboardsLoaderQuery = graphql`
-  query dashboardsLoaderQuery($hasSelectedProject: Boolean!, $projectId: ID!) {
+  query dashboardsLoaderQuery {
     ...ProjectMenu_projects
-      @arguments(
-        hasSelectedProject: $hasSelectedProject
-        selectedProjectId: $projectId
-      )
   }
 `;
 
 /**
  * A loader for the dashboards page
  */
-export function dashboardsLoader({ params }: LoaderFunctionArgs) {
-  const projectId = params.projectId ?? "";
+export function dashboardsLoader() {
   const queryRef = loadQuery<DashboardsLoaderQuery>(
     RelayEnvironment,
     dashboardsLoaderQuery,
-    {
-      hasSelectedProject: Boolean(params.projectId),
-      projectId,
-    }
+    {}
   );
 
   return { queryRef };

--- a/js/app/src/store/preferencesStore.tsx
+++ b/js/app/src/store/preferencesStore.tsx
@@ -251,7 +251,7 @@ export interface PreferencesState extends PreferencesProps {
   /**
    * Setter for the last project selected on the dashboards page.
    */
-  setLastSelectedDashboardProjectId: (projectId: string) => void;
+  setLastSelectedDashboardProjectId: (projectId: string | undefined) => void;
   /**
    * Setter for the user's preferred side nav open state
    */

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -328,11 +328,16 @@ class Project(Node):
         info: Info[Context, None],
         attr: InstrumentedAttribute[Any],
     ) -> Any:
-        """Load a non-nullable column via the dataloader, raising NotFound if the
-        project row no longer exists (e.g. it was deleted after the ID was issued)."""
+        """Load a column via the dataloader, raising NotFound if the project row
+        no longer exists (e.g. it was deleted after the ID was issued).
+
+        Only pass NOT NULL columns owned by the projects table: the dataloader
+        returns None both for a missing row and for a NULL column value, so None
+        is a reliable deleted-row signal only under that restriction.
+        """
         value = await info.context.data_loaders.project_fields.load((self.id, attr))
         if value is None:
-            raise NotFound(f"Project not found: {self.id}")
+            raise NotFound(f"Project not found: {GlobalID(Project.__name__, str(self.id))}")
         return value
 
     @strawberry.field
@@ -360,6 +365,10 @@ class Project(Node):
                     (self.id, models.Project.description),
                 ),
             )
+            if description is None:
+                # Distinguish a NULL description from a deleted project row so
+                # a stale ID cannot resolve to a phantom project.
+                await self._load_required_field(info, models.Project.id)
         return description
 
     @strawberry.field

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -34,7 +34,7 @@ from phoenix.db.trace_aggregates import (
 )
 from phoenix.server.api.annotation_metrics import build_entity_weighted_annotation_metrics_stmt
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest
+from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.extensions import RequireForwardPaginationExtension
 from phoenix.server.api.input_types.ProjectSessionSort import (
     ProjectSessionSort,
@@ -323,6 +323,18 @@ class Project(Node):
         if self.db_record and self.id != self.db_record.id:
             raise ValueError("Project ID mismatch")
 
+    async def _load_required_field(
+        self,
+        info: Info[Context, None],
+        attr: InstrumentedAttribute[Any],
+    ) -> Any:
+        """Load a non-nullable column via the dataloader, raising NotFound if the
+        project row no longer exists (e.g. it was deleted after the ID was issued)."""
+        value = await info.context.data_loaders.project_fields.load((self.id, attr))
+        if value is None:
+            raise NotFound(f"Project not found: {self.id}")
+        return value
+
     @strawberry.field
     async def name(
         self,
@@ -331,9 +343,7 @@ class Project(Node):
         if self.db_record:
             name = self.db_record.name
         else:
-            name = await info.context.data_loaders.project_fields.load(
-                (self.id, models.Project.name),
-            )
+            name = await self._load_required_field(info, models.Project.name)
         return name
 
     @strawberry.field
@@ -360,8 +370,8 @@ class Project(Node):
         if self.db_record:
             gradient_start_color = self.db_record.gradient_start_color
         else:
-            gradient_start_color = await info.context.data_loaders.project_fields.load(
-                (self.id, models.Project.gradient_start_color),
+            gradient_start_color = await self._load_required_field(
+                info, models.Project.gradient_start_color
             )
         return gradient_start_color
 
@@ -373,8 +383,8 @@ class Project(Node):
         if self.db_record:
             gradient_end_color = self.db_record.gradient_end_color
         else:
-            gradient_end_color = await info.context.data_loaders.project_fields.load(
-                (self.id, models.Project.gradient_end_color),
+            gradient_end_color = await self._load_required_field(
+                info, models.Project.gradient_end_color
             )
         return gradient_end_color
 
@@ -1606,9 +1616,7 @@ class Project(Node):
         if self.db_record:
             created_at = self.db_record.created_at
         else:
-            created_at = await info.context.data_loaders.project_fields.load(
-                (self.id, models.Project.created_at),
-            )
+            created_at = await self._load_required_field(info, models.Project.created_at)
         return created_at
 
     @strawberry.field
@@ -1619,9 +1627,7 @@ class Project(Node):
         if self.db_record:
             updated_at = self.db_record.updated_at
         else:
-            updated_at = await info.context.data_loaders.project_fields.load(
-                (self.id, models.Project.updated_at),
-            )
+            updated_at = await self._load_required_field(info, models.Project.updated_at)
         return updated_at
 
     @strawberry.field

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import json
 import logging
 import operator
@@ -359,16 +360,17 @@ class Project(Node):
         if self.db_record:
             description = self.db_record.description
         else:
-            description = cast(
-                Optional[str],
-                await info.context.data_loaders.project_fields.load(
+            # The existence check distinguishes a NULL description from a
+            # deleted project row so a stale ID cannot resolve to a phantom
+            # project. gather schedules both loads in the same dataloader
+            # batch, so it costs no extra query.
+            value, _ = await asyncio.gather(
+                info.context.data_loaders.project_fields.load(
                     (self.id, models.Project.description),
                 ),
+                self._load_required_field(info, models.Project.id),
             )
-            if description is None:
-                # Distinguish a NULL description from a deleted project row so
-                # a stale ID cannot resolve to a phantom project.
-                await self._load_required_field(info, models.Project.id)
+            description = cast(Optional[str], value)
         return description
 
     @strawberry.field

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -11,7 +11,7 @@ import httpx
 import pandas as pd
 import pytest
 from faker import Faker
-from sqlalchemy import insert
+from sqlalchemy import delete, insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 from typing_extensions import assert_never
@@ -2069,6 +2069,30 @@ class TestProject:
         httpx_client: httpx.AsyncClient,
     ) -> Any:
         return await _node(field, Project.__name__, project.id, httpx_client)
+
+    async def test_fields_of_deleted_project_return_not_found(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        """A stale ID (e.g. remembered by the UI for a since-deleted project) should
+        produce a clear NotFound error, not a masked internal server error from the
+        non-nullable field resolvers."""
+        async with db() as session:
+            project = await _add_project(session, name="deleted-project-not-found-test")
+            project_id = project.id
+        async with db() as session:
+            await session.execute(delete(models.Project).where(models.Project.id == project_id))
+        query = "query($id:ID!){node(id:$id){... on Project{name}}}"
+        gid = str(GlobalID(Project.__name__, str(project_id)))
+        response = await httpx_client.post(
+            "/graphql",
+            json={"query": query, "variables": {"id": gid}},
+        )
+        assert response.status_code == 200
+        errors = response.json().get("errors")
+        assert errors
+        assert errors[0]["message"] == f"Project not found: {project_id}"
 
     async def test_annotation_name_counts(
         self,

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -2083,16 +2083,24 @@ class TestProject:
             project_id = project.id
         async with db() as session:
             await session.execute(delete(models.Project).where(models.Project.id == project_id))
-        query = "query($id:ID!){node(id:$id){... on Project{name}}}"
         gid = str(GlobalID(Project.__name__, str(project_id)))
-        response = await httpx_client.post(
-            "/graphql",
-            json={"query": query, "variables": {"id": gid}},
-        )
-        assert response.status_code == 200
-        errors = response.json().get("errors")
-        assert errors
-        assert errors[0]["message"] == f"Project not found: {project_id}"
+        # `description` is nullable, so it needs the row-existence check to
+        # avoid resolving a deleted project as a phantom node with null fields.
+        for field_name in ("name", "description"):
+            query = "query($id:ID!){node(id:$id){... on Project{" + field_name + "}}}"
+            response = await httpx_client.post(
+                "/graphql",
+                json={"query": query, "variables": {"id": gid}},
+            )
+            assert response.status_code == 200
+            errors = response.json().get("errors")
+            assert errors
+            assert errors[0]["message"] == f"Project not found: {gid}"
+        # A live project with a NULL description still resolves to null rather
+        # than being mistaken for a deleted row.
+        async with db() as session:
+            live_project = await _add_project(session, name="live-project-null-description")
+        assert await self._node("description", live_project, httpx_client) is None
 
     async def test_annotation_name_counts(
         self,


### PR DESCRIPTION
resolves #15685

A remembered dashboard project or bookmarked project URL can point to a deleted project. Previously, resolving its name failed the page-level query and displayed the full-page error screen. The dashboard now keeps the project picker usable so the user can select another project.

- Fetch the selected project's name within a scoped error boundary, independently of the dashboard's project-list query.
- Clear the remembered project on a not-found error; retry transient lookup failures when the menu next opens.
- Keep project-list pagination intact when navigating between dashboard projects or adjusting the time range.
- Keep the last seen name of the selected project as a fallback while the connection refetches, so the button does not flash its placeholder when the selection drops out of the loaded pages (e.g. after picking a project from a search). The store-or-network lookup cannot resolve `node(id:)` from the Relay store without a missing-field handler, so a deleted project still flows through the error boundary.
- Return an explicit `NotFound` error from deleted-project field resolvers, including the nullable description field, while preserving null descriptions for existing projects.

Validation (branch is current with `main`):

- Frontend tests: 2,419 passed, 12 skipped.
- Project and node Python tests (SQLite): 186 passed; 153 PostgreSQL cases skipped.
- Frontend type checking, oxlint, oxfmt, and Python Ruff checks passed.
- Relay artifacts regenerated with no changes; `git diff --check` passed.

Known unrelated flake: an earlier Playwright run failed in the viewer-role user-creation spec, which is outside the dashboard changes (see comment below).
