### PR TITLE
test: share the app's routers across unit-test apps

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,7 +30,7 @@ from _pytest.fixtures import SubRequest
 from _pytest.tmpdir import TempPathFactory
 from asgi_lifespan import LifespanManager
 from faker import Faker
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from pydantic import SecretStr
 from pydantic_ai import RunContext
 from pytest import FixtureRequest
@@ -53,6 +53,7 @@ from phoenix.db.engines import (
 )
 from phoenix.db.facilitator import Facilitator
 from phoenix.db.insertion.helpers import DataManipulation
+from phoenix.server import app as server_app
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.api.schema import build_graphql_schema
 from phoenix.server.app import _db, create_app
@@ -106,6 +107,11 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "real_graphql_schema_build: build a fresh GraphQL schema for the app instead of "
         "reusing the worker's memoized one",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_app_routers: build the app's routers fresh instead of reusing the worker's "
+        "memoized ones",
     )
 
 
@@ -307,6 +313,49 @@ def _memoized_graphql_schema_build(
         return
 
     monkeypatch.setattr("phoenix.server.app.build_graphql_schema", _memoized_graphql_schema)
+
+
+# The auth router is left out: its builder reads environment flags at
+# construction, so it is not a function of its arguments alone.
+_ROUTER_BUILDER_NAMES = (
+    "create_v1_router",
+    "create_agents_router",
+    "create_legacy_agents_router",
+)
+_REAL_ROUTER_BUILDERS: dict[str, Callable[..., APIRouter]] = {
+    name: getattr(server_app, name) for name in _ROUTER_BUILDER_NAMES
+}
+_MEMOIZED_ROUTERS: dict[tuple[Any, ...], APIRouter] = {}
+
+
+def _memoized_router_builder(name: str) -> Callable[..., APIRouter]:
+    build = _REAL_ROUTER_BUILDERS[name]
+
+    def memoized(*args: Any, **kwargs: Any) -> APIRouter:
+        key = (name, args, tuple(sorted(kwargs.items())))
+        router = _MEMOIZED_ROUTERS.get(key)
+        if router is None:
+            router = _MEMOIZED_ROUTERS[key] = build(*args, **kwargs)
+        return router
+
+    return memoized
+
+
+@pytest.fixture(autouse=True)
+def _memoized_app_routers(request: FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``create_app`` builds the v1, agents, and legacy-agents routers per
+    app from a flag, and building a router registers every route, inspecting
+    its signature and modelling its fields before the app even includes it.
+    Each of those routers is a pure function of its flag, and including one
+    records it on the app without mutating it, so the worker memoizes each
+    builder per argument list: every app after the worker's first reuses the
+    routers. A test that needs its own routers opts out with
+    ``@pytest.mark.real_app_routers``."""
+    if request.node.get_closest_marker("real_app_routers"):
+        return
+
+    for name in _ROUTER_BUILDER_NAMES:
+        monkeypatch.setattr(server_app, name, _memoized_router_builder(name))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/server/test_app_routers.py
+++ b/tests/unit/server/test_app_routers.py
@@ -1,0 +1,54 @@
+"""The unit conftest memoizes the app's router builders per worker."""
+
+from contextlib import AsyncExitStack
+from typing import AsyncIterator
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import _IncludedRouter
+
+from phoenix.server.app import create_app
+from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import TestBulkInserter, patch_batched_caller, patch_grpc_server
+
+
+@pytest.fixture
+async def second_app(db: DbSessionFactory) -> AsyncIterator[FastAPI]:
+    """A second app built the way the ``app`` fixture builds its own."""
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        yield create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+
+
+def _included_routers(app: FastAPI) -> list[APIRouter]:
+    """The router objects the app included, in inclusion order."""
+    return [
+        route.original_router for route in app.router.routes if isinstance(route, _IncludedRouter)
+    ]
+
+
+def _unshared_routers(app: FastAPI, second_app: FastAPI) -> list[APIRouter]:
+    first, second = _included_routers(app), _included_routers(second_app)
+    assert len(first) == len(second) >= 3
+    return [a for a, b in zip(first, second) if a is not b]
+
+
+def test_unit_test_apps_share_routers(app: FastAPI, second_app: FastAPI) -> None:
+    """The suite-wide fixture is in force: two apps built in one worker with
+    the same flags include the same router objects, except the GraphQL
+    router, which ``create_app`` builds around each app's own database."""
+    unshared = _unshared_routers(app, second_app)
+    assert [type(router).__name__ for router in unshared] == ["GraphQLRouter"]
+
+
+@pytest.mark.real_app_routers
+def test_marker_restores_fresh_routers(app: FastAPI, second_app: FastAPI) -> None:
+    """Opting out builds the routers again, so the v1 router differs too."""
+    unshared = _unshared_routers(app, second_app)
+    assert "/v1" in [router.prefix for router in unshared]


### PR DESCRIPTION
### Why
`create_app` builds the v1, agents, and legacy-agents routers for every app from a flag, and building a router registers every route: signature inspection and field modelling before the app even includes it.

### What
- The three builders are memoized per argument list. Each router is a pure function of its flag, and including one records it on the app without mutation; FastAPI keeps per-app route state on the node it appends to the app. No unit test uses dependency overrides.
- The auth router is left out: its builder reads environment flags at construction, so it is not a function of its arguments alone. The GraphQL router is left per app, since `create_app` builds it around each app's database.
- Opt out with `real_app_routers`.

### Tests
- Two apps share every included router except the GraphQL one.
- The marker gives each app its own v1 router.

### Numbers
App construction about 95ms to about 65ms. Measured on an idle Apple-silicon Mac as the mean of six app boots of one test class, with an in-process timing plugin. CI runners are slower and contended.
