### PR TITLE
docs: add Harbor integration guide and agent skill

### DIFF
--- a/.agents/skills/phoenix-harbor/SKILL.md
+++ b/.agents/skills/phoenix-harbor/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: phoenix-harbor
+description: Configure and interpret the Phoenix plugin for Harbor agent evaluations. Use when adding `arize-phoenix` to Harbor jobs, choosing ATIF tracing, mapping Harbor tasks and rewards to Phoenix experiments, comparing agents or models, resuming jobs, or troubleshooting Harbor records in Phoenix.
+license: Apache-2.0
+metadata:
+  author: oss@arize.com
+  version: "1.0.0"
+---
+
+# Phoenix for Harbor
+
+Use the Phoenix Harbor plugin to record Harbor agent evaluations as versioned Phoenix datasets, experiments, runs, scores, and ATIF traces.
+
+Harbor runs agents and verifiers. Phoenix records and compares their results. Do not describe Phoenix as executing Harbor tasks or recalculating Harbor rewards.
+
+## Requirements
+
+- Python 3.12 or newer
+- Harbor 0.21.0 or newer
+- `arize-phoenix-client` installed with the `harbor` extra
+- Phoenix server 15.0 or newer
+
+Install the client and Harbor in the same Python environment:
+
+```bash
+pip install "arize-phoenix-client[harbor]"
+```
+
+## Choose the trace mode
+
+Use `atif` unless the agent has no ATIF trajectory or the user does not want traces. ATIF is the default. It reads trajectory files after the final trial attempt, so the sandbox needs no Phoenix endpoint, credentials, instrumentation, or outbound network access.
+
+Use `none` to record datasets, experiments, runs, and evaluations without traces:
+
+```bash
+--plugin-kwarg trace_mode=none
+```
+
+Live OpenTelemetry Protocol (OTLP) support is deferred to a follow-up. This release accepts only `atif` and `none`, and does not link live OpenTelemetry agent traces to experiment runs.
+
+## Set the Phoenix destination
+
+Set the endpoint for the Phoenix plugin process. ATIF agents and their sandboxes do not connect to Phoenix. Prefer environment variables so credentials do not enter shell history or job configuration:
+
+```bash
+export PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
+export PHOENIX_API_KEY=your-api-key
+```
+
+Omit `PHOENIX_API_KEY` when the Phoenix instance does not require authentication. The `endpoint` and `api_key` plugin kwargs override these values when the user asks for per-job settings.
+
+## Add the plugin
+
+Add `--plugin arize-phoenix` to the user's existing `harbor run` command. Preserve their dataset, agent, model, environment, concurrency, retry, and task selections.
+
+```bash
+harbor run \
+  -d terminal-bench/terminal-bench-2 \
+  -a terminus-2 \
+  -m openai/gpt-5-mini \
+  --plugin arize-phoenix \
+  --yes
+```
+
+Do not invent or replace Harbor settings that are unrelated to Phoenix.
+
+## Predict the Phoenix records
+
+Use this mapping when explaining a job or checking its results:
+
+| Harbor | Phoenix |
+| --- | --- |
+| One task collection | One versioned dataset |
+| One task | One dataset example |
+| One distinct agent and model configuration | One experiment |
+| One planned task attempt | One repetition |
+| One final logical trial | One experiment run |
+| Final verifier reward | Experiment evaluation with the original key and CODE annotator kind |
+| Step verifier reward | Evaluation named `<step_name>.<reward_key>` |
+| Trial or step exception | Run error and `infra_ok=0` |
+| Saved ATIF trajectories | One trace linked to the run |
+
+Each single-step or multi-step Harbor task becomes one Phoenix dataset example. A multi-step example input includes its ordered step names and instructions. Phoenix examples keep `output` empty because Harbor verifies the environment state rather than a single reference response.
+
+The plugin records only the terminal physical attempt for a logical trial. An attempt that Harbor will retry does not create a Phoenix run. Completion order does not define repetition numbers.
+
+## Name the dataset
+
+The plugin infers a Phoenix dataset name for each supported single-source job. Provide `dataset=<name>` only when a job contains several direct tasks, which have no shared collection name, or when you want to customize the dataset's display name in Phoenix.
+
+The inferred names are:
+
+| Harbor source | Phoenix dataset name |
+| --- | --- |
+| Named registry dataset | The selected dataset name |
+| Published package | The selected `<organization>/<dataset>` name |
+| Local dataset path | The resolved directory name |
+| Repository dataset | The resolved registry metadata name |
+| One direct task | `harbor-task/<task-name>` |
+
+To name several direct tasks or override an inferred name, add this setting to the Harbor command:
+
+```bash
+--plugin-kwarg dataset=release-candidate-tasks
+```
+
+Stop and explain the constraint if the job has any unsupported source shape:
+
+- more than one configured dataset;
+- both a configured dataset and direct tasks;
+- several direct tasks without `dataset=<name>`;
+- duplicate task IDs; or
+- a regrade job or another job derived from previous Harbor results.
+
+The plugin synchronizes the complete resolved task set at job start. An unchanged set reuses the dataset version. A task addition, removal, or content change creates a version. Existing experiments stay pinned to their creation-time version.
+
+## Name experiments
+
+The default template is:
+
+```text
+{job.name} · {agent.name} · {agent.model}
+```
+
+For one agent configuration, an exact name is valid:
+
+```bash
+--plugin-kwarg experiment_name=release-candidate
+```
+
+For several agent configurations, use `experiment_name_template`. Available fields are:
+
+- `{job.name}`
+- `{job.id}`
+- `{dataset.name}`
+- `{agent.name}`
+- `{agent.model}`
+- `{agent.short_digest}`
+
+Agent names do not need to be unique. Two agents with the same name but different effective configurations each get an experiment. If rendered names collide, the plugin appends the short agent digest. Stable identity comes from the Harbor job ID and effective agent configuration, not the display name.
+
+## Interpret scores
+
+Keep behavioral outcomes separate from execution health. Phoenix does not run another evaluator. The plugin records Harbor's completed verifier rewards as named experiment evaluations with the CODE annotator kind.
+
+| Evaluation | Interpretation |
+| --- | --- |
+| `reward` | Present only when the final Harbor verifier emits a literal `reward` key. A value of `0` is behavioral failure, not an infrastructure error. |
+| `infra_ok` | Present on every run. `1` means Harbor recorded no trial or step exception. `0` means at least one exception occurred. |
+| `<reward_key>` | A task-specific final-verifier score in its original numeric scale. |
+| `<step_name>.<reward_key>` | A task-specific step score for multi-step diagnosis. |
+
+Do not infer `reward` from another lone key. Check its coverage before computing cross-task summaries.
+
+A run may contain rewards and still have `infra_ok=0`. Harbor can produce verifier output before or alongside a step exception. Preserve both facts when explaining the result.
+
+For comparisons:
+
+1. Check the fraction of runs with `reward`.
+2. Compare `reward` among behaviorally completed runs.
+3. Compare `infra_ok` to find environment, timeout, agent-process, or verifier reliability problems.
+4. Use step scores and the linked trace to locate the failure within a task.
+
+## Interpret ATIF traces
+
+One logical trial maps to one trace and one Phoenix session. The trace starts with a plugin-owned `harbor.trial` CHAIN span:
+
+```text
+harbor.trial                         CHAIN
+  agent trajectory                  AGENT
+    turn                            AGENT
+      fresh ATIF operation          CHAIN
+        model call                  LLM
+        tool call                   TOOL
+          referenced subagent       AGENT
+```
+
+The converter keeps fresh operations, model calls, tool calls, continuations, and referenced subagents. Copied user or system context remains in LLM messages and does not become duplicate execution spans. All steps of a multi-step task share one trial root.
+
+ATIF timestamps are point events. Zero-duration LLM or TOOL spans can mean no unambiguous duration was available. Do not interpret them as proof that the operation took no time. Declared tool order does not prove serial execution.
+
+ATIF discovery and conversion are best-effort. If the trajectory is missing or invalid, the plugin warns and records the run without a trace. A later replay cannot attach a trace to an immutable successful run.
+
+## Handle failures and resume
+
+Selecting the plugin makes successful Phoenix recording required.
+
+- Setup failures stop the job before trials run.
+- Run or evaluation write failures stop the job. Already recorded trials remain in Phoenix.
+- Harbor keeps terminal results that the plugin can ingest during resume.
+- ATIF conversion or upload failure does not stop the job. The run is recorded without a trace.
+
+Sequential resume and replay reuse matching datasets, experiments, successful runs, evaluations, and traces. Failed runs can be retried. Do not run multiple ingesters for the same Harbor job because experiment recovery is not atomic across processes.
+
+If Phoenix reports a conflict, do not tell the user to ignore it. The plugin validates the stored run's trial output and trace identity. A mismatch requires a new Harbor job or resolution of the conflicting Phoenix record.
+
+## Current boundaries
+
+The plugin does not support:
+
+- Harbor regrade jobs and other jobs derived from previous Harbor results;
+- post-hoc ingestion of a completed job;
+- live OTLP trace linkage, which is deferred to a follow-up;
+- several configured datasets in one job;
+- mixed configured datasets and direct tasks; or
+- concurrent ingestion of one Harbor job.
+
+For the public guide, use [Phoenix's Harbor documentation](https://arize.com/docs/phoenix/integrations/evaluation-integrations/harbor). For Harbor command and task configuration, use the [Harbor documentation](https://harborframework.com/docs/).

--- a/.agents/skills/phoenix-harbor/SKILL.md
+++ b/.agents/skills/phoenix-harbor/SKILL.md
@@ -30,13 +30,13 @@ pip install "arize-phoenix-client[harbor]"
 
 Use `atif` unless the agent has no ATIF trajectory or the user does not want traces. ATIF is the default. It reads trajectory files after the final trial attempt, so the sandbox needs no Phoenix endpoint, credentials, instrumentation, or outbound network access.
 
-Use `none` to record datasets, experiments, runs, and evaluations without traces:
+Use `null` to record datasets, experiments, runs, and evaluations without traces:
 
 ```bash
---plugin-kwarg trace_mode=none
+--plugin-kwarg trace_mode=null
 ```
 
-Live OpenTelemetry Protocol (OTLP) support is deferred to a follow-up. This release accepts only `atif` and `none`, and does not link live OpenTelemetry agent traces to experiment runs.
+Live OpenTelemetry Protocol (OTLP) support is deferred to a follow-up. This release accepts `atif` or `null`, and does not link live OpenTelemetry agent traces to experiment runs.
 
 ## Set the Phoenix destination
 
@@ -78,7 +78,7 @@ Use this mapping when explaining a job or checking its results:
 | Final verifier reward | Experiment evaluation with the original key and CODE annotator kind |
 | Step verifier reward | Evaluation named `<step_name>.<reward_key>` |
 | Trial or step exception | Run error and `infra_ok=0` |
-| Saved ATIF trajectories | One trace linked to the run |
+| Saved ATIF trajectories | One trace linked to the run, with one step span per attempted step in a multi-step task |
 
 Each single-step or multi-step Harbor task becomes one Phoenix dataset example. A multi-step example input includes its ordered step names and instructions. Phoenix examples keep `output` empty because Harbor verifies the environment state rather than a single reference response.
 
@@ -154,6 +154,8 @@ Do not infer `reward` from another lone key. Check its coverage before computing
 
 A run may contain rewards and still have `infra_ok=0`. Harbor can produce verifier output before or alongside a step exception. Preserve both facts when explaining the result.
 
+For a multi-step task, trial-level reward evaluations include `multi_step_reward_strategy` metadata. Harbor's omitted default resolves to `mean`; preserve an explicit `final`. Step evaluations and `infra_ok` do not include this field.
+
 For comparisons:
 
 1. Check the fraction of runs with `reward`.
@@ -163,19 +165,26 @@ For comparisons:
 
 ## Interpret ATIF traces
 
-One logical trial maps to one trace and one Phoenix session. The trace starts with a plugin-owned `harbor.trial` CHAIN span:
+One logical trial maps to one trace and one Phoenix session. The trace starts with a plugin-owned `harbor.trial` CHAIN span. Multi-step trials add one `harbor.step` span per attempted step:
 
 ```text
-harbor.trial                         CHAIN
-  agent trajectory                  AGENT
-    turn                            AGENT
-      fresh ATIF operation          CHAIN
-        model call                  LLM
-        tool call                   TOOL
-          referenced subagent       AGENT
+harbor.trial <task>                  CHAIN
+  harbor.step 1 <step name>          CHAIN, multi-step trials only
+    <agent>                          AGENT
+      turn 1                         AGENT, multi-turn trajectories only
+        iteration 1                  CHAIN
+          <model>                    LLM
+          <tool>                     TOOL
+            <subagent>               AGENT
 ```
 
-The converter keeps fresh operations, model calls, tool calls, continuations, and referenced subagents. Copied user or system context remains in LLM messages and does not become duplicate execution spans. All steps of a multi-step task share one trial root.
+Single-step trajectories attach directly to the trial root. Each multi-step `harbor.step` span carries its instruction, timing, exception status, and any verifier rewards. A step remains visible even when its trajectory is missing. All step spans and trajectories share the trial root.
+
+Agent, model, and tool spans use their ATIF names. Fresh agent operations use `iteration N`; context-management operations use `compaction N`; and other operational system steps use `system event N`. Multi-turn trajectories add `turn N` spans. Steps with `llm_call_count: 0` keep their operation and tool spans but do not create an LLM span. Continuation roots use `<agent> (continuation N)`.
+
+The converter supports ATIF v1.0 through v1.7. It reconstructs LLM inputs from ATIF and marks them with `metadata.atif.input_source = "reconstructed"`. Copied prompt history contributes to those inputs without creating spans. It pairs an observation with a tool call only when `source_call_id` matches. Keep multiple results in order. Unmatched step observations stay on the operation span; unassigned feedback remains structured in the reconstructed input without an invented role or tool association. Structured text and image parts remain serialized, but media bytes are not uploaded. ATIF v1.8 audio fields are unsupported.
+
+Only LLM spans carry `llm.*` attributes. Trajectory `final_metrics` remain in agent-root metadata to avoid double-counting tokens. Producer-specific cache-write and reasoning token counts map to the corresponding OpenInference token-detail attributes when present.
 
 ATIF timestamps are point events. Zero-duration LLM or TOOL spans can mean no unambiguous duration was available. Do not interpret them as proof that the operation took no time. Declared tool order does not prove serial execution.
 
@@ -190,7 +199,7 @@ Selecting the plugin makes successful Phoenix recording required.
 - Harbor keeps terminal results that the plugin can ingest during resume.
 - ATIF conversion or upload failure does not stop the job. The run is recorded without a trace.
 
-Sequential resume and replay reuse matching datasets, experiments, successful runs, evaluations, and traces. Failed runs can be retried. Do not run multiple ingesters for the same Harbor job because experiment recovery is not atomic across processes.
+Sequential resume and replay reuse matching datasets, experiments, successful runs, evaluations, and traces. Failed runs can be retried. If another job creates a newer version of the shared dataset, recover the original experiment and keep it pinned to its creation-time version. Do not run multiple ingesters for the same Harbor job because experiment recovery is not atomic across processes.
 
 If Phoenix reports a conflict, do not tell the user to ignore it. The plugin validates the stored run's trial output and trace identity. A mismatch requires a new Harbor job or resolution of the conflicting Phoenix record.
 

--- a/docs.json
+++ b/docs.json
@@ -291,6 +291,7 @@
               {
                 "group": "Integrations",
                 "pages": [
+                  "docs/phoenix/integrations/evaluation-integrations/harbor",
                   "docs/phoenix/evaluation/integrations/pytest",
                   "docs/phoenix/evaluation/integrations/vitest-jest"
                 ]
@@ -901,6 +902,7 @@
             "group": "Evaluation Integrations",
             "icon": "clipboard-check",
             "pages": [
+              "docs/phoenix/integrations/evaluation-integrations/harbor",
               "docs/phoenix/integrations/evaluation-integrations/cleanlab",
               "docs/phoenix/integrations/evaluation-integrations/mlflow",
               "docs/phoenix/integrations/evaluation-integrations/ragas",

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -29,8 +29,8 @@ Phoenix offers several types of integrations to support your AI development work
   <Card title="Eval Model Integrations" icon="brain" href="#eval-model-integrations">
     Use any LLM provider to power Phoenix's evaluation capabilities for scoring and classifying your traces.
   </Card>
-  <Card title="Eval Library Integrations" icon="clipboard-check" href="#eval-library-integrations">
-    Integrate with external evaluation libraries like Ragas, Cleanlab, and MLflow to visualize results in Phoenix.
+  <Card title="Evaluation Integrations" icon="clipboard-check" href="#evaluation-integrations">
+    Record results from evaluation frameworks and libraries such as Harbor, Ragas, Cleanlab, and MLflow.
   </Card>
   <Card title="Span Processors" icon="arrows-rotate" href="#span-processors">
     Convert traces from other instrumentation libraries to the OpenInference format.
@@ -184,11 +184,12 @@ Phoenix's evaluation library (`phoenix-evals`) can use any LLM provider to power
 
 ---
 
-## Eval Library Integrations
+## Evaluation Integrations
 
-Use external evaluation libraries alongside Phoenix to get the best of both worlds:
+Connect external evaluation frameworks and libraries to Phoenix:
 
 <CardGroup cols={4}>
+  <Card title="Harbor" href="/docs/phoenix/integrations/evaluation-integrations/harbor" icon="anchor" description="Sandboxed agent evaluation tracking"/>
   <Card title="Ragas" href="/docs/phoenix/integrations/evaluation-integrations/ragas" icon="clipboard-check" description="RAG evaluation library"/>
   <Card title="Cleanlab" href="/docs/phoenix/integrations/evaluation-integrations/cleanlab" icon="check-circle" description="Model quality diagnostics"/>
   <Card title="Pydantic Evals" href="/docs/phoenix/integrations/python/pydantic/pydantic-evals" icon="code" description="Pydantic-based evals"/>
@@ -218,4 +219,3 @@ Run Phoenix [code evaluators](/docs/phoenix/evaluation/server-evals/code-evaluat
   <Card title="Vercel Sandbox" href="/docs/phoenix/integrations/sandboxes/vercel" icon="cube" description="Ephemeral compute on Vercel infrastructure"/>
   <Card title="Modal" href="/docs/phoenix/integrations/sandboxes/modal" icon="cube" description="Serverless containers, Python-first"/>
 </CardGroup>
-

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -182,7 +182,7 @@ This installs skills into the project's agent directory (for example, `.claude/s
 
 ### Available Skills
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="phoenix-cli" href="https://github.com/Arize-ai/phoenix/blob/main/.agents/skills/phoenix-cli/SKILL.md">
     Debug LLM apps using Phoenix CLI for traces, experiments, datasets, and prompts. Recommended.
   </Card>
@@ -191,6 +191,9 @@ This installs skills into the project's agent directory (for example, `.claude/s
   </Card>
   <Card title="phoenix-tracing" href="https://github.com/Arize-ai/phoenix/blob/main/.agents/skills/phoenix-tracing/SKILL.md">
     Implement OpenInference tracing conventions and instrumentation in Python and TypeScript.
+  </Card>
+  <Card title="phoenix-harbor" href="https://github.com/Arize-ai/phoenix/blob/main/.agents/skills/phoenix-harbor/SKILL.md">
+    Configure Harbor agent evaluations and interpret their Phoenix experiments, scores, and ATIF traces.
   </Card>
 </CardGroup>
 

--- a/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
+++ b/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
@@ -1,0 +1,247 @@
+---
+title: "Harbor"
+description: "Record Harbor agent evaluations as Phoenix datasets, experiments, scores, and ATIF traces."
+keywords: ["harbor", "agent evaluation", "agent benchmark", "atif", "experiments"]
+---
+
+[Harbor](https://harborframework.com/) runs AI agents against tasks in sandboxed environments. Its Phoenix plugin records those jobs as versioned datasets and experiments. You can compare agents, models, and repetitions in Phoenix, then open the trace behind an individual score.
+
+Harbor remains responsible for running agents and verifiers. Phoenix stores and displays the resulting tasks, runs, rewards, errors, and traces. The plugin does not rerun tasks or calculate a replacement reward.
+
+```mermaid
+flowchart LR
+    H["Harbor job"] --> D["Phoenix dataset<br/>one example per task"]
+    H --> E["Phoenix experiment<br/>one per agent and model"]
+    E --> R["Experiment run<br/>one per final logical trial"]
+    R --> S["Harbor rewards<br/>and infra_ok"]
+    R --> T["ATIF trace<br/>agent, LLM, and tool spans"]
+```
+
+## When to use the plugin
+
+Use the plugin when Harbor runs your benchmark and you want to:
+
+- compare agents or models over the same task set;
+- track results across repeated benchmark jobs;
+- separate behavioral scores from infrastructure failures;
+- inspect an Agent Trajectory Interchange Format (ATIF) trace for a scored run; or
+- keep completed results when a long job stops early.
+
+Omit the plugin when you want a Harbor-only job. Selecting the plugin makes Phoenix recording part of the job contract. A setup or result-write failure stops the job instead of continuing with unrecorded trials.
+
+<Info>
+The integration requires Python 3.12 or newer, Harbor 0.21.0 or newer, and Phoenix server 15.0 or newer.
+</Info>
+
+## Install and run
+
+Install the Phoenix client and Harbor in the same Python environment:
+
+```bash
+pip install "arize-phoenix-client[harbor]"
+```
+
+Set the connection to your Phoenix instance. Self-hosted Phoenix uses `http://localhost:6006` by default.
+
+```bash
+export PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
+export PHOENIX_API_KEY=your-api-key
+```
+
+You can omit `PHOENIX_API_KEY` when your instance does not require authentication. See [What is my Phoenix endpoint?](/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint) for hosted and self-hosted endpoint formats.
+
+Add the plugin to a Harbor job:
+
+```bash
+harbor run \
+  -d terminal-bench/terminal-bench-2 \
+  -a terminus-2 \
+  -m openai/gpt-5-mini \
+  --plugin arize-phoenix \
+  --yes
+```
+
+The plugin infers the Phoenix dataset name from the Harbor dataset. It creates one experiment for the selected agent and model. Each final task trial appears as a run as soon as that trial finishes.
+
+<Tip>
+Start with the default `atif` mode when your Harbor agent writes ATIF trajectories. It captures agent execution without adding tracing code or giving the sandbox network access to Phoenix.
+</Tip>
+
+## How Harbor data maps to Phoenix
+
+| Harbor object | Phoenix object | Details |
+| --- | --- | --- |
+| Dataset | Dataset | The plugin synchronizes the complete resolved task set at job start. |
+| Task | Dataset example | The input contains the task ID, name, instruction, and ordered step instructions. |
+| Task digest | Example metadata | The digest covers the solution, environment, tests, and steps. |
+| Agent and model | Experiment | Each distinct agent and model configuration gets its own experiment. |
+| Planned task attempt | Repetition | Repetitions use stable, one-based numbers from the job plan. |
+| Final logical trial | Experiment run | Physical retries keep the logical repetition number. The plugin records only the terminal attempt. |
+| Verifier reward | Experiment evaluation | The plugin records each Harbor reward as a named CODE evaluation on the experiment run. |
+| Trial or step exception | Run error | Errors are stored separately from behavioral rewards. |
+| ATIF trajectory | Trace | One trial-level trace links to the experiment run when conversion succeeds. |
+
+Each Harbor task becomes one dataset example, including a multi-step task. For a multi-step task, the example input also contains the ordered step names and instructions. Phoenix dataset examples have an empty reference `output` because Harbor verifies an environment state rather than a single reference response.
+
+Each run output includes the Harbor trial ID, trial name, trial URI, and task name. It also includes Harbor's token totals and cost when the agent reports them. Task metadata keeps environment variable names but redacts their values.
+
+### Dataset versions
+
+The plugin uses the Harbor task ID as the stable example ID. It synchronizes the full task set each time a job starts.
+
+- An unchanged task set reuses the current dataset version.
+- Adding, removing, or changing a task creates a new dataset version.
+- An experiment stays pinned to the dataset version used when the experiment was created.
+
+The plugin infers a Phoenix dataset name for each supported single-source job. The inferred name depends on the Harbor task source:
+
+| Harbor source | Phoenix dataset name |
+| --- | --- |
+| Named registry dataset | The selected dataset name |
+| Published package | The selected `<organization>/<dataset>` name |
+| Local dataset path | The resolved directory name |
+| Repository dataset | The resolved registry metadata name |
+| One direct task | `harbor-task/<task-name>` |
+
+Provide `dataset=<name>` only when a job contains several direct tasks, which have no shared collection name, or when you want to customize the dataset's display name in Phoenix. Add this setting to the job's existing command:
+
+```bash
+--plugin-kwarg dataset=release-candidate-tasks
+```
+
+Use one task collection per job. The plugin rejects jobs that mix a configured dataset with direct tasks or include several configured datasets.
+
+## Read scores correctly
+
+Harbor tasks can use different verifiers, so the plugin keeps summary metrics separate from task-specific diagnostics. Phoenix does not run a second evaluator. The plugin stores the rewards returned by Harbor as experiment evaluations on each run.
+
+| Phoenix evaluation | Coverage | Meaning |
+| --- | --- | --- |
+| `reward` | Runs whose final verifier emits a literal `reward` key | Harbor's conventional behavioral score. A score of `0` is a valid result, not an infrastructure error. |
+| `infra_ok` | Every recorded run | `1` when Harbor records no trial or step exception, otherwise `0`. |
+| `<reward_key>` | Runs whose final verifier emits that key | A trial-level reward or diagnostic in Harbor's original numeric scale. |
+| `<step_name>.<reward_key>` | Runs whose step verifier emits that key | A step-level score for diagnosing multi-step tasks. |
+
+A multi-step run can have verifier rewards and an exception at the same time. Phoenix keeps both: the reward remains available, while the run has an error and `infra_ok=0`.
+
+For comparisons, check `reward` coverage before calculating an aggregate. Then use `infra_ok` to separate agent behavior from broken environments, timeouts, or verifier failures. Step-level scores show where a multi-step task failed.
+
+## Understand ATIF traces
+
+ATIF is the default trace mode. The plugin reads saved trajectories after the final trial attempt, converts them to OpenInference spans, and uploads them to the experiment's Phoenix project. The sandbox does not need a Phoenix endpoint or Phoenix credentials.
+
+One Harbor trial becomes one trace and one Phoenix session:
+
+```text
+harbor.trial                         CHAIN
+  agent trajectory                  AGENT
+    turn                            AGENT
+      fresh ATIF operation          CHAIN
+        model call                  LLM
+        tool call                   TOOL
+          referenced subagent       AGENT
+```
+
+The converter preserves fresh agent operations, model calls, tool calls, continuations, and referenced subagents. User and system messages used as prompt history remain LLM context instead of becoming duplicate execution spans. Multi-step task trajectories share the same `harbor.trial` root.
+
+ATIF timestamps describe events rather than complete operation durations. The plugin uses request timings only when it can map every measurement to one LLM step. It leaves ambiguous LLM and tool durations at zero instead of inventing timing or concurrency.
+
+Trace discovery and conversion are best-effort. If the agent does not save a valid trajectory, the plugin logs a warning and records the run and evaluations without a trace. A successful Phoenix run is immutable, so replay cannot add a missing trace link later.
+
+Use `trace_mode=none` when the agent has no ATIF output or when you do not want traces:
+
+```bash
+harbor run \
+  -p ./tasks/customer-support \
+  -a your-agent \
+  -m your-provider/your-model \
+  --plugin arize-phoenix \
+  --plugin-kwarg trace_mode=none \
+  --yes
+```
+
+<Note>
+Live OpenTelemetry Protocol (OTLP) support is deferred to a follow-up. This release accepts `atif` and `none`, and does not link live OpenTelemetry traces from Harbor agents to experiment runs.
+</Note>
+
+## Name experiments
+
+The default experiment name is:
+
+```text
+{job.name} · {agent.name} · {agent.model}
+```
+
+For a job with one agent configuration, set an exact display name:
+
+```bash
+--plugin-kwarg experiment_name=release-candidate
+```
+
+For a job with several agent configurations, use a template:
+
+```bash
+--plugin-kwarg 'experiment_name_template={dataset.name} · {agent.name} · {agent.model}'
+```
+
+Available fields are `{job.name}`, `{job.id}`, `{dataset.name}`, `{agent.name}`, `{agent.model}`, and `{agent.short_digest}`.
+
+Agent names do not need to be unique. Two agents with the same name but different effective configurations each get an experiment. If their templates render the same experiment name, the plugin appends the short agent configuration digest to distinguish them.
+
+Experiment display names do not define identity. The plugin identifies an experiment by the Harbor job ID and the effective agent configuration. Use a new Harbor job for a new benchmark execution, even when you want to reuse the same display name.
+
+## Configure the plugin
+
+Pass settings with Harbor's `--plugin-kwarg` option.
+
+| Setting | Default | Use |
+| --- | --- | --- |
+| `dataset` | Inferred from Harbor | Override the Phoenix dataset name. Required for several direct tasks. |
+| `endpoint` | `PHOENIX_COLLECTOR_ENDPOINT` | Override the Phoenix base endpoint for this job. |
+| `api_key` | `PHOENIX_API_KEY` | Override the Phoenix API key. Prefer the environment variable so the key does not enter shell history. |
+| `trace_mode` | `atif` | Use `atif` or `none`. |
+| `experiment_name` | Unset | Set one exact name. Valid only for a job with one agent configuration. |
+| `experiment_name_template` | `{job.name} · {agent.name} · {agent.model}` | Name one experiment per agent configuration. |
+
+## Resume and failure behavior
+
+The plugin writes each trial when it reaches its final state. This gives you live progress and preserves completed runs when the job stops.
+
+On resume or replay, the plugin recovers the matching experiment, reuses matching successful runs, retries failed runs, and upserts their evaluations. Deterministic task, run, and trace identities prevent duplicate records during sequential ingestion.
+
+Run only one process for a given Harbor job. Experiment recovery is not atomic across multiple ingesters.
+
+The plugin handles failures as follows:
+
+- Phoenix setup failures stop the job before Harbor spends trial compute.
+- Run or evaluation write failures stop the job. Records from completed trials remain in Phoenix and Harbor keeps its terminal results for resume.
+- Missing or invalid ATIF data does not stop the job. The run remains available without a trace.
+
+## Current limits
+
+The plugin does not support:
+
+- [Harbor regrade jobs](https://harborframework.com/docs/run-jobs/regrade), which run a new verifier against recorded agent work;
+- post-hoc import of a finished job;
+- live OTLP trace linkage, which is deferred to a follow-up;
+- several configured datasets in one job;
+- a mixture of configured datasets and direct tasks; or
+- concurrent ingestion of the same Harbor job.
+
+For Harbor task, dataset, agent, and job configuration, see the [Harbor documentation](https://harborframework.com/docs/).
+
+## Give a coding agent Harbor context
+
+Install the `phoenix-harbor` skill when a coding agent will configure or interpret the integration:
+
+```bash
+npx skills add Arize-ai/phoenix --skill phoenix-harbor
+```
+
+For example:
+
+```text
+Use the phoenix-harbor skill to add Phoenix recording to this Harbor benchmark. Keep ATIF tracing enabled and explain how I should compare behavioral reward with infra_ok.
+```
+
+See [Coding agents](/docs/phoenix/integrations/developer-tools/coding-agents#skills) for supported agents and installation options.

--- a/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
+++ b/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
@@ -79,7 +79,7 @@ Start with the default `atif` mode when your Harbor agent writes ATIF trajectori
 | Final logical trial | Experiment run | Physical retries keep the logical repetition number. The plugin records only the terminal attempt. |
 | Verifier reward | Experiment evaluation | The plugin records each Harbor reward as a named CODE evaluation on the experiment run. |
 | Trial or step exception | Run error | Errors are stored separately from behavioral rewards. |
-| ATIF trajectory | Trace | One trial-level trace links to the experiment run when conversion succeeds. |
+| ATIF trajectory | Trace | One trial-level trace links to the experiment run when conversion succeeds. Multi-step trials include one span per attempted step. |
 
 Each Harbor task becomes one dataset example, including a multi-step task. For a multi-step task, the example input also contains the ordered step names and instructions. Phoenix dataset examples have an empty reference `output` because Harbor verifies an environment state rather than a single reference response.
 
@@ -124,31 +124,40 @@ Harbor tasks can use different verifiers, so the plugin keeps summary metrics se
 
 A multi-step run can have verifier rewards and an exception at the same time. Phoenix keeps both: the reward remains available, while the run has an error and `infra_ok=0`.
 
+Trial-level evaluations for a multi-step task include the resolved `multi_step_reward_strategy` in their metadata. Harbor uses `mean` when the task does not set a strategy; an explicit `final` value remains `final`. Step evaluations and `infra_ok` do not carry this metadata.
+
 For comparisons, check `reward` coverage before calculating an aggregate. Then use `infra_ok` to separate agent behavior from broken environments, timeouts, or verifier failures. Step-level scores show where a multi-step task failed.
 
 ## Understand ATIF traces
 
 ATIF is the default trace mode. The plugin reads saved trajectories after the final trial attempt, converts them to OpenInference spans, and uploads them to the experiment's Phoenix project. The sandbox does not need a Phoenix endpoint or Phoenix credentials.
 
-One Harbor trial becomes one trace and one Phoenix session:
+One Harbor trial becomes one trace and one Phoenix session. A multi-step trial adds a span for each attempted step:
 
 ```text
-harbor.trial                         CHAIN
-  agent trajectory                  AGENT
-    turn                            AGENT
-      fresh ATIF operation          CHAIN
-        model call                  LLM
-        tool call                   TOOL
-          referenced subagent       AGENT
+harbor.trial <task>                  CHAIN
+  harbor.step 1 <step name>          CHAIN, multi-step trials only
+    <agent>                          AGENT
+      turn 1                         AGENT, multi-turn trajectories only
+        iteration 1                  CHAIN
+          <model>                    LLM
+          <tool>                     TOOL
+            <subagent>               AGENT
 ```
 
-The converter preserves fresh agent operations, model calls, tool calls, continuations, and referenced subagents. User and system messages used as prompt history remain LLM context instead of becoming duplicate execution spans. Multi-step task trajectories share the same `harbor.trial` root.
+Single-step trajectories attach directly to the `harbor.trial` root. Each multi-step `harbor.step` span records the step instruction, timing, exception status, and any verifier rewards. Its trajectories appear beneath it. This keeps an attempted step visible even when Harbor did not save a trajectory for that step.
+
+Agent, model, and tool spans use their names from ATIF. Fresh agent operations use `iteration N`; context-management operations use `compaction N`; and other operational system steps use `system event N`. An agent step with `llm_call_count: 0` has no LLM span, but it still keeps its operation and tool spans. Continuation roots use `<agent> (continuation N)`. Referenced subagents attach to the matching tool call when `source_call_id` proves that relationship, or to the referencing operation when it does not.
+
+The converter supports ATIF v1.0 through v1.7. It reconstructs LLM inputs from ATIF messages and marks them with `metadata.atif.input_source = "reconstructed"`; it does not parse provider-native message formats. User and system prompts and copied context contribute to those inputs without creating duplicate execution spans. An observation becomes a tool result only when its `source_call_id` matches the call. Multiple results for one call remain in order. Unmatched step observations stay on the operation span, while unassigned feedback remains structured in the reconstructed input without an invented message role or tool association. Structured text and image parts remain in serialized messages, but the plugin does not read or upload media bytes. ATIF v1.8 audio fields are not supported.
+
+Only LLM spans carry `llm.*` attributes. The converter keeps trajectory-level `final_metrics` on the agent root so Phoenix does not count the same tokens twice. It maps producer-specific cache-write and reasoning token counts when they are present.
 
 ATIF timestamps describe events rather than complete operation durations. The plugin uses request timings only when it can map every measurement to one LLM step. It leaves ambiguous LLM and tool durations at zero instead of inventing timing or concurrency.
 
 Trace discovery and conversion are best-effort. If the agent does not save a valid trajectory, the plugin logs a warning and records the run and evaluations without a trace. A successful Phoenix run is immutable, so replay cannot add a missing trace link later.
 
-Use `trace_mode=none` when the agent has no ATIF output or when you do not want traces:
+Use `trace_mode=null` when the agent has no ATIF output or when you do not want traces:
 
 ```bash
 harbor run \
@@ -156,12 +165,12 @@ harbor run \
   -a your-agent \
   -m your-provider/your-model \
   --plugin arize-phoenix \
-  --plugin-kwarg trace_mode=none \
+  --plugin-kwarg trace_mode=null \
   --yes
 ```
 
 <Note>
-Live OpenTelemetry Protocol (OTLP) support is deferred to a follow-up. This release accepts `atif` and `none`, and does not link live OpenTelemetry traces from Harbor agents to experiment runs.
+Live OpenTelemetry Protocol (OTLP) support is deferred to a follow-up. This release accepts `atif` or `null`, and does not link live OpenTelemetry traces from Harbor agents to experiment runs.
 </Note>
 
 ## Name experiments
@@ -199,7 +208,7 @@ Pass settings with Harbor's `--plugin-kwarg` option.
 | `dataset` | Inferred from Harbor | Override the Phoenix dataset name. Required for several direct tasks. |
 | `endpoint` | `PHOENIX_COLLECTOR_ENDPOINT` | Override the Phoenix base endpoint for this job. |
 | `api_key` | `PHOENIX_API_KEY` | Override the Phoenix API key. Prefer the environment variable so the key does not enter shell history. |
-| `trace_mode` | `atif` | Use `atif` or `none`. |
+| `trace_mode` | `atif` | Use `atif`, or pass `null` to disable tracing. |
 | `experiment_name` | Unset | Set one exact name. Valid only for a job with one agent configuration. |
 | `experiment_name_template` | `{job.name} · {agent.name} · {agent.model}` | Name one experiment per agent configuration. |
 
@@ -207,7 +216,7 @@ Pass settings with Harbor's `--plugin-kwarg` option.
 
 The plugin writes each trial when it reaches its final state. This gives you live progress and preserves completed runs when the job stops.
 
-On resume or replay, the plugin recovers the matching experiment, reuses matching successful runs, retries failed runs, and upserts their evaluations. Deterministic task, run, and trace identities prevent duplicate records during sequential ingestion.
+On resume or replay, the plugin recovers the matching experiment, reuses matching successful runs, retries failed runs, and upserts their evaluations. If another Harbor job created a newer version of the shared dataset, the recovered experiment remains pinned to its original version. Deterministic task, run, and trace identities prevent duplicate records during sequential ingestion.
 
 Run only one process for a given Harbor job. Experiment recovery is not atomic across multiple ingesters.
 

--- a/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
+++ b/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
@@ -61,7 +61,11 @@ harbor run \
   --yes
 ```
 
-The plugin infers the Phoenix dataset name from the Harbor dataset. It creates one experiment for the selected agent and model. Each final task trial appears as a run as soon as that trial finishes.
+## What you'll see in Phoenix
+
+At job start, the plugin creates or reuses a versioned dataset for the resolved task set. Each Harbor task becomes a dataset example, and each agent and model configuration gets its own experiment.
+
+As each final logical trial finishes, Phoenix adds a run to the matching experiment. The run has Harbor's verifier rewards and an `infra_ok` evaluation. It also shows an error when Harbor recorded an exception and links to an ATIF trace when tracing succeeds.
 
 <Tip>
 Start with the default `atif` mode when your Harbor agent writes ATIF trajectories. It captures agent execution without adding tracing code or giving the sandbox network access to Phoenix.

--- a/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
+++ b/docs/phoenix/integrations/evaluation-integrations/harbor.mdx
@@ -65,7 +65,13 @@ harbor run \
 
 At job start, the plugin creates or reuses a versioned dataset for the resolved task set. Each Harbor task becomes a dataset example, and each agent and model configuration gets its own experiment.
 
-As each final logical trial finishes, Phoenix adds a run to the matching experiment. The run has Harbor's verifier rewards and an `infra_ok` evaluation. It also shows an error when Harbor recorded an exception and links to an ATIF trace when tracing succeeds.
+As each final logical trial finishes, Phoenix records:
+
+- an experiment run linked to the task's dataset example;
+- Harbor's verifier rewards as experiment evaluations;
+- an `infra_ok` evaluation for execution health;
+- a run error when Harbor recorded an exception; and
+- a link to the ATIF trace when tracing succeeds.
 
 <Tip>
 Start with the default `atif` mode when your Harbor agent writes ATIF trajectories. It captures agent execution without adding tracing code or giving the sandbox network access to Phoenix.

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -322,6 +322,7 @@
 
 ### Evaluation Integrations
 
+- [Harbor](https://arize.com/docs/phoenix/integrations/evaluation-integrations/harbor): Record Harbor agent benchmarks as Phoenix experiments with rewards, infrastructure status, and ATIF traces
 - [Cleanlab](https://arize.com/docs/phoenix/integrations/evaluation-integrations/cleanlab): Use Cleanlab TLM confidence scores to flag untrustworthy LLM outputs in Phoenix
 - [MLflow](https://arize.com/docs/phoenix/integrations/evaluation-integrations/mlflow): Use Phoenix evaluators as MLflow scorers for GenAI evaluation workflows
 - [Ragas](https://arize.com/docs/phoenix/integrations/evaluation-integrations/ragas): Evaluate agents and RAG pipelines using Ragas metrics alongside Phoenix tracing


### PR DESCRIPTION
## Summary

- add a public Harbor integration guide covering setup, Phoenix record mapping, dataset versioning, rewards, ATIF traces, naming, and resume behavior
- add the `phoenix-harbor` skill for coding agents
- add Harbor to the docs navigation, integration index, coding-agent skill list, and `llms.txt`

This documents the plugin shape in #15715.

## Testing

- `npx -y mint validate`
- `pnpm exec vitest run test/docs.test.ts` (25 tests)
- skill `quick_validate.py`
- `git diff --check`