### PR TITLE
feat(playground): add support for Gemini 3.8 Flash

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2954,6 +2954,7 @@ class GoogleClient(PlaygroundClient["GoogleAsyncClient"]):
 
 
 GEMINI_3_MODELS = [
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -1834,6 +1834,33 @@
       ]
     },
     {
+      "name": "gemini-3.8-flash",
+      "name_pattern": "gemini-3\\.8-flash",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 7.5e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 3.75e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 7.5e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-6,
+          "is_prompt": false,
+          "token_type": "reasoning"
+        }
+      ]
+    },
+    {
       "name": "gemini-exp-1206",
       "name_pattern": "gemini-exp-1206",
       "source": "litellm",


### PR DESCRIPTION
Adds `gemini-3.8-flash` to the playground:

- Registers the model in `GEMINI_3_MODELS` so it appears in the playground model list for the Google provider (served by `GoogleGemini3Client`).
- Adds a cost-tracking entry to `model_cost_manifest.json` with Google's published rates (input $0.75/M, output & reasoning $3.75/M, cache read $0.075/M), matching the format of the existing `gemini-3.7-flash` entry.

Verified the model resolves through the playground client registry, and `tests/unit/server/cost_tracking/` plus the playground helper tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvnHpVF8ByHPtJ7gd8AxGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvnHpVF8ByHPtJ7gd8AxGs)_