### PR TITLE
feat(ui): show evaluator inputs in gallery

### DIFF
--- a/js/app/schema.graphql
+++ b/js/app/schema.graphql
@@ -2651,7 +2651,7 @@ type LLMEvaluator implements Evaluator & Node {
   datasetEvaluators: [DatasetEvaluator!]!
   prompt: Prompt!
   promptVersionTag: PromptVersionTag
-  inputSchema: JSON
+  inputSchema: JSON!
   user: User
   promptVersion: PromptVersion!
 }

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -103,6 +103,10 @@ const projectEvaluatorGalleryPageQuery = graphql`
       scope
       category
       details
+      inputs {
+        name
+        description
+      }
       messages {
         ...promptUtils_promptMessages
       }
@@ -892,6 +896,50 @@ function EvaluatorOutputSummary({
   );
 }
 
+type EvaluatorInputSummaryItem = {
+  readonly name: string;
+  readonly type?: string;
+  readonly description?: string;
+};
+
+function EvaluatorInputSummary({
+  inputs,
+}: {
+  inputs: readonly EvaluatorInputSummaryItem[];
+}) {
+  if (inputs.length === 0) return null;
+  return (
+    <Flex direction="column" gap="size-75">
+      <Text elementType="h3" size="S" weight="heavy">
+        Inputs
+      </Text>
+      <List size="S">
+        {inputs.map((input) => (
+          <ListItem key={input.name}>
+            <Flex direction="column" gap="size-25">
+              <Flex direction="row" alignItems="baseline" gap="size-75" wrap>
+                <Text size="S" fontFamily="mono">
+                  {input.name}
+                </Text>
+                {input.type ? (
+                  <Text size="XS" color="text-500" fontFamily="mono">
+                    {input.type}
+                  </Text>
+                ) : null}
+              </Flex>
+              {input.description ? (
+                <Text size="XS" color="text-700">
+                  {input.description}
+                </Text>
+              ) : null}
+            </Flex>
+          </ListItem>
+        ))}
+      </List>
+    </Flex>
+  );
+}
+
 function AnnotationValues({
   values,
   optimizationDirection,
@@ -969,6 +1017,7 @@ function LlmCustomEvaluatorDetails({
     <Flex direction="column" gap="size-200" height="100%">
       <CustomEvaluatorDetailsHeader evaluator={evaluator} />
       <EvaluatorOutputSummary outputConfigs={evaluator.outputConfigs} />
+      <EvaluatorInputSummary inputs={evaluator.inputs} />
       <EvaluatorPromptPreview messages={messages} />
       <EvaluatorDetailsAction onPress={onDuplicateEvaluator}>
         Duplicate this evaluator
@@ -1002,6 +1051,7 @@ function CodeCustomEvaluatorDetails({
         </div>
       </dl>
       <EvaluatorOutputSummary outputConfigs={evaluator.outputConfigs} />
+      <EvaluatorInputSummary inputs={evaluator.inputs} />
       <Flex direction="column" gap="size-75">
         <Text elementType="h3" size="S" weight="heavy">
           Code
@@ -1145,6 +1195,12 @@ function EvaluatorTemplateDetails({
           </dd>
         </div>
       </dl>
+      <EvaluatorInputSummary
+        inputs={(template.inputs ?? []).map((input) => ({
+          name: input.name,
+          description: input.description,
+        }))}
+      />
       <AnnotationValues
         values={choices}
         optimizationDirection={template.optimizationDirection}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -917,7 +917,7 @@ function EvaluatorInputSummary({
           {inputs.map((input) => (
             <ListItem key={input.name}>
               <Flex direction="column" gap="size-25">
-                <Text size="S" fontFamily="mono">
+                <Text size="S" fontFamily="mono" css={inputNameCSS}>
                   {input.name}
                 </Text>
                 {input.description ? (
@@ -1238,6 +1238,10 @@ const detailsSectionWellCSS = css`
 
 const listSectionWellCSS = css`
   padding: var(--global-dimension-size-50);
+`;
+
+const inputNameCSS = css`
+  overflow-wrap: anywhere;
 `;
 
 const promptPreviewMessageCSS = css`

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -898,7 +898,6 @@ function EvaluatorOutputSummary({
 
 type EvaluatorInputSummaryItem = {
   readonly name: string;
-  readonly type?: string;
   readonly description?: string;
 };
 
@@ -913,29 +912,24 @@ function EvaluatorInputSummary({
       <Text elementType="h3" size="S" weight="heavy">
         Inputs
       </Text>
-      <List size="S">
-        {inputs.map((input) => (
-          <ListItem key={input.name}>
-            <Flex direction="column" gap="size-25">
-              <Flex direction="row" alignItems="baseline" gap="size-75" wrap>
+      <div css={[detailsSectionWellCSS, listSectionWellCSS]}>
+        <List size="S">
+          {inputs.map((input) => (
+            <ListItem key={input.name}>
+              <Flex direction="column" gap="size-25">
                 <Text size="S" fontFamily="mono">
                   {input.name}
                 </Text>
-                {input.type ? (
-                  <Text size="XS" color="text-500" fontFamily="mono">
-                    {input.type}
+                {input.description ? (
+                  <Text size="XS" color="text-700">
+                    {input.description}
                   </Text>
                 ) : null}
               </Flex>
-              {input.description ? (
-                <Text size="XS" color="text-700">
-                  {input.description}
-                </Text>
-              ) : null}
-            </Flex>
-          </ListItem>
-        ))}
-      </List>
+            </ListItem>
+          ))}
+        </List>
+      </div>
     </Flex>
   );
 }
@@ -960,33 +954,35 @@ function AnnotationValues({
       <Text elementType="h3" size="S" weight="heavy">
         Annotation values
       </Text>
-      <List size="S">
-        {values.map(({ label, score }) => (
-          <ListItem key={label}>
-            <Flex
-              direction="row"
-              alignItems="center"
-              justifyContent="space-between"
-              gap="size-100"
-            >
-              <Text size="S">{label}</Text>
-              <Text size="XS" color="text-500">
-                <AnnotationScoreText
-                  elementType="span"
-                  fontFamily="mono"
-                  size="XS"
-                  positiveOptimization={getPositiveOptimization({
-                    score,
-                    ...optimizationBounds,
-                  })}
-                >
-                  {score ?? "—"}
-                </AnnotationScoreText>
-              </Text>
-            </Flex>
-          </ListItem>
-        ))}
-      </List>
+      <div css={[detailsSectionWellCSS, listSectionWellCSS]}>
+        <List size="S">
+          {values.map(({ label, score }) => (
+            <ListItem key={label}>
+              <Flex
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                gap="size-100"
+              >
+                <Text size="S">{label}</Text>
+                <Text size="XS" color="text-500">
+                  <AnnotationScoreText
+                    elementType="span"
+                    fontFamily="mono"
+                    size="XS"
+                    positiveOptimization={getPositiveOptimization({
+                      score,
+                      ...optimizationBounds,
+                    })}
+                  >
+                    {score ?? "—"}
+                  </AnnotationScoreText>
+                </Text>
+              </Flex>
+            </ListItem>
+          ))}
+        </List>
+      </div>
     </Flex>
   );
 }
@@ -1094,7 +1090,7 @@ function EvaluatorPromptPreview({
       <Text elementType="h3" size="S" weight="heavy">
         Prompt
       </Text>
-      <div css={promptPreviewWellCSS}>
+      <div css={detailsSectionWellCSS}>
         <ExpandableContent
           height={PROMPT_PREVIEW_COLLAPSED_HEIGHT}
           expandedBehavior="grow"
@@ -1232,12 +1228,16 @@ const stickyUseTemplateFooterCSS = css`
 const PROMPT_PREVIEW_COLLAPSED_HEIGHT = 160;
 const CODE_PREVIEW_COLLAPSED_HEIGHT = 240;
 
-const promptPreviewWellCSS = css`
+const detailsSectionWellCSS = css`
   background-color: var(--global-background-color-100);
   border: var(--global-border-size-thin) solid
     var(--global-border-color-default);
   border-radius: var(--global-rounding-medium);
   padding: var(--global-dimension-size-150);
+`;
+
+const listSectionWellCSS = css`
+  padding: var(--global-dimension-size-50);
 `;
 
 const promptPreviewMessageCSS = css`

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f1e71a04b535ac9e76732247443c3b9>>
+ * @generated SignedSource<<3273bd674cc1f7229f5ef3a25faf817f>>
  * @lightSyntaxTransform
  */
 
@@ -74,17 +74,24 @@ v6 = {
   "storageKey": null
 },
 v7 = {
+  "alias": "llmInputSchema",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "inputSchema",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "InlineFragment",
   "selections": [
     (v4/*:: as any*/),
-    (v7/*:: as any*/),
+    (v8/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -114,36 +121,36 @@ v8 = {
   "type": "CategoricalAnnotationConfig",
   "abstractKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v11 = {
-  "kind": "InlineFragment",
-  "selections": [
-    (v4/*:: as any*/),
-    (v7/*:: as any*/),
-    (v9/*:: as any*/),
-    (v10/*:: as any*/)
-  ],
-  "type": "ContinuousAnnotationConfig",
-  "abstractKey": null
-},
 v12 = {
   "kind": "InlineFragment",
   "selections": [
     (v4/*:: as any*/),
-    (v7/*:: as any*/),
+    (v8/*:: as any*/),
+    (v10/*:: as any*/),
+    (v11/*:: as any*/)
+  ],
+  "type": "ContinuousAnnotationConfig",
+  "abstractKey": null
+},
+v13 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v4/*:: as any*/),
+    (v8/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -151,13 +158,13 @@ v12 = {
       "name": "threshold",
       "storageKey": null
     },
-    (v9/*:: as any*/),
-    (v10/*:: as any*/)
+    (v10/*:: as any*/),
+    (v11/*:: as any*/)
   ],
   "type": "FreeformAnnotationConfig",
   "abstractKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -166,20 +173,20 @@ v13 = {
   "plural": true,
   "selections": [
     (v2/*:: as any*/),
-    (v8/*:: as any*/),
-    (v11/*:: as any*/),
-    (v12/*:: as any*/)
+    (v9/*:: as any*/),
+    (v12/*:: as any*/),
+    (v13/*:: as any*/)
   ],
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "templateFormat",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -204,14 +211,14 @@ v15 = {
   "type": "TextContentPart",
   "abstractKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "role",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -225,7 +232,7 @@ v17 = {
   "type": "PromptStringTemplate",
   "abstractKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PromptTools",
@@ -287,34 +294,41 @@ v18 = {
   ],
   "storageKey": null
 },
-v19 = {
+v20 = {
+  "alias": "codeInputSchema",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "inputSchema",
+  "storageKey": null
+},
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "sourceCode",
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "language",
   "storageKey": null
 },
-v21 = [
+v23 = [
   (v3/*:: as any*/)
 ],
-v22 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "SandboxConfig",
   "kind": "LinkedField",
   "name": "sandboxConfig",
   "plural": false,
-  "selections": (v21/*:: as any*/),
+  "selections": (v23/*:: as any*/),
   "storageKey": null
 },
-v23 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "EvaluatorInputMapping",
@@ -339,7 +353,7 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -348,12 +362,12 @@ v24 = {
   "plural": true,
   "selections": [
     (v2/*:: as any*/),
-    (v8/*:: as any*/),
-    (v11/*:: as any*/),
+    (v9/*:: as any*/),
     (v12/*:: as any*/),
+    (v13/*:: as any*/),
     {
       "kind": "InlineFragment",
-      "selections": (v21/*:: as any*/),
+      "selections": (v23/*:: as any*/),
       "type": "Node",
       "abstractKey": "__isNode"
     }
@@ -388,7 +402,8 @@ return {
                   (v4/*:: as any*/),
                   (v5/*:: as any*/),
                   (v6/*:: as any*/),
-                  (v13/*:: as any*/),
+                  (v7/*:: as any*/),
+                  (v14/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -397,7 +412,7 @@ return {
                     "name": "promptVersion",
                     "plural": false,
                     "selections": [
-                      (v14/*:: as any*/),
+                      (v15/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -430,11 +445,11 @@ return {
                                         "name": "content",
                                         "plural": true,
                                         "selections": [
-                                          (v15/*:: as any*/)
+                                          (v16/*:: as any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v16/*:: as any*/)
+                                      (v17/*:: as any*/)
                                     ],
                                     "args": null,
                                     "argumentDefinitions": []
@@ -446,11 +461,11 @@ return {
                             "type": "PromptChatTemplate",
                             "abstractKey": null
                           },
-                          (v17/*:: as any*/)
+                          (v18/*:: as any*/)
                         ],
                         "storageKey": null
                       },
-                      (v18/*:: as any*/)
+                      (v19/*:: as any*/)
                     ],
                     "storageKey": null
                   }
@@ -474,11 +489,12 @@ return {
                   (v4/*:: as any*/),
                   (v5/*:: as any*/),
                   (v6/*:: as any*/),
-                  (v13/*:: as any*/),
-                  (v19/*:: as any*/),
                   (v20/*:: as any*/),
+                  (v14/*:: as any*/),
+                  (v21/*:: as any*/),
                   (v22/*:: as any*/),
-                  (v23/*:: as any*/)
+                  (v24/*:: as any*/),
+                  (v25/*:: as any*/)
                 ],
                 "type": "CodeEvaluator",
                 "abstractKey": null
@@ -516,7 +532,8 @@ return {
               (v4/*:: as any*/),
               (v5/*:: as any*/),
               (v6/*:: as any*/),
-              (v24/*:: as any*/),
+              (v7/*:: as any*/),
+              (v26/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -525,7 +542,7 @@ return {
                 "name": "promptVersion",
                 "plural": false,
                 "selections": [
-                  (v14/*:: as any*/),
+                  (v15/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -555,11 +572,11 @@ return {
                                 "plural": true,
                                 "selections": [
                                   (v2/*:: as any*/),
-                                  (v15/*:: as any*/)
+                                  (v16/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v16/*:: as any*/)
+                              (v17/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -567,11 +584,11 @@ return {
                         "type": "PromptChatTemplate",
                         "abstractKey": null
                       },
-                      (v17/*:: as any*/)
+                      (v18/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*:: as any*/),
+                  (v19/*:: as any*/),
                   (v3/*:: as any*/)
                 ],
                 "storageKey": null
@@ -586,11 +603,12 @@ return {
               (v4/*:: as any*/),
               (v5/*:: as any*/),
               (v6/*:: as any*/),
-              (v24/*:: as any*/),
-              (v19/*:: as any*/),
               (v20/*:: as any*/),
+              (v26/*:: as any*/),
+              (v21/*:: as any*/),
               (v22/*:: as any*/),
-              (v23/*:: as any*/)
+              (v24/*:: as any*/),
+              (v25/*:: as any*/)
             ],
             "type": "CodeEvaluator",
             "abstractKey": null
@@ -601,12 +619,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9142867e7a26fc8cca78b4ace9c8f639",
+    "cacheID": "a3698f1b10f211614fb82fa4527076d5",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorDetailsQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorDetailsQuery(\n  $id: ID!\n) {\n  evaluator: node(id: $id) {\n    __typename\n    ...projectEvaluatorOptions_llmEvaluatorDetails\n    ...projectEvaluatorOptions_codeEvaluatorDetails\n    id\n  }\n}\n\nfragment projectEvaluatorOptions_codeEvaluatorDetails on CodeEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  sourceCode\n  language\n  sandboxConfig {\n    id\n  }\n  inputMapping {\n    pathMapping\n    literalMapping\n  }\n}\n\nfragment projectEvaluatorOptions_llmEvaluatorDetails on LLMEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  promptVersion {\n    templateFormat\n    template {\n      __typename\n      ... on PromptChatTemplate {\n        messages {\n          ...promptUtils_promptMessages\n        }\n      }\n      ... on PromptStringTemplate {\n        template\n      }\n    }\n    tools {\n      tools {\n        __typename\n        ... on PromptToolFunction {\n          function {\n            parameters\n          }\n        }\n        ... on PromptToolRaw {\n          raw\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
+    "text": "query projectEvaluatorDetailsQuery(\n  $id: ID!\n) {\n  evaluator: node(id: $id) {\n    __typename\n    ...projectEvaluatorOptions_llmEvaluatorDetails\n    ...projectEvaluatorOptions_codeEvaluatorDetails\n    id\n  }\n}\n\nfragment projectEvaluatorOptions_codeEvaluatorDetails on CodeEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  codeInputSchema: inputSchema\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  sourceCode\n  language\n  sandboxConfig {\n    id\n  }\n  inputMapping {\n    pathMapping\n    literalMapping\n  }\n}\n\nfragment projectEvaluatorOptions_llmEvaluatorDetails on LLMEvaluator {\n  __typename\n  id\n  name\n  description\n  kind\n  llmInputSchema: inputSchema\n  outputConfigs {\n    __typename\n    ... on CategoricalAnnotationConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n    }\n    ... on ContinuousAnnotationConfig {\n      name\n      optimizationDirection\n      lowerBound\n      upperBound\n    }\n    ... on FreeformAnnotationConfig {\n      name\n      optimizationDirection\n      threshold\n      lowerBound\n      upperBound\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  promptVersion {\n    templateFormat\n    template {\n      __typename\n      ... on PromptChatTemplate {\n        messages {\n          ...promptUtils_promptMessages\n        }\n      }\n      ... on PromptStringTemplate {\n        template\n      }\n    }\n    tools {\n      tools {\n        __typename\n        ... on PromptToolFunction {\n          function {\n            parameters\n          }\n        }\n        ... on PromptToolRaw {\n          raw\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
   }
 };
 })();

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorGalleryPageQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorGalleryPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4c65a99ec6cba54ca38d8cd1367e5111>>
+ * @generated SignedSource<<e41d4da92d3735fd1cf66b8d3b782210>>
  * @lightSyntaxTransform
  */
 
@@ -21,6 +21,10 @@ export type projectEvaluatorGalleryPageQuery$data = {
     readonly choices: any;
     readonly description: string | null;
     readonly details: string | null;
+    readonly inputs: ReadonlyArray<{
+      readonly description: string;
+      readonly name: string;
+    }> | null;
     readonly messages: ReadonlyArray<{
       readonly " $fragmentSpreads": FragmentRefs<"promptUtils_promptMessages">;
     }>;
@@ -102,6 +106,19 @@ v7 = {
   "storageKey": null
 },
 v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EvaluatorInput",
+  "kind": "LinkedField",
+  "name": "inputs",
+  "plural": true,
+  "selections": [
+    (v1/*:: as any*/),
+    (v2/*:: as any*/)
+  ],
+  "storageKey": null
+},
+v9 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -126,33 +143,33 @@ v8 = {
   "type": "TextContentPart",
   "abstractKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "role",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Variable",
   "name": "excludeProjectId",
   "variableName": "projectId"
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": "evaluator",
   "args": null,
   "concreteType": null,
@@ -160,21 +177,21 @@ v13 = {
   "name": "node",
   "plural": false,
   "selections": [
-    (v11/*:: as any*/),
     (v12/*:: as any*/),
+    (v13/*:: as any*/),
     (v1/*:: as any*/),
     (v2/*:: as any*/)
   ],
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -199,8 +216,8 @@ v15 = {
   ],
   "storageKey": null
 },
-v16 = [
-  (v10/*:: as any*/),
+v17 = [
+  (v11/*:: as any*/),
   {
     "kind": "Literal",
     "name": "first",
@@ -237,6 +254,7 @@ return {
           (v5/*:: as any*/),
           (v6/*:: as any*/),
           (v7/*:: as any*/),
+          (v8/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -257,11 +275,11 @@ return {
                     "name": "content",
                     "plural": true,
                     "selections": [
-                      (v8/*:: as any*/)
+                      (v9/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v9/*:: as any*/)
+                  (v10/*:: as any*/)
                 ],
                 "args": null,
                 "argumentDefinitions": []
@@ -275,7 +293,7 @@ return {
       {
         "alias": "evaluators",
         "args": [
-          (v10/*:: as any*/)
+          (v11/*:: as any*/)
         ],
         "concreteType": "EvaluatorConnection",
         "kind": "LinkedField",
@@ -290,8 +308,8 @@ return {
             "name": "edges",
             "plural": true,
             "selections": [
-              (v13/*:: as any*/),
               (v14/*:: as any*/),
+              (v15/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -300,14 +318,14 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v11/*:: as any*/)
+                  (v12/*:: as any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v15/*:: as any*/)
+          (v16/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -336,6 +354,7 @@ return {
           (v5/*:: as any*/),
           (v6/*:: as any*/),
           (v7/*:: as any*/),
+          (v8/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -352,12 +371,12 @@ return {
                 "name": "content",
                 "plural": true,
                 "selections": [
-                  (v11/*:: as any*/),
-                  (v8/*:: as any*/)
+                  (v12/*:: as any*/),
+                  (v9/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v9/*:: as any*/)
+              (v10/*:: as any*/)
             ],
             "storageKey": null
           }
@@ -366,7 +385,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v16/*:: as any*/),
+        "args": (v17/*:: as any*/),
         "concreteType": "EvaluatorConnection",
         "kind": "LinkedField",
         "name": "evaluators",
@@ -380,8 +399,8 @@ return {
             "name": "edges",
             "plural": true,
             "selections": [
-              (v13/*:: as any*/),
               (v14/*:: as any*/),
+              (v15/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -390,21 +409,21 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v11/*:: as any*/),
-                  (v12/*:: as any*/)
+                  (v12/*:: as any*/),
+                  (v13/*:: as any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v15/*:: as any*/)
+          (v16/*:: as any*/)
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v16/*:: as any*/),
+        "args": (v17/*:: as any*/),
         "filters": [
           "excludeProjectId"
         ],
@@ -416,7 +435,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c65916cdaaa4447e7b4a926b4607e957",
+    "cacheID": "436e3265740db2e43c42fa0c6b0cccfa",
     "id": null,
     "metadata": {
       "connection": [
@@ -432,11 +451,11 @@ return {
     },
     "name": "projectEvaluatorGalleryPageQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorGalleryPageQuery(\n  $projectId: ID!\n) {\n  evaluatorGalleryConfigs {\n    name\n    description\n    choices\n    optimizationDirection\n    scope\n    category\n    details\n    messages {\n      ...promptUtils_promptMessages\n    }\n  }\n  evaluators(first: 100, sort: {col: updatedAt, dir: desc}, excludeProjectId: $projectId) {\n    edges {\n      evaluator: node {\n        __typename\n        id\n        name\n        description\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
+    "text": "query projectEvaluatorGalleryPageQuery(\n  $projectId: ID!\n) {\n  evaluatorGalleryConfigs {\n    name\n    description\n    choices\n    optimizationDirection\n    scope\n    category\n    details\n    inputs {\n      name\n      description\n    }\n    messages {\n      ...promptUtils_promptMessages\n    }\n  }\n  evaluators(first: 100, sort: {col: updatedAt, dir: desc}, excludeProjectId: $projectId) {\n    edges {\n      evaluator: node {\n        __typename\n        id\n        name\n        description\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
   }
 };
 })();
 
-(node as any).hash = "28ad96fb28fca0f8f2afea73560b063e";
+(node as any).hash = "2876d6ef4338ad6ef8db2c6fb35760f8";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_codeEvaluatorDetails.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<71bb70f9ed8db0416e5d7ab1671e0719>>
+ * @generated SignedSource<<2cb4782a5faedfe514bbda02a650856e>>
  * @lightSyntaxTransform
  */
 
@@ -14,6 +14,7 @@ export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 import { FragmentRefs } from "relay-runtime";
 export type projectEvaluatorOptions_codeEvaluatorDetails$data = {
   readonly __typename: "CodeEvaluator";
+  readonly codeInputSchema: any | null;
   readonly description: string | null;
   readonly id: string;
   readonly inputMapping: {
@@ -65,6 +66,6 @@ const node: ReaderInlineDataFragment = {
   "name": "projectEvaluatorOptions_codeEvaluatorDetails"
 };
 
-(node as any).hash = "909a71aa9d157eb5cff56e368fc79cc2";
+(node as any).hash = "f8acbca29ae9f38b9b1b91246145910b";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<43f898c03a309fbd942be0a3aa8e982e>>
+ * @generated SignedSource<<e84bae7f26625170d5a6fe7d1e03f8f0>>
  * @lightSyntaxTransform
  */
 
@@ -17,7 +17,7 @@ export type projectEvaluatorOptions_llmEvaluatorDetails$data = {
   readonly description: string | null;
   readonly id: string;
   readonly kind: EvaluatorKind;
-  readonly llmInputSchema: any | null;
+  readonly llmInputSchema: any;
   readonly name: string;
   readonly outputConfigs: ReadonlyArray<{
     readonly __typename: "CategoricalAnnotationConfig";

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorOptions_llmEvaluatorDetails.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<53b4844e90f6632cb246c0f7dc2d1067>>
+ * @generated SignedSource<<43f898c03a309fbd942be0a3aa8e982e>>
  * @lightSyntaxTransform
  */
 
@@ -17,6 +17,7 @@ export type projectEvaluatorOptions_llmEvaluatorDetails$data = {
   readonly description: string | null;
   readonly id: string;
   readonly kind: EvaluatorKind;
+  readonly llmInputSchema: any | null;
   readonly name: string;
   readonly outputConfigs: ReadonlyArray<{
     readonly __typename: "CategoricalAnnotationConfig";
@@ -87,6 +88,6 @@ const node: ReaderInlineDataFragment = {
   "name": "projectEvaluatorOptions_llmEvaluatorDetails"
 };
 
-(node as any).hash = "9f85a7ee11194d88d261c88f48464018";
+(node as any).hash = "e9490d681bf7fe3a06f782c3715dbef0";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql.ts
+++ b/js/app/src/pages/project/evaluators/__generated__/projectEvaluatorTemplatesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3ba5bece667c2aeb6e53064903e2ff41>>
+ * @generated SignedSource<<8a70b058b1df6d70c35b14c9be64c12a>>
  * @lightSyntaxTransform
  */
 
@@ -19,6 +19,10 @@ export type projectEvaluatorTemplatesQuery$data = {
     readonly choices: any;
     readonly description: string | null;
     readonly details: string | null;
+    readonly inputs: ReadonlyArray<{
+      readonly description: string;
+      readonly name: string;
+    }> | null;
     readonly messages: ReadonlyArray<{
       readonly " $fragmentSpreads": FragmentRefs<"promptUtils_promptMessages">;
     }>;
@@ -83,6 +87,19 @@ v6 = {
   "storageKey": null
 },
 v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EvaluatorInput",
+  "kind": "LinkedField",
+  "name": "inputs",
+  "plural": true,
+  "selections": [
+    (v0/*:: as any*/),
+    (v1/*:: as any*/)
+  ],
+  "storageKey": null
+},
+v8 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -107,7 +124,7 @@ v7 = {
   "type": "TextContentPart",
   "abstractKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -136,6 +153,7 @@ return {
           (v4/*:: as any*/),
           (v5/*:: as any*/),
           (v6/*:: as any*/),
+          (v7/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -156,11 +174,11 @@ return {
                     "name": "content",
                     "plural": true,
                     "selections": [
-                      (v7/*:: as any*/)
+                      (v8/*:: as any*/)
                     ],
                     "storageKey": null
                   },
-                  (v8/*:: as any*/)
+                  (v9/*:: as any*/)
                 ],
                 "args": null,
                 "argumentDefinitions": []
@@ -196,6 +214,7 @@ return {
           (v4/*:: as any*/),
           (v5/*:: as any*/),
           (v6/*:: as any*/),
+          (v7/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -219,11 +238,11 @@ return {
                     "name": "__typename",
                     "storageKey": null
                   },
-                  (v7/*:: as any*/)
+                  (v8/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v8/*:: as any*/)
+              (v9/*:: as any*/)
             ],
             "storageKey": null
           }
@@ -233,16 +252,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f0e73fa7c6554ae4221a97efd090ac9c",
+    "cacheID": "35fa7efa168c88d02a2ea034d5c720e5",
     "id": null,
     "metadata": {},
     "name": "projectEvaluatorTemplatesQuery",
     "operationKind": "query",
-    "text": "query projectEvaluatorTemplatesQuery {\n  evaluatorGalleryConfigs {\n    name\n    description\n    choices\n    optimizationDirection\n    scope\n    category\n    details\n    messages {\n      ...promptUtils_promptMessages\n    }\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
+    "text": "query projectEvaluatorTemplatesQuery {\n  evaluatorGalleryConfigs {\n    name\n    description\n    choices\n    optimizationDirection\n    scope\n    category\n    details\n    inputs {\n      name\n      description\n    }\n    messages {\n      ...promptUtils_promptMessages\n    }\n  }\n}\n\nfragment promptUtils_promptMessages on PromptMessage {\n  content {\n    __typename\n    ... on TextContentPart {\n      text {\n        text\n      }\n    }\n  }\n  role\n}\n"
   }
 };
 })();
 
-(node as any).hash = "157fdc1db6e6d4a22592570e2efd0a2d";
+(node as any).hash = "fde662a46912e3a998226124fcbb54ba";
 
 export default node;

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts
@@ -1,5 +1,6 @@
 import {
   buildCopyCodeCreationMode,
+  getEvaluatorInputSummaries,
   type CodeProjectEvaluatorDetails,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorOptions";
 
@@ -9,6 +10,12 @@ const codeEvaluator = {
   name: "checks-output",
   description: "Checks the final answer",
   kind: "CODE",
+  codeInputSchema: {
+    type: "object",
+    properties: { output: {} },
+    required: ["output"],
+  },
+  inputs: [{ name: "output" }],
   language: "TYPESCRIPT",
   sourceCode: "function evaluate(output: string) { return output.length; }",
   sandboxConfig: { id: "SandboxConfig:1" },
@@ -63,5 +70,38 @@ describe("buildCopyCodeCreationMode", () => {
         sandboxConfig: null,
       }).initialState.sandboxConfigId
     ).toBeNull();
+  });
+});
+
+describe("getEvaluatorInputSummaries", () => {
+  it("returns names and available type and description metadata", () => {
+    expect(
+      getEvaluatorInputSummaries({
+        type: "object",
+        properties: {
+          input: {
+            type: "string",
+            description: "The input to evaluate",
+          },
+          context: {},
+          score: {
+            anyOf: [{ type: "number" }, { type: "null" }],
+          },
+        },
+      })
+    ).toEqual([
+      {
+        name: "input",
+        type: "string",
+        description: "The input to evaluate",
+      },
+      { name: "context", type: undefined, description: undefined },
+      { name: "score", type: "number | null", description: undefined },
+    ]);
+  });
+
+  it("returns no inputs when the schema has no property map", () => {
+    expect(getEvaluatorInputSummaries(null)).toEqual([]);
+    expect(getEvaluatorInputSummaries({ type: "object" })).toEqual([]);
   });
 });

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts
@@ -74,7 +74,7 @@ describe("buildCopyCodeCreationMode", () => {
 });
 
 describe("getEvaluatorInputSummaries", () => {
-  it("returns names and available type and description metadata", () => {
+  it("returns names and descriptions without schema type metadata", () => {
     expect(
       getEvaluatorInputSummaries({
         type: "object",
@@ -92,11 +92,10 @@ describe("getEvaluatorInputSummaries", () => {
     ).toEqual([
       {
         name: "input",
-        type: "string",
         description: "The input to evaluate",
       },
-      { name: "context", type: undefined, description: undefined },
-      { name: "score", type: "number | null", description: undefined },
+      { name: "context", description: undefined },
+      { name: "score", description: undefined },
     ]);
   });
 

--- a/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -166,7 +166,6 @@ type ProjectEvaluatorDetailsNode = NonNullable<
 
 export type EvaluatorInputSummary = {
   readonly name: string;
-  readonly type?: string;
   readonly description?: string;
 };
 
@@ -218,27 +217,13 @@ export function getEvaluatorInputSummaries(
   if (!isStringKeyedObject(properties)) return [];
   return Object.entries(properties).map(([name, unknownProperty]) => {
     if (!isStringKeyedObject(unknownProperty)) return { name };
-    const type = getJsonSchemaPropertyType(unknownProperty);
     const description =
       typeof unknownProperty.description === "string" &&
       unknownProperty.description.trim()
         ? unknownProperty.description
         : undefined;
-    return { name, type, description };
+    return { name, description };
   });
-}
-
-function getJsonSchemaPropertyType(
-  property: Record<string, unknown>
-): string | undefined {
-  if (typeof property.type === "string") return property.type;
-  if (!Array.isArray(property.anyOf)) return undefined;
-  const types = property.anyOf.flatMap((variant) =>
-    isStringKeyedObject(variant) && typeof variant.type === "string"
-      ? [variant.type]
-      : []
-  );
-  return types.length > 0 ? types.join(" | ") : undefined;
 }
 
 export type BuildCopyLlmCreationModeResult =

--- a/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorOptions.ts
@@ -47,6 +47,7 @@ const llmProjectEvaluatorDetailsFragment = graphql`
     name
     description
     kind
+    llmInputSchema: inputSchema
     outputConfigs {
       __typename
       ... on CategoricalAnnotationConfig {
@@ -109,6 +110,7 @@ const codeProjectEvaluatorDetailsFragment = graphql`
     name
     description
     kind
+    codeInputSchema: inputSchema
     outputConfigs {
       __typename
       ... on CategoricalAnnotationConfig {
@@ -162,10 +164,20 @@ type ProjectEvaluatorDetailsNode = NonNullable<
   projectEvaluatorDetailsQuery["response"]["evaluator"]
 >;
 
+export type EvaluatorInputSummary = {
+  readonly name: string;
+  readonly type?: string;
+  readonly description?: string;
+};
+
 export type LlmProjectEvaluatorDetails =
-  projectEvaluatorOptions_llmEvaluatorDetails$data;
+  projectEvaluatorOptions_llmEvaluatorDetails$data & {
+    readonly inputs: readonly EvaluatorInputSummary[];
+  };
 export type CodeProjectEvaluatorDetails =
-  projectEvaluatorOptions_codeEvaluatorDetails$data;
+  projectEvaluatorOptions_codeEvaluatorDetails$data & {
+    readonly inputs: readonly EvaluatorInputSummary[];
+  };
 export type ProjectEvaluatorDetails =
   | LlmProjectEvaluatorDetails
   | CodeProjectEvaluatorDetails;
@@ -174,18 +186,59 @@ export function readProjectEvaluatorDetails(
   evaluator: ProjectEvaluatorDetailsNode | null
 ): ProjectEvaluatorDetails | null {
   if (evaluator?.__typename === "LLMEvaluator") {
-    return readInlineData<projectEvaluatorOptions_llmEvaluatorDetails$key>(
-      llmProjectEvaluatorDetailsFragment,
-      evaluator
-    );
+    const details =
+      readInlineData<projectEvaluatorOptions_llmEvaluatorDetails$key>(
+        llmProjectEvaluatorDetailsFragment,
+        evaluator
+      );
+    return {
+      ...details,
+      inputs: getEvaluatorInputSummaries(details.llmInputSchema),
+    };
   }
   if (evaluator?.__typename === "CodeEvaluator") {
-    return readInlineData<projectEvaluatorOptions_codeEvaluatorDetails$key>(
-      codeProjectEvaluatorDetailsFragment,
-      evaluator
-    );
+    const details =
+      readInlineData<projectEvaluatorOptions_codeEvaluatorDetails$key>(
+        codeProjectEvaluatorDetailsFragment,
+        evaluator
+      );
+    return {
+      ...details,
+      inputs: getEvaluatorInputSummaries(details.codeInputSchema),
+    };
   }
   return null;
+}
+
+export function getEvaluatorInputSummaries(
+  inputSchema: unknown
+): EvaluatorInputSummary[] {
+  if (!isStringKeyedObject(inputSchema)) return [];
+  const properties = inputSchema.properties;
+  if (!isStringKeyedObject(properties)) return [];
+  return Object.entries(properties).map(([name, unknownProperty]) => {
+    if (!isStringKeyedObject(unknownProperty)) return { name };
+    const type = getJsonSchemaPropertyType(unknownProperty);
+    const description =
+      typeof unknownProperty.description === "string" &&
+      unknownProperty.description.trim()
+        ? unknownProperty.description
+        : undefined;
+    return { name, type, description };
+  });
+}
+
+function getJsonSchemaPropertyType(
+  property: Record<string, unknown>
+): string | undefined {
+  if (typeof property.type === "string") return property.type;
+  if (!Array.isArray(property.anyOf)) return undefined;
+  const types = property.anyOf.flatMap((variant) =>
+    isStringKeyedObject(variant) && typeof variant.type === "string"
+      ? [variant.type]
+      : []
+  );
+  return types.length > 0 ? types.join(" | ") : undefined;
 }
 
 export type BuildCopyLlmCreationModeResult =

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTemplates.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTemplates.ts
@@ -18,6 +18,10 @@ export const projectEvaluatorTemplatesQuery = graphql`
       scope
       category
       details
+      inputs {
+        name
+        description
+      }
       messages {
         ...promptUtils_promptMessages
       }

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -40,6 +40,8 @@ from phoenix.db.types.model_provider import ModelProvider
 from phoenix.db.types.prompts import (
     PromptChatTemplate,
     PromptInvocationParameters,
+    PromptStringTemplate,
+    PromptTemplate,
     PromptTemplateFormat,
     PromptTools,
     RoleConversion,
@@ -301,20 +303,10 @@ class LLMEvaluator(BaseEvaluator):
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        formatter = get_template_formatter(self._template_format)
-        parsed: list[ParsedVariables] = []
-
-        for msg in self._template.messages:
-            if isinstance(msg.content, str):
-                parsed.append(formatter.parse_with_types(msg.content))
-            elif isinstance(msg.content, list):
-                for part in msg.content:
-                    if isinstance(part, TextContentPart):
-                        parsed.append(formatter.parse_with_types(part.text))
-            else:
-                assert_never(msg.content)
-
-        return input_schema_from_parsed_variables(parsed)
+        return infer_input_schema_from_prompt_template(
+            template=self._template,
+            template_format=self._template_format,
+        )
 
     async def evaluate(
         self,
@@ -1171,6 +1163,33 @@ def input_schema_from_parsed_variables(
         "properties": properties,
         "required": sorted(all_vars),
     }
+
+
+def infer_input_schema_from_prompt_template(
+    *,
+    template: PromptTemplate,
+    template_format: PromptTemplateFormat,
+) -> dict[str, Any]:
+    """Infer an evaluator input schema from a stored prompt template."""
+    formatter = get_template_formatter(template_format)
+    parsed: list[ParsedVariables] = []
+    if isinstance(template, PromptStringTemplate):
+        parsed.append(formatter.parse_with_types(template.template))
+    elif isinstance(template, PromptChatTemplate):
+        for message in template.messages:
+            if isinstance(message.content, str):
+                parsed.append(formatter.parse_with_types(message.content))
+            elif isinstance(message.content, list):
+                parsed.extend(
+                    formatter.parse_with_types(part.text)
+                    for part in message.content
+                    if isinstance(part, TextContentPart)
+                )
+            else:
+                assert_never(message.content)
+    else:
+        assert_never(template)
+    return input_schema_from_parsed_variables(parsed)
 
 
 def infer_input_schema_from_template(

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -282,7 +282,7 @@ class CodeEvaluatorVersion(Node):
     async def input_schema(
         self,
         info: Info[Context, None],
-    ) -> Optional[JSON]:
+    ) -> JSON:
         return await _infer_code_evaluator_input_schema(
             info=info,
             code_evaluator_id=self.code_evaluator_id,

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -25,7 +25,12 @@ from phoenix.db.types.annotation_configs import (
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.api.context import Context
 from phoenix.server.api.dataloaders.project_evaluator_run_counts import ProjectEvaluatorRunCounts
-from phoenix.server.api.evaluators import BuiltInEvaluator as BuiltInEvaluatorClass
+from phoenix.server.api.evaluators import (
+    BuiltInEvaluator as BuiltInEvaluatorClass,
+)
+from phoenix.server.api.evaluators import (
+    infer_input_schema_from_prompt_template,
+)
 from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.input_types.TimeBinConfig import TimeBinConfig
 from phoenix.server.api.input_types.TimeRange import TimeRange
@@ -277,7 +282,7 @@ class CodeEvaluatorVersion(Node):
     async def input_schema(
         self,
         info: Info[Context, None],
-    ) -> JSON:
+    ) -> Optional[JSON]:
         return await _infer_code_evaluator_input_schema(
             info=info,
             code_evaluator_id=self.code_evaluator_id,
@@ -770,7 +775,14 @@ class LLMEvaluator(Evaluator, Node):
     async def input_schema(
         self,
         info: Info[Context, None],
-    ) -> Optional[JSON]: ...  # TODO: Implement
+    ) -> JSON:
+        prompt_version = await self._get_prompt_version(info)
+        return JSON(
+            infer_input_schema_from_prompt_template(
+                template=prompt_version.template,
+                template_format=prompt_version.template_format,
+            )
+        )
 
     @strawberry.field
     async def user(
@@ -793,6 +805,15 @@ class LLMEvaluator(Evaluator, Node):
         self,
         info: Info[Context, None],
     ) -> Annotated["PromptVersion", strawberry.lazy(".PromptVersion")]:
+        prompt_version = await self._get_prompt_version(info)
+        from .PromptVersion import to_gql_prompt_version
+
+        return to_gql_prompt_version(prompt_version)
+
+    async def _get_prompt_version(
+        self,
+        info: Info[Context, None],
+    ) -> models.PromptVersion:
         if self.db_record:
             prompt_id = self.db_record.prompt_id
             prompt_version_tag_id = self.db_record.prompt_version_tag_id
@@ -807,26 +828,27 @@ class LLMEvaluator(Evaluator, Node):
                 ]
             )
         if prompt_version_tag_id is not None:
-            stmt = (
-                sa.select(models.PromptVersion)
-                .join(models.PromptVersionTag)
-                .where(models.PromptVersionTag.prompt_id == prompt_id)
-                .where(models.PromptVersionTag.id == prompt_version_tag_id)
+            (
+                tag_prompt_id,
+                prompt_version_id,
+            ) = await info.context.data_loaders.prompt_version_tag_fields.load_many(
+                [
+                    (prompt_version_tag_id, models.PromptVersionTag.prompt_id),
+                    (prompt_version_tag_id, models.PromptVersionTag.prompt_version_id),
+                ]
             )
-        else:
-            stmt = (
-                sa.select(models.PromptVersion)
-                .where(models.PromptVersion.prompt_id == prompt_id)
-                .order_by(models.PromptVersion.id.desc())
-                .limit(1)
-            )
-        async with info.context.db.read() as session:
-            prompt_version = await session.scalar(stmt)
-            if prompt_version is None:
+            if tag_prompt_id != prompt_id:
                 raise NotFound(f"Prompt version not found for prompt {prompt_id}")
-        from .PromptVersion import to_gql_prompt_version
-
-        return to_gql_prompt_version(prompt_version)
+        else:
+            prompt_version_id = await info.context.data_loaders.latest_prompt_version_ids.load(
+                prompt_id
+            )
+        if prompt_version_id is None:
+            raise NotFound(f"Prompt version not found for prompt {prompt_id}")
+        prompt_version = await info.context.data_loaders.prompt_versions.load(prompt_version_id)
+        if prompt_version is None or prompt_version.prompt_id != prompt_id:
+            raise NotFound(f"Prompt version not found for prompt {prompt_id}")
+        return prompt_version
 
 
 @strawberry.type

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -65,8 +65,8 @@ class TestEvaluatorFields:
             await session.flush()
 
             v1, v2 = (
-                _create_prompt_version(prompt.id, "V1: {input}", "gpt-4"),
-                _create_prompt_version(prompt.id, "V2: {input}", "gpt-3.5-turbo"),
+                _create_prompt_version(prompt.id, "V1: {tagged_input}", "gpt-4"),
+                _create_prompt_version(prompt.id, "V2: {latest_input}", "gpt-3.5-turbo"),
             )
             session.add_all([v1, v2])
             await session.flush()
@@ -197,6 +197,30 @@ class TestEvaluatorFields:
             GlobalID("PromptVersionTag", str(_test_data["tag"]))
         )
         assert node["promptVersion"]["id"] == str(GlobalID("PromptVersion", str(_test_data["v1"])))
+
+    async def test_llm_evaluator_input_schema_uses_resolved_prompt_version(
+        self, _test_data: dict[str, Any], gql_client: AsyncGraphQLClient
+    ) -> None:
+        for evaluator_key, input_name in (
+            ("untagged", "latest_input"),
+            ("tagged", "tagged_input"),
+        ):
+            response = await gql_client.execute(
+                """query ($id: ID!) {
+                    node(id: $id) {
+                        ... on LLMEvaluator { inputSchema }
+                    }
+                }""",
+                variables={
+                    "id": str(GlobalID(LLMEvaluator.__name__, str(_test_data[evaluator_key])))
+                },
+            )
+            assert not response.errors and response.data
+            assert response.data["node"]["inputSchema"] == {
+                "type": "object",
+                "properties": {input_name: {"type": "string"}},
+                "required": [input_name],
+            }
 
     async def test_dataset_evaluators_field(
         self, _test_data: dict[str, Any], gql_client: AsyncGraphQLClient


### PR DESCRIPTION
## Summary

- display evaluator input names and available descriptions in the gallery details pane for templates, custom LLM evaluators, and custom code evaluators
- omit input type and required/optional metadata, which is not consistently available across evaluator types
- infer custom LLM evaluator inputs from the selected tagged or latest prompt version using the shared prompt-variable schema logic
- visually group Inputs and Annotation values in bordered sections with spacing that matches Prompt
- keep long evaluator input names contained within the details pane by wrapping unbroken identifiers

## Screenshots

Built-in evaluator inputs show names and available descriptions. Inputs, Annotation values, and Prompt use matching bordered sections:

![Built-in evaluator input names and descriptions](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15851-template-input-descriptions-967a7c8.png)

Custom LLM evaluator inputs show names without unavailable type or description metadata:

![Custom LLM evaluator input names](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15851-custom-llm-inputs-967a7c8.png)

Custom code evaluator inputs are inferred from the evaluator's current source version:

![Custom code evaluator input names](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15851-custom-code-inputs-967a7c8.png)

## Test plan

- `make format-python`
- `make format-frontend`
- `make lint-python`
- `make lint-frontend`
- `make typecheck-frontend`
- `make graphql`
- `pnpm exec vitest run src/pages/project/evaluators/__tests__/projectEvaluatorOptions.test.ts`
- `uv run pytest tests/unit/server/api/types/test_Evaluator.py::TestEvaluatorFields::test_llm_evaluator_input_schema_uses_resolved_prompt_version -n auto`
- browser-verified template, custom LLM, and custom code evaluator details at 1440x900 and 1100x800
- browser-verified the exact rebased head at 1100x800 with a long unbroken input name and no horizontal overflow

Targets `version-online-evals` in #13989. The prerequisite gallery changes in #15771 and #15809 have merged into that stack.
