### PR TITLE
test: keep the arize-phoenix-client pytest plugin out of the unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,11 @@ addopts = [
   "--ignore=src/phoenix/db/migrations/env.py",
   "--new-first",
   "--showlocals",
+  # arize-phoenix-client's pytest plugin records marked tests as Phoenix experiments
+  # and, under xdist, collects the whole suite on the controller to find them. No
+  # test here carries its marker.
+  "-p",
+  "no:phoenix",
 ]
 doctest_optionflags = ["NORMALIZE_WHITESPACE"]
 testpaths = [

--- a/tests/unit/test_client_pytest_plugin.py
+++ b/tests/unit/test_client_pytest_plugin.py
@@ -1,0 +1,14 @@
+from importlib.metadata import entry_points
+
+import pytest
+
+
+def test_the_client_pytest_plugin_is_blocked(request: pytest.FixtureRequest) -> None:
+    """arize-phoenix-client's pytest plugin stays out of this suite via `-p no:phoenix` in
+    the project's pytest options; under xdist it would collect the whole suite on the
+    controller to look for its marker, which no test here carries."""
+    if not any(ep.name == "phoenix" for ep in entry_points(group="pytest11")):
+        pytest.skip("arize-phoenix-client's pytest plugin is not installed")
+    manager = request.config.pluginmanager
+    assert manager.is_blocked("phoenix")
+    assert not manager.hasplugin("phoenix")


### PR DESCRIPTION
### Why
`arize-phoenix-client` ships a `pytest11` entry point that records tests carrying its `phoenix` marker as Phoenix experiments. Under xdist its `pytest_configure_node` hook makes the controller run a full collection of the suite before the second worker is spawned, to find marked tests and broadcast experiment ids. No test in this repository uses the marker, so the plugin has nothing to record here.

### What
- `-p no:phoenix` in the project's pytest options, so the plugin stays out of every run, under tox and on a developer's machine alike. Blocking the plugin rather than setting its tracking switch means none of its hooks run at all.
- This does not spare the controller the server import: the unit conftest imports the app at module level, and the controller loads that conftest before it spawns a worker.

### Tests
- The plugin is blocked whenever its entry point is installed, and the test skips when it is not.

### Numbers
Time-neutral on its own. The controller's serialized collection took 12 to 19 seconds, during which no worker started, but it also imported every test module and so left pytest's rewritten bytecode on disk for the workers, whose own collection then took 8 seconds instead of 18. Workers that start 12 seconds earlier and collect for 10 seconds longer finish within two seconds of where they were. The layer above warms that cache deliberately. Measured on the 16-core CI runner from job-log timestamps, sqlite unit-test job, one run each; see the experiment log on #15886.
