### PR TITLE
test: warm pytest's rewritten bytecode across cores before the unit tests start

### DIFF
--- a/tests/unit/_warm_rewrite_cache.py
+++ b/tests/unit/_warm_rewrite_cache.py
@@ -1,0 +1,96 @@
+"""Write pytest's assertion-rewritten bytecode for the unit test modules before pytest starts.
+
+pytest rewrites the assertions in each test module and conftest it imports and caches the
+result as a ``.pyc`` beside the source. Under xdist every worker collects the whole suite, so
+on a fresh checkout all of them rewrite and compile the same sources at the same time.
+Running this first, with one process per CPU, leaves the cache warm for every worker.
+
+pytest validates a cached file by the source's mtime and size only, so the rewriter here has
+to see the same configuration as the real run: the same rootdir, and through it the same
+``pyproject.toml``, plus whatever command-line arguments the real run gets, since an
+``-o enable_assertion_pass_hook=true`` override changes the rewritten code. The pytest
+version is the other input, and it is part of the cache file's name.
+
+The rewriter's functions are private to pytest and are looked up when called, not when this
+module is imported, so ``--doctest-modules`` can import it safely and a pytest release that
+moves one of them fails only the tox step that runs it, which tox ignores.
+
+Usage: ``python _warm_rewrite_cache.py <rootdir> <tests dir> [pytest args...]``
+The process count comes from ``WARM_REWRITE_CACHE_JOBS`` or the CPU count.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from multiprocessing import Pool
+from pathlib import Path
+from typing import Any
+
+from _pytest.assertion import AssertionState
+from _pytest.assertion import rewrite as _rewrite
+from _pytest.config import get_config
+from _pytest.pathlib import fnmatch_ex
+
+_CONFIG: Any = None
+_STATE: Any = None
+
+
+def _configure(rootdir: str, pytest_args: list[str]) -> None:
+    """Build the pytest configuration the rewriter reads, once per process."""
+    global _CONFIG, _STATE
+    config = get_config()
+    # Loading the client's pytest plugin imports the whole server; nothing here needs it.
+    config.parse(["--rootdir", rootdir, "-p", "no:phoenix", *pytest_args])
+    _CONFIG = config
+    _STATE = AssertionState(config, "rewrite")
+
+
+def _warm(source: Path) -> bool:
+    """Write the rewritten bytecode for one module unless a valid cache file already exists."""
+    pyc = _rewrite.get_cache_dir(source) / (source.name[:-3] + _rewrite.PYC_TAIL)
+    if _rewrite._read_pyc(source, pyc, _STATE.trace) is not None:
+        return False
+    source_stat, code = _rewrite._rewrite_test(source, _CONFIG)
+    pyc.parent.mkdir(parents=True, exist_ok=True)
+    if not _rewrite._write_pyc(_STATE, code, source_stat, pyc):
+        raise OSError(f"could not write {pyc}")
+    return True
+
+
+def rewritten_modules(rootdir: Path, tests_dir: Path, patterns: list[str]) -> list[Path]:
+    """The modules pytest rewrites when it collects ``tests_dir``: every file there matching
+    ``python_files``, every conftest there, and the conftests of its ancestors up to the
+    rootdir, which pytest loads on the way in."""
+    ancestors = [d / "conftest.py" for d in tests_dir.parents if rootdir in (d, *d.parents)]
+    found = {path for path in ancestors if path.is_file()}
+    for path in tests_dir.rglob("*.py"):
+        if path.name == "conftest.py" or any(fnmatch_ex(pattern, path) for pattern in patterns):
+            found.add(path)
+    return sorted(found)
+
+
+def main(rootdir: str, tests_dir: str, pytest_args: list[str]) -> int:
+    started = time.perf_counter()
+    jobs = int(os.environ.get("WARM_REWRITE_CACHE_JOBS") or (os.cpu_count() or 1))
+    _configure(rootdir, pytest_args)
+    files = rewritten_modules(
+        Path(rootdir).absolute(),
+        Path(tests_dir).absolute(),
+        list(_CONFIG.getini("python_files")),
+    )
+    if jobs > 1:
+        with Pool(jobs, initializer=_configure, initargs=(rootdir, pytest_args)) as pool:
+            written = sum(pool.map(_warm, files, chunksize=4))
+    else:
+        written = sum(map(_warm, files))
+    print(
+        f"warm_rewrite_cache: rewrote {written} of {len(files)} modules "
+        f"in {time.perf_counter() - started:.1f}s with {jobs} process(es)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1], sys.argv[2], sys.argv[3:]))

--- a/tests/unit/test_warm_rewrite_cache.py
+++ b/tests/unit/test_warm_rewrite_cache.py
@@ -1,0 +1,99 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_rewrite = pytest.importorskip("_pytest.assertion.rewrite")
+if not all(hasattr(_rewrite, name) for name in ("_read_pyc", "_rewrite_test", "_write_pyc")):
+    pytest.skip(
+        "this pytest release moved the rewriter's private functions", allow_module_level=True
+    )
+
+_SCRIPT = Path(__file__).with_name("_warm_rewrite_cache.py")
+_SUBPROCESS_ENV = {**os.environ, "WARM_REWRITE_CACHE_JOBS": "1"}
+
+
+def _warm(rootdir: Path, tests_dir: Path, *pytest_args: str, jobs: int = 1) -> str:
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(rootdir), str(tests_dir), *pytest_args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**_SUBPROCESS_ENV, "WARM_REWRITE_CACHE_JOBS": str(jobs)},
+    )
+    return result.stdout.strip()
+
+
+def _cache_file(source: Path) -> Path:
+    return Path(_rewrite.get_cache_dir(source)) / (source.name[:-3] + str(_rewrite.PYC_TAIL))
+
+
+def _suite(tmp_path: Path) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.pytest.ini_options]\naddopts = ["-p", "no:phoenix", "-p", "no:cacheprovider"]\n'
+    )
+    (tmp_path / "conftest.py").write_text("ROOT = True\n")
+    tests_dir = tmp_path / "suite"
+    tests_dir.mkdir()
+    (tests_dir / "conftest.py").write_text("SUITE = True\n")
+    (tests_dir / "test_sample.py").write_text("def test_it() -> None:\n    assert 1 == 1\n")
+    (tests_dir / "helper.py").write_text("VALUE = 1\n")
+    return tests_dir
+
+
+def test_pytest_reads_the_warmed_bytecode_instead_of_rewriting(tmp_path: Path) -> None:
+    tests_dir = _suite(tmp_path)
+    assert _warm(tmp_path, tests_dir).startswith("warm_rewrite_cache: rewrote 3 of 3 modules")
+    for source in (
+        tests_dir / "test_sample.py",
+        tests_dir / "conftest.py",
+        tmp_path / "conftest.py",
+    ):
+        assert _rewrite._read_pyc(source, _cache_file(source)) is not None, source
+    assert not _cache_file(tests_dir / "helper.py").exists()
+
+    # A rejected cache file is rewritten and replaced, so an untouched file was accepted. For
+    # the test module pytest's own trace says so as well; the conftests are imported while
+    # arguments are still being parsed, before the debug writer is attached.
+    sources = (tests_dir / "test_sample.py", tests_dir / "conftest.py", tmp_path / "conftest.py")
+    before = {source: _cache_file(source).stat().st_mtime_ns for source in sources}
+    debug_log = tmp_path / "pytestdebug.log"
+    subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(tests_dir), f"--debug={debug_log}"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**_SUBPROCESS_ENV, "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"},
+    )
+    assert {source: _cache_file(source).stat().st_mtime_ns for source in sources} == before
+    trace = debug_log.read_text()
+    module = tests_dir / "test_sample.py"
+    assert f"found cached rewritten pyc for {module}" in trace
+    assert f"rewriting {module!r}" not in trace
+
+    assert _warm(tmp_path, tests_dir, jobs=2).startswith("warm_rewrite_cache: rewrote 0 of 3")
+
+
+def test_a_changed_source_is_rewritten(tmp_path: Path) -> None:
+    tests_dir = _suite(tmp_path)
+    module = tests_dir / "test_sample.py"
+    _warm(tmp_path, tests_dir)
+
+    module.write_text("def test_it() -> None:\n    assert 1 == 1  # edited\n")
+    assert _rewrite._read_pyc(module, _cache_file(module)) is None
+    assert _warm(tmp_path, tests_dir).startswith("warm_rewrite_cache: rewrote 1 of 3 modules")
+    assert _rewrite._read_pyc(module, _cache_file(module)) is not None
+
+
+def test_the_real_runs_overrides_shape_the_rewrite(tmp_path: Path) -> None:
+    tests_dir = _suite(tmp_path)
+    module = tests_dir / "test_sample.py"
+    _warm(tmp_path, tests_dir)
+    plain = _cache_file(module).read_bytes()
+
+    _cache_file(module).unlink()
+    _warm(tmp_path, tests_dir, "-o", "enable_assertion_pass_hook=true")
+    assert _cache_file(module).read_bytes() != plain

--- a/tox.ini
+++ b/tox.ini
@@ -158,6 +158,9 @@ commands_pre =
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
 commands =
   uv pip list -v
+  # Leaves pytest's rewritten bytecode warm for every xdist worker. It relies on
+  # pytest's private rewrite module, so a failure is reported and ignored.
+  - python unit/_warm_rewrite_cache.py {toxinidir} unit {posargs}
   pytest {posargs} unit/
 
 [testenv:unit_tests_local_evals]


### PR DESCRIPTION
### Why
pytest rewrites the assertions in every test module and conftest it imports and caches the result as a `.pyc` beside the source, validated by the source's mtime and size. Under xdist every worker collects the whole suite, so on a fresh CI checkout all sixteen rewrite and compile the same six megabytes of test source at the same moment.

### What
- A script under `tests/unit` drives pytest's rewriter directly, without importing a test module or the app, and writes the cache for every module pytest would rewrite when it collects `tests/unit`: files matching `python_files` by pytest's own matching, the conftests there, and the conftests of the ancestors up to the rootdir. One process per CPU. The pytest plugin packages in site-packages, which pytest also rewrites, are left to the workers; they are a handful of files.
- tox runs it before pytest and forwards pytest's command-line arguments to it, since an override such as `-o enable_assertion_pass_hook=true` changes the rewritten code and the cache validates only mtime and size.
- The rewriter's functions are private to pytest. The script looks them up when called rather than when imported, so `--doctest-modules` can import it during collection, and tox runs it as an ignorable step: a pytest release that moves one of them costs the warm-up, not the suite. The tests skip when that happens.

### Tests
- pytest's own run leaves every warmed file untouched and traces a cache hit for the test module.
- A helper module pytest would not rewrite is left alone, and a second run rewrites nothing.
- An edited source is rewritten.
- The assertion-pass-hook override produces different bytecode.

### Numbers
Per-worker collection 18.3s to 8.0s and the startup phase 34.1s to 24.6s, at a cost of 2.2s for the tree on 16 processes. Locally a single-process collection of `tests/unit` takes 15.2s with cold test-module bytecode and 9.8s warm; the script takes 5.4s on one process and 1.5s on eight. Measured on the 16-core CI runner from job-log timestamps, sqlite unit-test job, one run each; see the experiment log on #15886.