### PR TITLE
test: await the trace data sweeper instead of sleeping through it

### DIFF
--- a/tests/unit/server/test_retention.py
+++ b/tests/unit/server/test_retention.py
@@ -1,4 +1,5 @@
-from asyncio import Event, sleep
+from asyncio import Event, wait_for
+from asyncio import TimeoutError as AsyncTimeoutError
 from datetime import datetime, timedelta, timezone
 from secrets import token_hex
 from typing import Any, AsyncIterator
@@ -22,12 +23,48 @@ from phoenix.server.retention import TraceDataSweeper
 from phoenix.server.types import DbSessionFactory
 
 
+class _SweeperController:
+    """Drives the TraceDataSweeper one sweep at a time in place of its hourly sleep.
+
+    The sweeper parks in ``park`` where it would otherwise sleep. ``sweep`` releases it once
+    and returns when it has parked again, which is after that sweep has run to completion,
+    so a test never has to guess how long a sweep takes. One caller at a time: the patch has
+    to be in place before the app's lifespan starts the sweeper, so the fixture that hands
+    this out must be requested before ``asgi_app``.
+    """
+
+    def __init__(self) -> None:
+        self._release = Event()
+        self._parked = Event()
+
+    async def park(self, *_: Any, **__: Any) -> None:
+        self._parked.set()
+        await self._release.wait()
+        self._release.clear()
+
+    async def sweep(self, timeout: float = 30.0) -> None:
+        await self._parked_within(
+            timeout,
+            "the sweeper never parked; request sweeper_trigger before asgi_app so the patch "
+            "precedes the sweeper's start",
+        )
+        self._parked.clear()
+        self._release.set()
+        await self._parked_within(timeout, "the sweep did not finish")
+
+    async def _parked_within(self, timeout: float, failure: str) -> None:
+        try:
+            await wait_for(self._parked.wait(), timeout)
+        except AsyncTimeoutError:
+            pytest.fail(f"{failure} within {timeout:.0f}s")
+
+
 class TestTraceDataSweeper:
     @pytest.mark.parametrize("use_default_policy", [True, False])
     async def test_max_count_rule(
         self,
         use_default_policy: bool,
-        sweeper_trigger: Event,
+        sweeper_trigger: _SweeperController,
         db: DbSessionFactory,
         asgi_app: ASGIApp,
     ) -> None:
@@ -130,9 +167,7 @@ class TestTraceDataSweeper:
                     project_expected_trace_ids[project_id] = expected_trace_ids
 
             # Execute sweeper
-            sweeper_trigger.set()
-            wait_time = 1.0
-            await sleep(wait_time)  # Allow time for processing
+            await sweeper_trigger.sweep()
 
             # Verify final state for each project
             async with db() as session:
@@ -158,7 +193,7 @@ class TestTraceDataSweeper:
     async def test_max_days_rule(
         self,
         use_default_policy: bool,
-        sweeper_trigger: Event,
+        sweeper_trigger: _SweeperController,
         db: DbSessionFactory,
         asgi_app: ASGIApp,
     ) -> None:
@@ -254,9 +289,7 @@ class TestTraceDataSweeper:
                 )
 
         # Execute sweeper
-        sweeper_trigger.set()
-        wait_time = 1.0
-        await sleep(wait_time)  # Allow time for processing
+        await sweeper_trigger.sweep()
 
         # Verify final state for each project
         async with db() as session:
@@ -280,7 +313,7 @@ class TestTraceDataSweeper:
     async def test_max_days_or_count_rule(
         self,
         use_default_policy: bool,
-        sweeper_trigger: Event,
+        sweeper_trigger: _SweeperController,
         db: DbSessionFactory,
         asgi_app: ASGIApp,
     ) -> None:
@@ -410,9 +443,7 @@ class TestTraceDataSweeper:
                 )
 
         # Execute sweeper
-        sweeper_trigger.set()
-        wait_time = 1.0
-        await sleep(wait_time)  # Allow time for processing
+        await sweeper_trigger.sweep()
 
         # Verify final state for each project
         async with db() as session:
@@ -434,20 +465,15 @@ class TestTraceDataSweeper:
 
 
 @pytest.fixture
-async def sweeper_trigger() -> AsyncIterator[Event]:
-    """Control when the TraceDataSweeper runs by patching its sleep method.
+async def sweeper_trigger() -> AsyncIterator[_SweeperController]:
+    """Replace the TraceDataSweeper's hourly sleep so a test drives each sweep and awaits it.
 
-    Returns an event that can be set to trigger the sweeper's next run.
-    The sweeper will wait for this event instead of sleeping until the next hour.
+    Request this before ``asgi_app``: the patch has to be in place when the app's lifespan
+    starts the sweeper, or the sweeper enters its real hourly sleep and ``sweep`` times out.
     """
-    event = Event()
-
-    async def wait_for_event(*_: Any, **__: Any) -> None:
-        await event.wait()
-        event.clear()
-
-    with patch.object(TraceDataSweeper, "_sleep_until_next_hour", wait_for_event):
-        yield event
+    controller = _SweeperController()
+    with patch.object(TraceDataSweeper, "_sleep_until_next_hour", controller.park):
+        yield controller
 
 
 class TestOrphanSessionSweep:

--- a/tests/unit/server/test_retention.py
+++ b/tests/unit/server/test_retention.py
@@ -28,9 +28,7 @@ class _SweeperController:
 
     The sweeper parks in ``park`` where it would otherwise sleep. ``sweep`` releases it once
     and returns when it has parked again, which is after that sweep has run to completion,
-    so a test never has to guess how long a sweep takes. One caller at a time: the patch has
-    to be in place before the app's lifespan starts the sweeper, so the fixture that hands
-    this out must be requested before ``asgi_app``.
+    so a test never has to guess how long a sweep takes. Supports one caller at a time.
     """
 
     def __init__(self) -> None:
@@ -43,11 +41,7 @@ class _SweeperController:
         self._release.clear()
 
     async def sweep(self, timeout: float = 30.0) -> None:
-        await self._parked_within(
-            timeout,
-            "the sweeper never parked; request sweeper_trigger before asgi_app so the patch "
-            "precedes the sweeper's start",
-        )
+        await self._parked_within(timeout, "the sweeper never parked")
         self._parked.clear()
         self._release.set()
         await self._parked_within(timeout, "the sweep did not finish")
@@ -60,13 +54,24 @@ class _SweeperController:
 
 
 class TestTraceDataSweeper:
+    @pytest.fixture(autouse=True)
+    async def sweeper_trigger(self) -> AsyncIterator[_SweeperController]:
+        """Patch sleep before app startup for every test in this class.
+
+        Autouse ensures the patch precedes ``asgi_app`` regardless of test parameter order.
+        Each test gets a fresh controller, and app teardown runs before the patch is removed.
+        """
+        controller = _SweeperController()
+        with patch.object(TraceDataSweeper, "_sleep_until_next_hour", controller.park):
+            yield controller
+
     @pytest.mark.parametrize("use_default_policy", [True, False])
     async def test_max_count_rule(
         self,
         use_default_policy: bool,
-        sweeper_trigger: _SweeperController,
         db: DbSessionFactory,
         asgi_app: ASGIApp,
+        sweeper_trigger: _SweeperController,
     ) -> None:
         """Test that TraceDataSweeper correctly enforces trace retention policies.
 
@@ -193,9 +198,9 @@ class TestTraceDataSweeper:
     async def test_max_days_rule(
         self,
         use_default_policy: bool,
-        sweeper_trigger: _SweeperController,
         db: DbSessionFactory,
         asgi_app: ASGIApp,
+        sweeper_trigger: _SweeperController,
     ) -> None:
         """Test that TraceDataSweeper correctly enforces time-based retention policies.
 
@@ -313,9 +318,9 @@ class TestTraceDataSweeper:
     async def test_max_days_or_count_rule(
         self,
         use_default_policy: bool,
-        sweeper_trigger: _SweeperController,
         db: DbSessionFactory,
         asgi_app: ASGIApp,
+        sweeper_trigger: _SweeperController,
     ) -> None:
         """Test that TraceDataSweeper correctly enforces OR-based retention policies.
 
@@ -462,18 +467,6 @@ class TestTraceDataSweeper:
                     f"Project {project_id} ({test_case['description']}): "
                     f"trace IDs mismatch: expected {expected_trace_ids}, got {remaining_trace_ids}"
                 )
-
-
-@pytest.fixture
-async def sweeper_trigger() -> AsyncIterator[_SweeperController]:
-    """Replace the TraceDataSweeper's hourly sleep so a test drives each sweep and awaits it.
-
-    Request this before ``asgi_app``: the patch has to be in place when the app's lifespan
-    starts the sweeper, or the sweeper enters its real hourly sleep and ``sweep`` times out.
-    """
-    controller = _SweeperController()
-    with patch.object(TraceDataSweeper, "_sleep_until_next_hour", controller.park):
-        yield controller
 
 
 class TestOrphanSessionSweep:


### PR DESCRIPTION
### Why
The three `TraceDataSweeper` tests trigger a sweep and then sleep one second before reading the database back. On the PostgreSQL unit-test job that second is not always enough: `test_max_count_rule[postgresql-True]` failed on CI with all six traces still present ([job](https://github.com/Arize-ai/phoenix/actions/runs/33714027733/job/100519360278)), so the sweep had not run when the test looked. The likeliest reason is load on the one PostgreSQL server: 16 workers each clone a database per test with `CREATE DATABASE ... TEMPLATE`, PostgreSQL 14 checkpoints on every clone, and a delete caught behind one can outlast the budget. With the reruns gone (#15794) a single miss fails the job.

### What
- The `sweeper_trigger` fixture hands out a controller in the style of the daemon tests. The sweeper parks where it would sleep; `sweep()` releases it once and awaits its return to the parked state, which is after that sweep has run to completion.
- Both waits carry a timeout, and a timeout fails the test with the phase that stalled. The first one also names the fixture-order mistake that causes it: the patch has to be in place before the app's lifespan starts the sweeper, so the fixture must be requested before `asgi_app`, as the three tests do.
- The three tests call `await sweeper_trigger.sweep()` in place of setting the event and sleeping.

### Tests
- The existing retention tests, on SQLite and PostgreSQL locally, and a throwaway probe with the fixtures in the wrong order, which failed in two seconds with the message naming the fix.

### Numbers
Locally the two max-count cases went from about two seconds of call time to milliseconds and the four other cases from about one, on both databases. Independent of the unit-test startup stack (#15884); the failure was observed on one of its PRs but nothing in the stack touches the sweeper or these tests.
