### PR TITLE
feat(ui): show cache read/write in cumulative token count tooltips

### DIFF
--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -4333,6 +4333,11 @@ type Span implements Node {
   containedInDataset: Boolean!
   costSummary: SpanCostSummary
   costDetailSummaryEntries: [SpanCostDetailSummaryEntry!]!
+
+  """
+  Cost detail breakdown (by token type) aggregated from self and all descendant spans (children, grandchildren, etc.)
+  """
+  cumulativeCostDetailSummaryEntries: [SpanCostDetailSummaryEntry!]!
 }
 
 type SpanAnnotation implements Node & Annotation {

--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -4334,9 +4334,7 @@ type Span implements Node {
   costSummary: SpanCostSummary
   costDetailSummaryEntries: [SpanCostDetailSummaryEntry!]!
 
-  """
-  Cost detail breakdown (by token type) aggregated from self and all descendant spans (children, grandchildren, etc.)
-  """
+  """Cost details aggregated from this span and all descendant spans"""
   cumulativeCostDetailSummaryEntries: [SpanCostDetailSummaryEntry!]!
 }
 

--- a/js/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCountDetails.tsx
+++ b/js/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCountDetails.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
-import { TokenCountDetails } from "../trace/TokenCountDetails";
+import {
+  getTokenCountDetailsFromCostDetails,
+  TokenCountDetails,
+} from "../trace/TokenCountDetails";
 import type { ExperimentRepeatedRunGroupTokenCountDetailsQuery } from "./__generated__/ExperimentRepeatedRunGroupTokenCountDetailsQuery.graphql";
 
 export function ExperimentRepeatedRunGroupTokenCountDetails(props: {
@@ -25,6 +28,13 @@ export function ExperimentRepeatedRunGroupTokenCountDetails(props: {
                   tokens
                 }
               }
+              costDetailSummaryEntries {
+                tokenType
+                isPrompt
+                value {
+                  tokens
+                }
+              }
             }
           }
         }
@@ -38,10 +48,15 @@ export function ExperimentRepeatedRunGroupTokenCountDetails(props: {
       const completion = data.node.costSummary.completion.tokens;
       const total = data.node.costSummary.total.tokens;
 
+      const { promptDetails, completionDetails } =
+        getTokenCountDetailsFromCostDetails(data.node.costDetailSummaryEntries);
+
       return {
         total,
         prompt,
         completion,
+        promptDetails,
+        completionDetails,
       };
     }
 

--- a/js/app/src/components/experiment/ExperimentRunTokenCountDetails.tsx
+++ b/js/app/src/components/experiment/ExperimentRunTokenCountDetails.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
-import { TokenCountDetails } from "../trace/TokenCountDetails";
+import {
+  getTokenCountDetailsFromCostDetails,
+  TokenCountDetails,
+} from "../trace/TokenCountDetails";
 import type { ExperimentRunTokenCountDetailsQuery } from "./__generated__/ExperimentRunTokenCountDetailsQuery.graphql";
 
 export function ExperimentRunTokenCountDetails(props: {
@@ -24,6 +27,13 @@ export function ExperimentRunTokenCountDetails(props: {
                 tokens
               }
             }
+            costDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value {
+                tokens
+              }
+            }
           }
         }
       }
@@ -37,10 +47,15 @@ export function ExperimentRunTokenCountDetails(props: {
       const completion = data.node.costSummary?.completion?.tokens ?? 0;
       const total = data.node.costSummary?.total?.tokens ?? 0;
 
+      const { promptDetails, completionDetails } =
+        getTokenCountDetailsFromCostDetails(data.node.costDetailSummaryEntries);
+
       return {
         total,
         prompt,
         completion,
+        promptDetails,
+        completionDetails,
       };
     }
 

--- a/js/app/src/components/experiment/ExperimentTokenCountDetails.tsx
+++ b/js/app/src/components/experiment/ExperimentTokenCountDetails.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
-import { TokenCountDetails } from "../trace/TokenCountDetails";
+import {
+  getTokenCountDetailsFromCostDetails,
+  TokenCountDetails,
+} from "../trace/TokenCountDetails";
 import type { ExperimentTokenCountDetailsQuery } from "./__generated__/ExperimentTokenCountDetailsQuery.graphql";
 
 export function ExperimentTokenCountDetails(props: { experimentId: string }) {
@@ -22,6 +25,13 @@ export function ExperimentTokenCountDetails(props: { experimentId: string }) {
                 tokens
               }
             }
+            costDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value {
+                tokens
+              }
+            }
           }
         }
       }
@@ -35,10 +45,15 @@ export function ExperimentTokenCountDetails(props: { experimentId: string }) {
       const completion = data.node.costSummary?.completion?.tokens ?? 0;
       const total = data.node.costSummary?.total?.tokens ?? 0;
 
+      const { promptDetails, completionDetails } =
+        getTokenCountDetailsFromCostDetails(data.node.costDetailSummaryEntries);
+
       return {
         total,
         prompt,
         completion,
+        promptDetails,
+        completionDetails,
       };
     }
 

--- a/js/app/src/components/experiment/__generated__/ExperimentRepeatedRunGroupTokenCountDetailsQuery.graphql.ts
+++ b/js/app/src/components/experiment/__generated__/ExperimentRepeatedRunGroupTokenCountDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5ac9f77ff6a43a6c50e18985452cdb79>>
+ * @generated SignedSource<<1a3bf3997e2ac106615441aebfc44af7>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,13 @@ export type ExperimentRepeatedRunGroupTokenCountDetailsQuery$variables = {
 export type ExperimentRepeatedRunGroupTokenCountDetailsQuery$data = {
   readonly node: {
     readonly __typename: "ExperimentRepeatedRunGroup";
+    readonly costDetailSummaryEntries: ReadonlyArray<{
+      readonly isPrompt: boolean;
+      readonly tokenType: string;
+      readonly value: {
+        readonly tokens: number | null;
+      };
+    }>;
     readonly costSummary: {
       readonly completion: {
         readonly tokens: number | null;
@@ -110,6 +117,41 @@ v4 = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanCostDetailSummaryEntry",
+      "kind": "LinkedField",
+      "name": "costDetailSummaryEntries",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "tokenType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isPrompt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CostBreakdown",
+          "kind": "LinkedField",
+          "name": "value",
+          "plural": false,
+          "selections": (v3/*:: as any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "ExperimentRepeatedRunGroup",
@@ -168,16 +210,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "17535680d5a7af6fa77466bf5134c3e0",
+    "cacheID": "6a382a404bd78b0df69e895e50a8f5e5",
     "id": null,
     "metadata": {},
     "name": "ExperimentRepeatedRunGroupTokenCountDetailsQuery",
     "operationKind": "query",
-    "text": "query ExperimentRepeatedRunGroupTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on ExperimentRepeatedRunGroup {\n      costSummary {\n        total {\n          tokens\n        }\n        prompt {\n          tokens\n        }\n        completion {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ExperimentRepeatedRunGroupTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on ExperimentRepeatedRunGroup {\n      costSummary {\n        total {\n          tokens\n        }\n        prompt {\n          tokens\n        }\n        completion {\n          tokens\n        }\n      }\n      costDetailSummaryEntries {\n        tokenType\n        isPrompt\n        value {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fc023fee63f29794e61517820b6c9313";
+(node as any).hash = "838d92adc16b11291c4313fdd11629b9";
 
 export default node;

--- a/js/app/src/components/experiment/__generated__/ExperimentRunTokenCountDetailsQuery.graphql.ts
+++ b/js/app/src/components/experiment/__generated__/ExperimentRunTokenCountDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<48dd81db09c56dfa91de6643c9666c4d>>
+ * @generated SignedSource<<eb074a12bda7466bc2c0547ff7062e61>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,13 @@ export type ExperimentRunTokenCountDetailsQuery$variables = {
 export type ExperimentRunTokenCountDetailsQuery$data = {
   readonly node: {
     readonly __typename: "ExperimentRun";
+    readonly costDetailSummaryEntries: ReadonlyArray<{
+      readonly isPrompt: boolean;
+      readonly tokenType: string;
+      readonly value: {
+        readonly tokens: number | null;
+      };
+    }>;
     readonly costSummary: {
       readonly completion: {
         readonly tokens: number | null;
@@ -110,6 +117,41 @@ v4 = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanCostDetailSummaryEntry",
+      "kind": "LinkedField",
+      "name": "costDetailSummaryEntries",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "tokenType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isPrompt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CostBreakdown",
+          "kind": "LinkedField",
+          "name": "value",
+          "plural": false,
+          "selections": (v3/*:: as any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "ExperimentRun",
@@ -168,16 +210,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bb25f38a892f4b257794b8e43b04f835",
+    "cacheID": "19c94d87d491348a68db758550266527",
     "id": null,
     "metadata": {},
     "name": "ExperimentRunTokenCountDetailsQuery",
     "operationKind": "query",
-    "text": "query ExperimentRunTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on ExperimentRun {\n      costSummary {\n        total {\n          tokens\n        }\n        prompt {\n          tokens\n        }\n        completion {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ExperimentRunTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on ExperimentRun {\n      costSummary {\n        total {\n          tokens\n        }\n        prompt {\n          tokens\n        }\n        completion {\n          tokens\n        }\n      }\n      costDetailSummaryEntries {\n        tokenType\n        isPrompt\n        value {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0de1caa674a484b1e5d1449743805823";
+(node as any).hash = "ca98ea0f60bfb0a27978d70906ebba48";
 
 export default node;

--- a/js/app/src/components/experiment/__generated__/ExperimentTokenCountDetailsQuery.graphql.ts
+++ b/js/app/src/components/experiment/__generated__/ExperimentTokenCountDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f928ef045743eba314de4db6124f3465>>
+ * @generated SignedSource<<cb71354140e7ccb2057a9fe6491ea8bd>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,13 @@ export type ExperimentTokenCountDetailsQuery$variables = {
 export type ExperimentTokenCountDetailsQuery$data = {
   readonly node: {
     readonly __typename: "Experiment";
+    readonly costDetailSummaryEntries: ReadonlyArray<{
+      readonly isPrompt: boolean;
+      readonly tokenType: string;
+      readonly value: {
+        readonly tokens: number | null;
+      };
+    }>;
     readonly costSummary: {
       readonly completion: {
         readonly tokens: number | null;
@@ -110,6 +117,41 @@ v4 = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanCostDetailSummaryEntry",
+      "kind": "LinkedField",
+      "name": "costDetailSummaryEntries",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "tokenType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isPrompt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CostBreakdown",
+          "kind": "LinkedField",
+          "name": "value",
+          "plural": false,
+          "selections": (v3/*:: as any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Experiment",
@@ -168,16 +210,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3b40ee1d5d53511d1e5a6ff31b52cd01",
+    "cacheID": "4bb6283953506da1052c9696f747ce16",
     "id": null,
     "metadata": {},
     "name": "ExperimentTokenCountDetailsQuery",
     "operationKind": "query",
-    "text": "query ExperimentTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on Experiment {\n      costSummary {\n        total {\n          tokens\n        }\n        prompt {\n          tokens\n        }\n        completion {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ExperimentTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on Experiment {\n      costSummary {\n        total {\n          tokens\n        }\n        prompt {\n          tokens\n        }\n        completion {\n          tokens\n        }\n      }\n      costDetailSummaryEntries {\n        tokenType\n        isPrompt\n        value {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0946f26e471401c182db5b8107b9c3dd";
+(node as any).hash = "d3f13d7ad31e006fa9318d2877e80303";
 
 export default node;

--- a/js/app/src/components/trace/SessionTokenCountDetails.tsx
+++ b/js/app/src/components/trace/SessionTokenCountDetails.tsx
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
 import type { SessionTokenCountDetailsQuery } from "./__generated__/SessionTokenCountDetailsQuery.graphql";
-import { TokenCountDetails } from "./TokenCountDetails";
+import {
+  getTokenCountDetailsFromCostDetails,
+  TokenCountDetails,
+} from "./TokenCountDetails";
 
 export function SessionTokenCountDetails(props: { sessionNodeId: string }) {
   const data = useLazyLoadQuery<SessionTokenCountDetailsQuery>(
@@ -15,6 +18,13 @@ export function SessionTokenCountDetails(props: { sessionNodeId: string }) {
               prompt
               completion
             }
+            costDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value {
+                tokens
+              }
+            }
           }
         }
       }
@@ -26,10 +36,15 @@ export function SessionTokenCountDetails(props: { sessionNodeId: string }) {
     if (data.node.__typename === "ProjectSession") {
       const sessionPrompt = data.node.tokenUsage.prompt;
       const sessionCompletion = data.node.tokenUsage.completion;
+      const { promptDetails, completionDetails } =
+        getTokenCountDetailsFromCostDetails(data.node.costDetailSummaryEntries);
+
       return {
         total: sessionPrompt + sessionCompletion,
         prompt: sessionPrompt,
         completion: sessionCompletion,
+        promptDetails,
+        completionDetails,
       };
     }
 

--- a/js/app/src/components/trace/SpanCumulativeTokenCountDetails.tsx
+++ b/js/app/src/components/trace/SpanCumulativeTokenCountDetails.tsx
@@ -14,6 +14,13 @@ export function SpanCumulativeTokenCountDetails(props: { spanNodeId: string }) {
             cumulativeTokenCountTotal
             cumulativeTokenCountPrompt
             cumulativeTokenCountCompletion
+            cumulativeCostDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value {
+                tokens
+              }
+            }
           }
         }
       }
@@ -26,10 +33,30 @@ export function SpanCumulativeTokenCountDetails(props: { spanNodeId: string }) {
       const prompt = data.node.cumulativeTokenCountPrompt ?? 0;
       const completion = data.node.cumulativeTokenCountCompletion ?? 0;
       const total = data.node.cumulativeTokenCountTotal ?? 0;
+
+      // CostBreakdown.tokens includes tokens for which no cost was computed,
+      // so the per-token-type breakdown renders even when a model has no
+      // pricing configured.
+      const promptDetails: Record<string, number> = {};
+      const completionDetails: Record<string, number> = {};
+      data.node.cumulativeCostDetailSummaryEntries?.forEach((detail) => {
+        if (detail.value.tokens == null) {
+          return;
+        }
+        const details = detail.isPrompt ? promptDetails : completionDetails;
+        details[detail.tokenType] = detail.value.tokens;
+      });
+
       return {
         total,
         prompt,
         completion,
+        promptDetails:
+          Object.keys(promptDetails).length > 0 ? promptDetails : undefined,
+        completionDetails:
+          Object.keys(completionDetails).length > 0
+            ? completionDetails
+            : undefined,
       };
     }
 

--- a/js/app/src/components/trace/SpanCumulativeTokenCountDetails.tsx
+++ b/js/app/src/components/trace/SpanCumulativeTokenCountDetails.tsx
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
 import type { SpanCumulativeTokenCountDetailsQuery } from "./__generated__/SpanCumulativeTokenCountDetailsQuery.graphql";
-import { TokenCountDetails } from "./TokenCountDetails";
+import {
+  getTokenCountDetailsFromCostDetails,
+  TokenCountDetails,
+} from "./TokenCountDetails";
 
 export function SpanCumulativeTokenCountDetails(props: { spanNodeId: string }) {
   const data = useLazyLoadQuery<SpanCumulativeTokenCountDetailsQuery>(
@@ -34,29 +37,17 @@ export function SpanCumulativeTokenCountDetails(props: { spanNodeId: string }) {
       const completion = data.node.cumulativeTokenCountCompletion ?? 0;
       const total = data.node.cumulativeTokenCountTotal ?? 0;
 
-      // CostBreakdown.tokens includes tokens for which no cost was computed,
-      // so the per-token-type breakdown renders even when a model has no
-      // pricing configured.
-      const promptDetails: Record<string, number> = {};
-      const completionDetails: Record<string, number> = {};
-      data.node.cumulativeCostDetailSummaryEntries?.forEach((detail) => {
-        if (detail.value.tokens == null) {
-          return;
-        }
-        const details = detail.isPrompt ? promptDetails : completionDetails;
-        details[detail.tokenType] = detail.value.tokens;
-      });
+      const { promptDetails, completionDetails } =
+        getTokenCountDetailsFromCostDetails(
+          data.node.cumulativeCostDetailSummaryEntries
+        );
 
       return {
         total,
         prompt,
         completion,
-        promptDetails:
-          Object.keys(promptDetails).length > 0 ? promptDetails : undefined,
-        completionDetails:
-          Object.keys(completionDetails).length > 0
-            ? completionDetails
-            : undefined,
+        promptDetails,
+        completionDetails,
       };
     }
 

--- a/js/app/src/components/trace/TokenCountDetails.tsx
+++ b/js/app/src/components/trace/TokenCountDetails.tsx
@@ -1,5 +1,6 @@
 import { numberFormatter } from "@phoenix/utils/numberFormatUtils";
 
+import type { SpanCumulativeTokenCountDetailsQuery$data } from "./__generated__/SpanCumulativeTokenCountDetailsQuery.graphql";
 import type { TokenDetailsBreakdownProps } from "./TokenDetailsBreakdown";
 import { TokenDetailsBreakdown } from "./TokenDetailsBreakdown";
 
@@ -12,6 +13,32 @@ export type TokenCountDetailsProps = Omit<
    */
   label?: string;
 };
+
+type Span = Extract<
+  SpanCumulativeTokenCountDetailsQuery$data["node"],
+  { __typename: "Span" }
+>;
+
+type CostDetailSummaryEntry =
+  Span["cumulativeCostDetailSummaryEntries"][number];
+
+export function getTokenCountDetailsFromCostDetails(
+  costDetails: ReadonlyArray<CostDetailSummaryEntry>
+): Pick<TokenCountDetailsProps, "promptDetails" | "completionDetails"> {
+  const getDetails = (isPrompt: boolean) => {
+    const entries = costDetails.flatMap((detail) =>
+      detail.isPrompt === isPrompt && detail.value.tokens != null
+        ? [[detail.tokenType, detail.value.tokens] as const]
+        : []
+    );
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  };
+
+  return {
+    promptDetails: getDetails(true),
+    completionDetails: getDetails(false),
+  };
+}
 
 export function TokenCountDetails({
   total,

--- a/js/app/src/components/trace/TraceTokenCountDetails.tsx
+++ b/js/app/src/components/trace/TraceTokenCountDetails.tsx
@@ -15,6 +15,13 @@ export function TraceTokenCountDetails(props: { traceNodeId: string }) {
               cumulativeTokenCountPrompt
               cumulativeTokenCountCompletion
             }
+            costDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value {
+                tokens
+              }
+            }
           }
         }
       }
@@ -27,10 +34,30 @@ export function TraceTokenCountDetails(props: { traceNodeId: string }) {
       const tracePrompt = data.node.rootSpan?.cumulativeTokenCountPrompt ?? 0;
       const traceCompletion =
         data.node.rootSpan?.cumulativeTokenCountCompletion ?? 0;
+
+      // CostBreakdown.tokens includes tokens for which no cost was computed,
+      // so the per-token-type breakdown renders even when a model has no
+      // pricing configured.
+      const promptDetails: Record<string, number> = {};
+      const completionDetails: Record<string, number> = {};
+      data.node.costDetailSummaryEntries?.forEach((detail) => {
+        if (detail.value.tokens == null) {
+          return;
+        }
+        const details = detail.isPrompt ? promptDetails : completionDetails;
+        details[detail.tokenType] = detail.value.tokens;
+      });
+
       return {
         total: tracePrompt + traceCompletion,
         prompt: tracePrompt,
         completion: traceCompletion,
+        promptDetails:
+          Object.keys(promptDetails).length > 0 ? promptDetails : undefined,
+        completionDetails:
+          Object.keys(completionDetails).length > 0
+            ? completionDetails
+            : undefined,
       };
     }
 

--- a/js/app/src/components/trace/TraceTokenCountDetails.tsx
+++ b/js/app/src/components/trace/TraceTokenCountDetails.tsx
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
 import type { TraceTokenCountDetailsQuery } from "./__generated__/TraceTokenCountDetailsQuery.graphql";
-import { TokenCountDetails } from "./TokenCountDetails";
+import {
+  getTokenCountDetailsFromCostDetails,
+  TokenCountDetails,
+} from "./TokenCountDetails";
 
 export function TraceTokenCountDetails(props: { traceNodeId: string }) {
   const data = useLazyLoadQuery<TraceTokenCountDetailsQuery>(
@@ -35,29 +38,15 @@ export function TraceTokenCountDetails(props: { traceNodeId: string }) {
       const traceCompletion =
         data.node.rootSpan?.cumulativeTokenCountCompletion ?? 0;
 
-      // CostBreakdown.tokens includes tokens for which no cost was computed,
-      // so the per-token-type breakdown renders even when a model has no
-      // pricing configured.
-      const promptDetails: Record<string, number> = {};
-      const completionDetails: Record<string, number> = {};
-      data.node.costDetailSummaryEntries?.forEach((detail) => {
-        if (detail.value.tokens == null) {
-          return;
-        }
-        const details = detail.isPrompt ? promptDetails : completionDetails;
-        details[detail.tokenType] = detail.value.tokens;
-      });
+      const { promptDetails, completionDetails } =
+        getTokenCountDetailsFromCostDetails(data.node.costDetailSummaryEntries);
 
       return {
         total: tracePrompt + traceCompletion,
         prompt: tracePrompt,
         completion: traceCompletion,
-        promptDetails:
-          Object.keys(promptDetails).length > 0 ? promptDetails : undefined,
-        completionDetails:
-          Object.keys(completionDetails).length > 0
-            ? completionDetails
-            : undefined,
+        promptDetails,
+        completionDetails,
       };
     }
 

--- a/js/app/src/components/trace/__generated__/SessionTokenCountDetailsQuery.graphql.ts
+++ b/js/app/src/components/trace/__generated__/SessionTokenCountDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dc2f28bccd7332a3e447be97ed1f51a4>>
+ * @generated SignedSource<<1016956133572d79f6a47addec1b9f54>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,13 @@ export type SessionTokenCountDetailsQuery$variables = {
 export type SessionTokenCountDetailsQuery$data = {
   readonly node: {
     readonly __typename: "ProjectSession";
+    readonly costDetailSummaryEntries: ReadonlyArray<{
+      readonly isPrompt: boolean;
+      readonly tokenType: string;
+      readonly value: {
+        readonly tokens: number | null;
+      };
+    }>;
     readonly tokenUsage: {
       readonly completion: number;
       readonly prompt: number;
@@ -78,6 +85,49 @@ v3 = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanCostDetailSummaryEntry",
+      "kind": "LinkedField",
+      "name": "costDetailSummaryEntries",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "tokenType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isPrompt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CostBreakdown",
+          "kind": "LinkedField",
+          "name": "value",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "tokens",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "ProjectSession",
@@ -136,16 +186,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5df073c3f0f20378aed5118f6f0d2f4b",
+    "cacheID": "93497e7310b4997d752381d6dc4cb664",
     "id": null,
     "metadata": {},
     "name": "SessionTokenCountDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on ProjectSession {\n      tokenUsage {\n        prompt\n        completion\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query SessionTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on ProjectSession {\n      tokenUsage {\n        prompt\n        completion\n      }\n      costDetailSummaryEntries {\n        tokenType\n        isPrompt\n        value {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "da1b954f5615c67f552ece1b8b3478b5";
+(node as any).hash = "3a24cdce58fdf51b24b7b555304f4e33";
 
 export default node;

--- a/js/app/src/components/trace/__generated__/SpanCumulativeTokenCountDetailsQuery.graphql.ts
+++ b/js/app/src/components/trace/__generated__/SpanCumulativeTokenCountDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<317f7db06bcb9b75de9f08ef6d676808>>
+ * @generated SignedSource<<a1f94ff201b3b2cfde0938668b0cf627>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,13 @@ export type SpanCumulativeTokenCountDetailsQuery$variables = {
 export type SpanCumulativeTokenCountDetailsQuery$data = {
   readonly node: {
     readonly __typename: "Span";
+    readonly cumulativeCostDetailSummaryEntries: ReadonlyArray<{
+      readonly isPrompt: boolean;
+      readonly tokenType: string;
+      readonly value: {
+        readonly tokens: number | null;
+      };
+    }>;
     readonly cumulativeTokenCountCompletion: number | null;
     readonly cumulativeTokenCountPrompt: number | null;
     readonly cumulativeTokenCountTotal: number | null;
@@ -73,6 +80,49 @@ v3 = {
       "kind": "ScalarField",
       "name": "cumulativeTokenCountCompletion",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanCostDetailSummaryEntry",
+      "kind": "LinkedField",
+      "name": "cumulativeCostDetailSummaryEntries",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "tokenType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isPrompt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CostBreakdown",
+          "kind": "LinkedField",
+          "name": "value",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "tokens",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Span",
@@ -131,16 +181,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c1da825bac7aac7aafa07638290f6f1d",
+    "cacheID": "975f0a6fc9e19d2c2c80e4394d4751e7",
     "id": null,
     "metadata": {},
     "name": "SpanCumulativeTokenCountDetailsQuery",
     "operationKind": "query",
-    "text": "query SpanCumulativeTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on Span {\n      cumulativeTokenCountTotal\n      cumulativeTokenCountPrompt\n      cumulativeTokenCountCompletion\n    }\n    id\n  }\n}\n"
+    "text": "query SpanCumulativeTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on Span {\n      cumulativeTokenCountTotal\n      cumulativeTokenCountPrompt\n      cumulativeTokenCountCompletion\n      cumulativeCostDetailSummaryEntries {\n        tokenType\n        isPrompt\n        value {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f7a968d87890a07d6e1dd6f06bad6b51";
+(node as any).hash = "8ad6ab6ae7d391f888e4fa5509986f73";
 
 export default node;

--- a/js/app/src/components/trace/__generated__/TraceTokenCountDetailsQuery.graphql.ts
+++ b/js/app/src/components/trace/__generated__/TraceTokenCountDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f2e12ca063296b20818d3067347d3ae>>
+ * @generated SignedSource<<66f6de5fdd31687492c79088172620be>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,13 @@ export type TraceTokenCountDetailsQuery$variables = {
 export type TraceTokenCountDetailsQuery$data = {
   readonly node: {
     readonly __typename: "Trace";
+    readonly costDetailSummaryEntries: ReadonlyArray<{
+      readonly isPrompt: boolean;
+      readonly tokenType: string;
+      readonly value: {
+        readonly tokens: number | null;
+      };
+    }>;
     readonly rootSpan: {
       readonly cumulativeTokenCountCompletion: number | null;
       readonly cumulativeTokenCountPrompt: number | null;
@@ -68,6 +75,49 @@ v4 = {
 v5 = {
   "alias": null,
   "args": null,
+  "concreteType": "SpanCostDetailSummaryEntry",
+  "kind": "LinkedField",
+  "name": "costDetailSummaryEntries",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tokenType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isPrompt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CostBreakdown",
+      "kind": "LinkedField",
+      "name": "value",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "tokens",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
@@ -103,7 +153,8 @@ return {
                   (v4/*:: as any*/)
                 ],
                 "storageKey": null
-              }
+              },
+              (v5/*:: as any*/)
             ],
             "type": "Trace",
             "abstractKey": null
@@ -143,31 +194,32 @@ return {
                 "selections": [
                   (v3/*:: as any*/),
                   (v4/*:: as any*/),
-                  (v5/*:: as any*/)
+                  (v6/*:: as any*/)
                 ],
                 "storageKey": null
-              }
+              },
+              (v5/*:: as any*/)
             ],
             "type": "Trace",
             "abstractKey": null
           },
-          (v5/*:: as any*/)
+          (v6/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "e9131ab8a67b6b79dc9995bb3ce0cb55",
+    "cacheID": "2bbabae3886d6f4ab54e142c3e6dbe83",
     "id": null,
     "metadata": {},
     "name": "TraceTokenCountDetailsQuery",
     "operationKind": "query",
-    "text": "query TraceTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on Trace {\n      rootSpan {\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TraceTokenCountDetailsQuery(\n  $nodeId: ID!\n) {\n  node(id: $nodeId) {\n    __typename\n    ... on Trace {\n      rootSpan {\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        id\n      }\n      costDetailSummaryEntries {\n        tokenType\n        isPrompt\n        value {\n          tokens\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c0178c78b8c3bb146caa2579d6bc75c4";
+(node as any).hash = "e5db20a0ad1678586935beb2f41120c7";
 
 export default node;

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -89,6 +89,9 @@ from .span_cost_detail_summary_entries_by_model_and_scope import (
     SpanCostDetailSummaryEntriesByModelAndScopeDataLoader,
 )
 from .span_cost_detail_summary_entries_by_span import SpanCostDetailSummaryEntriesBySpanDataLoader
+from .span_cost_detail_summary_entries_by_span_cumulative import (
+    SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader,
+)
 from .span_cost_detail_summary_entries_by_trace import SpanCostDetailSummaryEntriesByTraceDataLoader
 from .span_cost_details_by_span_cost import SpanCostDetailsBySpanCostDataLoader
 from .span_cost_summary_by_experiment import SpanCostSummaryByExperimentDataLoader
@@ -264,6 +267,9 @@ class DataLoaders:
         SpanCostDetailSummaryEntriesByProjectSessionDataLoader
     )
     span_cost_detail_summary_entries_by_span: SpanCostDetailSummaryEntriesBySpanDataLoader
+    span_cost_detail_summary_entries_by_span_cumulative: (
+        SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader
+    )
     span_cost_detail_summary_entries_by_trace: SpanCostDetailSummaryEntriesByTraceDataLoader
     span_cost_details_by_span_cost: SpanCostDetailsBySpanCostDataLoader
     span_cost_fields: TableFieldsDataLoader
@@ -447,6 +453,9 @@ def build_data_loaders(
             db
         ),
         span_cost_detail_summary_entries_by_span=SpanCostDetailSummaryEntriesBySpanDataLoader(db),
+        span_cost_detail_summary_entries_by_span_cumulative=(
+            SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(db)
+        ),
         span_cost_detail_summary_entries_by_trace=SpanCostDetailSummaryEntriesByTraceDataLoader(db),
         span_cost_details_by_span_cost=SpanCostDetailsBySpanCostDataLoader(db),
         span_cost_detail_fields=TableFieldsDataLoader(db, models.SpanCostDetail),

--- a/src/phoenix/server/api/dataloaders/span_cost_detail_summary_entries_by_span_cumulative.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_detail_summary_entries_by_span_cumulative.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+from typing import Iterable
+
+import sqlalchemy as sa
+from sqlalchemy import func, select
+from sqlalchemy.sql.functions import coalesce
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.api.dataloaders.types import (
+    CostBreakdown,
+    SpanCostDetailSummaryEntry,
+)
+from phoenix.server.types import DbSessionFactory
+
+SpanRowId: TypeAlias = int
+Key: TypeAlias = SpanRowId
+Result: TypeAlias = list[SpanCostDetailSummaryEntry]
+
+
+class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Result]):
+    """
+    Aggregates SpanCostDetail rows, grouped by token type, across a span and
+    all of its descendants (children, grandchildren, etc.). Mirrors
+    SpanCostDetailSummaryEntriesByTraceDataLoader, but scoped to the subtree
+    rooted at each key instead of the whole trace, the same way
+    Span.cumulative_token_count_prompt is scoped relative to
+    Trace.rootSpan.cumulativeTokenCountPrompt.
+    """
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        roots = sa.values(
+            sa.Column("root_rowid", sa.Integer),
+            name="roots",
+        ).data([(key,) for key in keys])
+
+        subtree = (
+            select(
+                models.Span.id,
+                models.Span.span_id,
+                models.Span.trace_rowid,
+                roots.c.root_rowid,
+            )
+            .join_from(roots, models.Span, models.Span.id == roots.c.root_rowid)
+            .cte("subtree", recursive=True)
+        )
+        parents = subtree.alias("parents")
+        subtree = subtree.union_all(
+            select(
+                models.Span.id,
+                models.Span.span_id,
+                models.Span.trace_rowid,
+                parents.c.root_rowid,
+            ).join_from(
+                parents,
+                models.Span,
+                sa.and_(
+                    models.Span.trace_rowid == parents.c.trace_rowid,
+                    models.Span.parent_id == parents.c.span_id,
+                ),
+            )
+        )
+
+        stmt = (
+            select(
+                subtree.c.root_rowid,
+                models.SpanCostDetail.token_type,
+                models.SpanCostDetail.is_prompt,
+                coalesce(func.sum(models.SpanCostDetail.cost), 0).label("cost"),
+                coalesce(func.sum(models.SpanCostDetail.tokens), 0).label("tokens"),
+            )
+            .select_from(subtree)
+            .join(models.SpanCost, models.SpanCost.span_rowid == subtree.c.id)
+            .join(
+                models.SpanCostDetail,
+                models.SpanCostDetail.span_cost_id == models.SpanCost.id,
+            )
+            .group_by(
+                subtree.c.root_rowid,
+                models.SpanCostDetail.token_type,
+                models.SpanCostDetail.is_prompt,
+            )
+        )
+
+        results: defaultdict[Key, Result] = defaultdict(list)
+        async with self._db.read() as session:
+            data = await session.stream(stmt)
+            async for (
+                root_rowid,
+                token_type,
+                is_prompt,
+                cost,
+                tokens,
+            ) in data:
+                entry = SpanCostDetailSummaryEntry(
+                    token_type=token_type,
+                    is_prompt=is_prompt,
+                    value=CostBreakdown(tokens=tokens, cost=cost),
+                )
+                results[root_rowid].append(entry)
+        return list(map(list, map(results.__getitem__, keys)))

--- a/src/phoenix/server/api/dataloaders/span_cost_detail_summary_entries_by_span_cumulative.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_detail_summary_entries_by_span_cumulative.py
@@ -3,7 +3,6 @@ from typing import Iterable
 
 import sqlalchemy as sa
 from sqlalchemy import func, select
-from sqlalchemy.sql.functions import coalesce
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
@@ -25,10 +24,12 @@ class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Res
         self._db = db
 
     async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        keys = list(keys)
+        span_path_segment = sa.cast(models.Span.id, sa.String) + ","
         roots = sa.values(
             sa.Column("root_rowid", sa.Integer),
             name="roots",
-        ).data([(key,) for key in keys])
+        ).data([(key,) for key in set(keys)])
 
         subtree = (
             select(
@@ -36,6 +37,7 @@ class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Res
                 models.Span.span_id,
                 models.Span.trace_rowid,
                 roots.c.root_rowid,
+                (sa.literal(",", sa.String) + span_path_segment).label("path"),
             )
             .join_from(roots, models.Span, models.Span.id == roots.c.root_rowid)
             .cte("subtree", recursive=True)
@@ -47,7 +49,9 @@ class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Res
                 models.Span.span_id,
                 models.Span.trace_rowid,
                 parents.c.root_rowid,
-            ).join_from(
+                (parents.c.path + span_path_segment).label("path"),
+            )
+            .join_from(
                 parents,
                 models.Span,
                 sa.and_(
@@ -55,6 +59,7 @@ class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Res
                     models.Span.parent_id == parents.c.span_id,
                 ),
             )
+            .where(parents.c.path.not_like(sa.literal("%,", sa.String) + span_path_segment + "%"))
         )
 
         stmt = (
@@ -62,8 +67,8 @@ class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Res
                 subtree.c.root_rowid,
                 models.SpanCostDetail.token_type,
                 models.SpanCostDetail.is_prompt,
-                coalesce(func.sum(models.SpanCostDetail.cost), 0).label("cost"),
-                coalesce(func.sum(models.SpanCostDetail.tokens), 0).label("tokens"),
+                func.sum(models.SpanCostDetail.cost).label("cost"),
+                func.sum(models.SpanCostDetail.tokens).label("tokens"),
             )
             .select_from(subtree)
             .join(models.SpanCost, models.SpanCost.span_rowid == subtree.c.id)

--- a/src/phoenix/server/api/dataloaders/span_cost_detail_summary_entries_by_span_cumulative.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_detail_summary_entries_by_span_cumulative.py
@@ -20,15 +20,6 @@ Result: TypeAlias = list[SpanCostDetailSummaryEntry]
 
 
 class SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader(DataLoader[Key, Result]):
-    """
-    Aggregates SpanCostDetail rows, grouped by token type, across a span and
-    all of its descendants (children, grandchildren, etc.). Mirrors
-    SpanCostDetailSummaryEntriesByTraceDataLoader, but scoped to the subtree
-    rooted at each key instead of the whole trace, the same way
-    Span.cumulative_token_count_prompt is scoped relative to
-    Trace.rootSpan.cumulativeTokenCountPrompt.
-    """
-
     def __init__(self, db: DbSessionFactory) -> None:
         super().__init__(load_fn=self._load_fn)
         self._db = db

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -831,6 +831,24 @@ class Span(Node):
             for entry in entries
         ]
 
+    @strawberry.field(
+        description="Cost detail breakdown (by token type) aggregated from self "
+        "and all descendant spans (children, grandchildren, etc.)",
+    )  # type: ignore
+    async def cumulative_cost_detail_summary_entries(
+        self, info: Info[Context, None]
+    ) -> list[SpanCostDetailSummaryEntry]:
+        loader = info.context.data_loaders.span_cost_detail_summary_entries_by_span_cumulative
+        entries = await loader.load(self.id)
+        return [
+            SpanCostDetailSummaryEntry(
+                token_type=entry.token_type,
+                is_prompt=entry.is_prompt,
+                value=CostBreakdown(tokens=entry.value.tokens, cost=entry.value.cost),
+            )
+            for entry in entries
+        ]
+
 
 def _hide_embedding_vectors(attributes: Mapping[str, Any]) -> Mapping[str, Any]:
     if not (

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -832,8 +832,7 @@ class Span(Node):
         ]
 
     @strawberry.field(
-        description="Cost detail breakdown (by token type) aggregated from self "
-        "and all descendant spans (children, grandchildren, etc.)",
+        description="Cost details aggregated from this span and all descendant spans",
     )  # type: ignore
     async def cumulative_cost_detail_summary_entries(
         self, info: Info[Context, None]

--- a/tests/unit/server/api/types/test_Span.py
+++ b/tests/unit/server/api/types/test_Span.py
@@ -1156,7 +1156,7 @@ async def test_cumulative_cost_detail_summary_entries_aggregates_self_and_descen
       }
     """
 
-    async def _entries(span_rowid: int) -> dict[tuple[str, bool], tuple[float, float]]:
+    async def _entries(span_rowid: int) -> dict[tuple[str, bool], tuple[Any, Any]]:
         response = await gql_client.execute(
             query=query,
             variables={"spanId": str(GlobalID(Span.__name__, str(span_rowid)))},

--- a/tests/unit/server/api/types/test_Span.py
+++ b/tests/unit/server/api/types/test_Span.py
@@ -1033,3 +1033,163 @@ async def test_as_example_revision_with_annotations(
         assert "annotator_kind" in annotation
         # annotator_kind should be a string, not a function or enum
         assert annotation["annotator_kind"] in ("HUMAN", "LLM", "CODE")
+
+
+@pytest.fixture
+async def _span_cost_cumulative_data(
+    db: DbSessionFactory,
+) -> tuple[models.Span, models.Span, models.Span]:
+    """
+    A trace with a 3-level span chain (root -> child -> grandchild), each
+    carrying its own SpanCostDetail rows, so cumulativeCostDetailSummaryEntries
+    can be checked at every level of the tree.
+    """
+    async with db() as session:
+        project = models.Project(name=token_hex(8))
+        session.add(project)
+        await session.flush()
+        now = datetime.now(timezone.utc)
+        trace = models.Trace(
+            trace_id=token_hex(16),
+            project_rowid=project.id,
+            start_time=now,
+            end_time=now,
+        )
+        session.add(trace)
+        await session.flush()
+
+        def _new_span(parent: Optional[models.Span]) -> models.Span:
+            return models.Span(
+                trace_rowid=trace.id,
+                span_id=token_hex(8),
+                parent_id=None if parent is None else parent.span_id,
+                name=token_hex(8),
+                span_kind="LLM",
+                start_time=now,
+                end_time=now,
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+
+        root = _new_span(None)
+        session.add(root)
+        await session.flush()
+        child = _new_span(root)
+        session.add(child)
+        await session.flush()
+        grandchild = _new_span(child)
+        session.add(grandchild)
+        await session.flush()
+
+        async def _add_cost_details(
+            span: models.Span,
+            entries: list[tuple[str, bool, float, float]],
+        ) -> None:
+            span_cost = models.SpanCost(
+                span_rowid=span.id,
+                trace_rowid=trace.id,
+                span_start_time=span.start_time,
+                model_id=None,
+            )
+            session.add(span_cost)
+            await session.flush()
+            for token_type, is_prompt, tokens, cost in entries:
+                session.add(
+                    models.SpanCostDetail(
+                        span_cost_id=span_cost.id,
+                        token_type=token_type,
+                        is_prompt=is_prompt,
+                        tokens=tokens,
+                        cost=cost,
+                        cost_per_token=None,
+                    )
+                )
+            await session.flush()
+
+        await _add_cost_details(
+            root,
+            [("input", True, 10, 0.1), ("cache_read", True, 5, 0.01)],
+        )
+        await _add_cost_details(
+            child,
+            [("input", True, 20, 0.2), ("output", False, 8, 0.08)],
+        )
+        await _add_cost_details(
+            grandchild,
+            [("cache_read", True, 3, 0.003), ("output", False, 2, 0.02)],
+        )
+
+        await session.commit()
+    return root, child, grandchild
+
+
+async def test_cumulative_cost_detail_summary_entries_aggregates_self_and_descendants(
+    _span_cost_cumulative_data: tuple[models.Span, models.Span, models.Span],
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """
+    cumulativeCostDetailSummaryEntries must fold in every descendant's
+    SpanCostDetail rows, the same way cumulativeTokenCountPrompt folds in
+    every descendant's token count, so a query can tell whether prompt
+    caching was hit anywhere under a given span.
+    """
+    root, child, grandchild = _span_cost_cumulative_data
+    query = """
+      query ($spanId: ID!) {
+        span: node(id: $spanId) {
+          ... on Span {
+            cumulativeCostDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value {
+                tokens
+                cost
+              }
+            }
+          }
+        }
+      }
+    """
+
+    async def _entries(span_rowid: int) -> dict[tuple[str, bool], tuple[float, float]]:
+        response = await gql_client.execute(
+            query=query,
+            variables={"spanId": str(GlobalID(Span.__name__, str(span_rowid)))},
+        )
+        assert not response.errors
+        assert (data := response.data) is not None
+        return {
+            (entry["tokenType"], entry["isPrompt"]): (
+                entry["value"]["tokens"],
+                entry["value"]["cost"],
+            )
+            for entry in data["span"]["cumulativeCostDetailSummaryEntries"]
+        }
+
+    # A leaf span's cumulative entries are exactly its own entries.
+    grandchild_entries = await _entries(grandchild.id)
+    assert grandchild_entries == {
+        ("cache_read", True): (3, pytest.approx(0.003)),
+        ("output", False): (2, pytest.approx(0.02)),
+    }
+
+    # An interior span folds in its own entries plus its descendants'.
+    child_entries = await _entries(child.id)
+    assert child_entries == {
+        ("input", True): (20, pytest.approx(0.2)),
+        ("cache_read", True): (3, pytest.approx(0.003)),
+        ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
+    }
+
+    # The root folds in the whole subtree.
+    root_entries = await _entries(root.id)
+    assert root_entries == {
+        ("input", True): (10 + 20, pytest.approx(0.1 + 0.2)),
+        ("cache_read", True): (5 + 3, pytest.approx(0.01 + 0.003)),
+        ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
+    }

--- a/tests/unit/server/api/types/test_Span.py
+++ b/tests/unit/server/api/types/test_Span.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from random import choice, randint, random
 from secrets import token_hex
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, NamedTuple, Optional
 
 import pytest
 from faker import Faker
@@ -26,6 +26,12 @@ _SpanRowId: TypeAlias = int
 _SpanId: TypeAlias = str
 
 fake = Faker()
+
+
+class _SpanCostDetailsTree(NamedTuple):
+    root: models.Span
+    child: models.Span
+    grandchild: models.Span
 
 
 async def test_project_resolver_returns_correct_project(
@@ -1036,14 +1042,9 @@ async def test_as_example_revision_with_annotations(
 
 
 @pytest.fixture
-async def _span_cost_cumulative_data(
+async def _span_cost_details_tree(
     db: DbSessionFactory,
-) -> tuple[models.Span, models.Span, models.Span]:
-    """
-    A trace with a 3-level span chain (root -> child -> grandchild), each
-    carrying its own SpanCostDetail rows, so cumulativeCostDetailSummaryEntries
-    can be checked at every level of the tree.
-    """
+) -> _SpanCostDetailsTree:
     async with db() as session:
         project = models.Project(name=token_hex(8))
         session.add(project)
@@ -1125,20 +1126,13 @@ async def _span_cost_cumulative_data(
         )
 
         await session.commit()
-    return root, child, grandchild
+    return _SpanCostDetailsTree(root=root, child=child, grandchild=grandchild)
 
 
 async def test_cumulative_cost_detail_summary_entries_aggregates_self_and_descendants(
-    _span_cost_cumulative_data: tuple[models.Span, models.Span, models.Span],
+    _span_cost_details_tree: _SpanCostDetailsTree,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    """
-    cumulativeCostDetailSummaryEntries must fold in every descendant's
-    SpanCostDetail rows, the same way cumulativeTokenCountPrompt folds in
-    every descendant's token count, so a query can tell whether prompt
-    caching was hit anywhere under a given span.
-    """
-    root, child, grandchild = _span_cost_cumulative_data
     query = """
       query ($spanId: ID!) {
         span: node(id: $spanId) {
@@ -1171,23 +1165,20 @@ async def test_cumulative_cost_detail_summary_entries_aggregates_self_and_descen
             for entry in data["span"]["cumulativeCostDetailSummaryEntries"]
         }
 
-    # A leaf span's cumulative entries are exactly its own entries.
-    grandchild_entries = await _entries(grandchild.id)
+    grandchild_entries = await _entries(_span_cost_details_tree.grandchild.id)
     assert grandchild_entries == {
         ("cache_read", True): (3, pytest.approx(0.003)),
         ("output", False): (2, pytest.approx(0.02)),
     }
 
-    # An interior span folds in its own entries plus its descendants'.
-    child_entries = await _entries(child.id)
+    child_entries = await _entries(_span_cost_details_tree.child.id)
     assert child_entries == {
         ("input", True): (20, pytest.approx(0.2)),
         ("cache_read", True): (3, pytest.approx(0.003)),
         ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
     }
 
-    # The root folds in the whole subtree.
-    root_entries = await _entries(root.id)
+    root_entries = await _entries(_span_cost_details_tree.root.id)
     assert root_entries == {
         ("input", True): (10 + 20, pytest.approx(0.1 + 0.2)),
         ("cache_read", True): (5 + 3, pytest.approx(0.01 + 0.003)),

--- a/tests/unit/server/api/types/test_Span.py
+++ b/tests/unit/server/api/types/test_Span.py
@@ -32,6 +32,8 @@ class _SpanCostDetailsTree(NamedTuple):
     root: models.Span
     child: models.Span
     grandchild: models.Span
+    sibling: models.Span
+    costless_leaf: models.Span
 
 
 async def test_project_resolver_returns_correct_project(
@@ -1086,6 +1088,12 @@ async def _span_cost_details_tree(
         grandchild = _new_span(child)
         session.add(grandchild)
         await session.flush()
+        sibling = _new_span(root)
+        session.add(sibling)
+        await session.flush()
+        costless_leaf = _new_span(sibling)
+        session.add(costless_leaf)
+        await session.flush()
 
         async def _add_cost_details(
             span: models.Span,
@@ -1124,63 +1132,228 @@ async def _span_cost_details_tree(
             grandchild,
             [("cache_read", True, 3, 0.003), ("output", False, 2, 0.02)],
         )
+        await _add_cost_details(
+            sibling,
+            [("input", True, 7, 0.07)],
+        )
 
         await session.commit()
-    return _SpanCostDetailsTree(root=root, child=child, grandchild=grandchild)
+    return _SpanCostDetailsTree(
+        root=root,
+        child=child,
+        grandchild=grandchild,
+        sibling=sibling,
+        costless_leaf=costless_leaf,
+    )
+
+
+_CUMULATIVE_COST_DETAIL_QUERY = """
+  query ($spanId: ID!) {
+    span: node(id: $spanId) {
+      ... on Span {
+        cumulativeCostDetailSummaryEntries {
+          tokenType
+          isPrompt
+          value {
+            tokens
+            cost
+          }
+        }
+      }
+    }
+  }
+"""
+
+_Entries: TypeAlias = dict[tuple[str, bool], tuple[Any, Any]]
+
+
+def _entries_by_key(entries: list[dict[str, Any]]) -> _Entries:
+    return {
+        (entry["tokenType"], entry["isPrompt"]): (
+            entry["value"]["tokens"],
+            entry["value"]["cost"],
+        )
+        for entry in entries
+    }
+
+
+async def _cumulative_entries(gql_client: AsyncGraphQLClient, span_rowid: int) -> _Entries:
+    response = await gql_client.execute(
+        query=_CUMULATIVE_COST_DETAIL_QUERY,
+        variables={"spanId": str(GlobalID(Span.__name__, str(span_rowid)))},
+    )
+    assert not response.errors
+    assert (data := response.data) is not None
+    return _entries_by_key(data["span"]["cumulativeCostDetailSummaryEntries"])
 
 
 async def test_cumulative_cost_detail_summary_entries_aggregates_self_and_descendants(
     _span_cost_details_tree: _SpanCostDetailsTree,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    query = """
-      query ($spanId: ID!) {
-        span: node(id: $spanId) {
-          ... on Span {
-            cumulativeCostDetailSummaryEntries {
-              tokenType
-              isPrompt
-              value {
-                tokens
-                cost
-              }
-            }
-          }
-        }
-      }
-    """
-
-    async def _entries(span_rowid: int) -> dict[tuple[str, bool], tuple[Any, Any]]:
-        response = await gql_client.execute(
-            query=query,
-            variables={"spanId": str(GlobalID(Span.__name__, str(span_rowid)))},
-        )
-        assert not response.errors
-        assert (data := response.data) is not None
-        return {
-            (entry["tokenType"], entry["isPrompt"]): (
-                entry["value"]["tokens"],
-                entry["value"]["cost"],
-            )
-            for entry in data["span"]["cumulativeCostDetailSummaryEntries"]
-        }
-
-    grandchild_entries = await _entries(_span_cost_details_tree.grandchild.id)
+    grandchild_entries = await _cumulative_entries(
+        gql_client, _span_cost_details_tree.grandchild.id
+    )
     assert grandchild_entries == {
         ("cache_read", True): (3, pytest.approx(0.003)),
         ("output", False): (2, pytest.approx(0.02)),
     }
 
-    child_entries = await _entries(_span_cost_details_tree.child.id)
+    child_entries = await _cumulative_entries(gql_client, _span_cost_details_tree.child.id)
     assert child_entries == {
         ("input", True): (20, pytest.approx(0.2)),
         ("cache_read", True): (3, pytest.approx(0.003)),
         ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
     }
 
-    root_entries = await _entries(_span_cost_details_tree.root.id)
+    root_entries = await _cumulative_entries(gql_client, _span_cost_details_tree.root.id)
     assert root_entries == {
-        ("input", True): (10 + 20, pytest.approx(0.1 + 0.2)),
+        ("input", True): (10 + 20 + 7, pytest.approx(0.1 + 0.2 + 0.07)),
         ("cache_read", True): (5 + 3, pytest.approx(0.01 + 0.003)),
         ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
     }
+
+
+async def test_cumulative_cost_detail_summary_entries_excludes_sibling_subtree(
+    _span_cost_details_tree: _SpanCostDetailsTree,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    sibling_entries = await _cumulative_entries(gql_client, _span_cost_details_tree.sibling.id)
+    assert sibling_entries == {("input", True): (7, pytest.approx(0.07))}
+
+
+async def test_cumulative_cost_detail_summary_entries_is_empty_without_costs(
+    _span_cost_details_tree: _SpanCostDetailsTree,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    leaf_entries = await _cumulative_entries(gql_client, _span_cost_details_tree.costless_leaf.id)
+    assert leaf_entries == {}
+
+
+async def test_cumulative_cost_detail_summary_entries_batches_overlapping_roots(
+    _span_cost_details_tree: _SpanCostDetailsTree,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    query = """
+      query ($rootId: ID!, $childId: ID!, $duplicateRootId: ID!) {
+        root: node(id: $rootId) {
+          ... on Span {
+            cumulativeCostDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value { tokens cost }
+            }
+          }
+        }
+        child: node(id: $childId) {
+          ... on Span {
+            cumulativeCostDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value { tokens cost }
+            }
+          }
+        }
+        duplicateRoot: node(id: $duplicateRootId) {
+          ... on Span {
+            cumulativeCostDetailSummaryEntries {
+              tokenType
+              isPrompt
+              value { tokens cost }
+            }
+          }
+        }
+      }
+    """
+    root_gid = str(GlobalID(Span.__name__, str(_span_cost_details_tree.root.id)))
+    child_gid = str(GlobalID(Span.__name__, str(_span_cost_details_tree.child.id)))
+    response = await gql_client.execute(
+        query=query,
+        variables={"rootId": root_gid, "childId": child_gid, "duplicateRootId": root_gid},
+    )
+    assert not response.errors
+    assert (data := response.data) is not None
+
+    expected_root = {
+        ("input", True): (10 + 20 + 7, pytest.approx(0.1 + 0.2 + 0.07)),
+        ("cache_read", True): (5 + 3, pytest.approx(0.01 + 0.003)),
+        ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
+    }
+    assert _entries_by_key(data["root"]["cumulativeCostDetailSummaryEntries"]) == expected_root
+    assert (
+        _entries_by_key(data["duplicateRoot"]["cumulativeCostDetailSummaryEntries"])
+        == expected_root
+    )
+    assert _entries_by_key(data["child"]["cumulativeCostDetailSummaryEntries"]) == {
+        ("input", True): (20, pytest.approx(0.2)),
+        ("cache_read", True): (3, pytest.approx(0.003)),
+        ("output", False): (2 + 8, pytest.approx(0.02 + 0.08)),
+    }
+
+
+async def test_cumulative_cost_detail_summary_entries_terminates_on_parent_cycle(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    async with db() as session:
+        project = models.Project(name=token_hex(8))
+        session.add(project)
+        await session.flush()
+        now = datetime.now(timezone.utc)
+        trace = models.Trace(
+            trace_id=token_hex(16),
+            project_rowid=project.id,
+            start_time=now,
+            end_time=now,
+        )
+        session.add(trace)
+        await session.flush()
+
+        first_span_id, second_span_id = token_hex(8), token_hex(8)
+
+        def _new_span(span_id: str, parent_id: str) -> models.Span:
+            return models.Span(
+                trace_rowid=trace.id,
+                span_id=span_id,
+                parent_id=parent_id,
+                name=token_hex(8),
+                span_kind="LLM",
+                start_time=now,
+                end_time=now,
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+
+        first = _new_span(first_span_id, parent_id=second_span_id)
+        second = _new_span(second_span_id, parent_id=first_span_id)
+        session.add_all([first, second])
+        await session.flush()
+
+        for span, tokens, cost in ((first, 4, 0.04), (second, 6, 0.06)):
+            span_cost = models.SpanCost(
+                span_rowid=span.id,
+                trace_rowid=trace.id,
+                span_start_time=span.start_time,
+                model_id=None,
+            )
+            session.add(span_cost)
+            await session.flush()
+            session.add(
+                models.SpanCostDetail(
+                    span_cost_id=span_cost.id,
+                    token_type="input",
+                    is_prompt=True,
+                    tokens=tokens,
+                    cost=cost,
+                    cost_per_token=None,
+                )
+            )
+        await session.commit()
+
+    entries = await _cumulative_entries(gql_client, first.id)
+    assert entries == {("input", True): (4 + 6, pytest.approx(0.04 + 0.06))}


### PR DESCRIPTION
resolves #14899

The session and traces/spans table hover tooltips for cumulative token
counts could not show whether prompt caching was hit on a turn, even
though the per-span and trace-cost tooltips already break down by
token type. `TraceTokenCountDetails` only queried
`rootSpan.cumulativeTokenCountPrompt/Completion`, and
`SpanCumulativeTokenCountDetails` only queried
`Span.cumulativeTokenCountPrompt/Completion/Total`.

`Trace.costDetailSummaryEntries` already carries a per-token-type
breakdown for a whole trace, so `TraceTokenCountDetails` now also
queries it and maps `value.tokens` into the `promptDetails` /
`completionDetails` props `TokenCountDetails` already accepts, the
same way `TraceTokenCostsDetails` does for cost.

No equivalent existed at the span level, so this adds
`Span.cumulativeCostDetailSummaryEntries`, backed by a new
`SpanCostDetailSummaryEntriesBySpanCumulativeDataLoader` that
aggregates `SpanCostDetail` rows, grouped by token type, over a span
and all of its descendants. It follows the same shape as
`SpanCostDetailSummaryEntriesByTraceDataLoader`, but the aggregation
is scoped to the subtree rooted at each key (a recursive CTE over
`Span.parent_id`, matching `SpanDescendantsDataLoader`) instead of the
whole trace.

## Verification

- New `test_cumulative_cost_detail_summary_entries_aggregates_self_and_descendants`
  builds a 3-level span chain (root -> child -> grandchild) with its own
  `SpanCostDetail` rows at each level and checks the GraphQL field
  aggregates correctly at the leaf, an interior span, and the root;
  passes against both SQLite and PostgreSQL.
- `make schema-graphql` regenerates `js/app/schema.graphql` with only
  the new field, and `pnpm run build:relay` regenerates only the two
  touched query files; both checked in.
- `pnpm run build`, `typecheck`, `fmt:check`, `lint`, and `test`
  (2343 passed) are all clean, and `uv run mypy` is clean on Python
  3.10 and 3.14.
- I have not loaded a real cache-hit trace in a running server to
  check the rendered tooltip in the browser; I verified the UI change
  only through the GraphQL query shape and the existing
  `TokenDetailsBreakdown` rendering it already reuses.
