### PR TITLE
ci: compile bytecode when installing the unit-test tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -144,8 +144,11 @@ commands =
 [testenv:unit_tests]
 description = Run unit tests
 changedir = tests
+# uv installs without bytecode by default, which leaves every xdist worker to
+# compile each module it imports on first use.
 setenv =
   PHOENIX_MASK_INTERNAL_SERVER_ERRORS = false
+  UV_COMPILE_BYTECODE = 1
   # pytest's stdout is a block-buffered pipe on CI; unbuffered output gives each
   # line its own timestamp in the job log.
   PYTHONUNBUFFERED = 1


### PR DESCRIPTION
### Why
The unit-test tox environment is built fresh on every CI job with `uv pip install`, whose default skips bytecode compilation. Each xdist worker then compiles every module it imports from source before it can collect a single test, and all 16 workers repeat the same compilation.

### What
- `UV_COMPILE_BYTECODE=1` in the environment's `setenv`, so the three install lines compile the installed packages once, in parallel, at install time.
- The setting lives in `tox.ini` rather than the workflow because tox passes `PIP_*` through from the caller's environment by default but not `UV_*`.
- Test modules and conftest files are outside this: pytest rewrites their assertions and keeps its own cache for them, which each worker still builds itself.

### Verification
Rebuilt the environment locally with `tox run -r -e unit_tests`. uv reports the compile on each install line, and a test selection passes in the result:

```
Bytecode compiled 15766 files in 2.85s
Bytecode compiled 95 files in 99ms
Bytecode compiled 3475 files in 818ms
19 passed, 1 skipped, 11338 deselected in 6.04s
```

On the runner, the sqlite unit-test job on this PR reports the same compile on all three install lines and the suite passes.

The effect sits in the xdist controller's own startup, and it is measurable once pytest's output is unbuffered so the job log carries per-line timestamps (#15887). The controller is the first process to import the server app, and every worker spawns only after that import. Measured from the pytest command echo to "test session starts" on the 16-core CI runner, one run each with nothing else importing the app first (runs 11 and 12 on #15886):

| Job | Not precompiled | Precompiled |
|---|---|---|
| sqlite | 12.2s | 6.4s |
| postgresql | 12.8s | 5.6s |

The workers see no difference, since the controller's import has already written the site-packages bytecode by the time they start; the layer that warms the test-module bytecode before pytest (#15889) also runs 1.4 seconds faster with its own imports precompiled. The phase from the command echo to the first progress line, the only measurement available before #15887, could not show a 6-second change inside its 47 to 62 second spread.

### Numbers
Single process on an idle Apple-silicon Mac, with an empty bytecode cache versus a warm one (`PYTHONPYCACHEPREFIX` pointed at an empty directory): importing the server app 11.1s cold to 5.0s warm, collecting `tests/unit` 12.5s cold to 5.8s warm. Compiling the whole environment serially takes 25.5s; uv's parallel compile of it took under 4s here. CI runners are slower and contended.
