### PR TITLE
fix(annotations): validate all configured ID columns, not just the first

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/utils/annotation_helpers.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/annotation_helpers.py
@@ -414,9 +414,9 @@ def _validate_annotations_dataframe(
                 )
 
     if available_id_columns:
-        actual_id_column = available_id_columns[0]
-        expected_type = id_config.columns.get(actual_id_column, str)
-        _validate_column_values(dataframe, actual_id_column, expected_type, actual_id_column)
+        for actual_id_column in available_id_columns:
+            expected_type = id_config.columns.get(actual_id_column, str)
+            _validate_column_values(dataframe, actual_id_column, expected_type, actual_id_column)
 
     elif available_id_index_names:
         for index_name in available_id_index_names:

--- a/packages/phoenix-client/tests/client/resources/spans/test_spans.py
+++ b/packages/phoenix-client/tests/client/resources/spans/test_spans.py
@@ -1,10 +1,57 @@
 from urllib.parse import parse_qs, urlparse
 
 import httpx
+import pandas as pd
 import pytest
 
+from phoenix.client import Client
 from phoenix.client.__generated__ import v1
 from phoenix.client.resources.spans import AsyncSpans, Spans
+
+
+@pytest.mark.parametrize(
+    ("span_id", "document_position", "expected_message"),
+    [
+        pytest.param(
+            "span-1",
+            "not-an-int",
+            "document_position values must be of type int",
+            id="non-integer-document-position",
+        ),
+        pytest.param(
+            "span-1",
+            None,
+            "document_position values cannot be None",
+            id="missing-document-position",
+        ),
+        pytest.param(
+            "",
+            0,
+            "span_id values must be non-empty strings",
+            id="empty-span-id",
+        ),
+    ],
+)
+def test_log_document_annotations_dataframe_rejects_invalid_identifiers(
+    span_id: object,
+    document_position: object,
+    expected_message: str,
+) -> None:
+    dataframe = pd.DataFrame(
+        {
+            "name": ["relevance"],
+            "annotator_kind": ["HUMAN"],
+            "span_id": [span_id],
+            "document_position": [document_position],
+            "label": ["relevant"],
+        }
+    )
+    transport = httpx.MockTransport(lambda request: pytest.fail("request must not be sent"))
+    http_client = httpx.Client(transport=transport, base_url="http://test")
+    client = Client(http_client=http_client)
+
+    with pytest.raises(ValueError, match=expected_message):
+        client.spans.log_document_annotations_dataframe(dataframe=dataframe)
 
 
 def _make_span(

--- a/packages/phoenix-client/tests/client/utils/test_annotation_hepers.py
+++ b/packages/phoenix-client/tests/client/utils/test_annotation_hepers.py
@@ -120,6 +120,54 @@ class TestAnnotationDataFrameValidation:
         with pytest.raises(ValueError, match="DataFrame must have ALL required ID columns"):
             _validate_document_annotations_dataframe(dataframe=df_missing_doc)
 
+    def test_all_id_columns_are_type_checked_not_just_the_first(self) -> None:
+        """Regression test: every configured ID column must be type-validated.
+
+        _DOCUMENT_ID_CONFIG has two ID columns (span_id, document_position).
+        Validation used to only check available_id_columns[0] (span_id),
+        silently skipping document_position. An invalid document_position
+        would then pass validation and only fail later during chunking with
+        a confusing, deep error instead of a clear validation error.
+        """
+        # Non-integer document_position must fail validation, not chunking.
+        df_bad_type = pd.DataFrame(
+            {
+                "name": ["relevance"],
+                "annotator_kind": ["HUMAN"],
+                "span_id": ["span1"],
+                "document_position": ["not-an-int"],
+                "label": ["relevant"],
+            }
+        )
+        with pytest.raises(ValueError, match="document_position values must be of type int"):
+            _validate_document_annotations_dataframe(dataframe=df_bad_type)
+
+        # A None document_position must also fail validation, not chunking.
+        df_none = pd.DataFrame(
+            {
+                "name": ["relevance", "relevance"],
+                "annotator_kind": ["HUMAN", "HUMAN"],
+                "span_id": ["span1", "span2"],
+                "document_position": [0, None],
+                "label": ["relevant", "relevant"],
+            }
+        )
+        with pytest.raises(ValueError, match="document_position values cannot be None"):
+            _validate_document_annotations_dataframe(dataframe=df_none)
+
+        # A bad span_id (the first configured column) must still fail too.
+        df_bad_span = pd.DataFrame(
+            {
+                "name": ["relevance"],
+                "annotator_kind": ["HUMAN"],
+                "span_id": [""],
+                "document_position": [0],
+                "label": ["relevant"],
+            }
+        )
+        with pytest.raises(ValueError, match="span_id values must be non-empty strings"):
+            _validate_document_annotations_dataframe(dataframe=df_bad_span)
+
     def test_global_parameter_validation(self) -> None:
         """Test validation when fields are required vs optional in DataFrame."""
         df_with_fields = pd.DataFrame(

--- a/packages/phoenix-client/tests/client/utils/test_annotation_hepers.py
+++ b/packages/phoenix-client/tests/client/utils/test_annotation_hepers.py
@@ -120,54 +120,6 @@ class TestAnnotationDataFrameValidation:
         with pytest.raises(ValueError, match="DataFrame must have ALL required ID columns"):
             _validate_document_annotations_dataframe(dataframe=df_missing_doc)
 
-    def test_all_id_columns_are_type_checked_not_just_the_first(self) -> None:
-        """Regression test: every configured ID column must be type-validated.
-
-        _DOCUMENT_ID_CONFIG has two ID columns (span_id, document_position).
-        Validation used to only check available_id_columns[0] (span_id),
-        silently skipping document_position. An invalid document_position
-        would then pass validation and only fail later during chunking with
-        a confusing, deep error instead of a clear validation error.
-        """
-        # Non-integer document_position must fail validation, not chunking.
-        df_bad_type = pd.DataFrame(
-            {
-                "name": ["relevance"],
-                "annotator_kind": ["HUMAN"],
-                "span_id": ["span1"],
-                "document_position": ["not-an-int"],
-                "label": ["relevant"],
-            }
-        )
-        with pytest.raises(ValueError, match="document_position values must be of type int"):
-            _validate_document_annotations_dataframe(dataframe=df_bad_type)
-
-        # A None document_position must also fail validation, not chunking.
-        df_none = pd.DataFrame(
-            {
-                "name": ["relevance", "relevance"],
-                "annotator_kind": ["HUMAN", "HUMAN"],
-                "span_id": ["span1", "span2"],
-                "document_position": [0, None],
-                "label": ["relevant", "relevant"],
-            }
-        )
-        with pytest.raises(ValueError, match="document_position values cannot be None"):
-            _validate_document_annotations_dataframe(dataframe=df_none)
-
-        # A bad span_id (the first configured column) must still fail too.
-        df_bad_span = pd.DataFrame(
-            {
-                "name": ["relevance"],
-                "annotator_kind": ["HUMAN"],
-                "span_id": [""],
-                "document_position": [0],
-                "label": ["relevant"],
-            }
-        )
-        with pytest.raises(ValueError, match="span_id values must be non-empty strings"):
-            _validate_document_annotations_dataframe(dataframe=df_bad_span)
-
     def test_global_parameter_validation(self) -> None:
         """Test validation when fields are required vs optional in DataFrame."""
         df_with_fields = pd.DataFrame(


### PR DESCRIPTION
Fixes #13771