### PR TITLE
test: memoize FastAPI's dependency analysis of each route across unit-test apps

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,10 +3,13 @@ import contextlib
 import os
 import threading
 from asyncio import AbstractEventLoop
+from copy import copy
+from dataclasses import fields
 from functools import partial
 from importlib.metadata import version
 from random import getrandbits
 from secrets import token_hex
+from types import FunctionType
 from typing import (
     Any,
     AsyncIterator,
@@ -31,7 +34,9 @@ from _pytest.tmpdir import TempPathFactory
 from asgi_lifespan import LifespanManager
 from faker import Faker
 from fastapi import APIRouter, FastAPI
+from fastapi import routing as fastapi_routing
 from fastapi._compat import v2 as fastapi_v2
+from fastapi.dependencies.models import Dependant
 from pydantic import SecretStr, TypeAdapter
 from pydantic_ai import RunContext
 from pytest import FixtureRequest
@@ -118,6 +123,11 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "real_fastapi_type_adapters: build fresh pydantic TypeAdapters for the app's routes "
         "instead of reusing the worker's memoized ones",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_fastapi_dependants: analyze every route's dependencies fresh instead of reusing "
+        "the worker's memoized analysis",
     )
 
 
@@ -448,6 +458,130 @@ def _memoized_app_routers(request: FixtureRequest, monkeypatch: pytest.MonkeyPat
 
     for name in _ROUTER_BUILDER_NAMES:
         monkeypatch.setattr(server_app, name, _memoized_router_builder(name))
+
+
+# The name route registration resolves at call time; looked up through the
+# module so a FastAPI release that drops it fails here, at import.
+_BUILD_FASTAPI_DEPENDANT: Callable[..., Dependant] = vars(fastapi_routing)["get_dependant"]
+_MEMOIZED_FASTAPI_DEPENDANTS: dict[tuple[Any, ...], Dependant] = {}
+_FASTAPI_DEPENDANT_CACHE_LIMIT = 4096
+# The list-valued fields of a Dependant. FastAPI inserts a route's own
+# dependencies into the list it gets back, so a memoized dependant is handed
+# out as a copy whose lists are its own.
+_DEPENDANT_LIST_FIELDS = tuple(
+    field.name for field in fields(Dependant) if field.default_factory is list
+)
+
+
+class _ByIdentity:
+    """A dictionary key that stands for one object, compared by identity, so
+    two callables that happen to compare equal do not share an entry."""
+
+    __slots__ = ("obj",)
+
+    def __init__(self, obj: Any) -> None:
+        self.obj = obj
+
+    def __hash__(self) -> int:
+        return id(self.obj)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _ByIdentity) and other.obj is self.obj
+
+
+_SHARED_ROUTER_ENDPOINT_IDS: dict[int, set[int]] = {}
+
+
+def _shared_router_endpoint_ids() -> set[int]:
+    """The identities of every endpoint on a memoized router, recomputed when
+    a router is added to the memo."""
+    count = len(_MEMOIZED_ROUTERS)
+    if count not in _SHARED_ROUTER_ENDPOINT_IDS:
+        ids: set[int] = set()
+
+        def walk(routes: Iterable[Any]) -> None:
+            for route in routes:
+                nested = getattr(route, "original_router", None)
+                if nested is not None:
+                    walk(nested.routes)
+                elif (endpoint := getattr(route, "endpoint", None)) is not None:
+                    ids.add(id(endpoint))
+
+        for router in _MEMOIZED_ROUTERS.values():
+            walk(router.routes)
+        _SHARED_ROUTER_ENDPOINT_IDS.clear()
+        _SHARED_ROUTER_ENDPOINT_IDS[count] = ids
+    return _SHARED_ROUTER_ENDPOINT_IDS[count]
+
+
+def _is_memoizable_endpoint(call: Callable[..., Any]) -> bool:
+    # An endpoint recurs across apps when it is a function defined at module
+    # or class level, or when it belongs to a router the worker shares. A
+    # function created per app, such as the handlers a GraphQL router builds
+    # for each instance, is new every time, and caching its analysis would
+    # only retain the app it closes over.
+    if isinstance(call, FunctionType) and "<locals>" not in call.__qualname__:
+        return True
+    return id(call) in _shared_router_endpoint_ids()
+
+
+def _memoized_fastapi_dependant(
+    *,
+    path: str,
+    call: Callable[..., Any],
+    name: Optional[str] = None,
+    own_oauth_scopes: Optional[list[str]] = None,
+    parent_oauth_scopes: Optional[list[str]] = None,
+    use_cache: bool = True,
+    scope: Optional[Literal["function", "request"]] = None,
+) -> Dependant:
+    build = partial(
+        _BUILD_FASTAPI_DEPENDANT,
+        path=path,
+        call=call,
+        name=name,
+        own_oauth_scopes=own_oauth_scopes,
+        parent_oauth_scopes=parent_oauth_scopes,
+        use_cache=use_cache,
+        scope=scope,
+    )
+    if not _is_memoizable_endpoint(call):
+        return build()
+    key = (
+        path,
+        _ByIdentity(call),
+        name,
+        tuple(own_oauth_scopes or ()),
+        tuple(parent_oauth_scopes or ()),
+        use_cache,
+        scope,
+    )
+    dependant = _MEMOIZED_FASTAPI_DEPENDANTS.get(key)
+    if dependant is None:
+        dependant = build()
+        if len(_MEMOIZED_FASTAPI_DEPENDANTS) < _FASTAPI_DEPENDANT_CACHE_LIMIT:
+            _MEMOIZED_FASTAPI_DEPENDANTS[key] = dependant
+    handed_out = copy(dependant)
+    for list_field in _DEPENDANT_LIST_FIELDS:
+        setattr(handed_out, list_field, list(getattr(dependant, list_field)))
+    return handed_out
+
+
+@pytest.fixture(autouse=True)
+def _memoized_fastapi_dependants(request: FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Registering a route has FastAPI analyze the endpoint's dependencies:
+    it inspects the signature, classifies every parameter, and models each
+    one, recursively through sub-dependencies. With the type adapters memoized
+    this analysis is what remains of route registration, and FastAPI repeats
+    it for every app that includes the route. The analysis is a pure function
+    of the endpoint, path, and scopes, so the worker memoizes it for
+    endpoints defined at module or class level and hands each app a copy with
+    its own lists. A test that needs the app's routes analyzed fresh opts out
+    with ``@pytest.mark.real_fastapi_dependants``."""
+    if request.node.get_closest_marker("real_fastapi_dependants"):
+        return
+
+    monkeypatch.setattr(fastapi_routing, "get_dependant", _memoized_fastapi_dependant)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/server/test_app_fastapi_dependants.py
+++ b/tests/unit/server/test_app_fastapi_dependants.py
@@ -1,0 +1,130 @@
+"""The unit conftest memoizes FastAPI's dependency analysis of each route per worker."""
+
+from contextlib import AsyncExitStack
+from dataclasses import fields
+from typing import Any, AsyncIterator, Iterable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import _IncludedRouter
+
+from phoenix.server.app import create_app
+from phoenix.server.types import DbSessionFactory
+from tests.unit import conftest
+from tests.unit.conftest import (
+    _DEPENDANT_LIST_FIELDS,
+    TestBulkInserter,
+    patch_batched_caller,
+    patch_grpc_server,
+)
+
+
+@pytest.fixture
+async def second_app(db: DbSessionFactory) -> AsyncIterator[FastAPI]:
+    """A second app built the way the ``app`` fixture builds its own."""
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        yield create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+
+
+def _route_dependants(app: FastAPI) -> dict[str, Dependant]:
+    """Every route's dependant, keyed by route id, forcing the per-app route
+    state FastAPI otherwise builds on the first request."""
+    dependants: dict[str, Dependant] = {}
+
+    def walk(candidates: Iterable[Any]) -> None:
+        for candidate in candidates:
+            if isinstance(candidate, _IncludedRouter):
+                walk(candidate.effective_candidates())
+                continue
+            dependant = getattr(candidate, "dependant", None)
+            if dependant is not None:
+                dependants[candidate.unique_id] = dependant
+
+    walk(app.router.routes)
+    assert dependants, "expected routes with dependants"
+    return dependants
+
+
+def test_unit_test_apps_share_route_dependency_analysis(app: FastAPI, second_app: FastAPI) -> None:
+    """The suite-wide fixture is in force: two apps built in one worker get
+    distinct dependants for a route, so router-level dependencies inserted
+    into one cannot leak into the other, but the fields inside are the same
+    objects."""
+    first, second = _route_dependants(app), _route_dependants(second_app)
+    assert first.keys() == second.keys()
+    shared_fields = 0
+    for route_id, dependant in first.items():
+        other = second[route_id]
+        assert dependant is not other
+        for list_field in _DEPENDANT_LIST_FIELDS:
+            assert getattr(dependant, list_field) is not getattr(other, list_field)
+        assert len(dependant.dependencies) == len(other.dependencies)
+        for kind in ("path_params", "query_params", "header_params", "cookie_params"):
+            mine, theirs = getattr(dependant, kind), getattr(other, kind)
+            assert len(mine) == len(theirs)
+            assert all(a is b for a, b in zip(mine, theirs))
+            shared_fields += len(mine)
+    assert shared_fields > 0
+
+
+@pytest.mark.real_fastapi_dependants
+def test_marker_restores_fresh_route_dependency_analysis(app: FastAPI, second_app: FastAPI) -> None:
+    first, second = _route_dependants(app), _route_dependants(second_app)
+    assert first.keys() == second.keys()
+    compared = [
+        (a, b)
+        for route_id in first
+        for a, b in zip(first[route_id].query_params, second[route_id].query_params)
+    ]
+    assert compared
+    assert not any(a is b for a, b in compared)
+
+
+async def _module_level_endpoint(limit: int = 0) -> None:
+    return None
+
+
+def test_only_recurring_endpoints_are_memoized() -> None:
+    """A handler created per app, such as the ones a GraphQL router builds
+    for each instance, is analyzed fresh and not retained; a module-level
+    endpoint is analyzed once and handed out as copies. Endpoints on a shared
+    router recur too, which the sharing test above covers through the legacy
+    agent chat route."""
+    memoized: Any = vars(conftest)["_memoized_fastapi_dependant"]
+    cache: dict[Any, Any] = vars(conftest)["_MEMOIZED_FASTAPI_DEPENDANTS"]
+
+    def per_app_handler() -> Any:
+        async def endpoint(limit: int = 0) -> None:
+            return None
+
+        return endpoint
+
+    size_before = len(cache)
+    first = memoized(path="/per-app", call=per_app_handler(), scope="function")
+    second = memoized(path="/per-app", call=per_app_handler(), scope="function")
+    assert len(cache) == size_before
+    assert first.query_params[0] is not second.query_params[0]
+
+    first = memoized(path="/shared", call=_module_level_endpoint, scope="function")
+    second = memoized(path="/shared", call=_module_level_endpoint, scope="function")
+    assert len(cache) == size_before + 1
+    assert first is not second
+    assert first.query_params is not second.query_params
+    assert first.query_params[0] is second.query_params[0]
+
+
+def test_every_list_on_a_dependant_is_copied() -> None:
+    """The memoized dependant is copied list by list. This pins that the set
+    of lists is derived from the dataclass, so a FastAPI release that adds one
+    is copied too rather than shared and mutated across apps."""
+    list_fields = {field.name for field in fields(Dependant) if field.default_factory is list}
+    assert set(_DEPENDANT_LIST_FIELDS) == list_fields
+    assert {"dependencies", "path_params", "query_params", "body_params"} <= list_fields

--- a/tests/unit/server/test_app_fastapi_type_adapters.py
+++ b/tests/unit/server/test_app_fastapi_type_adapters.py
@@ -72,10 +72,12 @@ def _route_fields(app: FastAPI) -> dict[str, fastapi_v2.ModelField]:
     return fields
 
 
+@pytest.mark.real_fastapi_dependants
 def test_unit_test_apps_share_route_type_adapters(app: FastAPI, second_app: FastAPI) -> None:
     """The suite-wide fixture is in force: two apps built in one worker hand
     back the same adapter object for every route field except the ones whose
-    annotation embeds a FieldInfo."""
+    annotation embeds a FieldInfo. The dependency analysis runs fresh here so
+    the fields themselves are new objects and only the adapters can be shared."""
     first, second = _route_fields(app), _route_fields(second_app)
     assert first.keys() == second.keys()
     not_shared = sorted(
@@ -107,6 +109,7 @@ def test_fields_with_different_default_factories_do_not_share_an_adapter() -> No
 
 
 @pytest.mark.real_fastapi_type_adapters
+@pytest.mark.real_fastapi_dependants
 def test_marker_restores_fresh_route_type_adapters(app: FastAPI, second_app: FastAPI) -> None:
     first, second = _route_fields(app), _route_fields(second_app)
     assert first.keys() == second.keys()


### PR DESCRIPTION
### Why
Registering a route has FastAPI analyze the endpoint's dependencies: signature inspection, parameter classification, and modelling, recursively through sub-dependencies. FastAPI repeats it for every app that includes the route, once at include time and again on the first request, because each include invalidates the route state the previous one built.

### What
- `get_dependant` is memoized per worker on the name route registration resolves, keyed on endpoint, path, name, scopes, and scope. Callables key by identity, and the cache is bounded.
- Only endpoints that recur across apps are memoized: module-level or class-level functions, and any endpoint on a shared router. A handler created per app, such as the ones a GraphQL router builds for each instance, is analyzed fresh and never retained, so no app is kept alive by the cache.
- FastAPI inserts a route's own dependencies into the dependant it gets back, so each app receives a copy whose list fields are its own; the set of list fields comes from the dataclass. The fields and sub-dependants inside are shared; nothing mutates them after analysis.
- Opt out with `real_fastapi_dependants`. The adapter tests from #15878 now run with fresh dependants, since with them memoized the fields themselves are shared.

### Tests
- Two apps get distinct dependants with distinct list containers, the same parameter-field objects, and equal dependency-list lengths.
- The marker gives each app fresh fields, over a non-empty comparison.
- The copied list fields are exactly the dataclass's list fields.
- A per-app handler is analyzed fresh without growing the cache; a module-level endpoint is analyzed once and handed out as copies.

### Numbers
Per-test setup about 100ms to about 45ms and first-request work about 55ms to about 20ms, this layer together with #15880. Measured on an idle Apple-silicon Mac from per-test phase durations after the first test of one class. CI runners are slower and contended.
