### PR TITLE
fix(app): let metadata cells use the traces filter context

### DIFF
--- a/js/app/src/pages/project/MetadataTableCell.tsx
+++ b/js/app/src/pages/project/MetadataTableCell.tsx
@@ -10,14 +10,14 @@ import { jsonStringToFlatObject } from "@phoenix/utils/jsonUtils";
 type MetadataTableCellProps = {
   metadata: unknown;
   /**
-   * Called with a filter DSL condition when the user picks a metadata value to filter on
+   * Called with a filter DSL condition when the user presses the label or a "Match" button in the tooltip
    */
-  onValidFilterCondition: (condition: string) => void;
+  onFilterConditionPressed: (condition: string) => void;
 };
 
 export const MetadataTableCell = ({
   metadata,
-  onValidFilterCondition,
+  onFilterConditionPressed,
 }: MetadataTableCellProps) => {
   // Try to parse the metadata and stringify it
   // This is intended to work with object metadata but will technically work for arrays as well
@@ -50,7 +50,7 @@ export const MetadataTableCell = ({
       <MetadataTooltip
         width="800px"
         metadata={parsedMetadata}
-        onValidFilterCondition={onValidFilterCondition}
+        onFilterConditionPressed={onFilterConditionPressed}
       >
         <MetadataLabel
           metadata={stringifiedMetadata}
@@ -61,7 +61,7 @@ export const MetadataTableCell = ({
               key,
               value
             );
-            onValidFilterCondition(filterCondition);
+            onFilterConditionPressed(filterCondition);
           }}
         />
       </MetadataTooltip>

--- a/js/app/src/pages/project/MetadataTableCell.tsx
+++ b/js/app/src/pages/project/MetadataTableCell.tsx
@@ -46,7 +46,11 @@ export const MetadataTableCell = ({
 
   return (
     <div style={{ maxWidth: "100%" }}>
-      <MetadataTooltip width="800px" metadata={parsedMetadata}>
+      <MetadataTooltip
+        width="800px"
+        metadata={parsedMetadata}
+        appendFilterCondition={appendFilterCondition}
+      >
         <MetadataLabel
           metadata={stringifiedMetadata}
           onClick={() => {

--- a/js/app/src/pages/project/MetadataTableCell.tsx
+++ b/js/app/src/pages/project/MetadataTableCell.tsx
@@ -5,16 +5,19 @@ import {
   makeMetadataTooltipFilterCondition,
   MetadataTooltip,
 } from "@phoenix/pages/project/MetadataTooltip";
-import { useSpanFilterActions } from "@phoenix/pages/project/SpanFiltersContext";
 import { jsonStringToFlatObject } from "@phoenix/utils/jsonUtils";
+
+type AppendFilterCondition = (condition: string) => void;
 
 type MetadataTableCellProps = {
   metadata: unknown;
+  appendFilterCondition: AppendFilterCondition;
 };
 
-export const MetadataTableCell = ({ metadata }: MetadataTableCellProps) => {
-  const { appendFilterCondition } = useSpanFilterActions();
-
+export const MetadataTableCell = ({
+  metadata,
+  appendFilterCondition,
+}: MetadataTableCellProps) => {
   // Try to parse the metadata and stringify it
   // This is intended to work with object metadata but will technically work for arrays as well
   const [parsedMetadata, stringifiedMetadata] = useMemo(() => {

--- a/js/app/src/pages/project/MetadataTableCell.tsx
+++ b/js/app/src/pages/project/MetadataTableCell.tsx
@@ -7,6 +7,15 @@ import {
 } from "@phoenix/pages/project/MetadataTooltip";
 import { jsonStringToFlatObject } from "@phoenix/utils/jsonUtils";
 
+/**
+ * TODO(future improvement): this prop is named after the action the parent
+ * performs (`appendFilterCondition`), which forces the same name to be threaded
+ * through MetadataTableCell -> MetadataTooltip and back out to whichever filter
+ * context the table uses. A cleaner shape is for the cell to expose an
+ * event-style callback (e.g. `onValidFilterCondition(condition)`) and let the
+ * table's cell wrapper call `appendFilterCondition` inside it, so the cell
+ * describes what happened and the table decides what to do about it.
+ */
 type AppendFilterCondition = (condition: string) => void;
 
 type MetadataTableCellProps = {

--- a/js/app/src/pages/project/MetadataTableCell.tsx
+++ b/js/app/src/pages/project/MetadataTableCell.tsx
@@ -7,25 +7,17 @@ import {
 } from "@phoenix/pages/project/MetadataTooltip";
 import { jsonStringToFlatObject } from "@phoenix/utils/jsonUtils";
 
-/**
- * TODO(future improvement): this prop is named after the action the parent
- * performs (`appendFilterCondition`), which forces the same name to be threaded
- * through MetadataTableCell -> MetadataTooltip and back out to whichever filter
- * context the table uses. A cleaner shape is for the cell to expose an
- * event-style callback (e.g. `onValidFilterCondition(condition)`) and let the
- * table's cell wrapper call `appendFilterCondition` inside it, so the cell
- * describes what happened and the table decides what to do about it.
- */
-type AppendFilterCondition = (condition: string) => void;
-
 type MetadataTableCellProps = {
   metadata: unknown;
-  appendFilterCondition: AppendFilterCondition;
+  /**
+   * Called with a filter DSL condition when the user picks a metadata value to filter on
+   */
+  onValidFilterCondition: (condition: string) => void;
 };
 
 export const MetadataTableCell = ({
   metadata,
-  appendFilterCondition,
+  onValidFilterCondition,
 }: MetadataTableCellProps) => {
   // Try to parse the metadata and stringify it
   // This is intended to work with object metadata but will technically work for arrays as well
@@ -58,7 +50,7 @@ export const MetadataTableCell = ({
       <MetadataTooltip
         width="800px"
         metadata={parsedMetadata}
-        appendFilterCondition={appendFilterCondition}
+        onValidFilterCondition={onValidFilterCondition}
       >
         <MetadataLabel
           metadata={stringifiedMetadata}
@@ -69,7 +61,7 @@ export const MetadataTableCell = ({
               key,
               value
             );
-            appendFilterCondition(filterCondition);
+            onValidFilterCondition(filterCondition);
           }}
         />
       </MetadataTooltip>

--- a/js/app/src/pages/project/MetadataTooltip.tsx
+++ b/js/app/src/pages/project/MetadataTooltip.tsx
@@ -12,8 +12,6 @@ import {
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { toPythonPrimitiveStr } from "@phoenix/utils/pythonUtils";
 
-import { useSpanFilterActions } from "./SpanFiltersContext";
-
 export const makeMetadataTooltipFilterCondition = (
   key: string,
   /**
@@ -34,14 +32,15 @@ type MetadataTooltipProps = {
   children: ReactNode;
   metadata: Record<string, string | number | boolean>;
   width?: CSSProperties["width"];
+  appendFilterCondition: (condition: string) => void;
 };
 
 export function MetadataTooltip({
   children,
   metadata,
   width,
+  appendFilterCondition,
 }: MetadataTooltipProps) {
-  const { appendFilterCondition } = useSpanFilterActions();
   const entries = Object.entries(metadata).map(([key, value]) => ({
     key,
     value: String(value),

--- a/js/app/src/pages/project/MetadataTooltip.tsx
+++ b/js/app/src/pages/project/MetadataTooltip.tsx
@@ -33,16 +33,16 @@ type MetadataTooltipProps = {
   metadata: Record<string, string | number | boolean>;
   width?: CSSProperties["width"];
   /**
-   * Called with a filter DSL condition when the user clicks a "Match" button
+   * Called with a filter DSL condition when the user presses a "Match" button
    */
-  onValidFilterCondition: (condition: string) => void;
+  onFilterConditionPressed: (condition: string) => void;
 };
 
 export function MetadataTooltip({
   children,
   metadata,
   width,
-  onValidFilterCondition,
+  onFilterConditionPressed,
 }: MetadataTooltipProps) {
   const entries = Object.entries(metadata).map(([key, value]) => ({
     key,
@@ -124,7 +124,7 @@ export function MetadataTooltip({
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        onValidFilterCondition(filterCondition);
+                        onFilterConditionPressed(filterCondition);
                       }}
                       css={css`
                         all: unset;

--- a/js/app/src/pages/project/MetadataTooltip.tsx
+++ b/js/app/src/pages/project/MetadataTooltip.tsx
@@ -32,14 +32,17 @@ type MetadataTooltipProps = {
   children: ReactNode;
   metadata: Record<string, string | number | boolean>;
   width?: CSSProperties["width"];
-  appendFilterCondition: (condition: string) => void;
+  /**
+   * Called with a filter DSL condition when the user clicks a "Match" button
+   */
+  onValidFilterCondition: (condition: string) => void;
 };
 
 export function MetadataTooltip({
   children,
   metadata,
   width,
-  appendFilterCondition,
+  onValidFilterCondition,
 }: MetadataTooltipProps) {
   const entries = Object.entries(metadata).map(([key, value]) => ({
     key,
@@ -121,7 +124,7 @@ export function MetadataTooltip({
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        appendFilterCondition(filterCondition);
+                        onValidFilterCondition(filterCondition);
                       }}
                       css={css`
                         all: unset;

--- a/js/app/src/pages/project/SpansTable.tsx
+++ b/js/app/src/pages/project/SpansTable.tsx
@@ -224,7 +224,7 @@ const MetadataCell = <TData extends { metadata: unknown }, TValue>({
   return (
     <MetadataTableCell
       metadata={row.original.metadata}
-      appendFilterCondition={appendFilterCondition}
+      onValidFilterCondition={appendFilterCondition}
     />
   );
 };

--- a/js/app/src/pages/project/SpansTable.tsx
+++ b/js/app/src/pages/project/SpansTable.tsx
@@ -1,5 +1,10 @@
 import { css } from "@emotion/react";
-import type { ColumnDef, SortingState, Table } from "@tanstack/react-table";
+import type {
+  CellContext,
+  ColumnDef,
+  SortingState,
+  Table,
+} from "@tanstack/react-table";
 import {
   flexRender,
   getCoreRowModel,
@@ -212,10 +217,20 @@ export const MemoizedTableBody = React.memo(
   TableBody,
   (prev, next) => prev.table.options.data === next.table.options.data
 ) as typeof TableBody;
+const MetadataCell = <TData extends { metadata: unknown }, TValue>({
+  row,
+}: CellContext<TData, TValue>) => {
+  const { appendFilterCondition } = useSpanFilterActions();
+  return (
+    <MetadataTableCell
+      metadata={row.original.metadata}
+      appendFilterCondition={appendFilterCondition}
+    />
+  );
+};
 
 export function SpansTable(props: SpansTableProps) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { appendFilterCondition } = useSpanFilterActions();
   const { fetchKey } = useStreamState();
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -716,12 +731,7 @@ export function SpansTable(props: SpansTableProps) {
     {
       header: "metadata",
       accessorKey: "metadata",
-      cell: ({ row }) => (
-        <MetadataTableCell
-          metadata={row.original.metadata}
-          appendFilterCondition={appendFilterCondition}
-        />
-      ),
+      cell: MetadataCell,
       enableSorting: false,
     },
     {

--- a/js/app/src/pages/project/SpansTable.tsx
+++ b/js/app/src/pages/project/SpansTable.tsx
@@ -77,6 +77,7 @@ import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SpanTraceAnnotationTooltipFilterActions } from "@phoenix/pages/project/AnnotationTooltipFilterActions";
 import { MetadataTableCell } from "@phoenix/pages/project/MetadataTableCell";
+import { useSpanFilterActions } from "@phoenix/pages/project/SpanFiltersContext";
 import { useTracePagination } from "@phoenix/pages/trace/TracePaginationContext";
 import { getTraceDetailsPath } from "@phoenix/utils/urlUtils";
 
@@ -214,6 +215,7 @@ export const MemoizedTableBody = React.memo(
 
 export function SpansTable(props: SpansTableProps) {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { appendFilterCondition } = useSpanFilterActions();
   const { fetchKey } = useStreamState();
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -714,7 +716,12 @@ export function SpansTable(props: SpansTableProps) {
     {
       header: "metadata",
       accessorKey: "metadata",
-      cell: ({ row }) => <MetadataTableCell metadata={row.original.metadata} />,
+      cell: ({ row }) => (
+        <MetadataTableCell
+          metadata={row.original.metadata}
+          appendFilterCondition={appendFilterCondition}
+        />
+      ),
       enableSorting: false,
     },
     {

--- a/js/app/src/pages/project/SpansTable.tsx
+++ b/js/app/src/pages/project/SpansTable.tsx
@@ -224,7 +224,7 @@ const MetadataCell = <TData extends { metadata: unknown }, TValue>({
   return (
     <MetadataTableCell
       metadata={row.original.metadata}
-      onValidFilterCondition={appendFilterCondition}
+      onFilterConditionPressed={appendFilterCondition}
     />
   );
 };

--- a/js/app/src/pages/project/TracesTable.tsx
+++ b/js/app/src/pages/project/TracesTable.tsx
@@ -268,7 +268,7 @@ const MetadataCell = <TData extends ISpanItem, TValue>({
   return (
     <MetadataTableCell
       metadata={row.original.metadata}
-      appendFilterCondition={appendFilterCondition}
+      onValidFilterCondition={appendFilterCondition}
     />
   );
 };

--- a/js/app/src/pages/project/TracesTable.tsx
+++ b/js/app/src/pages/project/TracesTable.tsx
@@ -115,6 +115,7 @@ import {
   TRACE_ANNOTATIONS_COLUMN_ID,
 } from "./tableUtils";
 import { TraceFilterConditionField } from "./TraceFilterConditionField";
+import { useTraceFilters } from "./TraceFiltersContext";
 
 type TracesTableProps = {
   project: TracesTable_spans$key;
@@ -260,10 +261,16 @@ export const MemoizedTableBody = React.memo(
 const MetadataCell = <TData extends ISpanItem, TValue>({
   row,
 }: CellContext<TData, TValue>) => {
+  const { appendFilterCondition } = useTraceFilters();
   if (row.original.__additionalRow) {
     return null;
   }
-  return <MetadataTableCell metadata={row.original.metadata} />;
+  return (
+    <MetadataTableCell
+      metadata={row.original.metadata}
+      appendFilterCondition={appendFilterCondition}
+    />
+  );
 };
 
 const trCSS = css`

--- a/js/app/src/pages/project/TracesTable.tsx
+++ b/js/app/src/pages/project/TracesTable.tsx
@@ -268,7 +268,7 @@ const MetadataCell = <TData extends ISpanItem, TValue>({
   return (
     <MetadataTableCell
       metadata={row.original.metadata}
-      onValidFilterCondition={appendFilterCondition}
+      onFilterConditionPressed={appendFilterCondition}
     />
   );
 };


### PR DESCRIPTION
Fixes #15759

## Summary
Each table supplies the action from the corresponding provider:

- MetadataTableCell.tsx no longer calls any hook. It now takes appendFilterCondition as a prop.
- SpansTable.tsx pulls appendFilterCondition from useSpanFilterActions()
- In TracesTable.tsx the MetadataCell component pulls appendFilterCondition from useTraceFilters() 

MetadataTableCell renders MetadataTooltip for every non-empty metadata value, and MetadataTooltip called useSpanFilterActions(), so the same logic was applied there:

- MetadataTooltip.tsx also dropped the useSpanFilterActions() hook and its import. It now takes appendFilterCondition as a prop.
- And MetadataTableCell.tsx forwards the appendFilterCondition it already receives down into MetadataTooltip.

