### PR TITLE
test: stop deriving the MCP servers for every unit-test app

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,6 +55,10 @@ def pytest_configure(config: Config) -> None:
         "real_monty_runtime_probe: run the real Monty runtime startup probe "
         "(spawns a worker subprocess)",
     )
+    config.addinivalue_line(
+        "markers",
+        "real_agent_mcp_server: derive the agent's MCP server from the OpenAPI document",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +74,27 @@ def _stub_code_mode_startup_check(request: FixtureRequest, monkeypatch: pytest.M
         return True
 
     monkeypatch.setattr("phoenix.server.monty_runtime.MontyRuntime.probe_runtime", _skip)
+
+
+@pytest.fixture(autouse=True)
+def _stub_agent_mcp_server(request: FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deriving the agent's MCP server generates the OpenAPI document, about
+    half a second per app. Stubbed suite-wide; tests that need the real server
+    opt in with ``@pytest.mark.real_agent_mcp_server``."""
+    if request.node.get_closest_marker("real_agent_mcp_server"):
+        return
+
+    monkeypatch.setattr(
+        "phoenix.server.app.build_phoenix_mcp_server", lambda *_, **__: (None, None)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mcp_mount_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Building the ``/mcp`` mount derives a FastMCP server from the app's
+    OpenAPI document, about half a second per app. Off suite-wide; the MCP
+    tests patch ``get_env_enable_mcp_server`` on, which wins over the env var."""
+    monkeypatch.setenv("PHOENIX_ENABLE_MCP_SERVER", "false")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/server/agents/capabilities/test_phoenix_mcp.py
+++ b/tests/unit/server/agents/capabilities/test_phoenix_mcp.py
@@ -473,6 +473,7 @@ async def test_the_instructions_account_for_every_directly_named_catalog_tool() 
         assert name in rendered, f"{name} is reachable but the instructions never name it"
 
 
+@pytest.mark.real_agent_mcp_server
 class TestBoundPrincipalAgainstRealV1Auth:
     """The in-memory toolset must present a principal that real /v1 auth accepts.
 

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -3191,6 +3191,45 @@ async def test_chat_endpoint_rejects_regenerate_requests(
     assert response.status_code == 422
 
 
+@pytest.mark.real_agent_mcp_server
+async def test_chat_turn_hands_the_agent_the_phoenix_mcp_server(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The route passes the server ``create_app`` wires to the agent, which the
+    suite-wide stub leaves out of every other test here. The agent sees its
+    code-mode and skill tools and carries its instructions."""
+    session_id = "33333333-3333-4333-8333-333333333333"
+    agent_session_id = await _create_agent_session_row(db)
+    seen: dict[str, Any] = {}
+
+    async def stream_function(
+        messages: list[ModelMessage],
+        agent_info: AgentInfo,
+    ) -> AsyncIterator[str | DeltaToolCalls]:
+        seen["tools"] = {tool.name for tool in agent_info.function_tools}
+        seen["instructions"] = agent_info.instructions or ""
+        yield "done"
+
+    def function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart(tool_name="summary", args={"summary": "title"})])
+
+    _mock_turn_models(
+        monkeypatch, FunctionModel(function=function, stream_function=stream_function)
+    )
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(session_id, _user_message("first question")),
+    )
+
+    assert response.status_code == 200
+    assert {"execute", "search", "get_schema", "tags", "list_tools"} <= seen["tools"]
+    assert {"load_skill", "load_skill_reference"} <= seen["tools"]
+    assert "<name>phoenix-graphql</name>" in seen["instructions"]
+
+
 async def test_generated_session_title_is_limited(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,

--- a/tests/unit/server/test_app_mcp_mount.py
+++ b/tests/unit/server/test_app_mcp_mount.py
@@ -142,6 +142,7 @@ async def test_the_mount_serves_no_skills(
     assert tool_names.isdisjoint({"load_skill", "load_skill_reference"})
 
 
+@pytest.mark.real_agent_mcp_server
 async def test_the_agents_own_server_adds_the_pxi_skills(
     db: DbSessionFactory,
 ) -> None:
@@ -158,6 +159,14 @@ async def test_the_agents_own_server_adds_the_pxi_skills(
     instructions = app.state.pxi_mcp_server.instructions
     assert "<name>phoenix-graphql</name>" in instructions
     assert "<name>project-overview</name>" not in instructions
+
+
+async def test_fixture_app_does_not_generate_the_openapi_document(app: FastAPI) -> None:
+    """Generating the document costs about half a second per app; the suite-wide
+    stubs keep it off every fixture app, so the derived servers are absent."""
+    assert app.openapi_schema is None
+    assert app.state.mcp_http_app is None
+    assert app.state.pxi_mcp_server is None
 
 
 def test_code_mode_requires_a_monty_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -305,6 +314,7 @@ async def test_mcp_server_not_mounted_by_default(
         assert not any(getattr(r, "path", None) == MCP_MOUNT_PATH for r in app.routes)
 
 
+@pytest.mark.real_agent_mcp_server
 class TestAgentMCPServerIsIndependentOfTheMount:
     """The agent's server shares the mount's derivation but not its lifetime or
     configuration."""
@@ -346,26 +356,29 @@ class TestAgentMCPServerIsIndependentOfTheMount:
     async def test_surface_is_read_only(
         self, db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Against the real ``/v1`` spec rather than a stand-in.
-
-        Code mode hides the derived tools behind ``execute``, so this asserts on
-        the derivation the agent's server is built from. That the sandbox catalog
-        reflects it is covered in ``test_phoenix_mcp``.
+        """Through the server ``create_app`` wires, so the read-only derivation is
+        the one sessions get. Code mode hides the derived tools behind
+        ``execute``; the ``list_tools`` discovery tool is the view of that catalog,
+        checked against every operation in the OpenAPI document.
         """
-        from phoenix.server.mcp_server import build_phoenix_mcp_server
+        import json
+
+        from fastmcp import Client
 
         monkeypatch.setattr("phoenix.server.app.get_env_enable_mcp_server", lambda: False)
 
         app = await self._create_app(db)
         assert app.state.pxi_mcp_server is not None
-        derived, _ = build_phoenix_mcp_server(app, code_mode=False, read_only=True, db=_unused_db())
-        tools = await derived.list_tools()
+        async with Client(app.state.pxi_mcp_server) as client:
+            result = await client.call_tool("list_tools", {"detail": "full"})
+        catalog = {tool["name"] for tool in json.loads(result.structured_content["result"])}
 
-        assert tools, "expected the /v1 spec to yield tools"
-        for tool in tools:
-            if tool.annotations is None:  # the group meta-tools carry their own
-                continue
-            assert tool.annotations.readOnlyHint is True, f"{tool.name} is not read-only"
+        operation_ids: dict[bool, set[str]] = {True: set(), False: set()}
+        for operations in app.openapi()["paths"].values():
+            for method, operation in operations.items():
+                operation_ids[method == "get"].add(operation["operationId"])
+        assert operation_ids[True] <= catalog
+        assert catalog.isdisjoint(operation_ids[False]), catalog & operation_ids[False]
 
 
 async def test_mcp_code_mode_replaces_tool_surface(


### PR DESCRIPTION
resolves #15835

`create_app` derives two FastMCP servers from the REST API, and the first derivation generates the app's OpenAPI document, which takes a few hundred milliseconds. The unit-test `app` fixture is function scoped, so about 1,500 tests paid for it, and each generation emitted 107 `json_encoders` deprecation warnings.

Two autouse fixtures in `tests/unit/conftest.py` now keep both derivations off fixture apps, following the pattern of the existing startup-probe and WASM-prefetch stubs:

- the `/mcp` mount is disabled through `PHOENIX_ENABLE_MCP_SERVER`, which the MCP tests already patch back on;
- the agent's server build is stubbed at its import seam in `phoenix.server.app`, and `@pytest.mark.real_agent_mcp_server` opts a test back in (the agent-server tests in `test_app_mcp_mount.py`, the real-auth class in `test_phoenix_mcp.py`, and one chat-turn test in `test_agents_router.py`).

Three tests keep the wiring covered under the marker: the read-only test runs against the server `create_app` wires and checks its full `list_tools` catalog against every operation in the OpenAPI document (all GETs present, no non-GET); a chat-turn test asserts the route hands the agent that server's code-mode and skill tools and its instructions; and a new test pins that a fixture app never generates the OpenAPI document. Production code is unchanged: the server still builds eagerly at startup, once per process.

Local run of `tests/unit/server/api/routers/v1/test_secrets.py` (10 tests, SQLite):

| | Warnings | Setup per test |
|---|---|---|
| main | 1,070 | ~1.8s |
| this branch | 107 (one genuine OpenAPI test) | ~1.0s |

The remaining `json_encoders` warnings per OpenAPI generation are removed by #15836. The two `test_oauth2.py` failures in CI come from authlib 1.8.0 switching to httpx2 and are unrelated to this branch.
