### PR TITLE
test: memoize the GraphQL schema build across unit-test apps

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,13 +7,24 @@ from functools import partial
 from importlib.metadata import version
 from random import getrandbits
 from secrets import token_hex
-from typing import Any, AsyncIterator, Awaitable, Callable, Iterator, Literal, Optional
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterable,
+    Iterator,
+    Literal,
+    Optional,
+    Union,
+)
 
 import aiosqlite
 import httpx
 import pytest
 import sqlalchemy
 import sqlean
+import strawberry
 from _pytest.config import Config
 from _pytest.fixtures import SubRequest
 from _pytest.tmpdir import TempPathFactory
@@ -28,6 +39,7 @@ from sqlalchemy import URL, StaticPool
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession, create_async_engine
 from starlette.types import ASGIApp
+from strawberry.extensions import SchemaExtension
 
 from phoenix.db import models
 from phoenix.db.bulk_inserter import BulkInserter
@@ -42,6 +54,7 @@ from phoenix.db.engines import (
 from phoenix.db.facilitator import Facilitator
 from phoenix.db.insertion.helpers import DataManipulation
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
+from phoenix.server.api.schema import build_graphql_schema
 from phoenix.server.app import _db, create_app
 from phoenix.server.encryption import EncryptionService
 from phoenix.server.grpc_server import GrpcServer
@@ -88,6 +101,11 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "pristine_db: give the test an empty database instead of one carrying the rows the "
         "app seeds at startup",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_graphql_schema_build: build a fresh GraphQL schema for the app instead of "
+        "reusing the worker's memoized one",
     )
 
 
@@ -243,6 +261,52 @@ def _memoized_key_derivation(request: FixtureRequest, monkeypatch: pytest.Monkey
         EncryptionService, "_derive_encryption_key", staticmethod(_memoized_encryption_key)
     )
     monkeypatch.setattr(Redactor, "_derive_key", staticmethod(_memoized_redaction_key))
+
+
+_GraphQLExtensions = Iterable[Union[type[SchemaExtension], Callable[[], SchemaExtension]]]
+_MEMOIZED_GRAPHQL_SCHEMAS: dict[tuple[Any, ...], strawberry.Schema] = {}
+
+
+def _graphql_extension_key(extension: Any) -> Any:
+    # Extension classes identify themselves. The app passes its other
+    # extensions as lambdas built fresh per app; two such lambdas are
+    # equivalent when they share code, defaults, and captured values.
+    if isinstance(extension, type):
+        return extension
+    code = getattr(extension, "__code__", None)
+    if code is None:
+        return extension
+    captured = tuple(cell.cell_contents for cell in (extension.__closure__ or ()))
+    return (code, extension.__defaults__, captured)
+
+
+def _memoized_graphql_schema(extensions: Optional[_GraphQLExtensions] = None) -> strawberry.Schema:
+    extension_list = list(extensions or ())
+    key = tuple(_graphql_extension_key(extension) for extension in extension_list)
+    try:
+        schema = _MEMOIZED_GRAPHQL_SCHEMAS.get(key)
+    except TypeError:
+        return build_graphql_schema(extension_list)
+    if schema is None:
+        schema = _MEMOIZED_GRAPHQL_SCHEMAS[key] = build_graphql_schema(extension_list)
+    return schema
+
+
+@pytest.fixture(autouse=True)
+def _memoized_graphql_schema_build(
+    request: FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Building the Strawberry schema converts every type, field, and enum of
+    the API into GraphQL core objects, a full pass over the API per app. The
+    schema is a pure function of the extension list, so the worker memoizes
+    it per list: every app after the worker's first reuses the same schema
+    object. A test that needs its own schema opts out with
+    ``@pytest.mark.real_graphql_schema_build``."""
+    if request.node.get_closest_marker("real_graphql_schema_build"):
+        return
+
+    monkeypatch.setattr("phoenix.server.app.build_graphql_schema", _memoized_graphql_schema)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/server/test_app_graphql_schema_build.py
+++ b/tests/unit/server/test_app_graphql_schema_build.py
@@ -1,0 +1,108 @@
+"""The unit conftest memoizes the app's GraphQL schema build per worker."""
+
+from contextlib import AsyncExitStack
+from typing import Any, Callable
+
+import pytest
+import strawberry
+from fastapi import FastAPI
+from strawberry.extensions import SchemaExtension
+
+from phoenix.server import app as app_module
+from phoenix.server.api.schema import build_graphql_schema
+from phoenix.server.app import create_app
+from phoenix.server.types import DbSessionFactory
+from tests.unit import conftest
+from tests.unit.conftest import TestBulkInserter, patch_batched_caller, patch_grpc_server
+
+
+class _Extension(SchemaExtension):
+    pass
+
+
+class _CapturingExtension(SchemaExtension):
+    def __init__(self, limit: int, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.limit = limit
+
+
+def _extension_factory() -> SchemaExtension:
+    return _Extension()
+
+
+async def _build_app(db: DbSessionFactory) -> FastAPI:
+    """Build an app the way the ``app`` fixture does."""
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        return create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+
+
+def _builder_the_app_calls() -> Callable[..., strawberry.Schema]:
+    """The name ``create_app`` resolves at call time, patched or not."""
+    builder: Callable[..., strawberry.Schema] = vars(app_module)["build_graphql_schema"]
+    return builder
+
+
+def test_unit_test_apps_share_one_schema_per_extension_list() -> None:
+    """The suite-wide fixture is in force: the builder the app calls hands
+    back the same schema for an equivalent extension list and a different
+    one for a different list. The app's own factories are lambdas on fixed
+    lines, so their code objects repeat across apps the way this one does."""
+    builder = _builder_the_app_calls()
+    assert builder is not build_graphql_schema
+    extensions: list[Any] = [_extension_factory]
+    first = builder(extensions)
+    again = builder(list(extensions))
+    other = builder([_Extension])
+    assert first is again
+    assert other is not first
+
+
+async def test_a_second_app_in_the_worker_skips_the_schema_build(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Through ``create_app`` and the extension lambdas it builds per call:
+    once one app has been built in the worker, building another calls the
+    real builder zero times."""
+    real_builds: list[Any] = []
+    # The name the memoized builder resolves at call time.
+    real_builder: Callable[..., strawberry.Schema] = vars(conftest)["build_graphql_schema"]
+
+    def counting_builder(extensions: Any = None) -> strawberry.Schema:
+        real_builds.append(extensions)
+        return real_builder(extensions)
+
+    monkeypatch.setattr(conftest, "build_graphql_schema", counting_builder)
+    await _build_app(db)
+    builds_after_first = len(real_builds)
+    await _build_app(db)
+    assert len(real_builds) == builds_after_first
+
+
+def _capturing_factory(limit: int) -> Callable[[], SchemaExtension]:
+    return lambda: _CapturingExtension(limit)
+
+
+def test_extension_lambdas_with_different_captures_get_different_schemas() -> None:
+    """Two lambdas from one source line that capture different values are not
+    the same extension, so they must not share a schema."""
+    builder = _builder_the_app_calls()
+    one, two = _capturing_factory(1), _capturing_factory(2)
+    assert builder([one]) is not builder([two])
+    assert builder([one]) is builder([_capturing_factory(1)])
+
+
+@pytest.mark.real_graphql_schema_build
+def test_marker_restores_a_fresh_schema_per_app() -> None:
+    builder = _builder_the_app_calls()
+    assert builder is build_graphql_schema
+    first = builder([_Extension])
+    again = builder([_Extension])
+    assert first is not again


### PR DESCRIPTION
### Why
Each app builds the Strawberry schema: every type, field, input, and enum of the API converted into GraphQL core objects. With the key derivations memoized it is the largest remaining piece of construction.

### What
- `build_graphql_schema` is memoized per worker, keyed on the extension list. Extension classes key as themselves; the app's per-call lambdas key by code object plus defaults and captured values. One-shot iterables are materialized first, and an unhashable key falls back to a fresh build.
- Opt out with `real_graphql_schema_build`.

### Tests
- Same schema for an equivalent extension list, a different one for a different list.
- A second app built through `create_app` calls the real builder zero times.
- Lambdas with different captures get different schemas.
- The marker restores a fresh build.

### Numbers
App construction about 280ms to about 200ms. Measured on an idle Apple-silicon Mac as the mean of six app boots of one test class, with an in-process timing plugin. CI runners are slower and contended.
