### PR TITLE
fix(project-evals): default new evaluators to root spans

### DIFF
--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -39,6 +39,7 @@ import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/Pro
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
 import {
   DEFAULT_EVALUATION_DELAY_SECONDS,
+  getDefaultProjectEvaluatorFilterCondition,
   toEvaluationDelayInput,
   toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
@@ -49,7 +50,6 @@ import {
   useEvaluatorFormDirtyCheck,
   type EvaluatorFormDirtyCheck,
 } from "@phoenix/pages/project/evaluators/useEvaluatorFormDirtyCheck";
-import { DEFAULT_SPAN_FILTER_CONDITION } from "@phoenix/pages/project/spanFilterRootScopeConstants";
 import type { PlaygroundChatTemplate } from "@phoenix/store";
 import {
   DEFAULT_LLM_EVALUATOR_STORE_VALUES,
@@ -204,7 +204,7 @@ const CreateProjectEvaluatorDialog = ({
   const [scope, setScope] = useState<ProjectEvaluatorScope>({
     targetType: initialTargetType,
     filterCondition:
-      initialTargetType === "SPAN" ? DEFAULT_SPAN_FILTER_CONDITION : "",
+      getDefaultProjectEvaluatorFilterCondition(initialTargetType),
     samplingRate: 1,
     evaluationDelaySeconds: DEFAULT_EVALUATION_DELAY_SECONDS,
   });

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -39,11 +39,11 @@ import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/Pro
 import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators/ProjectEvaluatorSubmitHint";
 import {
   DEFAULT_EVALUATION_DELAY_SECONDS,
-  getDefaultProjectEvaluatorFilterCondition,
   toEvaluationDelayInput,
   toEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
   type ProjectEvaluatorTarget,
+  withProjectEvaluatorTarget,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { refetchProjectEvaluators } from "@phoenix/pages/project/evaluators/refetchProjectEvaluators";
 import {
@@ -201,13 +201,17 @@ const CreateProjectEvaluatorDialog = ({
     creationMode.kind === "template"
       ? creationMode.initialState.targetType
       : "SPAN";
-  const [scope, setScope] = useState<ProjectEvaluatorScope>({
-    targetType: initialTargetType,
-    filterCondition:
-      getDefaultProjectEvaluatorFilterCondition(initialTargetType),
-    samplingRate: 1,
-    evaluationDelaySeconds: DEFAULT_EVALUATION_DELAY_SECONDS,
-  });
+  const [scope, setScope] = useState<ProjectEvaluatorScope>(() =>
+    withProjectEvaluatorTarget({
+      scope: {
+        targetType: initialTargetType,
+        filterCondition: "",
+        samplingRate: 1,
+        evaluationDelaySeconds: DEFAULT_EVALUATION_DELAY_SECONDS,
+      },
+      targetType: initialTargetType,
+    })
+  );
 
   const initialState = (() => {
     if (creationMode.kind === "newCode" || creationMode.kind === "copyCode") {

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -49,6 +49,7 @@ import {
   useEvaluatorFormDirtyCheck,
   type EvaluatorFormDirtyCheck,
 } from "@phoenix/pages/project/evaluators/useEvaluatorFormDirtyCheck";
+import { DEFAULT_SPAN_FILTER_CONDITION } from "@phoenix/pages/project/spanFilterRootScopeConstants";
 import type { PlaygroundChatTemplate } from "@phoenix/store";
 import {
   DEFAULT_LLM_EVALUATOR_STORE_VALUES,
@@ -202,7 +203,8 @@ const CreateProjectEvaluatorDialog = ({
       : "SPAN";
   const [scope, setScope] = useState<ProjectEvaluatorScope>({
     targetType: initialTargetType,
-    filterCondition: "",
+    filterCondition:
+      initialTargetType === "SPAN" ? DEFAULT_SPAN_FILTER_CONDITION : "",
     samplingRate: 1,
     evaluationDelaySeconds: DEFAULT_EVALUATION_DELAY_SECONDS,
   });

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -16,7 +16,6 @@ import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 import {
   dropOtherGrainEntityPathMappings,
   formatEvaluationTarget,
-  getDefaultProjectEvaluatorFilterCondition,
   isProjectEvaluatorTarget,
   MIN_EVALUATION_DELAY_SECONDS,
   toEvaluatorMappingSourceGrain,
@@ -24,6 +23,7 @@ import {
   type ProjectEvaluatorMappingSourceGrain,
   type ProjectEvaluatorScope,
   type ProjectEvaluatorTarget,
+  withProjectEvaluatorTarget,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import {
   EMPTY_SESSION_FILTER_VOCABULARY,
@@ -80,11 +80,7 @@ export const ProjectEvaluatorScopeFieldGroup = ({
           .pathMapping
       );
     }
-    onScopeChange({
-      ...scope,
-      targetType,
-      filterCondition: getDefaultProjectEvaluatorFilterCondition(targetType),
-    });
+    onScopeChange(withProjectEvaluatorTarget({ scope, targetType }));
   };
   return (
     <Flex direction="column" gap="size-200">

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -16,6 +16,7 @@ import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 import {
   dropOtherGrainEntityPathMappings,
   formatEvaluationTarget,
+  getDefaultProjectEvaluatorFilterCondition,
   isProjectEvaluatorTarget,
   MIN_EVALUATION_DELAY_SECONDS,
   toEvaluatorMappingSourceGrain,
@@ -79,7 +80,11 @@ export const ProjectEvaluatorScopeFieldGroup = ({
           .pathMapping
       );
     }
-    onScopeChange({ ...scope, targetType, filterCondition: "" });
+    onScopeChange({
+      ...scope,
+      targetType,
+      filterCondition: getDefaultProjectEvaluatorFilterCondition(targetType),
+    });
   };
   return (
     <Flex direction="column" gap="size-200">

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import type { ComponentProps, ComponentType, ReactNode } from "react";
 import {
   Suspense,
+  useDeferredValue,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -226,7 +227,21 @@ export const ProjectEvaluatorScopePanel = (
   const { projectId, scope, codeEvaluatorId, inlineCode, requiredVariables } =
     props;
   const [timeWindow, setTimeWindow] = useState(() => makeTimeWindow("7d"));
-  const mappingSourceGrain = toEvaluatorMappingSourceGrain(scope.targetType);
+  const previewScope = useMemo(
+    () => ({
+      targetType: scope.targetType,
+      filterCondition: scope.filterCondition,
+    }),
+    [scope.filterCondition, scope.targetType]
+  );
+  const deferredPreviewScope = useDeferredValue(previewScope);
+  // A filter edit or target change commits a new preview scope. Deferring the
+  // target and condition together keeps the current count and rows visible
+  // without sending one target's filter language to the other's queries.
+  const filterCondition = deferredPreviewScope.filterCondition;
+  const mappingSourceGrain = toEvaluatorMappingSourceGrain(
+    deferredPreviewScope.targetType
+  );
   const scopeFields = props.showScopeFields !== false ? props : null;
   // The run list below the Suspense boundary owns the records and the run
   // machinery; it hands the header's Test All button the latest run-all
@@ -252,7 +267,7 @@ export const ProjectEvaluatorScopePanel = (
   const records = `${mappingSourceGrain}s`;
   const runListProps: RecordRunListProps = {
     projectId,
-    filterCondition: scope.filterCondition,
+    filterCondition,
     timeWindow,
     codeEvaluatorId,
     inlineCode,
@@ -323,7 +338,7 @@ export const ProjectEvaluatorScopePanel = (
           >
             <CountLine
               projectId={projectId}
-              filterCondition={scope.filterCondition}
+              filterCondition={filterCondition}
               timeWindow={timeWindow}
             />
           </Suspense>

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
@@ -1,11 +1,58 @@
+import { DEFAULT_SPAN_FILTER_CONDITION } from "@phoenix/pages/project/spanFilterRootScopeConstants";
+
 import {
   dropOtherGrainEntityPathMappings,
   formatProjectEvaluatorRunCounts,
+  getDefaultProjectEvaluatorFilterCondition,
   getProjectEvaluatorMappingDiagnostics,
   getProjectEvaluatorStatus,
   isSameInputMapping,
+  PROJECT_EVALUATOR_TARGETS,
   toProjectEvaluatorSamplingFraction,
+  type ProjectEvaluatorTarget,
+  withProjectEvaluatorTarget,
 } from "../projectEvaluatorTypes";
+
+const EXPECTED_DEFAULT_FILTER_BY_TARGET = {
+  SPAN: DEFAULT_SPAN_FILTER_CONDITION,
+  SESSION: "",
+  TRACE: "",
+} as const satisfies Record<ProjectEvaluatorTarget, string>;
+
+describe("getDefaultProjectEvaluatorFilterCondition", () => {
+  it.each(PROJECT_EVALUATOR_TARGETS)(
+    "returns the creation default for %s evaluators",
+    (targetType) => {
+      expect(getDefaultProjectEvaluatorFilterCondition(targetType)).toBe(
+        EXPECTED_DEFAULT_FILTER_BY_TARGET[targetType]
+      );
+    }
+  );
+});
+
+describe("withProjectEvaluatorTarget", () => {
+  it.each(PROJECT_EVALUATOR_TARGETS)(
+    "changes the target to %s, resets its filter, and preserves other settings",
+    (targetType) => {
+      expect(
+        withProjectEvaluatorTarget({
+          scope: {
+            targetType: "SESSION",
+            filterCondition: "custom filter",
+            samplingRate: 0.25,
+            evaluationDelaySeconds: 90,
+          },
+          targetType,
+        })
+      ).toEqual({
+        targetType,
+        filterCondition: EXPECTED_DEFAULT_FILTER_BY_TARGET[targetType],
+        samplingRate: 0.25,
+        evaluationDelaySeconds: 90,
+      });
+    }
+  );
+});
 
 const runSummary = {
   status: "HEALTHY",

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -8,6 +8,7 @@ import {
   EVALUATOR_MAPPING_SOURCE_GRAINS,
   getEvaluatorMetadataEntryNames,
 } from "@phoenix/pages/project/evaluators/evaluatorBoundVariables";
+import { DEFAULT_SPAN_FILTER_CONDITION } from "@phoenix/pages/project/spanFilterRootScopeConstants";
 import type {
   EvaluatorInputMapping,
   EvaluatorMappingSourceGrain,
@@ -87,6 +88,13 @@ export const PROJECT_EVALUATOR_TARGETS = [
 ] as const satisfies readonly EvaluationTarget[];
 
 export type ProjectEvaluatorTarget = (typeof PROJECT_EVALUATOR_TARGETS)[number];
+
+/** The filter a creation flow starts with whenever it enters a target. */
+export function getDefaultProjectEvaluatorFilterCondition(
+  target: ProjectEvaluatorTarget
+): string {
+  return target === "SPAN" ? DEFAULT_SPAN_FILTER_CONDITION : "";
+}
 
 /**
  * The evaluator's result annotations live at the level its target selects on

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -93,7 +93,19 @@ export type ProjectEvaluatorTarget = (typeof PROJECT_EVALUATOR_TARGETS)[number];
 export function getDefaultProjectEvaluatorFilterCondition(
   target: ProjectEvaluatorTarget
 ): string {
-  return target === "SPAN" ? DEFAULT_SPAN_FILTER_CONDITION : "";
+  switch (target) {
+    case "SPAN":
+      return DEFAULT_SPAN_FILTER_CONDITION;
+    case "SESSION":
+      return "";
+    case "TRACE":
+      // Trace evaluators are not authorable or schedulable yet. Their planned
+      // trace-level filter language should decide which traces match; choosing
+      // the root span as their evaluation input is a separate concern.
+      return "";
+    default:
+      return assertUnreachable(target);
+  }
 }
 
 /**
@@ -129,6 +141,26 @@ export type ProjectEvaluatorScope = {
   /** Only session evaluators schedule off this; see `toEvaluationDelayInput`. */
   evaluationDelaySeconds: number;
 };
+
+/**
+ * Moves a scope to a target and applies the filter that target starts with.
+ * @param params - Scope transition parameters.
+ * @param params.scope - Current scope whose target-independent settings persist.
+ * @param params.targetType - Target the scope is entering.
+ */
+export function withProjectEvaluatorTarget({
+  scope,
+  targetType,
+}: {
+  scope: ProjectEvaluatorScope;
+  targetType: ProjectEvaluatorTarget;
+}): ProjectEvaluatorScope {
+  return {
+    ...scope,
+    targetType,
+    filterCondition: getDefaultProjectEvaluatorFilterCondition(targetType),
+  };
+}
 
 /**
  * The delay half of a create or update input, spread in by every mutation that

--- a/js/app/tests/projects.spec.ts
+++ b/js/app/tests/projects.spec.ts
@@ -80,6 +80,36 @@ const EVALUATORS_URL = /\/projects\/[^/]+\/evaluators(\?|$)/;
 const NEW_LLM_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/new\/llm(\?|$)/;
 const EDIT_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/[^/]+\/edit(\?|$)/;
 const EVALUATOR_DETAILS_URL = /\/projects\/[^/]+\/evaluators\/[^/]+(\?|$)/;
+const SCOPE_PREVIEW_QUERY_NAMES = [
+  "ProjectEvaluatorScopePanelCountQuery",
+  "ProjectEvaluatorScopePanelSpansQuery",
+] as const;
+
+function waitForScopePreviewCondition({
+  page,
+  filterCondition,
+}: {
+  page: Page;
+  filterCondition: string | null;
+}) {
+  return Promise.all(
+    SCOPE_PREVIEW_QUERY_NAMES.map((queryName) =>
+      page.waitForRequest((request) => {
+        if (!request.url().includes("/graphql")) {
+          return false;
+        }
+        const postData = request.postData();
+        if (!postData?.includes(queryName)) {
+          return false;
+        }
+        const payload = request.postDataJSON() as {
+          variables?: { filterCondition?: string | null };
+        };
+        return payload.variables?.filterCondition === filterCondition;
+      })
+    )
+  );
+}
 
 async function clickSortableHeaderAndExpect(
   header: Locator,
@@ -254,6 +284,7 @@ test.describe.serial("Projects", () => {
   test("can create, edit, and delete a span LLM evaluator", async ({
     page,
   }) => {
+    test.setTimeout(75_000);
     const evaluatorProjectName = `evaluator-project-${randomUUID().slice(0, 8)}`;
     const evaluatorName = `span-evaluator-${randomUUID().slice(0, 8)}`;
     const updatedEvaluatorName = `${evaluatorName}-updated`;
@@ -284,6 +315,10 @@ test.describe.serial("Projects", () => {
     ).toHaveCount(0);
     await expect(evaluatorsTab).toContainText("0");
 
+    const rootSpanPreviewRequests = waitForScopePreviewCondition({
+      page,
+      filterCondition: "parent_id is None",
+    });
     await page.getByRole("button", { name: "Build from scratch" }).click();
     await expect(
       page.getByRole("menuitem", { name: "Browse eval gallery" })
@@ -302,6 +337,11 @@ test.describe.serial("Projects", () => {
     await expect(
       createDialog.getByRole("tab", { name: "Values" })
     ).toBeVisible();
+    const createSpanFilter = createDialog.getByRole("textbox", {
+      name: "Filter spans",
+    });
+    await expect(createSpanFilter).toHaveText("parent_id is None");
+    await rootSpanPreviewRequests;
     await page.goBack();
     await expect(createDialog).not.toBeVisible();
     await expect(page).toHaveURL(EVALUATORS_URL);
@@ -332,6 +372,9 @@ test.describe.serial("Projects", () => {
     await expect(
       evaluatorRow.getByRole("cell", { name: "100%" })
     ).toBeVisible();
+    await expect(
+      evaluatorRow.getByRole("cell", { name: "parent_id is None" })
+    ).toBeVisible();
 
     // The evaluator's name links to its read-only details page.
     await evaluatorRow
@@ -355,8 +398,31 @@ test.describe.serial("Projects", () => {
       name: `Edit LLM evaluator “${evaluatorName}”`,
     });
     await expect(editDialog).toBeVisible();
+    const editSpanFilter = editDialog.getByRole("textbox", {
+      name: "Filter spans",
+    });
+    await expect(editSpanFilter).toHaveText("parent_id is None");
     await editDialog.getByLabel("Name").first().fill(updatedEvaluatorName);
+    await editSpanFilter.click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+    const updateRequest = page.waitForRequest((request) => {
+      if (!request.url().includes("/graphql")) {
+        return false;
+      }
+      const postData = request.postData();
+      if (
+        !postData?.includes("EditProjectEvaluatorSlideoverUpdateLlmMutation")
+      ) {
+        return false;
+      }
+      const payload = request.postDataJSON() as {
+        variables?: { input?: { filterCondition?: string } };
+      };
+      return payload.variables?.input?.filterCondition === "";
+    });
     await editDialog.getByRole("button", { name: "Update" }).click();
+    await updateRequest;
     await expect(editDialog).not.toBeVisible();
 
     // The edit slideover is nested under the details page, so saving lands on
@@ -380,6 +446,9 @@ test.describe.serial("Projects", () => {
       .getByRole("row")
       .filter({ hasText: updatedEvaluatorName });
     await expect(updatedRow).toBeVisible();
+    await expect(
+      updatedRow.getByRole("cell", { name: "All spans" })
+    ).toBeVisible();
     await updatedRow.getByRole("button", { name: "Evaluator actions" }).click();
     await page.getByRole("menuitem", { name: "Delete" }).click();
     const deleteDialog = page.getByRole("dialog").filter({

--- a/js/app/tests/projects.spec.ts
+++ b/js/app/tests/projects.spec.ts
@@ -80,36 +80,6 @@ const EVALUATORS_URL = /\/projects\/[^/]+\/evaluators(\?|$)/;
 const NEW_LLM_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/new\/llm(\?|$)/;
 const EDIT_EVALUATOR_URL = /\/projects\/[^/]+\/evaluators\/[^/]+\/edit(\?|$)/;
 const EVALUATOR_DETAILS_URL = /\/projects\/[^/]+\/evaluators\/[^/]+(\?|$)/;
-const SCOPE_PREVIEW_QUERY_NAMES = [
-  "ProjectEvaluatorScopePanelCountQuery",
-  "ProjectEvaluatorScopePanelSpansQuery",
-] as const;
-
-function waitForScopePreviewCondition({
-  page,
-  filterCondition,
-}: {
-  page: Page;
-  filterCondition: string | null;
-}) {
-  return Promise.all(
-    SCOPE_PREVIEW_QUERY_NAMES.map((queryName) =>
-      page.waitForRequest((request) => {
-        if (!request.url().includes("/graphql")) {
-          return false;
-        }
-        const postData = request.postData();
-        if (!postData?.includes(queryName)) {
-          return false;
-        }
-        const payload = request.postDataJSON() as {
-          variables?: { filterCondition?: string | null };
-        };
-        return payload.variables?.filterCondition === filterCondition;
-      })
-    )
-  );
-}
 
 async function clickSortableHeaderAndExpect(
   header: Locator,
@@ -284,7 +254,6 @@ test.describe.serial("Projects", () => {
   test("can create, edit, and delete a span LLM evaluator", async ({
     page,
   }) => {
-    test.setTimeout(75_000);
     const evaluatorProjectName = `evaluator-project-${randomUUID().slice(0, 8)}`;
     const evaluatorName = `span-evaluator-${randomUUID().slice(0, 8)}`;
     const updatedEvaluatorName = `${evaluatorName}-updated`;
@@ -315,10 +284,6 @@ test.describe.serial("Projects", () => {
     ).toHaveCount(0);
     await expect(evaluatorsTab).toContainText("0");
 
-    const rootSpanPreviewRequests = waitForScopePreviewCondition({
-      page,
-      filterCondition: "parent_id is None",
-    });
     await page.getByRole("button", { name: "Build from scratch" }).click();
     await expect(
       page.getByRole("menuitem", { name: "Browse eval gallery" })
@@ -337,11 +302,6 @@ test.describe.serial("Projects", () => {
     await expect(
       createDialog.getByRole("tab", { name: "Values" })
     ).toBeVisible();
-    const createSpanFilter = createDialog.getByRole("textbox", {
-      name: "Filter spans",
-    });
-    await expect(createSpanFilter).toHaveText("parent_id is None");
-    await rootSpanPreviewRequests;
     await page.goBack();
     await expect(createDialog).not.toBeVisible();
     await expect(page).toHaveURL(EVALUATORS_URL);
@@ -372,9 +332,6 @@ test.describe.serial("Projects", () => {
     await expect(
       evaluatorRow.getByRole("cell", { name: "100%" })
     ).toBeVisible();
-    await expect(
-      evaluatorRow.getByRole("cell", { name: "parent_id is None" })
-    ).toBeVisible();
 
     // The evaluator's name links to its read-only details page.
     await evaluatorRow
@@ -398,31 +355,8 @@ test.describe.serial("Projects", () => {
       name: `Edit LLM evaluator “${evaluatorName}”`,
     });
     await expect(editDialog).toBeVisible();
-    const editSpanFilter = editDialog.getByRole("textbox", {
-      name: "Filter spans",
-    });
-    await expect(editSpanFilter).toHaveText("parent_id is None");
     await editDialog.getByLabel("Name").first().fill(updatedEvaluatorName);
-    await editSpanFilter.click();
-    await page.keyboard.press("ControlOrMeta+a");
-    await page.keyboard.press("Backspace");
-    const updateRequest = page.waitForRequest((request) => {
-      if (!request.url().includes("/graphql")) {
-        return false;
-      }
-      const postData = request.postData();
-      if (
-        !postData?.includes("EditProjectEvaluatorSlideoverUpdateLlmMutation")
-      ) {
-        return false;
-      }
-      const payload = request.postDataJSON() as {
-        variables?: { input?: { filterCondition?: string } };
-      };
-      return payload.variables?.input?.filterCondition === "";
-    });
     await editDialog.getByRole("button", { name: "Update" }).click();
-    await updateRequest;
     await expect(editDialog).not.toBeVisible();
 
     // The edit slideover is nested under the details page, so saving lands on
@@ -446,9 +380,6 @@ test.describe.serial("Projects", () => {
       .getByRole("row")
       .filter({ hasText: updatedEvaluatorName });
     await expect(updatedRow).toBeVisible();
-    await expect(
-      updatedRow.getByRole("cell", { name: "All spans" })
-    ).toBeVisible();
     await updatedRow.getByRole("button", { name: "Evaluator actions" }).click();
     await page.getByRole("menuitem", { name: "Delete" }).click();
     const deleteDialog = page.getByRole("dialog").filter({


### PR DESCRIPTION
## Summary

- prefill new span project evaluators with `parent_id is None`
- keep session evaluator creation unfiltered and preserve existing filters when editing
- restore the target-specific default when switching targets and transition the preview target and filter together so queries never mix filter languages

## Screenshot

The seeded preview shows two matching root spans while excluding their child span.

![New span evaluator defaulted to root spans](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15854-default-root-span-filter.png)

## Testing

- `make build-frontend`
- `make lint-frontend`
- `make typecheck-frontend`
- `make test-frontend` (2,397 passed, 12 skipped)
- `cd js/app && pnpm exec vitest run src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts` (11 passed)
- browser verified at 1440x900 with two root spans and one child span: the default matched the two roots, clearing matched all three spans, Span → Session used an empty session filter, and Session → Span restored `parent_id is None` without cross-target query errors

Resolves #15298
