### PR TITLE
test: decouple unit tests from daemon timing inside the app

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,6 +59,10 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "real_agent_mcp_server: derive the agent's MCP server from the OpenAPI document",
     )
+    config.addinivalue_line(
+        "markers",
+        "real_agent_session_sweeper: run the app's agent-session sweeper loop",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -108,6 +112,24 @@ def _stub_wasm_prefetch(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr("phoenix.server.app.prefetch_wasm_binary_if_needed", _skip)
+
+
+@pytest.fixture(autouse=True)
+def _agent_session_sweeper_off(request: FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The app's agent-session sweeper makes its first pass concurrently with
+    the test body, so a test that seeds a session past its retention cannot
+    know whether the pass has already reaped it. Off suite-wide; the sweeper
+    tests call ``_sweep`` on their own instance, and a test that needs the
+    loop opts in with ``@pytest.mark.real_agent_session_sweeper``."""
+    if request.node.get_closest_marker("real_agent_session_sweeper"):
+        return
+
+    async def _idle(self: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "phoenix.server.daemons.agent_session_sweeper.AgentSessionSweeper._run", _idle
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -1,5 +1,7 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from sqlalchemy import select
 
 from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
@@ -347,3 +349,45 @@ async def test_default_settings_enforce_both_rules_without_admin_configuration(
     # the 30 most recently active of the user's remaining sessions.
     assert idle_session_id not in remaining_ids
     assert remaining_ids == set(recent_session_ids[:DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER])
+
+
+def _past_ephemeral_ttl() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(
+        hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1
+    )
+
+
+async def test_sweeper_loop_is_idle_in_unit_test_apps(db: DbSessionFactory) -> None:
+    """The suite-wide fixture leaves the loop inert: a started sweeper's task
+    finishes at once and a session past its retention survives it."""
+    expired_id = await _add_agent_session(
+        db, title="expired", updated_at=_past_ephemeral_ttl(), is_ephemeral=True
+    )
+    settings = await _make_settings(db)
+    sweeper = AgentSessionSweeper(db, settings=settings)
+    async with sweeper:
+        await asyncio.wait_for(asyncio.gather(*sweeper._tasks), timeout=1)
+    assert expired_id in await _remaining_session_ids(db)
+
+
+@pytest.mark.real_agent_session_sweeper
+async def test_sweeper_loop_sweeps_on_start_when_opted_in(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the marker the real loop runs, and its first pass reaps a session
+    past its retention before the loop first sleeps."""
+    expired_id = await _add_agent_session(
+        db, title="expired", updated_at=_past_ephemeral_ttl(), is_ephemeral=True
+    )
+    first_pass_done = asyncio.Event()
+
+    async def park(_: float) -> None:
+        first_pass_done.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("phoenix.server.daemons.agent_session_sweeper.sleep", park)
+    settings = await _make_settings(db)
+    async with AgentSessionSweeper(db, settings=settings):
+        await asyncio.wait_for(first_pass_done.wait(), timeout=10)
+    assert expired_id not in await _remaining_session_ids(db)

--- a/tests/unit/server/daemons/test_generative_model_store.py
+++ b/tests/unit/server/daemons/test_generative_model_store.py
@@ -14,19 +14,29 @@ _CYCLE_TIMEOUT_SECONDS = 30.0
 
 
 class _DaemonCycleController:
-    """Steps the store's fetch loop one cycle at a time through its patched sleep.
+    """Steps one store's fetch loop a cycle at a time through the module's patched sleep.
 
     The loop assigns _last_fetch_time before it sleeps, so entering sleep marks a
     finished cycle: the patched sleep signals completion, then parks the loop until
     the test releases the next cycle. Each release runs exactly one cycle -- a
     failed fetch is not retried, it surfaces in the next assertion.
+
+    The app under test runs its own store through the same module sleep. The
+    controller tells the loops apart by the refresh interval: the store it steps
+    is built with ``refresh_interval_seconds``, and any other loop parks until
+    its daemon is cancelled at shutdown.
     """
+
+    refresh_interval_seconds = 60 * 60
 
     def __init__(self) -> None:
         self._cycle_completed = Event()
         self._release_next = Event()
 
     async def sleep(self, seconds: float) -> None:
+        if seconds != self.refresh_interval_seconds:
+            await Event().wait()
+            return
         self._cycle_completed.set()
         await self._release_next.wait()
         self._release_next.clear()
@@ -139,7 +149,10 @@ class TestGenerativeModelStore:
         model2_id = result2.data["createModel"]["model"]["id"]
 
         # Start the daemon; its first cycle runs without a release.
-        store = GenerativeModelStore(db=db)
+        store = GenerativeModelStore(
+            db=db,
+            refresh_interval_seconds=daemon_cycles.refresh_interval_seconds,
+        )
         await store.start()
         try:
             await daemon_cycles.wait_for_cycle("initial fetch")


### PR DESCRIPTION
### Why
App-backed tests were racing the app's own daemons. The agent-session sweeper's first pass happened to finish inside a network wait during startup, so anything that shortens startup lets it reap the sessions a test just seeded. The model-store lifecycle test stepped the app's store as well as its own.

### What
- The sweeper loop is off in unit-test apps. Opt in with `real_agent_session_sweeper`.
- The lifecycle test's controller keys on the refresh interval it builds its own store with, and parks any other loop.

### Tests
- A started sweeper's task finishes at once and a session past its retention survives.
- With the marker, the real loop reaps it on its first pass.

### Notes
The four "sweeper has not reached it" tests and the fixed-date session tests now hold by construction rather than by timing.
