### PR TITLE
fix(pxi): make skill loading mandatory when triggers match

### DIFF
--- a/src/phoenix/server/agents/prompts/skills/SKILLS_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/skills/SKILLS_INSTRUCTIONS.xml.j2
@@ -1,5 +1,5 @@
 <skills>
-  <description>Skills carry task-specific instructions for working with Phoenix. If you find yourself working on a task that is relevant to one of the skills below, call `load_skill` to read instructions for that particular skill.</description>
+  <description>Skills carry task-specific instructions for working with Phoenix. Before acting on a user request, check whether any available skill matches the task. When a request matches a skill's trigger guidance, call `load_skill` for that skill before doing substantive work in that domain.</description>
   <available_skills>
 {% for skill in skills %}
     <skill>
@@ -9,6 +9,9 @@
 {% endfor %}
   </available_skills>
   <usage>
+    If a user request clearly matches one skill, load it first.
+    If a request spans multiple skills, load each relevant skill before proceeding.
+    Do not load unrelated skills.
     Load each skill at most once per conversation: if a successful load already appears in the conversation, reuse it.
     A loaded skill may list reference files; load one with `load_skill_reference`, using the exact names the skill lists.
   </usage>


### PR DESCRIPTION
Addresses #15869

## Summary
- Strengthens `SKILLS_INSTRUCTIONS.xml.j2` so the PXI agent treats `load_skill` as mandatory when a user request matches a skill's trigger guidance: check available skills before acting, load the matching skill (or each relevant skill for multi-skill requests) before substantive work, and never load unrelated skills.
- Split out of #15857, where it was unrelated to the Z.ai provider feature.

## Test plan
- [ ] PXI Regression Evals: the `debug_trace_skill_trigger`, `evaluators_skill_trigger`, and `experiments_skill_trigger` datasets should improve toward their thresholds (1.0 / 0.65 / 1.0).

Caveat from #15869: in the one CI run on #15857 that included this change, the skill-trigger pass rates did not move (identical 11/18, 4/10, 5/13 to runs without it), so this prompt tweak may be insufficient on its own — the eval run on this PR should judge it, and the issue tracks the broader repo-wide failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWbcuznyqzpDG9YHmqe4ky

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWbcuznyqzpDG9YHmqe4ky)_