### PR TITLE
fix(experiments): count dispatched work items as in-flight

### DIFF
--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -96,6 +96,7 @@ from typing import (
 import anyio
 from anyio import Semaphore
 from anyio.abc import TaskGroup
+from anyio.lowlevel import checkpoint
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from cachetools import LRUCache
 from opentelemetry.context import Context as OtelContext
@@ -1370,8 +1371,8 @@ class RunningExperiment:
         #   - it is in _in_flight, so a completion check triggered by another task
         #     finishing before the worker starts still sees pending work;
         #   - it has its cancel scope, so stop() can cancel it before the worker has
-        #     entered the scope (a pre-entry cancel takes effect at the worker's first
-        #     checkpoint after entry);
+        #     entered the scope (the worker checkpoints right after entering, so a
+        #     stopped item does no work);
         #   - it has an undo callback, so a hand-off that fails can put it back where
         #     it came from (see undispatch()).
         # The scope is created before the pop so a failure here leaves the queue intact.
@@ -1425,9 +1426,9 @@ class RunningExperiment:
         """Hand a dispatched item's cancel scope to the worker task about to run it.
 
         Called by the daemon's worker task as its first step. The scope was created at
-        dispatch, so stop() may already have cancelled it; entering it then cancels the
-        worker at its first checkpoint. From here on the dispatch can no longer be
-        undone, so the undo callback is dropped.
+        dispatch, so stop() may already have cancelled it; the worker checkpoints right
+        after entering it, so a stopped item is cancelled before doing any work. From
+        here on the dispatch can no longer be undone, so the undo callback is dropped.
         """
         self._dispatch_undo.pop(work_item, None)
         return self._cancel_scopes[work_item]
@@ -2430,9 +2431,13 @@ class ExperimentRunner(DaemonTask):
     async def _run_and_release(self, work_item: WorkItem) -> None:
         """Execute work item and release semaphore."""
         try:
-            # Enter the cancel scope created at dispatch, so a stop() that ran before
-            # this task started still takes effect at the first checkpoint.
             with work_item.running_experiment.start_execution(work_item):
+                # The scope was created at dispatch, so stop() may have cancelled it
+                # before this task ever ran. That cancellation is delivered at the next
+                # checkpoint, and execute() can do real work before reaching one: format
+                # a template, run a synchronous evaluator, then persist the result under
+                # a shield. Checkpoint first so a stopped item does no work at all.
+                await checkpoint()
                 await work_item.execute()
         except anyio.get_cancelled_exc_class():
             logger.debug(f"Work item {work_item.debug_identifier} was cancelled")

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -95,6 +95,7 @@ from typing import (
 
 import anyio
 from anyio import Semaphore
+from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from cachetools import LRUCache
 from opentelemetry.context import Context as OtelContext
@@ -1189,6 +1190,9 @@ class RunningExperiment:
         self._retry_heap: list[RetryItem] = []
         self._in_flight: set[WorkItem] = set()
         self._cancel_scopes: dict[WorkItem, anyio.CancelScope] = {}
+        # Items dispatched to a worker task that has not started yet, mapped to the
+        # callback that puts them back where they came from. See undispatch().
+        self._dispatch_undo: dict[WorkItem, Callable[[], None]] = {}
 
         # UI subscribers for streaming
         self._subscribers: list[MemoryObjectSendStream[ChatCompletionSubscriptionPayload]] = []
@@ -1337,7 +1341,7 @@ class RunningExperiment:
             return None
 
         # Peek at next work item without popping
-        work_item, pop = self._peek_next_work_item()
+        work_item, pop, unpop = self._peek_next_work_item()
         if work_item is None:
             logger.debug(
                 f"Experiment {self._experiment.id}: try_get_ready_work_item() -> None "
@@ -1358,47 +1362,92 @@ class RunningExperiment:
             )
             return None
 
-        # Allowed - pop and return (update fairness so we're served last next time)
-        self.last_served_at = datetime.now(timezone.utc)
+        # Allowed: hand the item over. Ownership moves from its queue to the worker in
+        # one synchronous step with no await in between. The daemon starts the worker
+        # task with start_soon(), which only begins on a later event-loop turn, so
+        # everything the rest of the runner needs to know about the item must already
+        # be in place before this method returns:
+        #   - it is in _in_flight, so a completion check triggered by another task
+        #     finishing before the worker starts still sees pending work;
+        #   - it has its cancel scope, so stop() can cancel it before the worker has
+        #     entered the scope (a pre-entry cancel takes effect at the worker's first
+        #     checkpoint after entry);
+        #   - it has an undo callback, so a hand-off that fails can put it back where
+        #     it came from (see undispatch()).
+        # The scope is created before the pop so a failure here leaves the queue intact.
+        scope = anyio.CancelScope()
+        self.last_served_at = datetime.now(timezone.utc)  # served last next time
         pop()
-        # Count the item as in-flight from the moment it leaves the queue. The daemon
-        # hands it to its task group with start_soon(), so the task that registers the
-        # item's cancel scope only begins on a later event-loop turn. Until then the
-        # item would be in neither the queue nor _in_flight, and a completion check
-        # triggered by another task finishing in that window would find no work and
-        # close the experiment with this item still unprocessed.
+        self._cancel_scopes[work_item] = scope
         self._in_flight.add(work_item)
+        self._dispatch_undo[work_item] = unpop
         return work_item
 
-    def _peek_next_work_item(self) -> tuple[WorkItem | None, Callable[[], Any]]:
-        """Peek at the next work item in priority order without removing it."""
+    def _peek_next_work_item(
+        self,
+    ) -> tuple[WorkItem | None, Callable[[], Any], Callable[[], None]]:
+        """Peek at the next work item in priority order without removing it.
+
+        Returns the item, a callback that removes it from its source, and a callback
+        that puts it back exactly where it was. A retry is restored as its original
+        RetryItem, so it keeps its ready time and its place in the ordering.
+        """
         # Priority 1: Evals
         if self._eval_queue:
-            return self._eval_queue[0], lambda: self._eval_queue.popleft()
+            eval_item = self._eval_queue[0]
+            return (
+                eval_item,
+                lambda: self._eval_queue.popleft(),
+                lambda: self._eval_queue.appendleft(eval_item),
+            )
 
         # Priority 2: Ready retries
         if self._has_ready_retries():
-            return self._retry_heap[0].work_item, lambda: heapq.heappop(self._retry_heap)
+            retry_item = self._retry_heap[0]
+            return (
+                retry_item.work_item,
+                lambda: heapq.heappop(self._retry_heap),
+                lambda: heapq.heappush(self._retry_heap, retry_item),
+            )
 
         # Priority 3: Tasks
         if self._task_queue:
-            return self._task_queue[0], lambda: self._task_queue.popleft()
+            task_item = self._task_queue[0]
+            return (
+                task_item,
+                lambda: self._task_queue.popleft(),
+                lambda: self._task_queue.appendleft(task_item),
+            )
 
-        return None, lambda: None
+        return None, lambda: None, lambda: None
 
-    def register_cancel_scope(self, work_item: WorkItem, scope: anyio.CancelScope) -> None:
-        """Register a cancel scope for an in-flight work item.
+    def start_execution(self, work_item: WorkItem) -> anyio.CancelScope:
+        """Hand a dispatched item's cancel scope to the worker task about to run it.
 
-        Called by Runner when execution starts. The item already counts as in-flight
-        from dispatch (see try_get_ready_work_item), so adding it here is idempotent;
-        what this adds is cancellability. If the experiment was stopped between
-        dispatch and now, stop() had no scope to cancel, so cancel it here to keep a
-        stopped experiment from running stale work.
+        Called by the daemon's worker task as its first step. The scope was created at
+        dispatch, so stop() may already have cancelled it; entering it then cancels the
+        worker at its first checkpoint. From here on the dispatch can no longer be
+        undone, so the undo callback is dropped.
         """
-        self._cancel_scopes[work_item] = scope
-        self._in_flight.add(work_item)
-        if not self._active:
-            scope.cancel()
+        self._dispatch_undo.pop(work_item, None)
+        return self._cancel_scopes[work_item]
+
+    def undispatch(self, work_item: WorkItem) -> None:
+        """Reverse a dispatch whose worker task could not be started.
+
+        The item stops counting as in-flight, so the experiment can still complete or
+        drain, and goes back to the front of the source it was taken from, so it is
+        dispatched again on the next pass. If the experiment has been stopped in the
+        meantime its queues are already cleared, and the item is simply dropped along
+        with the rest of the transient queue state.
+        """
+        self._cancel_scopes.pop(work_item, None)
+        self._in_flight.discard(work_item)
+        undo = self._dispatch_undo.pop(work_item, None)
+        if undo is not None and self._active:
+            undo()
+        if not self._active and not self._in_flight:
+            self._drained.set()
 
     async def unregister_cancel_scope(self, work_item: WorkItem) -> None:
         """Unregister a cancel scope when work item completes.
@@ -1406,6 +1455,7 @@ class RunningExperiment:
         Called by Runner when execution ends.
         """
         self._cancel_scopes.pop(work_item, None)
+        self._dispatch_undo.pop(work_item, None)
         self._in_flight.discard(work_item)
         if not self._active and not self._in_flight:
             self._drained.set()
@@ -2261,8 +2311,7 @@ class ExperimentRunner(DaemonTask):
                         work_item = await self._try_get_ready_work_item()
 
                         if work_item:
-                            logger.debug(f"Dispatching work item: {work_item.debug_identifier}")
-                            tg.start_soon(self._run_and_release, work_item)
+                            self._hand_off(tg, work_item)
                             acquired = False  # Ownership transferred to work item
                         else:
                             self._seats.release()
@@ -2361,12 +2410,29 @@ class ExperimentRunner(DaemonTask):
         )
         return None
 
+    def _hand_off(self, tg: TaskGroup, work_item: WorkItem) -> None:
+        """Start the worker task for a dispatched item, undoing the dispatch if that fails.
+
+        Dispatch already moved the item out of its queue and into the experiment's
+        in-flight set. If no worker task gets created (a task group refuses new tasks
+        once it is shutting down), nothing would ever take the item out of that set:
+        the experiment could not complete, and a stop would wait for a drain that
+        never comes. So put the item back where it came from before the error
+        propagates to the dispatch loop, which releases the seat and backs off.
+        """
+        try:
+            logger.debug(f"Dispatching work item: {work_item.debug_identifier}")
+            tg.start_soon(self._run_and_release, work_item)
+        except BaseException:
+            work_item.running_experiment.undispatch(work_item)
+            raise
+
     async def _run_and_release(self, work_item: WorkItem) -> None:
         """Execute work item and release semaphore."""
         try:
-            # Create cancel scope so experiment can cancel this work item
-            with anyio.CancelScope() as scope:
-                work_item.running_experiment.register_cancel_scope(work_item, scope)
+            # Enter the cancel scope created at dispatch, so a stop() that ran before
+            # this task started still takes effect at the first checkpoint.
+            with work_item.running_experiment.start_execution(work_item):
                 await work_item.execute()
         except anyio.get_cancelled_exc_class():
             logger.debug(f"Work item {work_item.debug_identifier} was cancelled")

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -1361,6 +1361,13 @@ class RunningExperiment:
         # Allowed - pop and return (update fairness so we're served last next time)
         self.last_served_at = datetime.now(timezone.utc)
         pop()
+        # Count the item as in-flight from the moment it leaves the queue. The daemon
+        # hands it to its task group with start_soon(), so the task that registers the
+        # item's cancel scope only begins on a later event-loop turn. Until then the
+        # item would be in neither the queue nor _in_flight, and a completion check
+        # triggered by another task finishing in that window would find no work and
+        # close the experiment with this item still unprocessed.
+        self._in_flight.add(work_item)
         return work_item
 
     def _peek_next_work_item(self) -> tuple[WorkItem | None, Callable[[], Any]]:
@@ -1382,10 +1389,16 @@ class RunningExperiment:
     def register_cancel_scope(self, work_item: WorkItem, scope: anyio.CancelScope) -> None:
         """Register a cancel scope for an in-flight work item.
 
-        Called by Runner when execution starts.
+        Called by Runner when execution starts. The item already counts as in-flight
+        from dispatch (see try_get_ready_work_item), so adding it here is idempotent;
+        what this adds is cancellability. If the experiment was stopped between
+        dispatch and now, stop() had no scope to cancel, so cancel it here to keep a
+        stopped experiment from running stale work.
         """
         self._cancel_scopes[work_item] = scope
         self._in_flight.add(work_item)
+        if not self._active:
+            scope.cancel()
 
     async def unregister_cancel_scope(self, work_item: WorkItem) -> None:
         """Unregister a cancel scope when work item completes.

--- a/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionOverDatasetSubscription.test_example_dispatched_as_previous_example_finishes_is_not_dropped.yaml
+++ b/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionOverDatasetSubscription.test_example_dispatched_as_previous_example_finishes_is_not_dropped.yaml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: '{"messages": [{"content": "What country is Paris in? Answer in one word,
+      no punctuation.", "role": "user"}], "model": "gpt-4", "stream": true, "stream_options":
+      {"include_usage": true}}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-APl3gAa0ijjs5rzvUaYmj7Ez70DPt","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-APl3gAa0ijjs5rzvUaYmj7Ez70DPt","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"France"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-APl3gAa0ijjs5rzvUaYmj7Ez70DPt","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+        data: {"id":"chatcmpl-APl3gAa0ijjs5rzvUaYmj7Ez70DPt","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":0}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "What country is Tokyo in? Answer in one word,
+      no punctuation.", "role": "user"}], "model": "gpt-4", "stream": true, "stream_options":
+      {"include_usage": true}}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-APl3gw7gwhDebIGtteUiZ1RAsu4wQ","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-APl3gw7gwhDebIGtteUiZ1RAsu4wQ","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Japan"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-APl3gw7gwhDebIGtteUiZ1RAsu4wQ","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+        data: {"id":"chatcmpl-APl3gw7gwhDebIGtteUiZ1RAsu4wQ","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":0}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "What country is Berlin in? Answer in one word,
+      no punctuation.", "role": "user"}], "model": "gpt-4", "stream": true, "stream_options":
+      {"include_usage": true}}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-CassetteBerlin01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteBerlin01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Germany"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteBerlin01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteBerlin01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":0}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "What country is London in? Answer in one word,
+      no punctuation.", "role": "user"}], "model": "gpt-4", "stream": true, "stream_options":
+      {"include_usage": true}}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-CassetteLondon01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteLondon01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"UK"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteLondon01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteLondon01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":0}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "What country is Madrid in? Answer in one word,
+      no punctuation.", "role": "user"}], "model": "gpt-4", "stream": true, "stream_options":
+      {"include_usage": true}}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-CassetteMadrid01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteMadrid01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Spain"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteMadrid01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+        data: {"id":"chatcmpl-CassetteMadrid01","object":"chat.completion.chunk","created":1730702456,"model":"gpt-4-0613","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":0}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -1871,9 +1871,9 @@ class TestChatCompletionOverDatasetSubscription:
 
         The runner's token bucket starts with a single token, so the last example is
         dispatched only after the others have run. Dispatch hands the work item to the
-        daemon's task group with start_soon(), and the item's task registers its cancel
-        scope one event-loop turn later. If the previous example finishes in that turn,
-        its completion check must still see the dispatched item as pending work.
+        daemon's task group with start_soon(), so the worker that runs it only begins
+        one event-loop turn later. If the previous example finishes in that turn, its
+        completion check must still see the dispatched item as pending work.
         Otherwise the experiment completes and the subscription stream closes without
         the last result. The interleaving is pinned with events rather than timing.
         """
@@ -1903,8 +1903,9 @@ class TestChatCompletionOverDatasetSubscription:
         async def execute_and_hold_example_4(work_item: TaskWorkItem) -> None:
             await original_execute(work_item)
             if _dataset_example_id(work_item) == 4:
-                await examples_1_to_3_unregistered.wait()
-                await example_5_popped.wait()
+                with anyio.fail_after(30):  # fail rather than hang if the roles change
+                    await examples_1_to_3_unregistered.wait()
+                    await example_5_popped.wait()
 
         monkeypatch.setattr(TaskWorkItem, "execute", execute_and_hold_example_4)
 
@@ -1929,7 +1930,8 @@ class TestChatCompletionOverDatasetSubscription:
             runner: ExperimentRunner, work_item: WorkItem
         ) -> None:
             if _dataset_example_id(work_item) == 5:
-                await example_4_unregistered.wait()
+                with anyio.fail_after(30):
+                    await example_4_unregistered.wait()
             await original_run_and_release(runner, work_item)
 
         monkeypatch.setattr(

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -3,6 +3,8 @@ import re
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Mapping, Optional, cast
 
+import anyio
+import pytest
 from openinference.semconv.trace import (
     MessageAttributes,
     OpenInferenceMimeTypeValues,
@@ -56,6 +58,12 @@ from phoenix.server.api.types.Evaluator import DatasetEvaluator
 from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 from phoenix.server.api.types.node import from_global_id
+from phoenix.server.daemons.experiment_runner import (
+    ExperimentRunner,
+    RunningExperiment,
+    TaskWorkItem,
+    WorkItem,
+)
 from phoenix.server.experiments.utils import is_experiment_project_name
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.attributes import flatten, get_attribute_value
@@ -1851,6 +1859,144 @@ class TestChatCompletionOverDatasetSubscription:
             assert split_links[0].dataset_split_id == 1  # train split
             assert split_links[1].dataset_split_id == 2  # test split
 
+    async def test_example_dispatched_as_previous_example_finishes_is_not_dropped(
+        self,
+        gql_client: AsyncGraphQLClient,
+        openai_api_key: str,
+        playground_dataset_with_splits: None,
+        custom_vcr: CustomVCR,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The last example is not lost when dispatched while the previous one finishes.
+
+        The runner's token bucket starts with a single token, so the last example is
+        dispatched only after the others have run. Dispatch hands the work item to the
+        daemon's task group with start_soon(), and the item's task registers its cancel
+        scope one event-loop turn later. If the previous example finishes in that turn,
+        its completion check must still see the dispatched item as pending work.
+        Otherwise the experiment completes and the subscription stream closes without
+        the last result. The interleaving is pinned with events rather than timing.
+        """
+        example_5_popped = anyio.Event()
+        examples_1_to_3_unregistered = anyio.Event()
+        example_4_unregistered = anyio.Event()
+        unregistered_example_ids: set[int] = set()
+
+        original_try_get = RunningExperiment.try_get_ready_work_item
+
+        async def try_get_and_flag_example_5(
+            running_experiment: RunningExperiment,
+        ) -> Optional[WorkItem]:
+            work_item = await original_try_get(running_experiment)
+            if _dataset_example_id(work_item) == 5:
+                example_5_popped.set()
+            return work_item
+
+        monkeypatch.setattr(
+            RunningExperiment, "try_get_ready_work_item", try_get_and_flag_example_5
+        )
+
+        original_execute = TaskWorkItem.execute
+
+        # Example 4 must be the only other item in flight when it finishes, and it must
+        # finish after example 5 has been popped but before example 5's task starts.
+        async def execute_and_hold_example_4(work_item: TaskWorkItem) -> None:
+            await original_execute(work_item)
+            if _dataset_example_id(work_item) == 4:
+                await examples_1_to_3_unregistered.wait()
+                await example_5_popped.wait()
+
+        monkeypatch.setattr(TaskWorkItem, "execute", execute_and_hold_example_4)
+
+        original_unregister = RunningExperiment.unregister_cancel_scope
+
+        async def unregister_and_track(
+            running_experiment: RunningExperiment, work_item: WorkItem
+        ) -> None:
+            await original_unregister(running_experiment, work_item)
+            if (example_id := _dataset_example_id(work_item)) is not None:
+                unregistered_example_ids.add(example_id)
+            if {1, 2, 3} <= unregistered_example_ids:
+                examples_1_to_3_unregistered.set()
+            if example_id == 4:
+                example_4_unregistered.set()
+
+        monkeypatch.setattr(RunningExperiment, "unregister_cancel_scope", unregister_and_track)
+
+        original_run_and_release = ExperimentRunner._run_and_release
+
+        async def start_example_5_after_example_4_unregistered(
+            runner: ExperimentRunner, work_item: WorkItem
+        ) -> None:
+            if _dataset_example_id(work_item) == 5:
+                await example_4_unregistered.wait()
+            await original_run_and_release(runner, work_item)
+
+        monkeypatch.setattr(
+            ExperimentRunner, "_run_and_release", start_example_5_after_example_4_unregistered
+        )
+
+        dataset_id = str(GlobalID(type_name=Dataset.__name__, node_id=str(1)))
+        version_id = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
+        train_split_id = str(GlobalID(type_name="DatasetSplit", node_id=str(1)))
+        test_split_id = str(GlobalID(type_name="DatasetSplit", node_id=str(2)))
+
+        variables: dict[str, Any] = {
+            "input": {
+                "datasetId": dataset_id,
+                "datasetVersionId": version_id,
+                "promptVersion": {
+                    "templateFormat": "F_STRING",
+                    "template": {
+                        "messages": [
+                            {
+                                "role": "USER",
+                                "content": [
+                                    {
+                                        "text": {
+                                            "text": "What country is {city} in? Answer in one word, no punctuation."
+                                        }
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                    "modelProvider": "OPENAI",
+                    "modelName": "gpt-4",
+                    "invocationParameters": {"openai": {}},
+                    "tools": None,
+                },
+                "repetitions": 1,
+                "splitIds": [train_split_id, test_split_id],
+            }
+        }
+
+        payloads: dict[Optional[str], list[Any]] = {}
+        custom_vcr.register_matcher(
+            _request_bodies_contain_same_city.__name__, _request_bodies_contain_same_city
+        )
+        with custom_vcr.use_cassette(match_on=[_request_bodies_contain_same_city.__name__]):
+            async for payload in gql_client.subscription(
+                query=self.QUERY,
+                variables=variables,
+                operation_name="ChatCompletionOverDatasetSubscription",
+            ):
+                dataset_example_id = payload["chatCompletionOverDataset"]["datasetExampleId"]
+                payloads.setdefault(dataset_example_id, []).append(payload)
+
+        all_example_ids = [
+            str(GlobalID(type_name=DatasetExample.__name__, node_id=str(i))) for i in range(1, 6)
+        ]
+        assert set(payloads.keys()) == set(all_example_ids) | {None}
+        for example_id in all_example_ids:
+            result_payloads = [
+                p["chatCompletionOverDataset"]
+                for p in payloads[example_id]
+                if p["chatCompletionOverDataset"]["__typename"]
+                == ChatCompletionSubscriptionResult.__name__
+            ]
+            assert len(result_payloads) == 1, f"expected one result for {example_id}"
+
     async def test_experiment_without_splits_includes_all_examples(
         self,
         gql_client: AsyncGraphQLClient,
@@ -2739,6 +2885,13 @@ def _extract_city(body: str) -> str:
     if match := re.search(r"What country is (\w+) in\?", body):
         return match.group(1)
     raise ValueError(f"Could not extract city from body: {body}")
+
+
+def _dataset_example_id(work_item: object) -> Optional[int]:
+    """Dataset example ID of a task work item, or None for anything else."""
+    if isinstance(work_item, TaskWorkItem):
+        return int(work_item.dataset_example_revision.dataset_example_id)
+    return None
 
 
 # span kind values

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -1977,7 +1977,10 @@ class TestChatCompletionOverDatasetSubscription:
         custom_vcr.register_matcher(
             _request_bodies_contain_same_city.__name__, _request_bodies_contain_same_city
         )
-        with custom_vcr.use_cassette(match_on=[_request_bodies_contain_same_city.__name__]):
+        with (
+            custom_vcr.use_cassette(match_on=[_request_bodies_contain_same_city.__name__]),
+            anyio.fail_after(120),  # the stream must end on its own; never hang CI
+        ):
             async for payload in gql_client.subscription(
                 query=self.QUERY,
                 variables=variables,

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -478,6 +478,63 @@ class TestRunningExperimentQueueLogic:
         assert eval_item not in exp._cancel_scopes
 
     @pytest.mark.anyio
+    async def test_dispatched_work_item_counts_as_in_flight_before_it_starts(self) -> None:
+        """A popped work item keeps the experiment alive until its task registers a scope.
+
+        The daemon dispatches with start_soon(), so another task can finish and run a
+        completion check before the dispatched item's task has begun. The item must
+        already count as in-flight, or the experiment completes without it.
+        """
+        on_done = _make_on_done()
+        exp = _make_running_experiment(on_done=on_done)
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
+        finishing = _make_task_work_item(exp, dataset_example_id=1)
+        dispatched = _make_task_work_item(exp, dataset_example_id=2)
+        exp.register_cancel_scope(finishing, anyio.CancelScope())
+        exp._task_queue.append(dispatched)
+
+        assert await exp.try_get_ready_work_item() is dispatched
+        assert dispatched in exp._in_flight
+
+        # The other task finishes before the dispatched item's task has started.
+        await exp.unregister_cancel_scope(finishing)
+
+        assert exp._active
+        on_done.assert_not_called()
+
+        # The dispatched item starts and finishes; only now is the experiment complete.
+        exp.register_cancel_scope(dispatched, anyio.CancelScope())
+        await exp.unregister_cancel_scope(dispatched)
+
+        assert not exp._active
+        on_done.assert_called_once_with(exp._experiment.id)
+
+    @pytest.mark.anyio
+    async def test_register_cancel_scope_after_stop_cancels_dispatched_item(self) -> None:
+        """An item dispatched before stop() is cancelled when its task starts.
+
+        stop() can only cancel scopes that already exist. A dispatched item registers
+        its scope later, so registration has to cancel it and let the experiment drain.
+        """
+        exp = _make_running_experiment()
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
+        dispatched = _make_task_work_item(exp, dataset_example_id=1)
+        exp._task_queue.append(dispatched)
+        assert await exp.try_get_ready_work_item() is dispatched
+
+        exp.stop()
+        assert not exp._drained.is_set()
+
+        scope = anyio.CancelScope()
+        exp.register_cancel_scope(dispatched, scope)
+        assert scope.cancel_called
+
+        await exp.unregister_cancel_scope(dispatched)
+        assert exp._drained.is_set()
+
+    @pytest.mark.anyio
     async def test_retry_or_fail_exhausted(self) -> None:
         """After max retries, failure counted and error recorded."""
         exp = _make_running_experiment(max_retries=2)

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -212,6 +212,13 @@ def _make_eval_work_item(
     )
 
 
+def _assert_untracked(exp: RunningExperiment, work_item: WorkItem) -> None:
+    """The experiment holds no dispatch or execution state for the item."""
+    assert work_item not in exp._in_flight
+    assert work_item not in exp._cancel_scopes
+    assert work_item not in exp._dispatch_undo
+
+
 # ===========================================================================
 # Group 1: CircuitBreaker (pure unit, no fixtures)
 # ===========================================================================
@@ -475,12 +482,13 @@ class TestRunningExperimentQueueLogic:
         assert await exp.try_get_ready_work_item() is eval_item
         assert eval_item in exp._in_flight
         assert eval_item in exp._cancel_scopes
+        assert eval_item in exp._dispatch_undo
         assert exp.start_execution(eval_item) is exp._cancel_scopes[eval_item]
+        assert eval_item not in exp._dispatch_undo  # no longer undoable once started
 
         await exp.unregister_cancel_scope(eval_item)
 
-        assert eval_item not in exp._in_flight
-        assert eval_item not in exp._cancel_scopes
+        _assert_untracked(exp, eval_item)
 
     @pytest.mark.anyio
     async def test_dispatched_work_item_counts_as_in_flight_before_it_starts(self) -> None:
@@ -558,22 +566,26 @@ class TestRunningExperimentQueueLogic:
         exp._task_db_exhausted = True
         exp._eval_db_exhausted = True
         eval_item = _make_eval_work_item(exp)
-        retry_task = _make_task_work_item(exp, dataset_example_id=1, retry_count=1)
-        retry_item = RetryItem(
-            ready_at=datetime.now(timezone.utc) - timedelta(seconds=1),
-            work_item=retry_task,
+        now = datetime.now(timezone.utc)
+        first_retry = RetryItem(
+            ready_at=now - timedelta(seconds=2),
+            work_item=_make_task_work_item(exp, dataset_example_id=1, retry_count=1),
         )
-        task = _make_task_work_item(exp, dataset_example_id=2)
+        second_retry = RetryItem(
+            ready_at=now - timedelta(seconds=1),
+            work_item=_make_task_work_item(exp, dataset_example_id=2, retry_count=1),
+        )
+        task = _make_task_work_item(exp, dataset_example_id=3)
         exp._eval_queue.append(eval_item)
-        heapq.heappush(exp._retry_heap, retry_item)
+        heapq.heappush(exp._retry_heap, second_retry)
+        heapq.heappush(exp._retry_heap, first_retry)
         exp._task_queue.append(task)
 
         async def dispatch_then_undo(expected: WorkItem) -> None:
             dispatched = await exp.try_get_ready_work_item()
             assert dispatched is expected
             exp.undispatch(dispatched)
-            assert dispatched not in exp._in_flight
-            assert dispatched not in exp._cancel_scopes
+            _assert_untracked(exp, dispatched)
             assert exp.has_work()
 
         async def run_to_completion(expected: WorkItem) -> None:
@@ -581,14 +593,18 @@ class TestRunningExperimentQueueLogic:
             with exp.start_execution(expected):
                 pass
             await exp.unregister_cancel_scope(expected)
+            _assert_untracked(exp, expected)
 
         await dispatch_then_undo(eval_item)
         assert list(exp._eval_queue) == [eval_item]
         await run_to_completion(eval_item)
 
-        await dispatch_then_undo(retry_task)
-        assert exp._retry_heap == [retry_item]
-        await run_to_completion(retry_task)
+        # The earlier retry is restored as the same RetryItem, still ahead of its peer.
+        await dispatch_then_undo(first_retry.work_item)
+        assert exp._retry_heap[0] is first_retry
+        assert exp._retry_heap[1] is second_retry
+        await run_to_completion(first_retry.work_item)
+        await run_to_completion(second_retry.work_item)
 
         await dispatch_then_undo(task)
         assert list(exp._task_queue) == [task]
@@ -1107,11 +1123,13 @@ class TestDispatchHandOff:
         return runner
 
     @pytest.mark.anyio
-    async def test_failed_hand_off_undoes_the_dispatch(self) -> None:
-        """If no worker task can be created, the item goes back to its queue.
+    async def test_hand_off_rejected_by_task_group_undoes_the_dispatch(self) -> None:
+        """If the task group refuses to create the worker, the item goes back to its queue.
 
-        Otherwise it would sit in the in-flight set forever: the experiment could never
-        complete, and stop_experiment() would wait for a drain that never comes.
+        A task group that is not active (never entered, or already exited) rejects
+        start_soon() before any worker exists. Without the rollback the item would sit
+        in the in-flight set forever: the experiment could never complete, and
+        stop_experiment() would wait for a drain that never comes.
         """
         exp = _make_running_experiment()
         exp._task_db_exhausted = True
@@ -1122,15 +1140,48 @@ class TestDispatchHandOff:
 
         dispatched = await runner._try_get_ready_work_item()
         assert dispatched is task
-        never_entered_task_group = anyio.create_task_group()  # refuses new tasks
+        inactive_task_group = anyio.create_task_group()  # never entered
 
         with pytest.raises(RuntimeError):
-            runner._hand_off(never_entered_task_group, dispatched)
+            runner._hand_off(inactive_task_group, dispatched)
 
-        assert task not in exp._in_flight
-        assert task not in exp._cancel_scopes
+        _assert_untracked(exp, task)
         assert list(exp._task_queue) == [task]
         assert exp.has_work()
+
+    @pytest.mark.anyio
+    async def test_hand_off_into_cancelled_task_group_leaves_no_state_behind(self) -> None:
+        """A worker started into a task group that is shutting down does no work.
+
+        This is the shutdown case as it actually happens: an entered task group whose
+        scope has been cancelled still accepts the worker, so there is nothing to roll
+        back. The worker inherits the cancellation at its first checkpoint, and its
+        cleanup must still remove every trace of the item and release the seat.
+        """
+        exp = _make_running_experiment()
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
+        task = _make_task_work_item(exp, dataset_example_id=1)
+        exp._task_queue.append(task)
+        runner = self._make_runner(exp)
+        ran_past_first_checkpoint = False
+
+        async def execute() -> None:
+            nonlocal ran_past_first_checkpoint
+            await anyio.sleep(0)
+            ran_past_first_checkpoint = True
+
+        with patch.object(task, "execute", execute):
+            await runner._seats.acquire()
+            dispatched = await runner._try_get_ready_work_item()
+            assert dispatched is task
+            async with anyio.create_task_group() as tg:
+                tg.cancel_scope.cancel()  # the daemon's task group is shutting down
+                runner._hand_off(tg, dispatched)  # accepted, so no rollback happens
+
+        assert not ran_past_first_checkpoint
+        _assert_untracked(exp, task)
+        assert runner._seats.value == 10
 
     @pytest.mark.anyio
     async def test_stop_between_dispatch_and_worker_start_cancels_the_worker(self) -> None:
@@ -1166,7 +1217,7 @@ class TestDispatchHandOff:
 
         assert worker_started.is_set()
         assert not ran_past_first_checkpoint
-        assert task not in exp._in_flight
+        _assert_untracked(exp, task)
         assert exp._drained.is_set()
         assert runner._seats.value == 10
 

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -1155,8 +1155,9 @@ class TestDispatchHandOff:
 
         This is the shutdown case as it actually happens: an entered task group whose
         scope has been cancelled still accepts the worker, so there is nothing to roll
-        back. The worker inherits the cancellation at its first checkpoint, and its
-        cleanup must still remove every trace of the item and release the seat.
+        back. The worker inherits the cancellation at the checkpoint that precedes
+        execute(), so the item's work never starts, and the worker's cleanup must still
+        remove every trace of the item and release the seat.
         """
         exp = _make_running_experiment()
         exp._task_db_exhausted = True
@@ -1164,14 +1165,11 @@ class TestDispatchHandOff:
         task = _make_task_work_item(exp, dataset_example_id=1)
         exp._task_queue.append(task)
         runner = self._make_runner(exp)
-        worker_started = anyio.Event()
-        ran_past_first_checkpoint = False
+        execute_entered = False
 
         async def execute() -> None:
-            nonlocal ran_past_first_checkpoint
-            worker_started.set()
-            await anyio.sleep(0)
-            ran_past_first_checkpoint = True
+            nonlocal execute_entered
+            execute_entered = True
 
         with patch.object(task, "execute", execute):
             await runner._seats.acquire()
@@ -1181,11 +1179,10 @@ class TestDispatchHandOff:
                 tg.cancel_scope.cancel()  # the daemon's task group is shutting down
                 runner._hand_off(tg, dispatched)  # accepted, so no rollback happens
 
-        assert worker_started.is_set()  # the worker ran, so the hand-off was not undone
-        assert not exp._task_queue  # and the item was not put back
-        assert not ran_past_first_checkpoint
+        assert not execute_entered
+        assert not exp._task_queue  # the hand-off was not undone: nothing was put back
         _assert_untracked(exp, task)
-        assert runner._seats.value == 10
+        assert runner._seats.value == 10  # ...and the worker ran its cleanup
 
     @pytest.mark.anyio
     async def test_stop_between_dispatch_and_worker_start_cancels_the_worker(self) -> None:
@@ -1193,8 +1190,9 @@ class TestDispatchHandOff:
 
         The dispatch loop starts workers with start_soon(), so stop() can run after the
         item was handed off but before the worker's first step. The worker enters the
-        scope that stop() already cancelled, is cancelled at its first checkpoint, and
-        still unregisters so the experiment drains and the seat is released.
+        scope that stop() already cancelled and is cancelled at the checkpoint that
+        precedes execute(), so the item's work never starts. It still unregisters, so
+        the experiment drains and the seat is released.
         """
         exp = _make_running_experiment()
         exp._task_db_exhausted = True
@@ -1202,14 +1200,11 @@ class TestDispatchHandOff:
         task = _make_task_work_item(exp, dataset_example_id=1)
         exp._task_queue.append(task)
         runner = self._make_runner(exp)
-        worker_started = anyio.Event()
-        ran_past_first_checkpoint = False
+        execute_entered = False
 
         async def execute() -> None:
-            nonlocal ran_past_first_checkpoint
-            worker_started.set()
-            await anyio.sleep(0)
-            ran_past_first_checkpoint = True
+            nonlocal execute_entered
+            execute_entered = True
 
         with patch.object(task, "execute", execute):
             await runner._seats.acquire()
@@ -1219,8 +1214,7 @@ class TestDispatchHandOff:
                 runner._hand_off(tg, dispatched)
                 exp.stop()  # the worker has not had its first step yet
 
-        assert worker_started.is_set()
-        assert not ran_past_first_checkpoint
+        assert not execute_entered
         _assert_untracked(exp, task)
         assert exp._drained.is_set()
         assert runner._seats.value == 10

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -17,9 +17,11 @@ from phoenix.server.daemons.experiment_runner import (
     CircuitBreaker,
     EvaluatorRunSpec,
     EvalWorkItem,
+    ExperimentRunner,
     RetryItem,
     RunningExperiment,
     TaskWorkItem,
+    WorkItem,
     _NoOpLLMClient,
 )
 from phoenix.server.monty_runtime import MontyBusy
@@ -465,12 +467,15 @@ class TestRunningExperimentQueueLogic:
     async def test_unregister_cancel_scope_cleans_in_flight_state(self) -> None:
         """Unregister always removes work item from in-flight and scope maps."""
         exp = _make_running_experiment()
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
         eval_item = _make_eval_work_item(exp, run_id=313, dataset_evaluator_id=1)
-        scope = anyio.CancelScope()
+        exp._eval_queue.append(eval_item)
 
-        exp.register_cancel_scope(eval_item, scope)
+        assert await exp.try_get_ready_work_item() is eval_item
         assert eval_item in exp._in_flight
         assert eval_item in exp._cancel_scopes
+        assert exp.start_execution(eval_item) is exp._cancel_scopes[eval_item]
 
         await exp.unregister_cancel_scope(eval_item)
 
@@ -479,10 +484,10 @@ class TestRunningExperimentQueueLogic:
 
     @pytest.mark.anyio
     async def test_dispatched_work_item_counts_as_in_flight_before_it_starts(self) -> None:
-        """A popped work item keeps the experiment alive until its task registers a scope.
+        """A dispatched item keeps the experiment alive until its worker has run it.
 
-        The daemon dispatches with start_soon(), so another task can finish and run a
-        completion check before the dispatched item's task has begun. The item must
+        The daemon starts workers with start_soon(), so another task can finish and run
+        a completion check before the dispatched item's worker has begun. The item must
         already count as in-flight, or the experiment completes without it.
         """
         on_done = _make_on_done()
@@ -491,31 +496,35 @@ class TestRunningExperimentQueueLogic:
         exp._eval_db_exhausted = True
         finishing = _make_task_work_item(exp, dataset_example_id=1)
         dispatched = _make_task_work_item(exp, dataset_example_id=2)
-        exp.register_cancel_scope(finishing, anyio.CancelScope())
-        exp._task_queue.append(dispatched)
+        exp._task_queue.extend([finishing, dispatched])
 
+        assert await exp.try_get_ready_work_item() is finishing
         assert await exp.try_get_ready_work_item() is dispatched
-        assert dispatched in exp._in_flight
+        assert exp.has_work()
 
-        # The other task finishes before the dispatched item's task has started.
+        # The first item's worker runs to completion before the second one's has begun.
+        with exp.start_execution(finishing):
+            pass
         await exp.unregister_cancel_scope(finishing)
 
         assert exp._active
         on_done.assert_not_called()
 
-        # The dispatched item starts and finishes; only now is the experiment complete.
-        exp.register_cancel_scope(dispatched, anyio.CancelScope())
+        # The second item's worker runs and finishes; only now is the experiment done.
+        with exp.start_execution(dispatched):
+            pass
         await exp.unregister_cancel_scope(dispatched)
 
         assert not exp._active
         on_done.assert_called_once_with(exp._experiment.id)
 
     @pytest.mark.anyio
-    async def test_register_cancel_scope_after_stop_cancels_dispatched_item(self) -> None:
-        """An item dispatched before stop() is cancelled when its task starts.
+    async def test_stop_cancels_dispatched_item_before_its_worker_starts(self) -> None:
+        """An item dispatched before stop() is cancelled when its worker enters the scope.
 
-        stop() can only cancel scopes that already exist. A dispatched item registers
-        its scope later, so registration has to cancel it and let the experiment drain.
+        The scope exists from dispatch, so stop() cancels it like any other. A worker
+        that enters it afterwards is cancelled at its first checkpoint, and the
+        experiment drains once that worker has unregistered.
         """
         exp = _make_running_experiment()
         exp._task_db_exhausted = True
@@ -527,12 +536,65 @@ class TestRunningExperimentQueueLogic:
         exp.stop()
         assert not exp._drained.is_set()
 
-        scope = anyio.CancelScope()
-        exp.register_cancel_scope(dispatched, scope)
-        assert scope.cancel_called
+        reached_past_first_checkpoint = False
+        with exp.start_execution(dispatched) as scope:
+            assert scope.cancel_called
+            await anyio.sleep(0)  # first checkpoint: the pre-entry cancel lands here
+            reached_past_first_checkpoint = True
+        assert scope.cancelled_caught
+        assert not reached_past_first_checkpoint
 
         await exp.unregister_cancel_scope(dispatched)
         assert exp._drained.is_set()
+
+    @pytest.mark.anyio
+    async def test_undispatch_puts_item_back_where_it_came_from(self) -> None:
+        """A dispatch whose worker could not start is reversed exactly.
+
+        Evals, ready retries and tasks come from different structures. A retry must go
+        back as its original RetryItem so it keeps its ready time and its ordering.
+        """
+        exp = _make_running_experiment()
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
+        eval_item = _make_eval_work_item(exp)
+        retry_task = _make_task_work_item(exp, dataset_example_id=1, retry_count=1)
+        retry_item = RetryItem(
+            ready_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            work_item=retry_task,
+        )
+        task = _make_task_work_item(exp, dataset_example_id=2)
+        exp._eval_queue.append(eval_item)
+        heapq.heappush(exp._retry_heap, retry_item)
+        exp._task_queue.append(task)
+
+        async def dispatch_then_undo(expected: WorkItem) -> None:
+            dispatched = await exp.try_get_ready_work_item()
+            assert dispatched is expected
+            exp.undispatch(dispatched)
+            assert dispatched not in exp._in_flight
+            assert dispatched not in exp._cancel_scopes
+            assert exp.has_work()
+
+        async def run_to_completion(expected: WorkItem) -> None:
+            assert await exp.try_get_ready_work_item() is expected
+            with exp.start_execution(expected):
+                pass
+            await exp.unregister_cancel_scope(expected)
+
+        await dispatch_then_undo(eval_item)
+        assert list(exp._eval_queue) == [eval_item]
+        await run_to_completion(eval_item)
+
+        await dispatch_then_undo(retry_task)
+        assert exp._retry_heap == [retry_item]
+        await run_to_completion(retry_task)
+
+        await dispatch_then_undo(task)
+        assert list(exp._task_queue) == [task]
+        await run_to_completion(task)
+
+        assert not exp.has_work()
 
     @pytest.mark.anyio
     async def test_retry_or_fail_exhausted(self) -> None:
@@ -933,7 +995,6 @@ class TestRoundRobinFairness:
     @pytest.mark.anyio
     async def test_round_robin_picks_least_recently_served(self) -> None:
         """_try_get_ready_work_item in ExperimentRunner picks least-recently-served experiment."""
-        from phoenix.server.daemons.experiment_runner import ExperimentRunner
 
         runner = object.__new__(ExperimentRunner)
         runner._experiments = {}
@@ -1012,7 +1073,6 @@ class TestGracefulShutdown:
     @pytest.mark.anyio
     async def test_graceful_shutdown_stops_all(self) -> None:
         """_graceful_shutdown calls stop() on each experiment."""
-        from phoenix.server.daemons.experiment_runner import ExperimentRunner
 
         runner = object.__new__(ExperimentRunner)
         runner._experiments = {}
@@ -1031,6 +1091,84 @@ class TestGracefulShutdown:
 
         stop1.assert_called_once()
         stop2.assert_called_once()
+
+
+# ===========================================================================
+# Group 6b: Dispatch hand-off to worker tasks
+# ===========================================================================
+
+
+class TestDispatchHandOff:
+    @staticmethod
+    def _make_runner(exp: RunningExperiment) -> ExperimentRunner:
+        runner = object.__new__(ExperimentRunner)
+        runner._experiments = {exp._experiment.id: exp}
+        runner._seats = anyio.Semaphore(10)
+        return runner
+
+    @pytest.mark.anyio
+    async def test_failed_hand_off_undoes_the_dispatch(self) -> None:
+        """If no worker task can be created, the item goes back to its queue.
+
+        Otherwise it would sit in the in-flight set forever: the experiment could never
+        complete, and stop_experiment() would wait for a drain that never comes.
+        """
+        exp = _make_running_experiment()
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
+        task = _make_task_work_item(exp, dataset_example_id=1)
+        exp._task_queue.append(task)
+        runner = self._make_runner(exp)
+
+        dispatched = await runner._try_get_ready_work_item()
+        assert dispatched is task
+        never_entered_task_group = anyio.create_task_group()  # refuses new tasks
+
+        with pytest.raises(RuntimeError):
+            runner._hand_off(never_entered_task_group, dispatched)
+
+        assert task not in exp._in_flight
+        assert task not in exp._cancel_scopes
+        assert list(exp._task_queue) == [task]
+        assert exp.has_work()
+
+    @pytest.mark.anyio
+    async def test_stop_between_dispatch_and_worker_start_cancels_the_worker(self) -> None:
+        """A worker whose experiment was stopped before it began does no work.
+
+        The dispatch loop starts workers with start_soon(), so stop() can run after the
+        item was handed off but before the worker's first step. The worker enters the
+        scope that stop() already cancelled, is cancelled at its first checkpoint, and
+        still unregisters so the experiment drains and the seat is released.
+        """
+        exp = _make_running_experiment()
+        exp._task_db_exhausted = True
+        exp._eval_db_exhausted = True
+        task = _make_task_work_item(exp, dataset_example_id=1)
+        exp._task_queue.append(task)
+        runner = self._make_runner(exp)
+        worker_started = anyio.Event()
+        ran_past_first_checkpoint = False
+
+        async def execute() -> None:
+            nonlocal ran_past_first_checkpoint
+            worker_started.set()
+            await anyio.sleep(0)
+            ran_past_first_checkpoint = True
+
+        with patch.object(task, "execute", execute):
+            await runner._seats.acquire()
+            dispatched = await runner._try_get_ready_work_item()
+            assert dispatched is task
+            async with anyio.create_task_group() as tg:
+                runner._hand_off(tg, dispatched)
+                exp.stop()  # the worker has not had its first step yet
+
+        assert worker_started.is_set()
+        assert not ran_past_first_checkpoint
+        assert task not in exp._in_flight
+        assert exp._drained.is_set()
+        assert runner._seats.value == 10
 
 
 # ===========================================================================

--- a/tests/unit/server/daemons/test_experiment_runner.py
+++ b/tests/unit/server/daemons/test_experiment_runner.py
@@ -1164,10 +1164,12 @@ class TestDispatchHandOff:
         task = _make_task_work_item(exp, dataset_example_id=1)
         exp._task_queue.append(task)
         runner = self._make_runner(exp)
+        worker_started = anyio.Event()
         ran_past_first_checkpoint = False
 
         async def execute() -> None:
             nonlocal ran_past_first_checkpoint
+            worker_started.set()
             await anyio.sleep(0)
             ran_past_first_checkpoint = True
 
@@ -1179,6 +1181,8 @@ class TestDispatchHandOff:
                 tg.cancel_scope.cancel()  # the daemon's task group is shutting down
                 runner._hand_off(tg, dispatched)  # accepted, so no rollback happens
 
+        assert worker_started.is_set()  # the worker ran, so the hand-off was not undone
+        assert not exp._task_queue  # and the item was not put back
         assert not ran_past_first_checkpoint
         _assert_untracked(exp, task)
         assert runner._seats.value == 10


### PR DESCRIPTION
## Summary

Fixes a race in the experiment runner daemon that could end a playground experiment, and its subscription stream, before the last dispatched example ran. It surfaced in CI as a flaky `TestChatCompletionOverDatasetSubscription::test_experiment_with_multiple_splits[postgresql]` failure with example 5 missing from the payloads: https://github.com/Arize-ai/phoenix/actions/runs/33552926093/job/100037921452

## Root cause

`RunningExperiment.try_get_ready_work_item` pops a work item from the queue, and the dispatch loop hands it to the task group with `start_soon()`. The worker task that registered the item's cancel scope and its `_in_flight` membership only begins on a later event-loop turn. In that window the item was in neither the queue nor `_in_flight`. If another task's `unregister_cancel_scope` ran then, `has_work()` returned `False`, `_check_completion` closed the subscriber streams, and the experiment was marked done with the popped item still unprocessed. The item still ran and persisted afterwards, but the stream had already ended.

The per-model token bucket starts with a single token and refills at 5/s, so the last example is dispatched only after the earlier ones are finishing, which puts the pop right where the final completion can land. The window is one or two event-loop turns wide, hence the rare, load-dependent flake.

## Fix

Dispatch is now a single synchronous ownership transfer from the queue to the worker, done inside `try_get_ready_work_item` with no await in between:

- the cancel scope is created up front, then the item is popped, the scope recorded, and the item added to `_in_flight`, so a completion check triggered by another task finishing before the worker starts still sees pending work;
- the worker enters that pre-created scope instead of creating its own, so `stop()` cancels dispatched and executing items alike, and `register_cancel_scope` and its special-casing are gone. The worker checkpoints immediately after entering the scope, before `execute()`, so an item whose experiment was stopped between dispatch and its first step does no work at all. Without that checkpoint, a template-formatting failure or a synchronous evaluator could run and persist under a shield before the cancellation was observed;
- an undo callback is kept until the worker starts. If the task group refuses to start the worker (it does so once fully shut down), the daemon's new `_hand_off` reverses the dispatch and puts the item back exactly where it came from, a retry as its original `RetryItem` with its ready time intact. Without that, the item would sit in `_in_flight` forever and the experiment could neither complete nor drain.

The commits show the evolution: the first counts a popped item as in-flight, the second turns that into the explicit transfer above after review flagged the stranded-item case, and the last adds the checkpoint after review found the shielded-persistence window.

## Tests

- Unit tests in `tests/unit/server/daemons/test_experiment_runner.py`: a dispatched item keeps the experiment alive until its worker runs it; an item dispatched before `stop()` is cancelled at its worker's first checkpoint and the experiment drains; undispatch restores eval, retry, and task items to their exact sources, with retries proven by identity and ordering against a peer; every cleanup path leaves no entry in any tracking map; and, through the real `_hand_off` and `_run_and_release`, a hand-off rejected by an inactive task group is rolled back, a hand-off into a task group that is shutting down leaves no state behind, and a stop between dispatch and worker start means `execute()` is never entered while the seat is still released.
- An end-to-end subscription test, `test_example_dispatched_as_previous_example_finishes_is_not_dropped`, that pins the interleaving with events rather than timing: examples 1 to 3 finish, example 4 finishes only after example 5 is popped, and example 5 starts only after example 4 unregisters. Its waits and the subscription loop are bounded so a change in dispatch order fails instead of hanging. Against the runner from `main` it fails with the exact CI assertion.

The subscription suite passes on SQLite and PostgreSQL, the experiment mutation, REST experiment, Dataset type, and runner suites pass on SQLite, and ruff and mypy are clean.
