### PR TITLE
test: memoize the pydantic TypeAdapters behind FastAPI's route fields

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -31,7 +31,8 @@ from _pytest.tmpdir import TempPathFactory
 from asgi_lifespan import LifespanManager
 from faker import Faker
 from fastapi import APIRouter, FastAPI
-from pydantic import SecretStr
+from fastapi._compat import v2 as fastapi_v2
+from pydantic import SecretStr, TypeAdapter
 from pydantic_ai import RunContext
 from pytest import FixtureRequest
 from pytest_postgresql.janitor import DatabaseJanitor
@@ -112,6 +113,11 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "real_app_routers: build the app's routers fresh instead of reusing the worker's "
         "memoized ones",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_fastapi_type_adapters: build fresh pydantic TypeAdapters for the app's routes "
+        "instead of reusing the worker's memoized ones",
     )
 
 
@@ -313,6 +319,92 @@ def _memoized_graphql_schema_build(
         return
 
     monkeypatch.setattr("phoenix.server.app.build_graphql_schema", _memoized_graphql_schema)
+
+
+_BUILD_FASTAPI_TYPE_ADAPTER = fastapi_v2.ModelField.__post_init__
+_MEMOIZED_FASTAPI_TYPE_ADAPTERS: dict[tuple[Any, ...], TypeAdapter[Any]] = {}
+# A few annotations FastAPI rebuilds per app never compare equal, so the
+# cache is bounded rather than left to grow with every app in the worker.
+_FASTAPI_TYPE_ADAPTER_CACHE_LIMIT = 4096
+# Everything on a pydantic FieldInfo that can change the adapter it yields.
+_FIELD_INFO_ATTRIBUTES = (
+    "default",
+    "default_factory",
+    "alias",
+    "alias_priority",
+    "validation_alias",
+    "serialization_alias",
+    "title",
+    "field_title_generator",
+    "description",
+    "examples",
+    "exclude",
+    "exclude_if",
+    "discriminator",
+    "deprecated",
+    "json_schema_extra",
+    "frozen",
+    "validate_default",
+    "repr",
+    "init",
+    "init_var",
+    "kw_only",
+)
+
+
+def _by_value_or_repr(value: Any) -> Any:
+    # Hashable values key by type and equality, which for classes and
+    # callables is identity, so same-named types and same-named factories
+    # stay apart and 0, 0.0, and False do not collide. Unhashable values
+    # such as lists and dicts key by repr.
+    try:
+        hash(value)
+    except TypeError:
+        return repr(value)
+    return (type(value), value)
+
+
+def _fastapi_type_adapter_key(field: fastapi_v2.ModelField) -> tuple[Any, ...]:
+    info = field.field_info
+    return (
+        field.mode,
+        _by_value_or_repr(info.annotation),
+        repr(info.metadata),
+        *(_by_value_or_repr(getattr(info, name, None)) for name in _FIELD_INFO_ATTRIBUTES),
+        repr(field.config),
+    )
+
+
+def _memoized_fastapi_model_field_post_init(self: fastapi_v2.ModelField) -> None:
+    key = _fastapi_type_adapter_key(self)
+    adapter = _MEMOIZED_FASTAPI_TYPE_ADAPTERS.get(key)
+    if adapter is None:
+        _BUILD_FASTAPI_TYPE_ADAPTER(self)
+        if len(_MEMOIZED_FASTAPI_TYPE_ADAPTERS) < _FASTAPI_TYPE_ADAPTER_CACHE_LIMIT:
+            _MEMOIZED_FASTAPI_TYPE_ADAPTERS[key] = self._type_adapter
+    else:
+        self._type_adapter = adapter
+
+
+@pytest.fixture(autouse=True)
+def _memoized_fastapi_type_adapters(
+    request: FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FastAPI rebuilds every route for each app that includes its router, and
+    each route's parameters and response model become ModelFields whose
+    ``__post_init__`` builds a pydantic TypeAdapter, a core schema generated
+    per field per app. An adapter is a pure function of the field's mode,
+    annotation, FieldInfo, and config, and is stateless once built, so the
+    worker memoizes them: every app after the worker's first reuses them. A
+    test that needs fresh adapters opts out with
+    ``@pytest.mark.real_fastapi_type_adapters``."""
+    if request.node.get_closest_marker("real_fastapi_type_adapters"):
+        return
+
+    monkeypatch.setattr(
+        fastapi_v2.ModelField, "__post_init__", _memoized_fastapi_model_field_post_init
+    )
 
 
 # The auth router is left out: its builder reads environment flags at

--- a/tests/unit/server/test_app_fastapi_type_adapters.py
+++ b/tests/unit/server/test_app_fastapi_type_adapters.py
@@ -1,0 +1,125 @@
+"""The unit conftest memoizes the pydantic TypeAdapters behind FastAPI's route fields."""
+
+from contextlib import AsyncExitStack
+from typing import Annotated, Any, AsyncIterator, Iterable, get_args, get_origin
+
+import pytest
+from fastapi import FastAPI
+from fastapi._compat import v2 as fastapi_v2
+from fastapi.routing import _IncludedRouter
+from pydantic.fields import FieldInfo
+
+from phoenix.server.app import create_app
+from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import TestBulkInserter, patch_batched_caller, patch_grpc_server
+
+
+@pytest.fixture
+async def second_app(db: DbSessionFactory) -> AsyncIterator[FastAPI]:
+    """A second app built the way the ``app`` fixture builds its own."""
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        yield create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+
+
+def _embeds_field_info(annotation: Any) -> bool:
+    """Whether an ``Annotated`` anywhere in the annotation carries a FieldInfo.
+
+    FastAPI copies such a FieldInfo per app, and ``Annotated`` compares its
+    metadata by identity, so the annotation never equals its counterpart from
+    another app and its adapter cannot be shared. This is why the cache is
+    bounded."""
+    if get_origin(annotation) is Annotated:
+        if any(isinstance(item, FieldInfo) for item in annotation.__metadata__):
+            return True
+    return any(_embeds_field_info(argument) for argument in get_args(annotation))
+
+
+def _route_fields(app: FastAPI) -> dict[str, fastapi_v2.ModelField]:
+    """Every route's response-model field and its path, query, header, and
+    cookie parameter fields, keyed by route id and field.
+
+    FastAPI keeps the state it builds per app for an included router's routes
+    on the ``_IncludedRouter`` node it appends to the app's routes, so the walk
+    descends those nodes rather than reading the original router's routes.
+    Body parameters are left out: a route with several gets a synthetic model
+    class per app, which no cache can match."""
+    fields: dict[str, fastapi_v2.ModelField] = {}
+
+    def walk(candidates: Iterable[Any]) -> None:
+        for candidate in candidates:
+            if isinstance(candidate, _IncludedRouter):
+                walk(candidate.effective_candidates())
+                continue
+            response_field = getattr(candidate, "response_field", None)
+            if response_field is not None:
+                fields[f"{candidate.unique_id}:response"] = response_field
+            dependant = getattr(candidate, "dependant", None)
+            if dependant is None:
+                continue
+            for kind in ("path_params", "query_params", "header_params", "cookie_params"):
+                for field in getattr(dependant, kind):
+                    fields[f"{candidate.unique_id}:{kind}:{field.name}"] = field
+
+    walk(app.router.routes)
+    assert fields, "expected routes with response models or parameters"
+    return fields
+
+
+def test_unit_test_apps_share_route_type_adapters(app: FastAPI, second_app: FastAPI) -> None:
+    """The suite-wide fixture is in force: two apps built in one worker hand
+    back the same adapter object for every route field except the ones whose
+    annotation embeds a FieldInfo."""
+    first, second = _route_fields(app), _route_fields(second_app)
+    assert first.keys() == second.keys()
+    not_shared = sorted(
+        field_id
+        for field_id in first
+        if first[field_id]._type_adapter is not second[field_id]._type_adapter
+    )
+    assert not_shared == sorted(
+        field_id for field_id in first if _embeds_field_info(first[field_id].field_info.annotation)
+    )
+    assert len(not_shared) < len(first) // 10
+
+
+def test_fields_with_different_default_factories_do_not_share_an_adapter() -> None:
+    """Pydantic renders every factory as ``<lambda>`` in a FieldInfo's repr,
+    so the key has to tell them apart by identity."""
+    first = fastapi_v2.ModelField(
+        field_info=FieldInfo(annotation=int, default_factory=lambda: 1), name="x"
+    )
+    second = fastapi_v2.ModelField(
+        field_info=FieldInfo(annotation=int, default_factory=lambda: 2), name="x"
+    )
+    same_factory = fastapi_v2.ModelField(
+        field_info=FieldInfo(annotation=int, default_factory=first.field_info.default_factory),
+        name="x",
+    )
+    assert first._type_adapter is not second._type_adapter
+    assert same_factory._type_adapter is first._type_adapter
+
+
+@pytest.mark.real_fastapi_type_adapters
+def test_marker_restores_fresh_route_type_adapters(app: FastAPI, second_app: FastAPI) -> None:
+    first, second = _route_fields(app), _route_fields(second_app)
+    assert first.keys() == second.keys()
+    assert all(
+        first[field_id]._type_adapter is not second[field_id]._type_adapter for field_id in first
+    )
+
+
+@pytest.mark.real_fastapi_type_adapters
+def test_model_field_init_sets_only_the_type_adapter() -> None:
+    """The memoized ``__post_init__`` replaces FastAPI's whole method, so this
+    pins what that method does: beyond the dataclass fields it sets exactly
+    one attribute, the adapter. A FastAPI release that makes it do more fails
+    here instead of having that work silently skipped on a cache hit."""
+    field = fastapi_v2.ModelField(field_info=FieldInfo(annotation=int), name="x")
+    assert set(vars(field)) == {"field_info", "name", "mode", "config", "_type_adapter"}


### PR DESCRIPTION
### Why
FastAPI rebuilds every route for each app, and each parameter and response model becomes a `ModelField` whose `__post_init__` builds a pydantic `TypeAdapter`: hundreds of core schemas per app, and most of what is left of construction.

### What
- `ModelField.__post_init__` is patched to memoize adapters per worker. The key is the mode, the annotation, the constraint metadata, every `FieldInfo` attribute, and the config. Hashable values key by type and equality, so classes and callables key by identity; unhashable values key by repr.
- The cache is bounded: three `identifier` query parameters embed a `FieldInfo` that FastAPI copies per app, so they never compare equal.
- Opt out with `real_fastapi_type_adapters`.

### Tests
- Two apps share the adapter behind every response model and path, query, header, and cookie parameter except those three.
- Fields with different default factories get different adapters.
- The marker gives each app its own.
- A real `__post_init__` sets exactly one attribute beyond the dataclass fields, so a FastAPI release that makes it do more fails loudly.

### Private seam
`fastapi._compat.v2.ModelField`, its `__post_init__`, and the `_type_adapter` it sets. A rename raises at the first test's setup.

### Numbers
App construction about 200ms to about 95ms. Measured on an idle Apple-silicon Mac as the mean of six app boots of one test class, with an in-process timing plugin. CI runners are slower and contended.
