### PR TITLE
fix(server): replace deprecated json_encoders with an IsoDatetime serializer

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -180,7 +180,7 @@ from phoenix.server.api.helpers.agent_sessions import (
     set_session_model,
 )
 from phoenix.server.api.openapi.registry import register_openapi_schema
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.models import IsoDatetime, V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     ResponseBody,
@@ -744,8 +744,8 @@ class PatchAgentSessionRequestBody(V1RoutesBaseModel):
 class AgentSessionSummary(V1RoutesBaseModel):
     id: str
     title: str
-    created_at: datetime
-    updated_at: datetime
+    created_at: IsoDatetime
+    updated_at: IsoDatetime
     is_ephemeral: bool
 
 

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -13,7 +13,7 @@ from strawberry.relay import GlobalID
 from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.insertion.types import Precursors
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.models import IsoDatetime, V1RoutesBaseModel
 from phoenix.server.api.types.ProjectSessionAnnotation import (
     ProjectSessionAnnotation as SessionAnnotationNodeType,
 )
@@ -45,8 +45,8 @@ router = APIRouter(tags=["annotations"])
 
 class Annotation(V1RoutesBaseModel):
     id: str
-    created_at: datetime
-    updated_at: datetime
+    created_at: IsoDatetime
+    updated_at: IsoDatetime
     source: Literal["API", "APP"]
     user_id: Optional[str]
 

--- a/src/phoenix/server/api/routers/v1/api_keys.py
+++ b/src/phoenix/server/api/routers/v1/api_keys.py
@@ -38,7 +38,7 @@ from phoenix.server.api.helpers.api_key_policy import (
     get_user_role,
     get_user_role_and_api_keys,
 )
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.models import IsoDatetime, V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     RequestBody,
@@ -74,7 +74,7 @@ class ApiKeyData(V1RoutesBaseModel):
         default=None,
         description="An optional description of what the API key is for.",
     )
-    expires_at: Optional[datetime] = Field(
+    expires_at: Optional[IsoDatetime] = Field(
         default=None,
         description="When the API key expires. The key never expires when omitted.",
     )
@@ -103,8 +103,8 @@ class ApiKey(V1RoutesBaseModel):
     id: str
     name: str
     description: Optional[str] = UNDEFINED
-    created_at: datetime
-    expires_at: Optional[datetime] = UNDEFINED
+    created_at: IsoDatetime
+    expires_at: Optional[IsoDatetime] = UNDEFINED
 
 
 class CreatedApiKey(ApiKey):

--- a/src/phoenix/server/api/routers/v1/custom_model_providers.py
+++ b/src/phoenix/server/api/routers/v1/custom_model_providers.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -10,7 +9,7 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.models import GenerativeModelSDK
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.models import IsoDatetime, V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     add_errors_to_responses,
@@ -41,8 +40,10 @@ class CustomModelProvider(V1RoutesBaseModel):
         ...,
         description="The SDK used to communicate with the custom provider.",
     )
-    created_at: datetime = Field(..., description="The time the custom provider was created.")
-    updated_at: datetime = Field(..., description="The time the custom provider was last updated.")
+    created_at: IsoDatetime = Field(..., description="The time the custom provider was created.")
+    updated_at: IsoDatetime = Field(
+        ..., description="The time the custom provider was last updated."
+    )
 
 
 class GetCustomModelProvidersResponseBody(PaginatedResponseBody[CustomModelProvider]):

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -9,7 +9,6 @@ from asyncio import QueueFull
 from collections import Counter
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime
 from enum import Enum
 from functools import partial
 from typing import Any, Optional, Union, cast
@@ -47,6 +46,7 @@ from phoenix.db.insertion.dataset import (
     add_dataset_examples,
 )
 from phoenix.db.types.db_helper_types import UNDEFINED
+from phoenix.server.api.routers.v1.models import IsoDatetime
 from phoenix.server.api.types.Dataset import Dataset as DatasetNodeType
 from phoenix.server.api.types.DatasetExample import DatasetExample as DatasetExampleNodeType
 from phoenix.server.api.types.DatasetSplit import DatasetSplit as DatasetSplitNodeType
@@ -91,8 +91,8 @@ class Dataset(V1RoutesBaseModel):
     name: str
     description: Optional[str]
     metadata: dict[str, Any]
-    created_at: datetime
-    updated_at: datetime
+    created_at: IsoDatetime
+    updated_at: IsoDatetime
     example_count: int
 
 
@@ -268,7 +268,7 @@ class DatasetVersion(V1RoutesBaseModel):
     version_id: str
     description: Optional[str]
     metadata: dict[str, Any]
-    created_at: datetime
+    created_at: IsoDatetime
 
 
 class ListDatasetVersionsResponseBody(PaginatedResponseBody[DatasetVersion]):
@@ -1312,7 +1312,7 @@ class DatasetExample(V1RoutesBaseModel):
     input: dict[str, Any]
     output: dict[str, Any]
     metadata: dict[str, Any]
-    updated_at: datetime
+    updated_at: IsoDatetime
     source: Optional[DatasetExampleSource] = None
 
 
@@ -1509,8 +1509,8 @@ class DatasetSplit(V1RoutesBaseModel):
     color: str
     metadata: dict[str, Any]
     example_count: int
-    created_at: datetime
-    updated_at: datetime
+    created_at: IsoDatetime
+    updated_at: IsoDatetime
 
 
 class CreateDatasetSplitRequestBody(V1RoutesBaseModel):

--- a/src/phoenix/server/api/routers/v1/experiment_evaluations.py
+++ b/src/phoenix/server/api/routers/v1/experiment_evaluations.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Literal, Optional
 
 from dateutil.parser import isoparse
@@ -11,6 +10,7 @@ from typing_extensions import Self
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import insert_on_conflict
+from phoenix.server.api.routers.v1.models import IsoDatetime
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.dml_event import ExperimentRunAnnotationInsertEvent
 
@@ -34,8 +34,8 @@ class UpsertExperimentEvaluationRequestBody(V1RoutesBaseModel):
     annotator_kind: Literal["LLM", "CODE", "HUMAN"] = Field(
         description="The kind of annotator used for the evaluation"
     )
-    start_time: datetime = Field(description="The start time of the evaluation in ISO format")
-    end_time: datetime = Field(description="The end time of the evaluation in ISO format")
+    start_time: IsoDatetime = Field(description="The start time of the evaluation in ISO format")
+    end_time: IsoDatetime = Field(description="The end time of the evaluation in ISO format")
     result: Optional[ExperimentEvaluationResult] = Field(
         None, description="The result of the evaluation. Either result or error must be provided."
     )

--- a/src/phoenix/server/api/routers/v1/experiment_runs.py
+++ b/src/phoenix/server/api/routers/v1/experiment_runs.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -13,6 +12,7 @@ from phoenix.db.helpers import get_runs_with_incomplete_evaluations_query
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.db.models import ExperimentRunOutput
 from phoenix.server.api.routers.v1.datasets import DatasetExample
+from phoenix.server.api.routers.v1.models import IsoDatetime
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.authorization import is_not_locked
 from phoenix.server.dml_event import ExperimentRunInsertEvent
@@ -29,8 +29,8 @@ class ExperimentRunData(V1RoutesBaseModel):
     )
     output: Any = Field(description="The output of the experiment task")
     repetition_number: int = Field(description="The repetition number of the experiment run", gt=0)
-    start_time: datetime = Field(description="The start time of the experiment run")
-    end_time: datetime = Field(description="The end time of the experiment run")
+    start_time: IsoDatetime = Field(description="The start time of the experiment run")
+    end_time: IsoDatetime = Field(description="The end time of the experiment run")
     trace_id: Optional[str] = Field(
         default=None, description="The ID of the corresponding trace (if one exists)"
     )

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 from random import getrandbits
 from typing import Any, Optional
 
@@ -23,6 +22,7 @@ from phoenix.db.helpers import (
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.db.types.db_helper_types import UNDEFINED
 from phoenix.server.api.routers.v1.datasets import DatasetExample
+from phoenix.server.api.routers.v1.models import IsoDatetime
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.authorization import is_not_locked
 from phoenix.server.bearer_auth import PhoenixUser
@@ -66,8 +66,8 @@ class Experiment(V1RoutesBaseModel):
     project_name: Optional[str] = Field(
         description="The name of the project associated with the experiment"
     )
-    created_at: datetime = Field(description="The creation timestamp of the experiment")
-    updated_at: datetime = Field(description="The last update timestamp of the experiment")
+    created_at: IsoDatetime = Field(description="The creation timestamp of the experiment")
+    updated_at: IsoDatetime = Field(description="The last update timestamp of the experiment")
     example_count: int = Field(description="Number of examples in the experiment")
     successful_run_count: int = Field(description="Number of successful runs in the experiment")
     failed_run_count: int = Field(description="Number of failed runs in the experiment")

--- a/src/phoenix/server/api/routers/v1/models.py
+++ b/src/phoenix/server/api/routers/v1/models.py
@@ -1,46 +1,33 @@
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PlainSerializer, WithJsonSchema
 
 from phoenix.db.types.db_helper_types import UNDEFINED
 
 
 def datetime_encoder(dt: datetime) -> str:
-    """
-    Encodes a `datetime` object to an ISO-formatted timestamp string.
+    """ISO 8601 with a numeric UTC offset.
 
-    By default, Pydantic v2 serializes `datetime` objects in a format that
-    cannot be parsed by `datetime.fromisoformat`. Adding this encoder to the
-    `json_encoders` config for a Pydantic model ensures that the serialized
-    `datetime` objects are parseable.
+    Pydantic's default JSON form of a UTC `datetime` ends in ``Z``, which
+    `datetime.fromisoformat` rejects on Python 3.10.
     """
     return dt.isoformat()
 
 
-# `json_encoders` is a configuration setting from Pydantic v1 that was
-# removed in Pydantic v2.0.* but restored in Pydantic v2.1.0 with a
-# deprecation warning. At this time, it remains the simplest way to
-# configure custom JSON serialization for specific data types.
-#
-# For details, see:
-# - https://github.com/pydantic/pydantic/pull/6811
-# - https://github.com/pydantic/pydantic/releases/tag/v2.1.0
-#
-# The assertion below is added in case a future release of Pydantic v2 fully
-# removes the `json_encoders` parameter.
-assert "json_encoders" in ConfigDict.__annotations__, (
-    "If you encounter this error with `pydantic<2.1.0`, "
-    "please upgrade `pydantic` with `pip install -U pydantic>=2.1.0`. "
-    "If you encounter this error with `pydantic>=2.1.0`, "
-    "please upgrade `arize-phoenix` with `pip install -U arize-phoenix`, "
-    "or downgrade `pydantic` to a version that supports the `json_encoders` config setting."
-)
+#: A `datetime` serialized through `datetime_encoder` in JSON mode. Every
+#: datetime field on a V1 route model uses it. The serialization-mode JSON
+#: schema is pinned: inferred from the encoder's ``str`` return type, it would
+#: lose the ``date-time`` format.
+IsoDatetime = Annotated[
+    datetime,
+    PlainSerializer(datetime_encoder, when_used="json"),
+    WithJsonSchema({"type": "string", "format": "date-time"}, mode="serialization"),
+]
 
 
 class V1RoutesBaseModel(BaseModel):
     model_config = ConfigDict(
-        json_encoders={datetime: datetime_encoder},
         validate_assignment=True,
         protected_namespaces=tuple(
             []

--- a/src/phoenix/server/api/routers/v1/sessions.py
+++ b/src/phoenix/server/api/routers/v1/sessions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime
 from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
@@ -16,7 +15,7 @@ from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.db.session_aggregates import SESSION_ROWID, token_counts_by_session
 from phoenix.server.api.helpers.annotations import get_note_identifier
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.models import IsoDatetime, V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     ResponseBody,
@@ -100,16 +99,16 @@ class CreateSessionNoteResponseBody(ResponseBody[InsertedSessionAnnotation]):
 class SessionTraceData(V1RoutesBaseModel):
     id: str
     trace_id: str
-    start_time: datetime
-    end_time: datetime
+    start_time: IsoDatetime
+    end_time: IsoDatetime
 
 
 class SessionData(V1RoutesBaseModel):
     id: str
     session_id: str
     project_id: str
-    start_time: datetime
-    end_time: datetime
+    start_time: IsoDatetime
+    end_time: IsoDatetime
     traces: list[SessionTraceData]
     token_count_prompt: int = Field(
         default=0,

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -24,6 +24,7 @@ from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.utils import df_to_bytes
 from phoenix.server.api.routers.v1.annotations import SpanAnnotationData
+from phoenix.server.api.routers.v1.models import IsoDatetime
 from phoenix.server.api.routers.v1.validators import validate_enum_filter
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.authorization import (
@@ -151,8 +152,8 @@ class SpanQuery(V1RoutesBaseModel):
 
 class QuerySpansRequestBody(V1RoutesBaseModel):
     queries: list[SpanQuery]
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
+    start_time: Optional[IsoDatetime] = None
+    end_time: Optional[IsoDatetime] = None
     limit: int = DEFAULT_SPAN_LIMIT
     root_spans_only: Optional[bool] = Field(
         default=None,
@@ -184,7 +185,7 @@ class QuerySpansRequestBody(V1RoutesBaseModel):
         ),
         deprecated=True,
     )
-    stop_time: Optional[datetime] = Field(
+    stop_time: Optional[IsoDatetime] = Field(
         default=None,
         description=(
             "An upper bound on the time to query for. "
@@ -520,7 +521,7 @@ class SpanContext(V1RoutesBaseModel):
 
 class SpanEvent(V1RoutesBaseModel):
     name: str = Field(description="Name of the event")
-    timestamp: datetime = Field(description="When the event occurred (must be timezone-aware)")
+    timestamp: IsoDatetime = Field(description="When the event occurred (must be timezone-aware)")
     attributes: dict[str, Any] = Field(default_factory=dict, description="Event attributes")
 
     model_config = ConfigDict(
@@ -555,8 +556,8 @@ class Span(V1RoutesBaseModel):
     parent_id: Optional[str] = Field(
         default=None, description="OpenTelemetry span ID of the parent span"
     )
-    start_time: datetime = Field(description="Start time of the span (must be timezone-aware)")
-    end_time: datetime = Field(description="End time of the span (must be timezone-aware)")
+    start_time: IsoDatetime = Field(description="Start time of the span (must be timezone-aware)")
+    end_time: IsoDatetime = Field(description="End time of the span (must be timezone-aware)")
     status_code: str = Field(description="Status code of the span")
     status_message: str = Field(default="", description="Status message")
     attributes: dict[str, Any] = Field(default_factory=dict, description="Span attributes")

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -25,6 +25,7 @@ from phoenix.db.helpers import SupportedSQLDialect, token_counts_by_trace
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.annotations import TraceAnnotationData
+from phoenix.server.api.routers.v1.models import IsoDatetime
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.pagination import (
     Cursor,
@@ -67,16 +68,16 @@ class TraceSpanData(V1RoutesBaseModel):
     name: str
     span_kind: str
     status_code: str
-    start_time: datetime
-    end_time: datetime
+    start_time: IsoDatetime
+    end_time: IsoDatetime
 
 
 class TraceData(V1RoutesBaseModel):
     id: str
     trace_id: str
     project_id: str
-    start_time: datetime
-    end_time: datetime
+    start_time: IsoDatetime
+    end_time: IsoDatetime
     token_count_prompt: int = Field(
         default=0,
         description="Cumulative prompt token count across all spans in the trace.",

--- a/src/phoenix/server/api/routers/v1/users.py
+++ b/src/phoenix/server/api/routers/v1/users.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import secrets
-from datetime import datetime
 from functools import partial
 from typing import Annotated, Literal, Union
 
@@ -27,7 +26,7 @@ from phoenix.auth import (
 )
 from phoenix.db import models
 from phoenix.db.types.db_helper_types import UNDEFINED
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.models import IsoDatetime, V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
     PaginatedResponseBody,
     ResponseBody,
@@ -65,8 +64,8 @@ class LDAPUserData(UserData):
 
 class DbUser(V1RoutesBaseModel):
     id: str
-    created_at: datetime
-    updated_at: datetime
+    created_at: IsoDatetime
+    updated_at: IsoDatetime
 
 
 class LocalUser(LocalUserData, DbUser):

--- a/tests/unit/server/api/routers/v1/test_pydantic_compat.py
+++ b/tests/unit/server/api/routers/v1/test_pydantic_compat.py
@@ -1,23 +1,103 @@
+import importlib
 import json
+import pkgutil
 from datetime import datetime, timezone
+from typing import Any, Iterator, Literal, Mapping, Optional
 
-from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+import pytest
+
+import phoenix.server.api.routers.v1 as v1
+from phoenix.server.api.routers.v1.models import (
+    IsoDatetime,
+    V1RoutesBaseModel,
+    datetime_encoder,
+)
 
 
-class TestV1RoutesBaseModel:
+class TestIsoDatetime:
     def test_serialized_datetimes_are_parseable_iso_formatted_timestamps(self) -> None:
         class Model(V1RoutesBaseModel):
-            datetime_field: datetime
+            datetime_field: IsoDatetime
+            optional_field: Optional[IsoDatetime] = None
             string_field: str
 
         dt = datetime(2021, 1, 1, hour=2, minute=43, second=1, tzinfo=timezone.utc)
         model = Model(
             datetime_field=dt,
+            optional_field=dt,
             string_field="test",
         )
-        model_as_dict = json.loads(model.json())
-        assert set(model_as_dict.keys()) == {"datetime_field", "string_field"}
+        model_as_dict = json.loads(model.model_dump_json())
+        assert set(model_as_dict.keys()) == {"datetime_field", "optional_field", "string_field"}
         assert model_as_dict["string_field"] == "test"
-        datetime_field = model_as_dict["datetime_field"]
-        assert datetime_field == "2021-01-01T02:43:01+00:00"
-        assert dt == datetime.fromisoformat(datetime_field)
+        for field in ("datetime_field", "optional_field"):
+            datetime_field = model_as_dict[field]
+            assert datetime_field == "2021-01-01T02:43:01+00:00"
+            assert dt == datetime.fromisoformat(datetime_field)
+
+    def test_none_is_left_alone(self) -> None:
+        class Model(V1RoutesBaseModel):
+            optional_field: Optional[IsoDatetime] = None
+
+        assert json.loads(Model().model_dump_json()) == {"optional_field": None}
+
+    def test_python_mode_keeps_the_datetime(self) -> None:
+        class Model(V1RoutesBaseModel):
+            datetime_field: IsoDatetime
+
+        dt = datetime(2021, 1, 1, tzinfo=timezone.utc)
+        assert Model(datetime_field=dt).model_dump() == {"datetime_field": dt}
+
+    @pytest.mark.parametrize("mode", ["validation", "serialization"])
+    def test_json_schema_keeps_the_date_time_format(
+        self, mode: Literal["validation", "serialization"]
+    ) -> None:
+        class Model(V1RoutesBaseModel):
+            datetime_field: IsoDatetime
+
+        schema = Model.model_json_schema(mode=mode)["properties"]["datetime_field"]
+        assert schema == {"format": "date-time", "title": "Datetime Field", "type": "string"}
+
+
+def _v1_route_models() -> Iterator[type[V1RoutesBaseModel]]:
+    for module in pkgutil.iter_modules(v1.__path__):
+        importlib.import_module(f"{v1.__name__}.{module.name}")
+    importlib.import_module("phoenix.server.api.routers.agents")
+
+    def subclasses(cls: type[V1RoutesBaseModel]) -> Iterator[type[V1RoutesBaseModel]]:
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from subclasses(sub)
+
+    yield from sorted(set(subclasses(V1RoutesBaseModel)), key=lambda c: c.__qualname__)
+
+
+def _bare_datetime_fields(model: type[V1RoutesBaseModel]) -> list[str]:
+    """Names of the model's own fields with a datetime not serialized by `datetime_encoder`.
+
+    Walks each field's core schema through containers, unions, and nullables,
+    but not into nested models, which are checked as models of their own.
+    """
+    root: Mapping[str, Any] = model.__pydantic_core_schema__
+    while root["type"] in ("definitions", "function-after", "function-before", "function-wrap"):
+        root = root["schema"]
+    return [name for name, field in root["schema"]["fields"].items() if not _encoded(field, name)]
+
+
+def _encoded(node: Any, name: str) -> bool:
+    if isinstance(node, dict):
+        if node.get("type") == "datetime":
+            return node.get("serialization", {}).get("function") is datetime_encoder
+        if node.get("type") in ("model", "definition-ref", "dataclass"):
+            return True
+        return all(_encoded(value, name) for key, value in node.items() if key != "metadata")
+    if isinstance(node, (list, tuple)):
+        return all(_encoded(item, name) for item in node)
+    return True
+
+
+@pytest.mark.parametrize("model", list(_v1_route_models()), ids=lambda m: m.__qualname__)
+def test_every_v1_datetime_field_is_an_iso_datetime(model: type[V1RoutesBaseModel]) -> None:
+    """A bare `datetime` on a route model would serialize with a `Z` suffix that
+    `datetime.fromisoformat` rejects on Python 3.10."""
+    assert _bare_datetime_fields(model) == []


### PR DESCRIPTION
resolves #15836

`V1RoutesBaseModel` configured datetime serialization through Pydantic's v1-era `json_encoders` setting, which Pydantic 2 deprecates and warns about on every core-schema generation that meets a datetime field. FastAPI's OpenAPI generation builds a `TypeAdapter` per model field, so each generation emitted 107 such warnings; the unit-test job reported about 160k of them.

`IsoDatetime` is a `datetime` annotated with a `PlainSerializer` that applies the same encoder in JSON mode, and every datetime field on a V1 route model (37 declarations across 12 modules) is now declared with it. The wire format is unchanged: UTC timestamps carry `+00:00` rather than `Z`, which `datetime.fromisoformat` requires on Python 3.10, and `schemas/openapi.json` is byte-identical. The serialization-mode JSON schema is pinned to the `date-time` format, which the encoder's `str` return type would otherwise drop.

A parametrized test walks every route model's core schema and fails on a datetime field that is not serialized through the encoder, so a new field cannot regress to the `Z` form. The `json_encoders` warning count for `test_secrets.py` goes from 1,070 to 0; the 10 that remain are the `Undefined` JSON-schema warning tracked in #15837.
