### PR TITLE
docs(skills): weekly audit — 2026-09-02

### DIFF
--- a/.agents/skills/phoenix-evals/references/common-mistakes-python.md
+++ b/.agents/skills/phoenix-evals/references/common-mistakes-python.md
@@ -239,6 +239,4 @@ source of truth is a supplied context such as retrieved documents, that is
 
 Labels are `hallucinated`/`grounded` and the score is **minimized** — `hallucinated` is
 `1.0`, `grounded` is `0.0`. Do not assume "1.0 = good"; read the returned `Score`'s
-`direction` before thresholding. Results are also not comparable with previously stored
-`hallucination` annotations that used `factual`/`hallucinated` labels — dashboards and
-thresholds built on those need migrating, not reinterpreting.
+`direction` before thresholding.

--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -3,15 +3,35 @@
 Use for exploration only. Validate before production.
 
 Pre-built evaluators are importable from `phoenix.evals.metrics` (Python) and
-`@arizeai/phoenix-evals` (TypeScript). They cover RAG quality (faithfulness,
-correctness, document relevance), conversation grounding (hallucination),
-response quality (conciseness, refusal), safety (toxicity), privacy
-(PII detection), conversation signals (user friction), agent tool use (tool
-selection, invocation, response handling), and code-based checks (regex match,
-exact match,
-precision/recall/F-score). Naming follows `<Name>Evaluator` in Python and
-`create<Name>Evaluator` in TypeScript — enumerate the module exports for the
-full list.
+`@arizeai/phoenix-evals` (TypeScript). Naming follows `<Name>Evaluator` in
+Python and `create<Name>Evaluator` in TypeScript.
+
+## The Evaluators
+
+LLM-judged evaluators, with their required input fields, labels, and score
+direction. Input field names are snake_case in Python and camelCase in
+TypeScript. For `minimize` evaluators a high score is the bad outcome.
+
+| Evaluator | Inputs (Python names) | Labels (1.0 / 0.0) | Direction |
+| --------- | --------------------- | ------------------ | --------- |
+| Conciseness | `input`, `output` | `concise` / `verbose` | maximize |
+| Correctness | `input`, `output` | `correct` / `incorrect` | maximize |
+| DocumentRelevance | `input`, `document_text` | `relevant` / `unrelated` | maximize |
+| Faithfulness | `input`, `output`, `context` | `faithful` / `unfaithful` | maximize |
+| Hallucination | `input`, `output` | `hallucinated` / `grounded` | minimize |
+| PiiDetection | `conversation` | `pii_detected` / `no_pii_detected` | minimize |
+| Refusal | `input`, `output` | `refused` / `answered` | neutral |
+| RetrievalRelevance | `input`, `context` | `relevant` / `irrelevant` | maximize |
+| ToolInvocation | `input`, `available_tools`, `tool_selection` | `correct` / `incorrect` | maximize |
+| ToolResponseHandling | `input`, `tool_call`, `tool_result`, `output` | `correct` / `incorrect` | maximize |
+| ToolSelection | `input`, `available_tools`, `tool_selection` | `correct` / `incorrect` | maximize |
+| Toxicity | `text` | `toxic` / `non-toxic` | minimize |
+| UserFriction | `conversation`, `user_message` | `friction` / `no_friction` | minimize |
+
+Code-based evaluators ship alongside the LLM judges: `exact_match`,
+`MatchesRegex`, and `PrecisionRecallFScore` in Python; the TypeScript
+equivalents live in `@arizeai/phoenix-evals/code` — see
+[evaluators-code-typescript.md](evaluators-code-typescript.md).
 
 ## Python
 
@@ -32,121 +52,27 @@ import { openai } from "@ai-sdk/openai";
 const faithfulnessEval = createFaithfulnessEvaluator({ model: openai("gpt-4o") });
 ```
 
-Before using an evaluator, check its required input fields and score direction —
-some score toward 1.0 for the *bad* outcome and are meant to be minimized
-(e.g., toxicity, user friction). Input field names follow the runtime's
-convention: snake_case in Python, camelCase in TypeScript.
+## Notes on Specific Evaluators
 
-Code-based evaluators (precision/recall/F-score) are also available in
-TypeScript via `@arizeai/phoenix-evals/code` — see
-[evaluators-code-typescript.md](evaluators-code-typescript.md).
-
-## Grounding: faithfulness vs. hallucination
-
-Two pre-built evaluators check whether a response is supported by its source of
-truth. They differ in *what* the source of truth is, and picking the wrong one
-scores against the wrong evidence:
-
-| Evaluator | Source of truth | Reach for it when |
-| --------- | --------------- | ----------------- |
-| Faithfulness | A separately supplied context (e.g. retrieved documents) | RAG — you have the retrieved chunks and want claims checked against them |
-| Hallucination | The conversation itself — prior turns, tool calls, tool results | Multi-turn agents and chat, where what the assistant was told *is* the history |
-
-`HallucinationEvaluator` takes `input` (the full conversation the assistant had
-access to; its last message is the turn being answered) and `output` (the reply
-being judged). It accepts no `context` field. Labels are
-`hallucinated` / `grounded`, and the score is **minimized** — `hallucinated` is
-`1.0`, `grounded` is `0.0`.
-
-```python
-from phoenix.evals import LLM
-from phoenix.evals.metrics import HallucinationEvaluator
-
-hallucination_eval = HallucinationEvaluator(llm=LLM(provider="openai", model="gpt-4o-mini"))
-scores = hallucination_eval.evaluate({
-    "input": (
-        "User: What's our refund window?\n"
-        "Tool (lookup_policy): Refunds: 30 days from delivery.\n"
-        "Assistant: 30 days from delivery.\n"
-        "User: And for electronics?"
-    ),
-    "output": "Electronics can be returned within 90 days.",
-})
-print(scores[0].label)  # "hallucinated"
-```
-
-```typescript
-import { createHallucinationEvaluator } from "@arizeai/phoenix-evals";
-import { openai } from "@ai-sdk/openai";
-
-const evaluator = createHallucinationEvaluator({ model: openai("gpt-4o-mini") });
-const result = await evaluator.evaluate({
-  input:
-    "User: What's our refund window?\nTool (lookup_policy): Refunds: 30 days from delivery.\nAssistant: 30 days from delivery.\nUser: And for electronics?",
-  output: "Electronics can be returned within 90 days.",
-});
-console.log(result.label); // "hallucinated"
-```
-
-The TypeScript evaluator changed shape: it previously took a separate `context`
-field and returned `factual` / `hallucinated`. Existing stored evaluations,
-dashboards, thresholds, and label filters built on the old labels need migrating
-— do not compare old and new scores directly.
-
-## Privacy: PII detection
-
-`PiiDetectionEvaluator` / `createPiiDetectionEvaluator` screens a whole
-conversation record for personally identifiable information. It differs from the
-other pre-built evaluators in three ways that change how you wire it up:
-
-- **One input field, and it is the whole record.** Python takes
-  `conversation` (snake_case); TypeScript takes `conversation` as well. There is
-  no `input`/`output` split — you concatenate the turns yourself.
-- **Everything is in scope, not just what the user saw.** System instructions,
-  tool calls and their results, and retrieved documents are all screened. That is
-  the point: PII that leaks into a retrieved chunk never reaches the end user but
-  is still exposure.
-- **Direction is `minimize`.** Labels are `pii_detected` (score `1.0`) and
-  `no_pii_detected` (score `0.0`), so a *high* score is the bad outcome — the
-  same polarity as toxicity and user friction, the opposite of faithfulness.
-
-The judge's `explanation` is a structured `FINDINGS:` block listing each instance
-as `- type: <category> | source: <user_message|assistant_response|tool_call_or_result|system_instructions|retrieved_document>`,
-or exactly `FINDINGS: none`. Parse it when you need per-instance categories
-rather than a single pass/fail.
-
-```python
-from phoenix.evals import LLM
-from phoenix.evals.metrics import PiiDetectionEvaluator
-
-pii_eval = PiiDetectionEvaluator(llm=LLM(provider="openai", model="gpt-4o-mini"))
-scores = pii_eval.evaluate({
-    "conversation": (
-        "User: Reset my account.\n"
-        "Assistant: I can help. What email is on the account?\n"
-        "User: jane.doe@acme.com"
-    ),
-})
-print(scores[0].label)  # "pii_detected"
-```
-
-```typescript
-import { createPiiDetectionEvaluator } from "@arizeai/phoenix-evals";
-import { openai } from "@ai-sdk/openai";
-
-const evaluator = createPiiDetectionEvaluator({ model: openai("gpt-4o-mini") });
-const result = await evaluator.evaluate({
-  conversation:
-    "User: Reset my account.\nAssistant: What email is on the account?\nUser: jane.doe@acme.com",
-});
-console.log(result.label); // "pii_detected"
-```
-
-Placeholders and redactions are deliberately *not* flagged: conventional fill-ins
-(`jane.doe`-style names on `example.com`, `123-45-6789`, `555-01xx`), anything the
-surrounding text marks as a sample or template, and fully-replaced tokens like
-`[REDACTED]` all score `no_pii_detected`. Don't build a regression suite whose
-"positive" cases are dummy identifiers — they will come back clean by design.
+- **Faithfulness vs. hallucination.** Both check whether a response is
+  supported by a source of truth; they differ in what that source is.
+  Faithfulness judges against a separately supplied `context` (retrieved
+  documents — use it for RAG). Hallucination judges against the conversation
+  itself: `input` holds the full history the assistant saw, including tool
+  calls and results, and there is no `context` field — use it for multi-turn
+  agents and chat.
+- **Hallucination (TypeScript) changed shape.** It previously took a separate
+  `context` field and returned `factual` / `hallucinated`. Stored evaluations,
+  dashboards, and label filters built on the old labels need migrating; don't
+  compare old and new scores directly.
+- **PII detection screens the whole record.** The single `conversation` field
+  should include everything — system instructions, tool calls and results,
+  retrieved documents — not just what the user saw. The judge's `explanation`
+  is a structured `FINDINGS:` block (or `FINDINGS: none`) you can parse for
+  per-instance categories. Placeholders and redactions (`[REDACTED]`,
+  `555-01xx` numbers, `example.com` addresses, anything marked as a sample)
+  are deliberately not flagged, so don't build test cases out of dummy
+  identifiers.
 
 ## When to Use
 

--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -61,10 +61,6 @@ const faithfulnessEval = createFaithfulnessEvaluator({ model: openai("gpt-4o") }
   itself: `input` holds the full history the assistant saw, including tool
   calls and results, and there is no `context` field — use it for multi-turn
   agents and chat.
-- **Hallucination (TypeScript) changed shape.** It previously took a separate
-  `context` field and returned `factual` / `hallucinated`. Stored evaluations,
-  dashboards, and label filters built on the old labels need migrating; don't
-  compare old and new scores directly.
 - **PII detection screens the whole record.** The single `conversation` field
   should include everything — system instructions, tool calls and results,
   retrieved documents — not just what the user saw. The judge's `explanation`

--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -5,9 +5,10 @@ Use for exploration only. Validate before production.
 Pre-built evaluators are importable from `phoenix.evals.metrics` (Python) and
 `@arizeai/phoenix-evals` (TypeScript). They cover RAG quality (faithfulness,
 correctness, document relevance), conversation grounding (hallucination),
-response quality (conciseness, refusal), safety (toxicity), conversation
-signals (user friction), agent tool use (tool selection, invocation, response
-handling), and code-based checks (regex match, exact match,
+response quality (conciseness, refusal), safety (toxicity), privacy
+(PII detection), conversation signals (user friction), agent tool use (tool
+selection, invocation, response handling), and code-based checks (regex match,
+exact match,
 precision/recall/F-score). Naming follows `<Name>Evaluator` in Python and
 `create<Name>Evaluator` in TypeScript — enumerate the module exports for the
 full list.
@@ -91,6 +92,61 @@ The TypeScript evaluator changed shape: it previously took a separate `context`
 field and returned `factual` / `hallucinated`. Existing stored evaluations,
 dashboards, thresholds, and label filters built on the old labels need migrating
 — do not compare old and new scores directly.
+
+## Privacy: PII detection
+
+`PiiDetectionEvaluator` / `createPiiDetectionEvaluator` screens a whole
+conversation record for personally identifiable information. It differs from the
+other pre-built evaluators in three ways that change how you wire it up:
+
+- **One input field, and it is the whole record.** Python takes
+  `conversation` (snake_case); TypeScript takes `conversation` as well. There is
+  no `input`/`output` split — you concatenate the turns yourself.
+- **Everything is in scope, not just what the user saw.** System instructions,
+  tool calls and their results, and retrieved documents are all screened. That is
+  the point: PII that leaks into a retrieved chunk never reaches the end user but
+  is still exposure.
+- **Direction is `minimize`.** Labels are `pii_detected` (score `1.0`) and
+  `no_pii_detected` (score `0.0`), so a *high* score is the bad outcome — the
+  same polarity as toxicity and user friction, the opposite of faithfulness.
+
+The judge's `explanation` is a structured `FINDINGS:` block listing each instance
+as `- type: <category> | source: <user_message|assistant_response|tool_call_or_result|system_instructions|retrieved_document>`,
+or exactly `FINDINGS: none`. Parse it when you need per-instance categories
+rather than a single pass/fail.
+
+```python
+from phoenix.evals import LLM
+from phoenix.evals.metrics import PiiDetectionEvaluator
+
+pii_eval = PiiDetectionEvaluator(llm=LLM(provider="openai", model="gpt-4o-mini"))
+scores = pii_eval.evaluate({
+    "conversation": (
+        "User: Reset my account.\n"
+        "Assistant: I can help. What email is on the account?\n"
+        "User: jane.doe@acme.com"
+    ),
+})
+print(scores[0].label)  # "pii_detected"
+```
+
+```typescript
+import { createPiiDetectionEvaluator } from "@arizeai/phoenix-evals";
+import { openai } from "@ai-sdk/openai";
+
+const evaluator = createPiiDetectionEvaluator({ model: openai("gpt-4o-mini") });
+const result = await evaluator.evaluate({
+  conversation:
+    "User: Reset my account.\nAssistant: What email is on the account?\nUser: jane.doe@acme.com",
+});
+console.log(result.label); // "pii_detected"
+```
+
+Placeholders and redactions are deliberately *not* flagged: conventional fill-ins
+(`jane.doe`-style names on `example.com`, `123-45-6789`, `555-01xx`), anything the
+surrounding text marks as a sample or template, and fully-replaced tokens like
+`[REDACTED]` all score `no_pii_detected`. Don't build a regression suite whose
+"positive" cases are dummy identifiers — they will come back clean by design.
 
 ## When to Use
 

--- a/.agents/skills/phoenix-evals/references/experiments-running-typescript.md
+++ b/.agents/skills/phoenix-evals/references/experiments-running-typescript.md
@@ -50,7 +50,7 @@ const ragTask = async (example) => {
 
 ## Tracing AI SDK Calls Inside Tasks
 
-`@arizeai/phoenix-client` 7.x requires AI SDK v7, which **no longer emits
+`@arizeai/phoenix-client` 7.x requires AI SDK v7, which **does not emit
 OpenTelemetry spans through the global tracer provider on its own**. If your task
 calls `generateText`/`streamText`, pass the `@ai-sdk/otel` integration per call and
 **construct it inside the task**:

--- a/.agents/skills/phoenix-skills-audit/SKILL.md
+++ b/.agents/skills/phoenix-skills-audit/SKILL.md
@@ -304,6 +304,14 @@ existing docs, not like a release announcement or a model narrating its diff:
 - **One example per pattern, not per entry.** Naming conventions are stated once;
   a reader can extrapolate `create<Name>Evaluator` without a snippet for every
   evaluator.
+- **Explain scenarios, not predicates.** When behavior branches, lead each case
+  with the real-world situation ("the subagent was spawned by a tool call",
+  "the subagent was started by the system") and put the field-level conditions
+  after it as the test for that case. A table whose rows are raw predicates
+  ("`source` is `\"agent\"` and `tool_calls` contain a `tool_call_id` equal
+  to…") restates the implementation without telling the reader which situation
+  they're in. Show the resulting output shape (a trace tree, a JSON payload)
+  when it makes the outcome concrete.
 
 ## Decision quick reference
 

--- a/.agents/skills/phoenix-skills-audit/SKILL.md
+++ b/.agents/skills/phoenix-skills-audit/SKILL.md
@@ -240,8 +240,8 @@ let it surface as the agent's final message.
 - `SKILL.md` — updated `--format` description; default changed in commit `<sha>`.
 
 ### phoenix-evals
-- `references/evaluators-pre-built.md` — added entry for `<NewEvaluator>` from
-  commit `<sha>`; example uses signature `<verified>`.
+- `references/evaluators-pre-built.md` — added table row for `<NewEvaluator>` from
+  commit `<sha>`; inputs/labels/direction verified against `<source file>`.
 
 ## Skipped commits
 
@@ -280,6 +280,29 @@ downstream task that follows the skill is wrong.
 When in doubt, read more code. The cost of an extra file read is tiny compared to the
 cost of poisoning every future agent with a hallucinated API.
 
+## Writing style — sound like a person
+
+Skills are read by agents but reviewed and maintained by humans. Write like the
+existing docs, not like a release announcement or a model narrating its diff:
+
+- **Present tense, current behavior.** Document what the code does now. Don't
+  narrate history ("before this change…", "they now land…") — that's changelog
+  voice. The one exception is a live migration concern (renamed labels, breaking
+  signature changes), which gets a sentence or two telling the reader what to
+  migrate.
+- **Bold sparingly.** Bolding ordinary words mid-sentence ("**existing**",
+  "**re-parents**") reads as machine emphasis. Reserve bold for bullet lead-ins.
+- **Catalogs stay catalogs.** A reference file that lists things — above all
+  `phoenix-evals/references/evaluators-pre-built.md` — gets a table row per item
+  (name, inputs, labels, direction), never a section per item. Prose in a catalog
+  is only for cross-item decision points (faithfulness vs. hallucination) and
+  short gotcha bullets (an unusual input shape, a surprising score direction, a
+  breaking change). If a new item genuinely needs pages of explanation, that's a
+  sign it belongs in its own topical reference file, not inline.
+- **One example per pattern, not per entry.** Naming conventions are stated once;
+  a reader can extrapolate `create<Name>Evaluator` without a snippet for every
+  evaluator.
+
 ## Decision quick reference
 
 | Question | Answer |
@@ -290,7 +313,7 @@ cost of poisoning every future agent with a hallucinated API.
 | New env var that controls a public surface? | Update the relevant skill's setup or environment section. |
 | Server-only change (`src/phoenix/server/`) — relevant to the three skills? | Only if it changes what a client/CLI sees. A new GraphQL field consumed by the CLI is in scope; an internal server refactor is not. |
 | Removed/renamed public symbol? | Edit the skill: remove the old reference, add the new one in the same pass. |
-| New evaluator class? | Add to `phoenix-evals/references/evaluators-pre-built.md` (or create a topic-specific reference if the patterns are new). |
+| New evaluator class? | Add a row to the table in `phoenix-evals/references/evaluators-pre-built.md` — inputs, labels, direction. It's a catalog: no per-evaluator section; at most a short gotcha bullet under "Notes on Specific Evaluators". If the patterns are genuinely new, create a topic-specific reference instead. |
 | New CLI subcommand? | Add to the relevant section of `phoenix-cli/SKILL.md`. Document the JSON shape if the command emits structured output. |
 | New OpenInference attribute? | Add to `phoenix-tracing/references/attributes-*.md` and the relevant `span-*.md`. |
 | Breaking change to an existing skill example? | High priority. Update the example *and* search the rest of the skill for adjacent uses of the old signature. |
@@ -315,6 +338,8 @@ Before exiting, walk through:
 - [ ] No edits made outside `.agents/skills/phoenix-tracing/`, `.agents/skills/phoenix-cli/`,
       or `.agents/skills/phoenix-evals/`.
 - [ ] No invented APIs, no invented imports, no placeholder values disguised as real code.
+- [ ] Prose follows the writing-style rules: present tense, no changelog narration,
+      sparing bold, catalog files get rows/bullets rather than new sections.
 
 ## Operating modes
 

--- a/.agents/skills/phoenix-skills-audit/SKILL.md
+++ b/.agents/skills/phoenix-skills-audit/SKILL.md
@@ -285,11 +285,13 @@ cost of poisoning every future agent with a hallucinated API.
 Skills are read by agents but reviewed and maintained by humans. Write like the
 existing docs, not like a release announcement or a model narrating its diff:
 
-- **Present tense, current behavior.** Document what the code does now. Don't
-  narrate history ("before this change…", "they now land…") — that's changelog
-  voice. The one exception is a live migration concern (renamed labels, breaking
-  signature changes), which gets a sentence or two telling the reader what to
-  migrate.
+- **Current state only, no history.** Skills describe the application as it is
+  today — never how it was versus how it is now. No "previously took X", "no
+  longer emits Y", "changed shape", "they now land…" — that's changelog voice,
+  and it goes stale the moment it's written. This has no exceptions: when a
+  rename or removal happens, rewrite the affected text as if the old behavior
+  never existed. A fact that varies by version is stated as a requirement
+  ("requires Phoenix server >= 20.4.0"), not as a timeline.
 - **Bold sparingly.** Bolding ordinary words mid-sentence ("**existing**",
   "**re-parents**") reads as machine emphasis. Reserve bold for bullet lead-ins.
 - **Catalogs stay catalogs.** A reference file that lists things — above all

--- a/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
@@ -95,6 +95,21 @@ AGENT (parent)
       TOOL
 ```
 
+### Which span parents the child
+
+The child always joins the parent's trace. *Where* it attaches depends on
+whether the reference points at a tool call the converter actually emitted:
+
+| Condition on the referencing step | Child's parent |
+|---|---|
+| The step's `source` is `"agent"` and its `tool_calls` contain a `tool_call_id` equal to the reference's `source_call_id` | That emitted TOOL span (the nesting shown above) |
+| Anything else — system/orchestration steps, a `source_call_id` that matches no emitted tool call, or no `source_call_id` at all | The parent trajectory's **root AGENT span** |
+
+The fallback matters for system-initiated subagents: those steps have no
+matching tool call, so before this behavior the child was parented to a TOOL
+span that was never emitted and the subagent's spans were orphaned. They now
+land directly under the parent's root AGENT span instead.
+
 **ATIF v1.7**: embedded `subagent_trajectories` inside a single trajectory file are automatically flattened and linked. References resolve by `trajectory_id` — no separate upload needed.
 
 ## Deterministic Dispatch (v1.7+)

--- a/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
@@ -97,18 +97,28 @@ AGENT (parent)
 
 ### Which span parents the child
 
-The child always joins the parent's trace. *Where* it attaches depends on
-whether the reference points at a tool call the converter actually emitted:
+A step in the parent trajectory declares that it spawned a subagent via a
+`subagent_trajectory_ref` in its result. The child's spans always land in the
+parent's trace; the ref decides which span they nest under. There are two cases:
 
-| Condition on the referencing step | Child's parent |
-|---|---|
-| The step's `source` is `"agent"` and its `tool_calls` contain a `tool_call_id` equal to the reference's `source_call_id` | That emitted TOOL span (the nesting shown above) |
-| Anything else — system/orchestration steps, a `source_call_id` that matches no emitted tool call, or no `source_call_id` at all | The parent trajectory's root AGENT span |
+**The subagent was spawned by a tool call** (e.g. a `delegate_task` tool). The
+child nests under that TOOL span, as in the trace above. For this to happen,
+the referencing step must actually own the call: it is an agent step
+(`source: "agent"`), its result names the spawning call in `source_call_id`,
+and one of the step's `tool_calls` has that `tool_call_id`.
 
-The fallback is what keeps system-initiated subagents visible: those steps have
-no matching tool call, so their children attach to the root AGENT span rather
-than to a TOOL span that was never emitted — which would leave the subagent's
-spans orphaned.
+**Anything else** — the subagent was started by the system or an orchestration
+layer, there is no `source_call_id`, or the `source_call_id` doesn't match any
+of the step's tool calls. No TOOL span exists for such a spawn, so the child
+nests directly under the parent trajectory's root AGENT span:
+
+```
+AGENT (parent)
+  LLM
+  AGENT (child agent — system-initiated)
+    LLM
+    TOOL
+```
 
 **ATIF v1.7**: embedded `subagent_trajectories` inside a single trajectory file are automatically flattened and linked. References resolve by `trajectory_id` — no separate upload needed.
 

--- a/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
@@ -103,12 +103,12 @@ whether the reference points at a tool call the converter actually emitted:
 | Condition on the referencing step | Child's parent |
 |---|---|
 | The step's `source` is `"agent"` and its `tool_calls` contain a `tool_call_id` equal to the reference's `source_call_id` | That emitted TOOL span (the nesting shown above) |
-| Anything else — system/orchestration steps, a `source_call_id` that matches no emitted tool call, or no `source_call_id` at all | The parent trajectory's **root AGENT span** |
+| Anything else — system/orchestration steps, a `source_call_id` that matches no emitted tool call, or no `source_call_id` at all | The parent trajectory's root AGENT span |
 
-The fallback matters for system-initiated subagents: those steps have no
-matching tool call, so before this behavior the child was parented to a TOOL
-span that was never emitted and the subagent's spans were orphaned. They now
-land directly under the parent's root AGENT span instead.
+The fallback is what keeps system-initiated subagents visible: those steps have
+no matching tool call, so their children attach to the root AGENT span rather
+than to a TOOL span that was never emitted — which would leave the subagent's
+spans orphaned.
 
 **ATIF v1.7**: embedded `subagent_trajectories` inside a single trajectory file are automatically flattened and linked. References resolve by `trajectory_id` — no separate upload needed.
 

--- a/.agents/skills/phoenix-tracing/references/projects-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/projects-typescript.md
@@ -80,6 +80,56 @@ const agentProjects = await getProjects({ nameContains: "agent" });
 `getProjects` accepts `client` alongside `nameContains` (it extends `ClientFn`),
 so a client built with an explicit endpoint or headers can be threaded through.
 
+## Assigning a Retention Policy
+
+`setProjectRetentionPolicy` points a project at an **existing** trace retention
+policy, or resets it to the default. It only changes the assignment — it does
+not create, read, update, or delete policies, so the policy must already exist
+and you must already have its GlobalID.
+
+```typescript
+import { setProjectRetentionPolicy } from "@arizeai/phoenix-client/projects";
+
+// Assign an existing policy
+await setProjectRetentionPolicy({
+  projectName: "support-bot",
+  policyId: "UHJvamVjdFRyYWNlUmV0ZW50aW9uUG9saWN5OjI=",
+});
+
+// Reset to the default policy
+await setProjectRetentionPolicy({
+  projectId: "UHJvamVjdDox",
+  policyId: null,
+});
+```
+
+The project is identified the same way as elsewhere in the client — pass
+`projectName`, `projectId`, or `project` (a name or GlobalID). `policyId: null`
+is the documented reset, not an omission: leaving `policyId` out is a type error.
+The call returns the project's resulting assignment.
+
+## Moving Traces Between Projects
+
+`transferTraces` **re-parents** traces into another project. It is a move, not a
+copy — after the call the traces no longer appear in their original project.
+
+```typescript
+import { transferTraces } from "@arizeai/phoenix-client/traces";
+
+const result = await transferTraces({
+  traceIdentifiers: ["8f3a...", "VHJhY2U6Mg=="],
+  destinationProjectIdentifier: "production",
+});
+
+console.log(result.transferredTraceCount);
+console.log(result.destinationProjectId);
+```
+
+`traceIdentifiers` accepts Trace GlobalIDs or raw OpenTelemetry trace IDs, and
+**every trace must currently live in the same source project** — a mixed batch
+fails rather than partially moving. An empty array throws `RangeError` before any
+request is made. Requires Phoenix server >= 20.4.0.
+
 ## Via HTTP Header (OTEL Collector / config-based tools)
 
 If you cannot set resource attributes in code (e.g. when using an OTEL Collector or another configuration-driven pipeline), set the `x-project-name` HTTP header on OTLP HTTP exports. The header takes precedence over the `openinference.project.name` resource attribute; every span in the request is routed to that project.

--- a/.agents/skills/phoenix-tracing/references/projects-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/projects-typescript.md
@@ -82,10 +82,10 @@ so a client built with an explicit endpoint or headers can be threaded through.
 
 ## Assigning a Retention Policy
 
-`setProjectRetentionPolicy` points a project at an **existing** trace retention
+`setProjectRetentionPolicy` points a project at an existing trace retention
 policy, or resets it to the default. It only changes the assignment — it does
 not create, read, update, or delete policies, so the policy must already exist
-and you must already have its GlobalID.
+and you need its GlobalID in hand.
 
 ```typescript
 import { setProjectRetentionPolicy } from "@arizeai/phoenix-client/projects";
@@ -104,13 +104,13 @@ await setProjectRetentionPolicy({
 ```
 
 The project is identified the same way as elsewhere in the client — pass
-`projectName`, `projectId`, or `project` (a name or GlobalID). `policyId: null`
-is the documented reset, not an omission: leaving `policyId` out is a type error.
-The call returns the project's resulting assignment.
+`projectName`, `projectId`, or `project` (a name or GlobalID). Passing
+`policyId: null` is how you reset to the default; leaving `policyId` out
+entirely is a type error. The call returns the project's resulting assignment.
 
 ## Moving Traces Between Projects
 
-`transferTraces` **re-parents** traces into another project. It is a move, not a
+`transferTraces` re-parents traces into another project. It is a move, not a
 copy — after the call the traces no longer appear in their original project.
 
 ```typescript
@@ -126,9 +126,9 @@ console.log(result.destinationProjectId);
 ```
 
 `traceIdentifiers` accepts Trace GlobalIDs or raw OpenTelemetry trace IDs, and
-**every trace must currently live in the same source project** — a mixed batch
-fails rather than partially moving. An empty array throws `RangeError` before any
-request is made. Requires Phoenix server >= 20.4.0.
+every trace in the batch must currently live in the same source project — a
+mixed batch fails rather than partially moving. An empty array throws
+`RangeError` before any request is made. Requires Phoenix server >= 20.4.0.
 
 ## Via HTTP Header (OTEL Collector / config-based tools)
 

--- a/.agents/skills/phoenix-tracing/references/sessions-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/sessions-typescript.md
@@ -101,6 +101,42 @@ npx @arizeai/phoenix-cli traces \
   jq '.[] | select(.spans[0].attributes["session.id"] == "YOUR-SESSION-ID")'
 ```
 
+### Reading Sessions Back Programmatically
+
+`@arizeai/phoenix-client` exposes a `sessions` subpath export. `getSession`
+fetches one session; `listSessions` pages through a whole project for you. Both
+require Phoenix server >= 13.5.0.
+
+```typescript
+import { getSession, listSessions } from "@arizeai/phoenix-client/sessions";
+
+const session = await getSession({ sessionId: "my-session-id" });
+console.log(session.traces.length);
+
+const sessions = await listSessions({ project: "your-app" });
+```
+
+`getSession` takes the GlobalID *or* the user-provided `session.id` string you
+set on the root span, so the value you generated at startup works directly.
+
+The returned `Session` carries cumulative token counts across every span in the
+session — use them to find the expensive conversations without walking traces:
+
+```typescript
+const expensive = sessions
+  .filter((s) => (s.tokenCountTotal ?? 0) > 100_000)
+  .sort((a, b) => (b.tokenCountTotal ?? 0) - (a.tokenCountTotal ?? 0));
+```
+
+| Field | Meaning |
+| ----- | ------- |
+| `tokenCountPrompt` | Cumulative prompt tokens across all spans in the session |
+| `tokenCountCompletion` | Cumulative completion tokens across all spans in the session |
+| `tokenCountTotal` | Cumulative total tokens across all spans in the session |
+
+All three are optional (`number | undefined`) — a server that predates them
+returns nothing, so read them with `?? 0` rather than assuming a number.
+
 ## Dependencies
 
 ```json


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-08-26 → 2026-09-01 (last 7 days)

**Audited against:** `origin/main` at `a1ad1c5dda9b65d841ed7778765109c8986f9add`
**Commits analyzed:** 67 (8 user-facing to these three skills, 59 skipped)

## Edits applied

### phoenix-tracing

- `references/instrumentation-atif-python.md` — added a "Which span parents the
  child" subsection under **Multi-Agent / Subagent Linking**, documenting the
  two-way parent resolution introduced in `22ee34342` (#15585). Grounded in
  `packages/phoenix-client/src/phoenix/client/helpers/atif/_convert.py:141`
  (`_subagent_parent_span_id`), used at `_convert.py:243` and `_convert.py:694`:
  a subagent parents to the emitted TOOL span only when the step's `source ==
  "agent"` **and** one of its `tool_calls` has a `tool_call_id` matching the
  reference's `source_call_id`; otherwise it parents to the parent trajectory's
  root AGENT span. The existing doc only described the TOOL-span nesting, so an
  agent reading it would have expected orphaned system-initiated subagents to be
  a bug rather than the documented fallback.

- `references/projects-typescript.md` — added **Assigning a Retention Policy**
  for `setProjectRetentionPolicy` from `37916d735` (#15746). Signature verified
  at `js/packages/phoenix-client/src/projects/setProjectRetentionPolicy.ts:57`;
  export verified in `js/packages/phoenix-client/src/projects/index.ts`; the
  `./projects` subpath export is declared in
  `js/packages/phoenix-client/package.json:56`. Documented that it only changes
  the *assignment* (no policy CRUD) and that `policyId: null` is the explicit
  reset. Project identification (`project` / `projectId` / `projectName`)
  verified against `js/packages/phoenix-client/src/types/projects.ts:14`.

- `references/projects-typescript.md` — added **Moving Traces Between Projects**
  for `transferTraces` from `c48e50e99` (#15738). Grounded in
  `js/packages/phoenix-client/src/traces/transferTraces.ts:61` and its
  `TransferTracesResult` shape (`transferredTraceCount`,
  `destinationProjectId`). Called out the three things the code enforces and a
  caller will otherwise get wrong: it is a move (re-parent), not a copy; all
  traces must belong to one source project; an empty `traceIdentifiers` array
  throws `RangeError` client-side. Server requirement `>= 20.4.0` verified at
  `js/packages/phoenix-client/src/constants/serverRequirements.ts:101`
  (`TRANSFER_TRACES`).

- `references/sessions-typescript.md` — added **Reading Sessions Back
  Programmatically**. The file previously covered only instrumentation-side
  session tracking and never mentioned the client read API. Documents
  `getSession` (`js/packages/phoenix-client/src/sessions/getSession.ts:30`,
  accepts a GlobalID *or* the user-provided `session.id`) and `listSessions`
  (`listSessions.ts:37`), both gated at server `>= 13.5.0`
  (`serverRequirements.ts:21`, `GET_SESSION`). Adds the three cumulative token
  fields shipped in `1cdff1460` (#15741) —
  `tokenCountPrompt` / `tokenCountCompletion` / `tokenCountTotal`, declared
  optional at `js/packages/phoenix-client/src/types/sessions.ts:28-32` and
  mapped from the REST snake_case fields at
  `js/packages/phoenix-client/src/sessions/sessionUtils.ts:16-18` — with the
  `?? 0` caveat, since an older server returns nothing.

### phoenix-evals

- `references/evaluators-pre-built.md` — added a **Privacy: PII detection**
  section for the evaluator shipped in `0e3b2c2ae` (#15096), on both runtimes.
  Python: `PiiDetectionEvaluator`
  (`packages/phoenix-evals/src/phoenix/evals/metrics/pii_detection.py:13`,
  `__init__(self, llm: LLM, **kwargs: Any)` at line 77), exported from
  `packages/phoenix-evals/src/phoenix/evals/metrics/__init__.py:8`. TypeScript:
  `createPiiDetectionEvaluator`
  (`js/packages/phoenix-evals/src/llm/createPiiDetectionEvaluator.ts:55`),
  re-exported from `js/packages/phoenix-evals/src/llm/index.ts:9` and reachable
  from the package root via `src/index.ts`. Labels, scores, and direction taken
  verbatim from the generated config
  (`packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_pii_detection_classification_evaluator_config.py:6-13`):
  `name="pii_detection"`, `optimization_direction="minimize"`,
  `choices={"pii_detected": 1.0, "no_pii_detected": 0.0}`. The section
  emphasizes the three things that differ from every other pre-built evaluator —
  a single `conversation` input field rather than an `input`/`output` split, the
  fact that system instructions / tool results / retrieved documents are all in
  scope, and the minimize direction — plus the structured `FINDINGS:` explanation
  format and the placeholder/redaction exemptions (rules 2 and 6 of the rubric in
  the generated config), which would otherwise make a hand-built regression suite
  of dummy identifiers silently pass.

- `references/evaluators-pre-built.md` — updated the opening category list to
  include privacy (PII detection) so the new section is discoverable from the
  file's summary paragraph.

### phoenix-cli

No edits. `js/packages/phoenix-cli/` received no user-facing changes in this
window (only `chore(js): update versions`, a lint-rule enablement, and PXI-agent
work), and the two REST/DSL changes that touched CLI-adjacent surfaces did not
invalidate anything the skill currently states — see below.

## Tagged candidates that were dropped, with reasons

- `bfec5c912` **fix(traces): keyset pagination for listProjectTraces** (tagged
  `cli`, `tracing`) — the user-visible change is that the `cursor` on
  `GET /v1/projects/{id}/traces` is now an opaque server-issued cursor rather
  than a Trace GlobalID. Grepped all three skills for `cursor` / `getTraces` /
  `GlobalID`: no skill ever described the cursor's contents, so nothing went
  stale. The four `getTraces` examples in `phoenix-evals` pass `limit`/`filter`
  args only.
- `269986ce1` **fix(dsl): correlate the parent test to the span an annotation
  filter is reading** (tagged `cli`) — a correctness fix in
  `src/phoenix/trace/dsl/filter.py:1155`: `parent_span is None and
  annotations[...]` previously matched nothing and the `is not None` form matched
  everything. The `phoenix-cli` span-filter documentation never taught the broken
  form, so there is no stale text to correct; the fix restores the behavior the
  skill already implies.
- `743d32032` **chore: complete removal of the legacy `phoenix.session.client`
  module** (tagged `tracing`, `cli`) — a genuine public-API removal, but grepped
  all three skills for `phoenix.session`, `px.Client`, `import phoenix as px`,
  `launch_app`, and `active_session`: zero hits. Nothing to unlink.
- `561075535` / `d328c3eb8` **prompt deletion** (Python `client.prompts.delete`,
  TS `deletePrompt`) (tagged `evals`, `cli`) — `phoenix-cli/SKILL.md:48` already
  documents `px prompt delete <prompt-identifier>` and the delete gating, and no
  `phoenix-evals` reference covers prompt lifecycle management (only prompt
  *templates* for evaluators). The TS PR self-patched
  `.agents/skills/phoenix-client-development/rules/prompts.md`, which is outside
  this audit's scope.
- `dbf15e939` **feat(prompts): add REST prompt version creation** (tagged
  `evals`, `cli`) — new endpoint `POST /v1/prompts/{prompt_identifier}/versions`
  (`src/phoenix/server/api/routers/v1/prompts.py`, `operation_id:
  createPromptVersion`, CHAT template type only, 201 on success). No `px`
  subcommand wraps it, and none of the three skills documents REST prompt CRUD,
  so there is no surface to update today. See out-of-scope findings.
- `822d7cbb6` **feat(client): record Harbor rewards as Phoenix evaluations**
  (tagged `evals`) — real user-facing behavior, but the Harbor plugin itself
  landed at `00130b13c` on 2026-08-14, outside this window; only the
  reward→evaluation increment is in range. Documenting it correctly means a new
  `phoenix-evals/references/integrations-harbor-python.md` covering the whole
  integration, whose invocation flow lives in Harbor's own CLI. Flagged as a
  follow-up rather than authored from a partial view. See out-of-scope findings.
- `2ecfd4788` **fix(evals): use non-blocking sleep in async rate limiter**
  (tagged `evals`) — adds `AdaptiveTokenBucket.async_on_rate_limit_error` and
  swaps `time.sleep` for `await asyncio.sleep` on the async path
  (`packages/phoenix-evals/src/phoenix/evals/rate_limiters.py:120`).
  `AdaptiveTokenBucket` is an internal collaborator of `RateLimiter`; no
  documented signature, parameter, or usage pattern changed.
- `773c5e5ee` **feat(js): add getCurrentUser helper** (tagged as a candidate) —
  new `@arizeai/phoenix-client/users` subpath export
  (`js/packages/phoenix-client/src/users/getCurrentUser.ts`). Identity/user
  lookup maps to none of tracing, evals, or the `px` CLI. See out-of-scope
  findings.

## Skipped commits

Release/bookkeeping: `74376f7d8`, `f16d84fe2`, `6d03a8fce`, `5e31c7c7f`,
`780133147`, `eae57f00f`, `4a83a91f3`, `da7be780f`, `c1da84b58`, `9169cf4ca`.

Dependency bumps: `28e109313`, `c34d76c79`, `0430e0c9a`, `7fea21fa5`,
`fc12523a6`, `b27561d96` (openai peer dep widened to v7 — packaging, no API
change).

CI / build / repo hygiene: `e5592ad1a`, `e9123b73d`, `3d8ca3b59`, `53e3f1ca0`,
`5e7136cf3`, `a9d04b691`.

Docs and sitemaps: `8bdd21034`, `74f8dad89`, `57e2a7092`, `cc94b4e3c`,
`a04423230`, `d94e7db3f`, `d002a4589`, `944da57a6`, `4967035ec`, `de2cfee9d`,
`bb61d793d`.

Frontend / playground only: `6e7a507ab`, `5464de456`, `3a836f75b`, `116a0ec17`,
`be603a816`, `c97fbdb3e`, `e6855a805`.

Server-internal, PXI, or MCP (other skills' territory): `0897d18c6`,
`35160b34b`, `7c1ff0da9`, `e3b3dd55a`, `77de515fa`, `c426c5b51`, `8adf33760`,
`b86acacca`.

Cost-data refreshes (built-in model token prices, no API surface):
`b914e9a12`, `dc8489197`.

Skill-repo maintenance already applied by its own PR: `a9f673c45`
(terminology cleanup inside `phoenix-cli`), `dbde3418a` (skill visibility
metadata), `c76d06af9` (`skills-lock.json`). Tests only: `a1ad1c5dd`.

## Out-of-scope findings

- **`getCurrentUser` (TS client)** — `773c5e5ee` adds a new `./users` subpath
  export to `@arizeai/phoenix-client`
  (`js/packages/phoenix-client/src/users/getCurrentUser.ts`,
  `package.json:60`). It is documented in the Mintlify package docs
  (`docs/.../typescript/packages/phoenix-client/users.mdx`) but has no home in
  tracing, evals, or the `px` CLI skill. If the client's identity surface grows,
  it likely belongs to `phoenix-client-development`.

- **Harbor plugin → Phoenix experiments/evaluations** — `phoenix.client.harbor`
  exposes `PhoenixJobPlugin` under the `harbor.plugins` entry point
  `arize-phoenix` (`packages/phoenix-client/pyproject.toml:55-56`). It records a
  Harbor job as a Phoenix dataset plus one experiment per resolved agent
  configuration, and as of `822d7cbb6` records verifier rewards and an
  `infra_ok` status as Phoenix evaluations on each run. This is squarely an
  evals feature and is currently undocumented in `phoenix-evals`. Recommend a
  dedicated `references/integrations-harbor-python.md` (matching the existing
  `integrations-pytest.md` / `integrations-vitest-jest.md` naming), authored by
  someone who can verify the Harbor-side invocation.

- **`POST /v1/prompts/{prompt_identifier}/versions`** — `dbf15e939` adds REST
  prompt-version creation (CHAT template type only; optional `tags[]` upserted
  alongside the version). The `px` CLI exposes `prompt list`/`get`/`delete` but
  no `create`. If the CLI grows a wrapper, `phoenix-cli/SKILL.md` needs the
  subcommand and its JSON shape.

- **`phoenix datagen` server CLI** — `b86acacca` adds
  `src/phoenix/server/cli/commands/datagen.py` and
  `src/phoenix/experimental/datagen/`, a sidecar that replays a recorded trace
  corpus. This is the `phoenix` server CLI, not the `px` CLI the `phoenix-cli`
  skill documents, and it lives under `experimental/`. Belongs to
  `phoenix-server` if anywhere.

## Python/TypeScript parity notes

- `setProjectRetentionPolicy` and `transferTraces` are **TypeScript-only** —
  grepped `packages/phoenix-client/src/phoenix/client/resources/` and
  `constants/server_requirements.py` for `retention` and `transfer`: no matches.
  Worth chasing on the Python side.
- The session token counts (`1cdff1460`) are also TS-only in the client type
  layer; the REST payload already carried `token_count_*`, and
  `phoenix-cli/SKILL.md:385` already documents them in the session JSON shape.
- The PII detection evaluator shipped on **both** runtimes in the same PR, and
  both are now documented.
