### PR TITLE
test: stop seeding the model cost manifest for every unit-test app

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,6 +70,10 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "real_agent_session_sweeper: run the app's agent-session sweeper loop",
     )
+    config.addinivalue_line(
+        "markers",
+        "seeded_model_costs: sync the model cost manifest into the database during app startup",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -168,6 +172,23 @@ def _agent_session_sweeper_off(request: FixtureRequest, monkeypatch: pytest.Monk
     monkeypatch.setattr(
         "phoenix.server.daemons.agent_session_sweeper.AgentSessionSweeper._run", _idle
     )
+
+
+@pytest.fixture(autouse=True)
+def _stub_model_cost_seeding(request: FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """App startup syncs the model cost manifest, hundreds of built-in models
+    with their token prices, through the ORM, and each test's database then
+    discards the rows. Stubbed suite-wide; tests that read built-in models or
+    prices through the app opt in with ``@pytest.mark.seeded_model_costs``,
+    which leaves the real step in the Facilitator so the rows exist before the
+    model store's first fetch is scheduled."""
+    if request.node.get_closest_marker("seeded_model_costs"):
+        return
+
+    async def _skip(db: DbSessionFactory) -> None:
+        return None
+
+    monkeypatch.setattr("phoenix.db.facilitator._ensure_model_costs", _skip)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/db/test_facilitator.py
+++ b/tests/unit/db/test_facilitator.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from _pytest.monkeypatch import MonkeyPatch
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
+from starlette.types import ASGIApp
 
 from phoenix.db import models
 from phoenix.db.enums import ENUM_COLUMNS
@@ -749,6 +750,35 @@ class TestEnsureModelCosts:
         await _ensure_model_costs(db)
         input_price = await _get_input_price(db)
         assert input_price.customization is None
+
+
+async def _count_built_in_models(db: DbSessionFactory) -> int:
+    async with db() as session:
+        count = await session.scalar(
+            select(sa.func.count())
+            .select_from(models.GenerativeModel)
+            .where(models.GenerativeModel.is_built_in.is_(True))
+        )
+    return int(count or 0)
+
+
+async def test_unit_test_apps_skip_model_cost_seeding(
+    db: DbSessionFactory,
+    asgi_app: ASGIApp,
+) -> None:
+    """The suite-wide stub is in force: app startup leaves the built-in model
+    table empty."""
+    assert await _count_built_in_models(db) == 0
+
+
+@pytest.mark.seeded_model_costs
+async def test_marker_seeds_model_costs_during_startup(
+    db: DbSessionFactory,
+    asgi_app: ASGIApp,
+) -> None:
+    """Opting in leaves the real step in the Facilitator, so app startup seeds
+    the manifest's built-in models."""
+    assert await _count_built_in_models(db) > 0
 
 
 class TestEnsureBuiltinEvaluators:

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -2080,6 +2080,7 @@ class TestChatCompletionOverDatasetSubscription:
             split_links = result.scalars().all()
             assert len(split_links) == 0  # No splits associated
 
+    @pytest.mark.seeded_model_costs
     async def test_evaluator_emits_evaluation_chunk_and_persists_annotation(
         self,
         gql_client: AsyncGraphQLClient,


### PR DESCRIPTION
### Why
App startup upserts the model cost manifest, hundreds of models with their token prices, through the ORM on the single serialized SQLite connection, and each test's database discards the rows afterwards.

### What
- The Facilitator's manifest step is a no-op suite-wide. Opt in with `seeded_model_costs`, which leaves the real step inside the Facilitator so the rows exist before the model store's first fetch is scheduled.
- One test needed it: the playground-over-dataset subscription test that asserts a span cost resolved to a built-in model.

### Tests
- The fixture app starts with zero built-in models; the marker seeds them.

### Numbers
On top of the docs-MCP stub, lifespan startup about 360ms to about 30ms per app: the step itself is about 280ms, and the model store and cost calculator then have nothing to load. Alone against main, about 520ms to about 170ms. Measured on an idle Apple-silicon Mac as the mean of six app boots of one test class, with an in-process timing plugin. CI runners are slower and contended.
