### PR TITLE
test: seed each worker's template database with the app's startup rows

### DIFF
--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -353,3 +353,11 @@ async def verify_experiment_examples_junction_table(
     assert actual_examples_set == expected_examples_set, (
         f"Junction table entries {actual_examples_set} don't match expected {expected_examples_set}"
     )
+
+
+async def _user_role_id(session: AsyncSession, name: str) -> int:
+    """The id of a user role the app seeds at startup, which every test
+    database already carries."""
+    role_id = await session.scalar(select(models.UserRole.id).where(models.UserRole.name == name))
+    assert role_id is not None, f"user role {name!r} is not seeded"
+    return int(role_id)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import os
+import threading
 from asyncio import AbstractEventLoop
 from functools import partial
 from importlib.metadata import version
@@ -38,6 +39,7 @@ from phoenix.db.engines import (
     aio_sqlite_engine,
     set_sqlite_pragma,
 )
+from phoenix.db.facilitator import Facilitator
 from phoenix.db.insertion.helpers import DataManipulation
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.app import _db, create_app
@@ -81,6 +83,11 @@ def pytest_configure(config: Config) -> None:
         "markers",
         "real_key_derivation: derive the encryption and redaction keys with the real PBKDF2 "
         "rounds instead of the memoized ones",
+    )
+    config.addinivalue_line(
+        "markers",
+        "pristine_db: give the test an empty database instead of one carrying the rows the "
+        "app seeds at startup",
     )
 
 
@@ -330,15 +337,28 @@ def _postgresql_template_db(postgresql_proc: Any) -> Iterator[str]:
     sync_engine = sqlalchemy.create_engine(sync_url)
     models.Base.metadata.create_all(sync_engine)
     sync_engine.dispose()
+    async_url = URL.create(
+        "postgresql+asyncpg",
+        username=postgresql_proc.user,
+        password=postgresql_proc.password or None,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        database=template_name,
+    )
+    _seed_template_database(lambda: aio_postgresql_engine(async_url, migrate=False), "postgresql")
     yield template_name
     janitor.drop()
 
 
 @pytest.fixture(scope="function")
 async def postgresql_engine(
+    request: SubRequest,
     postgresql_proc: Any,
     _postgresql_template_db: str,
 ) -> AsyncIterator[AsyncEngine]:
+    # A pristine database is created from scratch with the schema only,
+    # instead of cloned from the seeded template.
+    pristine = request.node.get_closest_marker("pristine_db") is not None
     dbname = f"phoenix_test_{os.getpid()}_{token_hex(4)}"
     janitor = DatabaseJanitor(
         user=postgresql_proc.user,
@@ -347,7 +367,7 @@ async def postgresql_engine(
         version=postgresql_proc.version,
         dbname=dbname,
         password=postgresql_proc.password or None,
-        template_dbname=_postgresql_template_db,
+        template_dbname=None if pristine else _postgresql_template_db,
     )
     janitor.init()
     url = URL.create(
@@ -359,6 +379,9 @@ async def postgresql_engine(
         database=dbname,
     )
     engine = aio_postgresql_engine(url, migrate=False)
+    if pristine:
+        async with engine.begin() as conn:
+            await conn.run_sync(models.Base.metadata.create_all)
     yield engine
     await engine.dispose()
     janitor.drop()
@@ -379,9 +402,73 @@ def sqlalchemy_dialect(dialect: str) -> Any:
         raise ValueError(f"Unsupported dialect: {dialect}")
 
 
+def _seed_template_database(make_engine: Callable[[], AsyncEngine], dialect: str) -> None:
+    """Run the app's startup seeding once against a template database, so the
+    Facilitator every app runs at startup finds its rows already in place and
+    each of its steps is a read or a delete that matches nothing. The model
+    cost manifest is left out: the suite stubs that step, and a test opts into
+    it per app.
+
+    The seeding runs on its own thread with its own event loop, because the
+    template fixtures are synchronous and pytest-asyncio owns the calling
+    thread's loop."""
+
+    async def skip_model_costs(db: DbSessionFactory) -> None:
+        return None
+
+    async def seed() -> None:
+        engine = make_engine()
+        try:
+            db = DbSessionFactory(db=_db(engine), dialect=dialect)
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr("phoenix.db.facilitator._ensure_model_costs", skip_model_costs)
+                await Facilitator(db=db)()
+        finally:
+            await engine.dispose()
+
+    failure: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            asyncio.run(seed())
+        except BaseException as exc:
+            failure.append(exc)
+
+    thread = threading.Thread(target=run, name=f"seed-{dialect}-template")
+    thread.start()
+    thread.join()
+    if failure:
+        raise failure[0]
+
+
+def _named_memory_sqlite_engine(uri: str) -> AsyncEngine:
+    """An async engine on a named shared-cache in-memory SQLite database."""
+
+    def async_creator() -> aiosqlite.Connection:
+        conn = aiosqlite.Connection(
+            lambda: sqlean.connect(uri, uri=True),
+            iter_chunk_size=64,
+        )
+        # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
+        # aiosqlite dialect daemonizes it only when it creates the connection
+        # itself, not when an async_creator is used.
+        conn._thread.daemon = True
+        return conn
+
+    engine = create_async_engine(
+        url="sqlite+aiosqlite://",
+        async_creator=async_creator,
+        poolclass=StaticPool,
+        json_serializer=_json_serializer,
+    )
+    sqlalchemy.event.listen(engine.sync_engine, "connect", set_sqlite_pragma)
+    return engine
+
+
 @pytest.fixture(scope="session")
 def _sqlite_schema_db() -> Iterator[str]:
-    """Create the schema once per session in a named in-memory SQLite database."""
+    """Create and seed the schema once per session in a named in-memory
+    SQLite database."""
     db_name = f"phoenix_test_{os.getpid()}"
     uri = f"file:{db_name}?mode=memory&cache=shared"
     # Keeper connection keeps the named in-memory DB alive for the session
@@ -391,6 +478,7 @@ def _sqlite_schema_db() -> Iterator[str]:
         creator=lambda: sqlean.connect(uri, uri=True),
     )
     models.Base.metadata.create_all(sync_engine)
+    _seed_template_database(lambda: _named_memory_sqlite_engine(uri), "sqlite")
     yield db_name
     sync_engine.dispose()
     keeper.close()
@@ -413,30 +501,27 @@ async def sqlite_engine(
         async with engine.begin() as conn:
             await conn.run_sync(models.Base.metadata.drop_all)
             await conn.run_sync(models.Base.metadata.create_all)
+        if not request.node.get_closest_marker("pristine_db"):
+            _seed_template_database(lambda: aio_sqlite_engine(url, migrate=False), "sqlite")
         yield engine
         await engine.dispose()
+    elif request.node.get_closest_marker("pristine_db"):
+        # A private, unseeded database: the schema only.
+        uri = f"file:phoenix_pristine_{os.getpid()}_{token_hex(4)}?mode=memory&cache=shared"
+        keeper = sqlean.connect(uri, uri=True)
+        sync_engine = sqlalchemy.create_engine(
+            "sqlite://", creator=lambda: sqlean.connect(uri, uri=True)
+        )
+        models.Base.metadata.create_all(sync_engine)
+        engine = _named_memory_sqlite_engine(uri)
+        yield engine
+        await engine.dispose()
+        sync_engine.dispose()
+        keeper.close()
     else:
         db_name = _sqlite_schema_db
         uri = f"file:{db_name}?mode=memory&cache=shared"
-
-        def async_creator() -> aiosqlite.Connection:
-            conn = aiosqlite.Connection(
-                lambda: sqlean.connect(uri, uri=True),
-                iter_chunk_size=64,
-            )
-            # aiosqlite>=0.22 moved the worker to Connection._thread; SQLAlchemy's
-            # aiosqlite dialect daemonizes it only when it creates the connection
-            # itself, not when an async_creator is used.
-            conn._thread.daemon = True
-            return conn
-
-        engine = create_async_engine(
-            url="sqlite+aiosqlite://",
-            async_creator=async_creator,
-            poolclass=StaticPool,
-            json_serializer=_json_serializer,
-        )
-        sqlalchemy.event.listen(engine.sync_engine, "connect", set_sqlite_pragma)
+        engine = _named_memory_sqlite_engine(uri)
         yield engine
         await engine.dispose()
 

--- a/tests/unit/db/test_facilitator.py
+++ b/tests/unit/db/test_facilitator.py
@@ -30,6 +30,10 @@ from phoenix.db.types.trace_retention import (
 )
 from phoenix.server.types import DbSessionFactory
 
+# These tests exercise seeding from an empty database, so they opt out of the
+# seeded template every other test's database comes from.
+pytestmark = pytest.mark.pristine_db
+
 
 class _MockWelcomeEmailSender:
     def __init__(self, email_sending_fails: bool = False) -> None:

--- a/tests/unit/db/test_models.py
+++ b/tests/unit/db/test_models.py
@@ -780,6 +780,7 @@ class TestNumDocuments:
                 )
 
 
+@pytest.mark.pristine_db
 class TestEvaluatorPolymorphism:
     """Test polymorphic evaluator models with dataset relationships.
 

--- a/tests/unit/db/test_template_seeding.py
+++ b/tests/unit/db/test_template_seeding.py
@@ -1,0 +1,44 @@
+"""The unit conftest seeds each worker's template database with the app's startup rows."""
+
+import sqlalchemy as sa
+from sqlalchemy import select
+
+from phoenix.auth import DEFAULT_SYSTEM_EMAIL
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+
+async def _count(db: DbSessionFactory, table: type[models.Base]) -> int:
+    async with db() as session:
+        count = await session.scalar(select(sa.func.count()).select_from(table))
+    return int(count or 0)
+
+
+async def test_template_database_carries_the_apps_startup_rows(db: DbSessionFactory) -> None:
+    """A test that never boots an app still finds the rows the Facilitator
+    seeds at startup, because the template every test database comes from
+    was seeded once per worker."""
+    async with db() as session:
+        role_names = set((await session.scalars(select(models.UserRole.name))).all())
+        system_user = await session.scalar(
+            select(models.User).where(models.User.email == DEFAULT_SYSTEM_EMAIL)
+        )
+    assert {"SYSTEM", "ADMIN"} <= role_names
+    assert system_user is not None
+    assert await _count(db, models.BuiltinEvaluator) > 0
+    assert await _count(db, models.SandboxProvider) > 0
+
+
+async def test_template_database_leaves_model_costs_to_the_per_test_opt_in(
+    db: DbSessionFactory,
+) -> None:
+    """The model cost manifest is the one startup step the seeding skips: the
+    suite stubs it per app, and only tests marked ``seeded_model_costs`` get
+    the built-in models."""
+    async with db() as session:
+        built_in = await session.scalar(
+            select(sa.func.count())
+            .select_from(models.GenerativeModel)
+            .where(models.GenerativeModel.is_built_in.is_(True))
+        )
+    assert int(built_in or 0) == 0

--- a/tests/unit/server/api/dataloaders/test_user_credential_counts.py
+++ b/tests/unit/server/api/dataloaders/test_user_credential_counts.py
@@ -7,20 +7,19 @@ from phoenix.server.api.dataloaders.user_credential_counts import (
     UserCredentialCountsDataLoader,
 )
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _user_role_id
 
 
 async def test_user_credential_counts_batches_active_credentials(
     db: DbSessionFactory,
 ) -> None:
     async with db() as session:
-        member_role = models.UserRole(name="MEMBER")
-        session.add(member_role)
-        await session.flush()
+        member_role_id = await _user_role_id(session, "MEMBER")
         users = [
             models.OAuth2User(
                 email=f"{token_hex(8)}@example.com",
                 username=token_hex(8),
-                user_role_id=member_role.id,
+                user_role_id=member_role_id,
             )
             for _ in range(2)
         ]

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -33,7 +33,7 @@ from phoenix.server.api.routers.agents import (
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
 from phoenix.server.types import DbSessionFactory, UserId
-from tests.unit._helpers import _agent_session_model_kwargs, _message_uuid
+from tests.unit._helpers import _agent_session_model_kwargs, _message_uuid, _user_role_id
 
 
 def _ephemeral_sweep_cutoff() -> datetime:
@@ -586,11 +586,8 @@ class TestLoadPhoenixUserEmail:
 
     async def test_loads_email_from_authenticated_user_row(self, db: DbSessionFactory) -> None:
         async with db() as session:
-            user_role = models.UserRole(name="MEMBER")
-            session.add(user_role)
-            await session.flush()
             user = models.User(
-                user_role_id=user_role.id,
+                user_role_id=await _user_role_id(session, "MEMBER"),
                 username="agent-test-user",
                 email="agent-test-user@example.com",
                 password_hash=b"hash",
@@ -610,11 +607,8 @@ class TestLoadPhoenixUserEmail:
 
     async def test_returns_none_when_user_row_has_no_email(self, db: DbSessionFactory) -> None:
         async with db() as session:
-            user_role = models.UserRole(name="MEMBER")
-            session.add(user_role)
-            await session.flush()
             user = models.User(
-                user_role_id=user_role.id,
+                user_role_id=await _user_role_id(session, "MEMBER"),
                 username="agent-test-user-no-email",
                 email=None,
                 password_hash=None,

--- a/tests/unit/server/api/test_sync.py
+++ b/tests/unit/server/api/test_sync.py
@@ -14,6 +14,10 @@ from phoenix.server.sandbox.sync import (
 )
 from phoenix.server.types import DbSessionFactory
 
+# These tests exercise seeding from an empty database, so they opt out of the
+# seeded template every other test's database comes from.
+pytestmark = pytest.mark.pristine_db
+
 
 class TestSyncLanguages:
     async def test_inserts_python_and_typescript(self, db: DbSessionFactory) -> None:

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -24,6 +24,7 @@ from phoenix.db.types.prompts import (
 )
 from phoenix.server.api.types.Evaluator import BuiltInEvaluator, DatasetEvaluator, LLMEvaluator
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _user_role_id
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -1284,12 +1285,8 @@ class TestDatasetEvaluatorFields:
             session.add(llm_evaluator)
             await session.flush()
 
-            user_role = models.UserRole(name="MEMBER")
-            session.add(user_role)
-            await session.flush()
-
             user = models.User(
-                user_role_id=user_role.id,
+                user_role_id=await _user_role_id(session, "MEMBER"),
                 username=f"test-user-{token_hex(4)}",
                 email=f"{token_hex(4)}@test.com",
                 password_hash=b"hash",

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -15,7 +15,7 @@ from phoenix.server.settings.registry import (
     AgentSessionRetentionSetting,
 )
 from phoenix.server.types import DbSessionFactory
-from tests.unit._helpers import _agent_session_model_kwargs, _message_uuid
+from tests.unit._helpers import _agent_session_model_kwargs, _message_uuid, _user_role_id
 
 
 async def _make_settings(
@@ -59,11 +59,8 @@ async def _add_user(
     role_name: models.UserRoleName,
 ) -> int:
     async with db() as session:
-        user_role = models.UserRole(name=role_name)
-        session.add(user_role)
-        await session.flush()
         user = models.User(
-            user_role_id=user_role.id,
+            user_role_id=await _user_role_id(session, role_name),
             username=username,
             email=f"{username}@example.com",
             password_hash=b"hash",


### PR DESCRIPTION
### Why
Every app runs the Facilitator at startup: a dozen serialized steps seeding enums, roles and the system user, the default retention policy, builtin evaluators, the feedback annotation config, sandbox providers, and the CLI OAuth2 client. Against an empty test database each step writes, and the database discards the rows afterwards.

### What
- The Facilitator runs once per worker against the template every test database comes from: the named in-memory SQLite database, and the PostgreSQL template each per-test database is cloned from. The on-disk SQLite debugging path seeds its per-test database the same way. Per-app startup then only reads, or runs a delete that matches nothing.
- The model-cost step stays out; #15866 stubs it per app.
- The seeding runs on its own thread and loop, since the template fixtures are synchronous and pytest-asyncio owns the calling thread's loop.

### Test changes
- Nine tests that inserted a user role by hand look the seeded one up through a shared helper.
- Tests whose subject is seeding from empty, the Facilitator tests, the sandbox sync tests for languages, providers, and default configs, and one evaluator polymorphism test, opt out with `pristine_db`, a schema-only database on either dialect.

### Tests
- A database-only test finds the roles, the system user, the builtin evaluators, and the sandbox providers, and finds no built-in models.

### Numbers
Per-test setup about 45ms to about 35ms; suite wall time on eight local workers 1:13 to 1:00 across this layer and the two below it. Verified on SQLite and PostgreSQL. Measured on an idle Apple-silicon Mac from per-test phase durations after the first test of one class. CI runners are slower and contended.
