### PR TITLE
test: stop opening a docs MCP session for every unit-test app

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,7 @@ from _pytest.tmpdir import TempPathFactory
 from asgi_lifespan import LifespanManager
 from faker import Faker
 from fastapi import FastAPI
+from pydantic_ai import RunContext
 from pytest import FixtureRequest
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import URL, StaticPool
@@ -37,6 +38,7 @@ from phoenix.db.engines import (
     set_sqlite_pragma,
 )
 from phoenix.db.insertion.helpers import DataManipulation
+from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.app import _db, create_app
 from phoenix.server.grpc_server import GrpcServer
 from phoenix.server.types import BatchedCaller, DbSessionFactory
@@ -58,6 +60,11 @@ def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         "markers",
         "real_agent_mcp_server: derive the agent's MCP server from the OpenAPI document",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_docs_mcp_server: build the real docs MCP toolset, which opens an HTTPS MCP "
+        "session to the Mintlify host during lifespan startup",
     )
     config.addinivalue_line(
         "markers",
@@ -99,6 +106,37 @@ def _mcp_mount_off(monkeypatch: pytest.MonkeyPatch) -> None:
     OpenAPI document, about half a second per app. Off suite-wide; the MCP
     tests patch ``get_env_enable_mcp_server`` on, which wins over the env var."""
     monkeypatch.setenv("PHOENIX_ENABLE_MCP_SERVER", "false")
+
+
+class OfflineDocsMCPServer(MintlifyDocsMCPServer):
+    """``MintlifyDocsMCPServer`` with the MCP transport short-circuited.
+
+    Overrides ``get_tools`` to return an empty tool dict and the async
+    context-manager protocol to no-op, so neither app startup nor an agent
+    run opens an HTTP session to the Mintlify endpoint.
+    """
+
+    async def get_tools(self, ctx: RunContext[Any]) -> dict[str, Any]:
+        return {}
+
+    async def __aenter__(self) -> "OfflineDocsMCPServer":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_docs_mcp_server(request: FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The agent assistant and external resources default on, so every app
+    builds the docs MCP toolset and lifespan startup opens an HTTPS MCP session
+    to the Mintlify host: a network round trip per app, bounded only by the
+    client's init deadline. Stubbed suite-wide with the offline toolset; tests
+    that need the real transport opt in with ``@pytest.mark.real_docs_mcp_server``."""
+    if request.node.get_closest_marker("real_docs_mcp_server"):
+        return
+
+    monkeypatch.setattr("phoenix.server.app.MintlifyDocsMCPServer", OfflineDocsMCPServer)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -21,7 +21,7 @@ from anthropic.types.beta.message_create_params import MessageCreateParams
 from fastapi import FastAPI
 from opentelemetry.trace import NoOpTracerProvider
 from pydantic import SecretStr
-from pydantic_ai import Agent, RunContext, UserError
+from pydantic_ai import Agent, UserError
 from pydantic_ai.capabilities import AbstractCapability, CombinedCapability
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.test import TestModel
@@ -45,7 +45,6 @@ from phoenix.db.types.data_stream_protocol.ui_state_types import (
 from phoenix.server.agents.agent_factory import build_agent as _build_agent
 from phoenix.server.agents.capabilities import (
     GitHubMCPCapability,
-    MintlifyDocsMCPServer,
     build_anthropic_prompt_cache_capability,
 )
 from phoenix.server.agents.capabilities.github_mcp import GITHUB_WRITE_TOOLS
@@ -67,6 +66,7 @@ from phoenix.server.mcp.skills import PXI_SKILLS_ROOTS, load_skills
 from phoenix.server.mcp_server import build_phoenix_mcp_server
 from phoenix.server.monty_runtime import MontyRuntime
 from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import OfflineDocsMCPServer
 
 _DEFAULT_PROMPTS = AgentPrompts()
 
@@ -273,27 +273,9 @@ class TestPromptCacheCapabilityMounting:
         assert _DEFAULT_PROMPTS.base in _get_concatenated_text(cached_blocks)
 
 
-class _OfflineDocsMCPToolset(MintlifyDocsMCPServer):
-    """``MintlifyDocsMCPServer`` with the MCP transport short-circuited.
-
-    Overrides ``get_tools`` to return an empty tool dict and the async
-    context-manager protocol to no-op, so the agent run never opens an
-    HTTP/SSE session to the real Mintlify endpoint.
-    """
-
-    async def get_tools(self, ctx: RunContext[Any]) -> dict[str, Any]:
-        return {}
-
-    async def __aenter__(self) -> "_OfflineDocsMCPToolset":
-        return self
-
-    async def __aexit__(self, *args: object) -> None:
-        return None
-
-
 @pytest.fixture
-def docs_mcp_server() -> _OfflineDocsMCPToolset:
-    return _OfflineDocsMCPToolset()
+def docs_mcp_server() -> OfflineDocsMCPServer:
+    return OfflineDocsMCPServer()
 
 
 @pytest.fixture
@@ -1038,7 +1020,7 @@ class TestDocsMCPToolset:
         self,
         anthropic_model: AnthropicModel,
         captured_request: CapturedRequest,
-        docs_mcp_server: _OfflineDocsMCPToolset,
+        docs_mcp_server: OfflineDocsMCPServer,
         headless: bool,
     ) -> None:
         agent = build_agent(

--- a/tests/unit/server/test_app_docs_mcp_lifespan.py
+++ b/tests/unit/server/test_app_docs_mcp_lifespan.py
@@ -14,11 +14,13 @@ from contextlib import AsyncExitStack
 
 import pytest
 from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
 
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.app import create_app
 from phoenix.server.types import DbSessionFactory
 from tests.unit.conftest import (
+    OfflineDocsMCPServer,
     TestBulkInserter,
     patch_batched_caller,
     patch_grpc_server,
@@ -57,3 +59,16 @@ async def test_app_starts_up_when_docs_mcp_server_init_fails(
         assert isinstance(app.state.docs_mcp_server, _ExplodingDocsMCPServer)
         # Lifespan startup must not raise even though docs MCP init fails.
         await stack.enter_async_context(LifespanManager(app))
+
+
+async def test_unit_test_apps_get_the_offline_docs_toolset(app: FastAPI) -> None:
+    """The suite-wide stub is in force: the fixture app carries the offline
+    toolset, so its lifespan startup opens no session to the Mintlify host."""
+    assert isinstance(app.state.docs_mcp_server, OfflineDocsMCPServer)
+
+
+@pytest.mark.real_docs_mcp_server
+async def test_marker_restores_the_real_docs_toolset(app: FastAPI) -> None:
+    """Opting in builds the real toolset. Construction opens no connection, so
+    the check stops short of lifespan startup."""
+    assert type(app.state.docs_mcp_server) is MintlifyDocsMCPServer


### PR DESCRIPTION
### Why
Every unit-test app built the Mintlify docs MCP toolset and opened an HTTPS session to the Mintlify host during lifespan startup: a network round trip per app, roughly 1,400 times per job, bounded only by the client's five-second init deadline. It was the largest single startup cost and the only one bounded by a remote host.

### What
- An offline toolset is substituted suite-wide, hoisted from the agent-factory tests. Opt in with `real_docs_mcp_server`.

### Tests
- The fixture app carries the offline toolset.
- The marker restores the real class. Construction opens no connection.

### Numbers
Lifespan startup about 520ms to about 360ms per app, and the variance the remote host added is gone. Measured on an idle Apple-silicon Mac as the mean of six app boots of one test class, with an in-process timing plugin. CI runners are slower and contended.
