### PR TITLE
ci: unbuffer pytest's output in the unit-test tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -146,6 +146,9 @@ description = Run unit tests
 changedir = tests
 setenv =
   PHOENIX_MASK_INTERNAL_SERVER_ERRORS = false
+  # pytest's stdout is a block-buffered pipe on CI; unbuffered output gives each
+  # line its own timestamp in the job log.
+  PYTHONUNBUFFERED = 1
 commands_pre =
   uv pip install --strict -U -r {toxinidir}/requirements/unit-tests.txt
   uv pip install --strict --reinstall-package arize-phoenix-evals {toxinidir}/packages/phoenix-evals


### PR DESCRIPTION
### Why
On a CI runner pytest's stdout is a block-buffered pipe. Every line printed before the first test, from "test session starts" through "created: 16/16 workers" and "collected N items", is held until the first test starts and lands in the job log under one timestamp, so the startup phase of a unit-test job cannot be split from the log.

### What
- `PYTHONUNBUFFERED=1` in the unit-test tox environment. Every line then carries its own timestamp, and the log shows how long the controller's startup, worker spawning, and collection each take.
- The extra flushes cost nothing measurable; the progress dots already flush once per test.

### Numbers
Before: the phase from the pytest command echo to the first progress line read as one gap of 47 to 62 seconds across four runs. After: the same phase splits into the controller's 5.6 to 8 seconds and the workers' spawn, import, and collection stages. Measured on the 16-core CI runner from job-log timestamps, sqlite unit-test job, one run each; see the experiment log on #15886.
