### PR TITLE
chore(deps): floor authlib at 1.8 and declare httpx2 as a test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
   # here so the major version is chosen deliberately rather than by resolution.
   "anthropic>=1,<2",
   "bashkit>=0.10.0,!=0.14.2",  # 0.14.2 shipped no sdist and only cp310/cp311 wheels, breaking installs on 3.14; see https://pypi.org/project/bashkit/0.14.2/
-  "authlib>=1.7.0",
+  "authlib>=1.8.0",
   "joserfc",
   "arize-phoenix-client>=3.2.0",
   "email-validator",
@@ -108,6 +108,7 @@ dev = [
   "grpc-interceptor[testing]",
   "grpcio",
   "httpx",
+  "httpx2",
   "jsonpath-ng",
   "ldap3",
   "litellm>=1.83.14; python_version < '3.14'",  # >=1.83.14 fixes CVE-2026-42208; excluded because upstream metadata does not support Python 3.14 (https://github.com/BerriAI/litellm/issues/26343)

--- a/tests/unit/server/test_oauth2.py
+++ b/tests/unit/server/test_oauth2.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs
 
-import httpx
+import httpx2
 import jmespath
 import pytest
 from authlib.integrations.base_client import OAuthError
@@ -1686,7 +1686,7 @@ class TestClientAssertionJWT:
             client_kwargs={
                 "token_endpoint_auth_method": auth_method,
                 "revocation_endpoint_auth_method": auth_method,
-                "transport": httpx.MockTransport(handler),
+                "transport": httpx2.MockTransport(handler),
             },
         )
 
@@ -1700,9 +1700,9 @@ class TestClientAssertionJWT:
         assertion_file.write_text("header.payload.sig")
         captured: dict[str, str] = {}
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request: httpx2.Request) -> httpx2.Response:
             captured["body"] = request.content.decode()
-            return httpx.Response(200, json={"access_token": "at", "token_type": "Bearer"})
+            return httpx2.Response(200, json={"access_token": "at", "token_type": "Bearer"})
 
         client = self._client_through_base_app(assertion_file, handler)
         await client.fetch_access_token(
@@ -1727,9 +1727,9 @@ class TestClientAssertionJWT:
         assertion_file.write_text("header.payload.sig")
         captured: dict[str, str] = {}
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request: httpx2.Request) -> httpx2.Response:
             captured["body"] = request.content.decode()
-            return httpx.Response(200, json={})
+            return httpx2.Response(200, json={})
 
         client = self._client_through_base_app(assertion_file, handler)
         async with client._get_oauth_client() as session:

--- a/uv.lock
+++ b/uv.lock
@@ -623,6 +623,7 @@ dev = [
     { name = "grpcio" },
     { name = "grpcio-tools" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "jinja2" },
     { name = "jsonpath-ng" },
     { name = "jupyter" },
@@ -718,7 +719,7 @@ requires-dist = [
     { name = "arize-phoenix-otel", editable = "packages/phoenix-otel" },
     { name = "arize-phoenix-sqlean" },
     { name = "asyncpg", marker = "extra == 'pg'" },
-    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "authlib", specifier = ">=1.8.0" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.18.0" },
     { name = "azure-identity", marker = "extra == 'container'", specifier = ">=1.18.0" },
     { name = "bashkit", specifier = ">=0.10.0,!=0.14.2" },
@@ -820,6 +821,7 @@ dev = [
     { name = "grpcio" },
     { name = "grpcio-tools", specifier = ">=1.78.0" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonpath-ng" },
     { name = "jupyter", specifier = ">=1.1.1" },
@@ -1278,15 +1280,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.2"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/51/bc1729d3cfdc214b4935f4e886e4dd443c3065fd8e1e66423fe84b490f81/authlib-1.8.0.tar.gz", hash = "sha256:f3ecd5f1da737262fb53bf1a4d95c4ea1ad9dd509316587a255c99ab1838a4f0", size = 177759, upload-time = "2026-08-30T12:12:34.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c6/6f124bcfbbfb20fba22c939b4e43a06dccfc0e1ca20e5634ca573cb1e271/authlib-1.8.0-py2.py3-none-any.whl", hash = "sha256:88aebbd9af6757e14e912d5dc007ae1dc1f3e27e3b2152ce7c552ee2c3b3c121", size = 260804, upload-time = "2026-08-30T12:12:33.162Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Authlib 1.8 ([authlib#909](https://github.com/authlib/authlib/pull/909)) moved its OAuth2/OIDC client onto `httpx2`, with a fallback to a deprecated `httpx` path only when `httpx2` is absent:

```python
# authlib/integrations/httpx_client/_compat.py
try:
    import httpx2
except ImportError:
    import httpx as httpx2
    deprecate("The httpx module is deprecated; please use httpx2 instead.")
```

`httpx2` is always installed here — `anthropic` is a runtime dependency and pulls it in — so the fallback never engages and Phoenix's OIDC client runs on httpx2 in every install. Flooring `authlib` at `>=1.8.0` makes that the only case the code has to hold for, rather than letting the transport type vary with whatever version resolves.

## Changes

- **`pyproject.toml`**: `authlib>=1.7.0` → `authlib>=1.8.0`; `httpx2` added to the `dev` group.
- **`tests/unit/server/test_oauth2.py`**: the client-assertion tests' `MockTransport` and handler types move to `httpx2`.
- **`uv.lock`**: regenerated — `authlib 1.7.2 → 1.8.0` and the new dev entry, no other resolution movement.

The test change is required, not cosmetic. An `httpx` transport handed to authlib 1.8 fails:

```
FAILS with httpx transport: AssertionError
```

`httpx` stays in the `dev` group. The two packages ship separate, non-interchangeable transport and response types and the suite mocks both: 44 test modules import `httpx` (mostly `ASGITransport` against the Phoenix app), 4 import `httpx2`, and `test_chat_completions.py` imports both. `httpx2` was already imported directly by the openai-SDK mocks in `test_agent_factory`, `test_evaluators`, and `test_chat_completions` while only arriving transitively through those SDKs — this just declares it.

`oauth2.py` builds the real client with `http2=True`; httpx2 accepts that kwarg and shares the `h2` package already pulled in by the `httpx[http2]` runtime dependency.

`fastmcp-slim` also uses `authlib.integrations.httpx_client.AsyncOAuth2Client`, but requires `authlib>=1.6.11` with no upper cap and passes only plain kwargs to it, so the transport swap doesn't reach it.

## Overlap with #15843

#15843 fixes the same six lines in `test_oauth2.py` a different way — deriving the httpx module from `AsyncOAuth2Client.__mro__` so the test works under authlib both below and above 1.8. That indirection exists to straddle the floor this PR raises. If this lands, #15843 is unnecessary; if #15843 lands first, this PR should drop its test change and keep the dependency bump. Either order works, they just shouldn't both land as-is.

## Testing

- `tests/unit/server/test_oauth2.py` — 129 passed
- `tests/integration/auth/test_oidc.py` — 28 passed (exercises the real production path: live mock IdP, discovery, token exchange, PKCE, ID-token parsing, all over httpx2)
- `tests/integration/auth/test_oauth2.py` — 44 passed
- `tests/unit/server/test_app_mcp_mount.py` + `tests/unit/server/agents/` — 523 passed
- mypy and ruff clean on the changed file
