### PR TITLE
refactor(evals): consolidate structured-output/tool-calling fallback with explicit eligibility rules and output validation

### DIFF
--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "pystache",
   "pydantic>=2.0.0",
   "jsonpath_ng",
+  "jsonschema>=4.0.0",
   "openinference-semantic-conventions>=0.1.19",
   "openinference-instrumentation>=0.1.20",
   "opentelemetry-api",

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/anthropic/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/anthropic/adapter.py
@@ -10,7 +10,12 @@ from ...prompts import (
     validate_message_dict,
 )
 from ...registries import register_adapter, register_provider
-from ...types import BaseLLMAdapter, ObjectGenerationMethod
+from ...types import (
+    BaseLLMAdapter,
+    ObjectGenerationMethod,
+    RefusalError,
+    TruncatedResponseError,
+)
 from .factories import AnthropicClientWrapper, create_anthropic_client
 
 logger = logging.getLogger(__name__)
@@ -204,8 +209,9 @@ class AnthropicAdapter(BaseLLMAdapter):
 
         for content_block in response.content:
             if hasattr(content_block, "type") and content_block.type == "tool_use":
-                return cast(Dict[str, Any], content_block.input)
+                return self._validate_against_schema(content_block.input, schema)
 
+        self._raise_for_stop_reason(response)
         raise ValueError("No tool use in response")
 
     async def _async_generate_with_tool_calling(
@@ -231,9 +237,24 @@ class AnthropicAdapter(BaseLLMAdapter):
 
         for content_block in response.content:
             if hasattr(content_block, "type") and content_block.type == "tool_use":
-                return cast(Dict[str, Any], content_block.input)
+                return self._validate_against_schema(content_block.input, schema)
 
+        self._raise_for_stop_reason(response)
         raise ValueError("No tool use in response")
+
+    def _raise_for_stop_reason(self, response: Any) -> None:
+        """Raise a typed error for a refused/truncated response before falling
+        back to the generic "no tool use" error. Never a capability-mismatch
+        signal -- Anthropic has no fallback method to route around this.
+        """
+        stop_reason = getattr(response, "stop_reason", None)
+        if stop_reason == "max_tokens":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before the tool call completed."
+            )
+        if stop_reason == "refusal":
+            raise RefusalError(f"{self.model_name} declined to generate output.")
 
     def _schema_to_tool(self, schema: Dict[str, Any]) -> Dict[str, Any]:
         description = schema.get("description", "Respond in a format matching the provided schema")

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/google/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/google/adapter.py
@@ -11,10 +11,22 @@ from ...prompts import (
     validate_message_dict,
 )
 from ...registries import register_adapter, register_provider
-from ...types import BaseLLMAdapter, ObjectGenerationMethod
+from ...types import (
+    BaseLLMAdapter,
+    MalformedOutputError,
+    ObjectGenerationMethod,
+    RefusalError,
+    TruncatedResponseError,
+)
 from .factories import GoogleGenAIClientWrapper, create_google_genai_client
 
 logger = logging.getLogger(__name__)
+
+# finish_reason values that mean the model declined/blocked the output rather
+# than a capability mismatch or truncation.
+_REFUSAL_FINISH_REASONS = frozenset(
+    {"SAFETY", "PROHIBITED_CONTENT", "RECITATION", "BLOCKLIST", "SPII", "LANGUAGE"}
+)
 
 
 class GoogleGenAIRateLimitError(Exception):
@@ -31,6 +43,19 @@ def identify_google_genai_client(client: Any) -> bool:
 
 def get_google_genai_rate_limit_errors() -> list[Type[Exception]]:
     return [GoogleGenAIRateLimitError]
+
+
+def _is_google_capability_mismatch(error: BaseException) -> bool:
+    """A genuine capability-mismatch signal: an HTTP 400 (bad request) from the
+    API, e.g. the model rejecting ``response_schema`` or the tool config.
+    Authentication (401), permission/quota (403), and everything else must
+    return directly rather than trigger a fallback attempt.
+    """
+    try:
+        from google.genai.errors import ClientError
+    except ImportError:
+        return False
+    return isinstance(error, ClientError) and getattr(error, "code", None) == 400
 
 
 @register_adapter(
@@ -201,20 +226,14 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
             return self._generate_with_tool_calling(prompt, schema, **kwargs)
 
         elif method == ObjectGenerationMethod.AUTO:
-            try:
-                return self._generate_with_structured_output(prompt, schema, **kwargs)
-            except Exception as structured_error:
-                logger.debug(
-                    f"Structured output failed for {self.client.model}, falling back to tool "
-                    f"calling: {structured_error}"
-                )
-                try:
-                    return self._generate_with_tool_calling(prompt, schema, **kwargs)
-                except Exception as tool_error:
-                    raise ValueError(
-                        f"Google GenAI model {self.client.model} failed with both structured "
-                        f"output and tool calling. Tool calling error: {tool_error}"
-                    ) from tool_error
+            result, _ = self._try_with_fallback(
+                primary=lambda: self._generate_with_structured_output(prompt, schema, **kwargs),
+                fallback=lambda: self._generate_with_tool_calling(prompt, schema, **kwargs),
+                primary_name="structured output",
+                fallback_name="tool calling",
+                is_capability_mismatch=_is_google_capability_mismatch,
+            )
+            return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -239,20 +258,16 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
             return await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
 
         elif method == ObjectGenerationMethod.AUTO:
-            try:
-                return await self._async_generate_with_structured_output(prompt, schema, **kwargs)
-            except Exception as structured_error:
-                logger.debug(
-                    f"Structured output failed for {self.client.model}, falling back to tool "
-                    f"calling: {structured_error}"
-                )
-                try:
-                    return await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
-                except Exception as tool_error:
-                    raise ValueError(
-                        f"Google GenAI model {self.client.model} failed with both structured "
-                        f"output and tool calling. Tool calling error: {tool_error}"
-                    ) from tool_error
+            result, _ = await self._try_with_fallback_async(
+                primary=lambda: self._async_generate_with_structured_output(
+                    prompt, schema, **kwargs
+                ),
+                fallback=lambda: self._async_generate_with_tool_calling(prompt, schema, **kwargs),
+                primary_name="structured output",
+                fallback_name="tool calling",
+                is_capability_mismatch=_is_google_capability_mismatch,
+            )
+            return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -277,9 +292,16 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
             response = self.client.models.generate_content(
                 model=self.client.model, contents=content, config=config, **kwargs
             )
+            self._check_finish_reason(response)
 
-            if hasattr(response, "text"):
-                return cast(Dict[str, Any], json.loads(response.text))
+            if hasattr(response, "text") and response.text is not None:
+                try:
+                    data = json.loads(response.text)
+                except json.JSONDecodeError as e:
+                    raise MalformedOutputError(
+                        f"{self.model_name} structured output was not valid JSON: {e}"
+                    ) from e
+                return self._validate_against_schema(data, schema)
             else:
                 raise ValueError("Google GenAI returned no content")
         except Exception as e:
@@ -306,9 +328,16 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
             response = await self.client.models.generate_content(
                 model=self.client.model, contents=content, config=config, **kwargs
             )
+            self._check_finish_reason(response)
 
-            if hasattr(response, "text"):
-                return cast(Dict[str, Any], json.loads(response.text))
+            if hasattr(response, "text") and response.text is not None:
+                try:
+                    data = json.loads(response.text)
+                except json.JSONDecodeError as e:
+                    raise MalformedOutputError(
+                        f"{self.model_name} structured output was not valid JSON: {e}"
+                    ) from e
+                return self._validate_against_schema(data, schema)
             else:
                 raise ValueError("Google GenAI returned no content")
         except Exception as e:
@@ -339,13 +368,15 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
             response = self.client.models.generate_content(
                 model=self.client.model, contents=content, config=config, **kwargs
             )
+            self._check_finish_reason(response)
 
             if hasattr(response, "candidates") and response.candidates:
                 for candidate in response.candidates:
                     if hasattr(candidate, "content") and hasattr(candidate.content, "parts"):
                         for part in candidate.content.parts:
                             if hasattr(part, "function_call"):
-                                return cast(Dict[str, Any], dict(part.function_call.args))
+                                data = dict(part.function_call.args)
+                                return self._validate_against_schema(data, schema)
 
             raise ValueError("No function call in response")
         except Exception as e:
@@ -376,13 +407,15 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
             response = await self.client.models.generate_content(
                 model=self.client.model, contents=content, config=config, **kwargs
             )
+            self._check_finish_reason(response)
 
             if hasattr(response, "candidates") and response.candidates:
                 for candidate in response.candidates:
                     if hasattr(candidate, "content") and hasattr(candidate.content, "parts"):
                         for part in candidate.content.parts:
                             if hasattr(part, "function_call"):
-                                return cast(Dict[str, Any], dict(part.function_call.args))
+                                data = dict(part.function_call.args)
+                                return self._validate_against_schema(data, schema)
 
             raise ValueError("No function call in response")
         except Exception as e:
@@ -527,6 +560,27 @@ class GoogleGenAIAdapter(BaseLLMAdapter):
                     f"are not defined in properties. "
                     f"Properties: {list(property_names)}, Required: {list(required_names)}"
                 )
+
+    def _check_finish_reason(self, response: Any) -> None:
+        """Raise a typed error for a blocked/truncated candidate before we try
+        to parse its (possibly absent) content. Never a capability-mismatch
+        signal -- a refusal or truncation from one method says nothing about
+        whether the other method would succeed.
+        """
+        candidates = getattr(response, "candidates", None)
+        if not candidates:
+            return
+        finish_reason = getattr(candidates[0], "finish_reason", None)
+        if finish_reason is None:
+            return
+        if finish_reason == "MAX_TOKENS":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) before completion."
+            )
+        if finish_reason in _REFUSAL_FINISH_REASONS:
+            raise RefusalError(
+                f"{self.model_name} declined to generate output (finish_reason={finish_reason})."
+            )
 
     def _handle_api_error(self, error: Exception) -> None:
         try:

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/langchain/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/langchain/adapter.py
@@ -12,13 +12,57 @@ from ...prompts import (
     validate_message_dict,
 )
 from ...registries import register_adapter, register_provider
-from ...types import BaseLLMAdapter, ObjectGenerationMethod
+from ...types import BaseLLMAdapter, ObjectGenerationMethod, RefusalError, TruncatedResponseError
 from .factories import (
     create_anthropic_langchain_client,  # pyright: ignore
     create_openai_langchain_client,  # pyright: ignore
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_langchain_capability_mismatch(error: BaseException) -> bool:
+    """A genuine capability-mismatch signal from whichever provider backs this
+    LangChain model (only openai/anthropic are wired up as LangChain
+    providers here). Authentication, rate-limit, quota, timeout errors, and
+    any :class:`~phoenix.evals.llm.types.LLMOutputError` must return directly
+    instead of triggering a fallback attempt.
+    """
+    try:
+        from openai import BadRequestError as _OpenAIBadRequestError
+
+        if isinstance(error, _OpenAIBadRequestError):
+            return True
+    except ImportError:
+        pass
+    try:
+        from anthropic import BadRequestError as _AnthropicBadRequestError
+
+        if isinstance(error, _AnthropicBadRequestError):
+            return True
+    except ImportError:
+        pass
+    return False
+
+
+def _check_finish_reason(model_name: str, response: Any) -> None:
+    """Best-effort truncation/refusal check from LangChain's
+    ``response_metadata`` (populated for OpenAI/Anthropic-backed models on
+    the tool-calling path). Not available on the structured-output path,
+    since ``with_structured_output`` returns an already-parsed dict with no
+    metadata attached.
+    """
+    finish_reason = getattr(response, "response_metadata", {}).get("finish_reason") or getattr(
+        response, "response_metadata", {}
+    ).get("stop_reason")
+    if finish_reason in ("length", "max_tokens"):
+        raise TruncatedResponseError(
+            f"{model_name} response was truncated (hit the token limit) before completion."
+        )
+    if finish_reason in ("content_filter", "refusal"):
+        raise RefusalError(
+            f"{model_name} declined to generate output (finish_reason={finish_reason})."
+        )
 
 
 def identify_langchain_client(client: Any) -> bool:
@@ -136,7 +180,7 @@ class LangChainModelAdapter(BaseLLMAdapter):
             structured_model = self.client.with_structured_output(normalized_schema)
             response = structured_model.invoke(prompt_input, **kwargs)
             if isinstance(response, dict):
-                return response  # pyright: ignore[reportReturnType,reportUnknownVariableType]
+                return self._validate_against_schema(response, schema)
             else:
                 # If not a dict, this is unexpected for object schemas
                 raise ValueError(
@@ -157,14 +201,16 @@ class LangChainModelAdapter(BaseLLMAdapter):
             else:
                 raise ValueError("No tool binding method available")
 
+            _check_finish_reason(self.model_name, response)
             if hasattr(response, "tool_calls") and response.tool_calls:
                 tool_call = response.tool_calls[0]
                 if isinstance(tool_call, dict) and "args" in tool_call:
-                    return cast(Dict[str, Any], tool_call["args"])
+                    data = tool_call["args"]
                 elif hasattr(tool_call, "args"):  # pyright: ignore[reportArgumentType,reportUnknownArgumentType]
-                    return cast(Dict[str, Any], tool_call.args)  # pyright: ignore[reportAttributeAccessIssue]
+                    data = tool_call.args  # pyright: ignore[reportAttributeAccessIssue]
                 else:
                     raise ValueError("Tool call format not supported")
+                return self._validate_against_schema(data, schema)
             else:
                 raise ValueError("No tool calls found in response")
 
@@ -173,22 +219,19 @@ class LangChainModelAdapter(BaseLLMAdapter):
         elif method == ObjectGenerationMethod.TOOL_CALLING:
             return _generate_tool_call_output()
 
-        if supports_structured_output:
-            try:
-                return _generate_structured_output()
-            except Exception as e:
-                logger.warning(f"Structured output failed: {e}, falling back to tool calling")
-
-        if supports_tool_calls:
-            try:
-                return _generate_tool_call_output()
-            except Exception as e:
-                logger.warning(f"Tool calling failed: {e}")
-
-        raise ValueError(
-            "Failed to generate structured output: neither structured output nor tool "
-            "calling succeeded"
-        )
+        if supports_structured_output and supports_tool_calls:
+            result, _ = self._try_with_fallback(
+                primary=_generate_structured_output,
+                fallback=_generate_tool_call_output,
+                primary_name="structured output",
+                fallback_name="tool calling",
+                is_capability_mismatch=_is_langchain_capability_mismatch,
+            )
+            return result
+        elif supports_structured_output:
+            return _generate_structured_output()
+        else:
+            return _generate_tool_call_output()
 
     async def async_generate_object(
         self,
@@ -221,7 +264,7 @@ class LangChainModelAdapter(BaseLLMAdapter):
                 response = structured_model.invoke(prompt_input, **kwargs)
 
             if isinstance(response, dict):
-                return response  # pyright: ignore[reportReturnType,reportUnknownVariableType]
+                return self._validate_against_schema(response, schema)
             else:
                 raise ValueError(
                     f"Expected dict from structured output with object schema, "
@@ -244,14 +287,16 @@ class LangChainModelAdapter(BaseLLMAdapter):
             else:
                 response = tool_model.invoke(prompt_input, **kwargs)
 
+            _check_finish_reason(self.model_name, response)
             if hasattr(response, "tool_calls") and response.tool_calls:
                 tool_call = response.tool_calls[0]
                 if isinstance(tool_call, dict) and "args" in tool_call:
-                    return cast(Dict[str, Any], tool_call["args"])
+                    data = tool_call["args"]
                 elif hasattr(tool_call, "args"):  # pyright: ignore[reportArgumentType,reportUnknownArgumentType]
-                    return cast(Dict[str, Any], tool_call.args)  # pyright: ignore[reportAttributeAccessIssue]
+                    data = tool_call.args  # pyright: ignore[reportAttributeAccessIssue]
                 else:
                     raise ValueError("Tool call format not supported")
+                return self._validate_against_schema(data, schema)
             else:
                 raise ValueError("No tool calls found in response")
 
@@ -260,22 +305,19 @@ class LangChainModelAdapter(BaseLLMAdapter):
         elif method == ObjectGenerationMethod.TOOL_CALLING:
             return await _async_generate_tool_call_output()
 
-        if supports_structured_output:
-            try:
-                return await _async_generate_structured_output()
-            except Exception as e:
-                logger.warning(f"Async structured output failed: {e}, falling back to tool calling")
-
-        if supports_tool_calls:
-            try:
-                return await _async_generate_tool_call_output()
-            except Exception as e:
-                logger.warning(f"Async tool calling failed: {e}")
-
-        raise ValueError(
-            "Failed to generate structured output: neither structured output nor tool "
-            "calling succeeded"
-        )
+        if supports_structured_output and supports_tool_calls:
+            result, _ = await self._try_with_fallback_async(
+                primary=_async_generate_structured_output,
+                fallback=_async_generate_tool_call_output,
+                primary_name="structured output",
+                fallback_name="tool calling",
+                is_capability_mismatch=_is_langchain_capability_mismatch,
+            )
+            return result
+        elif supports_structured_output:
+            return await _async_generate_structured_output()
+        else:
+            return await _async_generate_tool_call_output()
 
     @property
     def model_name(self) -> str:

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/adapter.py
@@ -14,7 +14,14 @@ from ...prompts import (
     validate_message_dict,
 )
 from ...registries import register_provider
-from ...types import BaseLLMAdapter, ObjectGenerationMethod
+from ...types import (
+    BaseLLMAdapter,
+    MalformedOutputError,
+    ObjectGenerationMethod,
+    RefusalError,
+    TruncatedResponseError,
+    capability_mismatch_only,
+)
 from .client import LiteLLMClient
 from .factories import (
     create_anthropic_client,
@@ -197,26 +204,15 @@ class LiteLLMAdapter(BaseLLMAdapter):
                     return self._generate_with_structured_output(prompt, schema, **kwargs)
                 return self._generate_with_tool_calling(prompt, schema, **kwargs)
 
-            try:
-                result = _run(primary)
-                self._preferred_method = primary
-                return result
-            except _LiteLLMBadRequestError as primary_error:
-                logger.debug(
-                    f"{primary.value} rejected by {self.client.model}, falling back "
-                    f"to {fallback.value}: {primary_error}"
-                )
-                try:
-                    result = _run(fallback)
-                    self._preferred_method = fallback
-                    return result
-                except _LiteLLMBadRequestError as fallback_error:
-                    raise ValueError(
-                        f"LiteLLM model {self.client.model} failed with both "
-                        f"{primary.value} and {fallback.value}. "
-                        f"{primary.value} error: {primary_error}. "
-                        f"{fallback.value} error: {fallback_error}"
-                    ) from fallback_error
+            result, path = self._try_with_fallback(
+                primary=lambda: _run(primary),
+                fallback=lambda: _run(fallback),
+                primary_name=primary.value,
+                fallback_name=fallback.value,
+                is_capability_mismatch=capability_mismatch_only(_LiteLLMBadRequestError),
+            )
+            self._preferred_method = primary if path == "primary" else fallback
+            return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -264,26 +260,15 @@ class LiteLLMAdapter(BaseLLMAdapter):
                     )
                 return await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
 
-            try:
-                result = await _run(primary)
-                self._preferred_method = primary
-                return result
-            except _LiteLLMBadRequestError as primary_error:
-                logger.debug(
-                    f"{primary.value} rejected by {self.client.model}, falling back "
-                    f"to {fallback.value}: {primary_error}"
-                )
-                try:
-                    result = await _run(fallback)
-                    self._preferred_method = fallback
-                    return result
-                except _LiteLLMBadRequestError as fallback_error:
-                    raise ValueError(
-                        f"LiteLLM model {self.client.model} failed with both "
-                        f"{primary.value} and {fallback.value}. "
-                        f"{primary.value} error: {primary_error}. "
-                        f"{fallback.value} error: {fallback_error}"
-                    ) from fallback_error
+            result, path = await self._try_with_fallback_async(
+                primary=lambda: _run(primary),
+                fallback=lambda: _run(fallback),
+                primary_name=primary.value,
+                fallback_name=fallback.value,
+                is_capability_mismatch=capability_mismatch_only(_LiteLLMBadRequestError),
+            )
+            self._preferred_method = primary if path == "primary" else fallback
+            return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -312,10 +297,26 @@ class LiteLLMAdapter(BaseLLMAdapter):
             response_format=response_format,
             **kwargs,
         )
-        content = response.choices[0].message.content  # pyright: ignore
+        choice = response.choices[0]  # pyright: ignore
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before structured output completed."
+            )
+        content = choice.message.content
         if content is None:
             raise ValueError("LiteLLM returned no content")
-        return cast(Dict[str, Any], json.loads(content))
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise MalformedOutputError(
+                f"{self.model_name} structured output was not valid JSON: {e}"
+            ) from e
+        return self._validate_against_schema(data, schema)
 
     def _generate_with_tool_calling(
         self,
@@ -335,12 +336,30 @@ class LiteLLMAdapter(BaseLLMAdapter):
             **kwargs,
         )
 
-        tool_call = response.choices[0].message.tool_calls[0]
-        arguments = tool_call.function.arguments
+        choice = response.choices[0]
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before the tool call completed."
+            )
+        tool_calls = choice.message.tool_calls
+        if not tool_calls:
+            raise ValueError("No tool calls in response")
+        arguments = tool_calls[0].function.arguments
         if isinstance(arguments, str):
-            return cast(Dict[str, Any], json.loads(arguments))
+            try:
+                data = json.loads(arguments)
+            except json.JSONDecodeError as e:
+                raise MalformedOutputError(
+                    f"{self.model_name} tool call arguments were not valid JSON: {e}"
+                ) from e
         else:
-            return cast(Dict[str, Any], arguments)
+            data = arguments
+        return self._validate_against_schema(data, schema)
 
     async def _async_generate_with_structured_output(
         self,
@@ -366,10 +385,26 @@ class LiteLLMAdapter(BaseLLMAdapter):
             response_format=response_format,
             **kwargs,
         )
-        content = response.choices[0].message.content  # pyright: ignore
+        choice = response.choices[0]  # pyright: ignore
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before structured output completed."
+            )
+        content = choice.message.content
         if content is None:
             raise ValueError("LiteLLM returned no content")
-        return cast(Dict[str, Any], json.loads(content))
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise MalformedOutputError(
+                f"{self.model_name} structured output was not valid JSON: {e}"
+            ) from e
+        return self._validate_against_schema(data, schema)
 
     async def _async_generate_with_tool_calling(
         self,
@@ -389,12 +424,30 @@ class LiteLLMAdapter(BaseLLMAdapter):
             **kwargs,
         )
 
-        tool_call = response.choices[0].message.tool_calls[0]
-        arguments = tool_call.function.arguments
+        choice = response.choices[0]
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before the tool call completed."
+            )
+        tool_calls = choice.message.tool_calls
+        if not tool_calls:
+            raise ValueError("No tool calls in response")
+        arguments = tool_calls[0].function.arguments
         if isinstance(arguments, str):
-            return cast(Dict[str, Any], json.loads(arguments))
+            try:
+                data = json.loads(arguments)
+            except json.JSONDecodeError as e:
+                raise MalformedOutputError(
+                    f"{self.model_name} tool call arguments were not valid JSON: {e}"
+                ) from e
         else:
-            return cast(Dict[str, Any], arguments)
+            data = arguments
+        return self._validate_against_schema(data, schema)
 
     @property
     def model_name(self) -> str:

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/adapter.py
@@ -15,7 +15,14 @@ from ...prompts import (
     validate_message_dict,
 )
 from ...registries import register_adapter, register_provider
-from ...types import BaseLLMAdapter, ObjectGenerationMethod
+from ...types import (
+    BaseLLMAdapter,
+    MalformedOutputError,
+    ObjectGenerationMethod,
+    RefusalError,
+    TruncatedResponseError,
+    capability_mismatch_only,
+)
 from .factories import OpenAIClientWrapper, create_azure_openai_client, create_openai_client
 
 logger = logging.getLogger(__name__)
@@ -162,25 +169,19 @@ class OpenAIAdapter(BaseLLMAdapter):
             # failure (which would silently drop server-side schema enforcement).
             from openai import BadRequestError as _OpenAIBadRequestError
 
-            try:
-                result = self._generate_with_structured_output(prompt, schema, **kwargs)
-                self._preferred_method = ObjectGenerationMethod.STRUCTURED_OUTPUT
-                return result
-            except _OpenAIBadRequestError as structured_error:
-                logger.debug(
-                    f"Structured output rejected by {self.model_name}, falling back "
-                    f"to tool calling: {structured_error}"
-                )
-                try:
-                    result = self._generate_with_tool_calling(prompt, schema, **kwargs)
-                    self._preferred_method = ObjectGenerationMethod.TOOL_CALLING
-                    return result
-                except _OpenAIBadRequestError as tool_error:
-                    raise ValueError(
-                        f"OpenAI model {self.model_name} failed with both structured "
-                        f"output and tool calling. Structured output error: "
-                        f"{structured_error}. Tool calling error: {tool_error}"
-                    ) from tool_error
+            result, path = self._try_with_fallback(
+                primary=lambda: self._generate_with_structured_output(prompt, schema, **kwargs),
+                fallback=lambda: self._generate_with_tool_calling(prompt, schema, **kwargs),
+                primary_name="structured output",
+                fallback_name="tool calling",
+                is_capability_mismatch=capability_mismatch_only(_OpenAIBadRequestError),
+            )
+            self._preferred_method = (
+                ObjectGenerationMethod.STRUCTURED_OUTPUT
+                if path == "primary"
+                else ObjectGenerationMethod.TOOL_CALLING
+            )
+            return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -219,25 +220,21 @@ class OpenAIAdapter(BaseLLMAdapter):
             # failure (which would silently drop server-side schema enforcement).
             from openai import BadRequestError as _OpenAIBadRequestError
 
-            try:
-                result = await self._async_generate_with_structured_output(prompt, schema, **kwargs)
-                self._preferred_method = ObjectGenerationMethod.STRUCTURED_OUTPUT
-                return result
-            except _OpenAIBadRequestError as structured_error:
-                logger.debug(
-                    f"Structured output rejected by {self.model_name}, falling back "
-                    f"to tool calling: {structured_error}"
-                )
-                try:
-                    result = await self._async_generate_with_tool_calling(prompt, schema, **kwargs)
-                    self._preferred_method = ObjectGenerationMethod.TOOL_CALLING
-                    return result
-                except _OpenAIBadRequestError as tool_error:
-                    raise ValueError(
-                        f"OpenAI model {self.model_name} failed with both structured "
-                        f"output and tool calling. Structured output error: "
-                        f"{structured_error}. Tool calling error: {tool_error}"
-                    ) from tool_error
+            result, path = await self._try_with_fallback_async(
+                primary=lambda: self._async_generate_with_structured_output(
+                    prompt, schema, **kwargs
+                ),
+                fallback=lambda: self._async_generate_with_tool_calling(prompt, schema, **kwargs),
+                primary_name="structured output",
+                fallback_name="tool calling",
+                is_capability_mismatch=capability_mismatch_only(_OpenAIBadRequestError),
+            )
+            self._preferred_method = (
+                ObjectGenerationMethod.STRUCTURED_OUTPUT
+                if path == "primary"
+                else ObjectGenerationMethod.TOOL_CALLING
+            )
+            return result
 
         else:
             raise ValueError(f"Unsupported object generation method: {method}")
@@ -266,10 +263,26 @@ class OpenAIAdapter(BaseLLMAdapter):
             response_format=response_format,
             **kwargs,
         )
-        content = response.choices[0].message.content
+        choice = response.choices[0]
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before structured output completed."
+            )
+        content = choice.message.content
         if content is None:
             raise ValueError("OpenAI returned no content")
-        return cast(Dict[str, Any], json.loads(content))
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise MalformedOutputError(
+                f"{self.model_name} structured output was not valid JSON: {e}"
+            ) from e
+        return self._validate_against_schema(data, schema)
 
     def _generate_with_tool_calling(
         self,
@@ -292,16 +305,32 @@ class OpenAIAdapter(BaseLLMAdapter):
             **kwargs,
         )
 
-        tool_calls = response.choices[0].message.tool_calls
+        choice = response.choices[0]
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before the tool call completed."
+            )
+        tool_calls = choice.message.tool_calls
         if not tool_calls:
             raise ValueError("No tool calls in response")
 
         tool_call = tool_calls[0]
         arguments = tool_call.function.arguments
         if isinstance(arguments, str):
-            return cast(Dict[str, Any], json.loads(arguments))
+            try:
+                data = json.loads(arguments)
+            except json.JSONDecodeError as e:
+                raise MalformedOutputError(
+                    f"{self.model_name} tool call arguments were not valid JSON: {e}"
+                ) from e
         else:
-            return cast(Dict[str, Any], arguments)
+            data = arguments
+        return self._validate_against_schema(data, schema)
 
     async def _async_generate_with_structured_output(
         self,
@@ -327,10 +356,26 @@ class OpenAIAdapter(BaseLLMAdapter):
             response_format=response_format,
             **kwargs,
         )
-        content = response.choices[0].message.content
+        choice = response.choices[0]
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before structured output completed."
+            )
+        content = choice.message.content
         if content is None:
             raise ValueError("OpenAI returned no content")
-        return cast(Dict[str, Any], json.loads(content))
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise MalformedOutputError(
+                f"{self.model_name} structured output was not valid JSON: {e}"
+            ) from e
+        return self._validate_against_schema(data, schema)
 
     async def _async_generate_with_tool_calling(
         self,
@@ -353,16 +398,32 @@ class OpenAIAdapter(BaseLLMAdapter):
             **kwargs,
         )
 
-        tool_calls = response.choices[0].message.tool_calls
+        choice = response.choices[0]
+        if getattr(choice.message, "refusal", None):
+            raise RefusalError(
+                f"{self.model_name} refused to generate output: {choice.message.refusal}"
+            )
+        if choice.finish_reason == "length":
+            raise TruncatedResponseError(
+                f"{self.model_name} response was truncated (hit the token limit) "
+                "before the tool call completed."
+            )
+        tool_calls = choice.message.tool_calls
         if not tool_calls:
             raise ValueError("No tool calls in response")
 
         tool_call = tool_calls[0]
         arguments = tool_call.function.arguments
         if isinstance(arguments, str):
-            return cast(Dict[str, Any], json.loads(arguments))
+            try:
+                data = json.loads(arguments)
+            except json.JSONDecodeError as e:
+                raise MalformedOutputError(
+                    f"{self.model_name} tool call arguments were not valid JSON: {e}"
+                ) from e
         else:
-            return cast(Dict[str, Any], arguments)
+            data = arguments
+        return self._validate_against_schema(data, schema)
 
     @property
     def model_name(self) -> str:

--- a/packages/phoenix-evals/src/phoenix/evals/llm/types.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/types.py
@@ -1,7 +1,22 @@
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+)
+
+import jsonschema
 
 from .prompts import PromptLike
 
@@ -10,7 +25,64 @@ __all__ = [
     "BaseLLMAdapter",
     "AdapterRegistration",
     "ProviderRegistration",
+    "LLMOutputError",
+    "MalformedOutputError",
+    "SchemaViolationError",
+    "RefusalError",
+    "TruncatedResponseError",
+    "capability_mismatch_only",
 ]
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class LLMOutputError(ValueError):
+    """Base class for errors raised after a successful API call, when the
+    response content itself could not be turned into valid, schema-conforming
+    structured output.
+
+    These are never capability-mismatch signals: a malformed, refused, or
+    truncated result from one generation method says nothing about whether
+    the *other* method would work, so adapters must let these propagate
+    directly rather than routing them through ``_try_with_fallback``.
+    """
+
+
+class MalformedOutputError(LLMOutputError):
+    """The model's raw output could not be parsed as JSON."""
+
+
+class SchemaViolationError(LLMOutputError):
+    """The model's output was valid JSON but did not conform to the requested schema."""
+
+
+class RefusalError(LLMOutputError):
+    """The model declined to produce the requested output (e.g. a safety refusal)."""
+
+
+class TruncatedResponseError(LLMOutputError):
+    """The response was cut off (e.g. hit the token limit) before completion."""
+
+
+def capability_mismatch_only(
+    *exception_types: Type[BaseException],
+) -> Callable[[BaseException], bool]:
+    """Build an ``is_capability_mismatch`` predicate for
+    :meth:`BaseLLMAdapter._try_with_fallback` that matches only the given
+    exception types (e.g. a provider's ``BadRequestError``).
+
+    Errors that aren't genuine capability-mismatch signals -- authentication,
+    rate-limit, quota, timeout, and any :class:`LLMOutputError` (refusal,
+    truncation, malformed output, schema violation) -- must return directly
+    instead of triggering a second request against the fallback method.
+    """
+
+    def predicate(error: BaseException) -> bool:
+        return isinstance(error, exception_types)
+
+    return predicate
 
 
 class ObjectGenerationMethod(str, Enum):
@@ -111,6 +183,94 @@ class BaseLLMAdapter(ABC):
     def model_name(self) -> str:
         """Return the name/identifier of the underlying model."""
         return f"{type(self).__name__}-{type(self.client).__name__}"
+
+    def _try_with_fallback(
+        self,
+        *,
+        primary: Callable[[], T],
+        fallback: Callable[[], T],
+        primary_name: str,
+        fallback_name: str,
+        is_capability_mismatch: Callable[[BaseException], bool],
+    ) -> Tuple[T, Literal["primary", "fallback"]]:
+        """Try ``primary``, falling back to ``fallback`` on a capability-mismatch error.
+
+        ``is_capability_mismatch`` decides whether an error is eligible to
+        trigger the fallback at all -- typically built with
+        :func:`capability_mismatch_only` around a provider's
+        ``BadRequestError``. Everything else (authentication, rate-limit,
+        quota, timeout errors, and any :class:`LLMOutputError` -- refusal,
+        truncation, malformed output, schema violation) propagates
+        immediately, uncaught: those errors say nothing about whether the
+        other method would succeed, so retrying against it would just waste
+        a request, and for rate limits it would also rob the outer
+        ``RateLimiter`` of the chance to retry.
+
+        Returns the result together with which path produced it, so the caller
+        can update its own ``_preferred_method`` cache.
+        """
+        try:
+            return primary(), "primary"
+        except Exception as primary_error:
+            if not is_capability_mismatch(primary_error):
+                raise
+            logger.debug(
+                f"{primary_name} rejected by {self.model_name}, falling back "
+                f"to {fallback_name}: {primary_error}"
+            )
+            try:
+                return fallback(), "fallback"
+            except Exception as fallback_error:
+                if not is_capability_mismatch(fallback_error):
+                    raise
+                raise ValueError(
+                    f"{self.model_name} failed with both {primary_name} and "
+                    f"{fallback_name}. {primary_name} error: {primary_error}. "
+                    f"{fallback_name} error: {fallback_error}"
+                ) from fallback_error
+
+    async def _try_with_fallback_async(
+        self,
+        *,
+        primary: Callable[[], Awaitable[T]],
+        fallback: Callable[[], Awaitable[T]],
+        primary_name: str,
+        fallback_name: str,
+        is_capability_mismatch: Callable[[BaseException], bool],
+    ) -> Tuple[T, Literal["primary", "fallback"]]:
+        """Async counterpart of :meth:`_try_with_fallback`."""
+        try:
+            return await primary(), "primary"
+        except Exception as primary_error:
+            if not is_capability_mismatch(primary_error):
+                raise
+            logger.debug(
+                f"{primary_name} rejected by {self.model_name}, falling back "
+                f"to {fallback_name}: {primary_error}"
+            )
+            try:
+                return await fallback(), "fallback"
+            except Exception as fallback_error:
+                if not is_capability_mismatch(fallback_error):
+                    raise
+                raise ValueError(
+                    f"{self.model_name} failed with both {primary_name} and "
+                    f"{fallback_name}. {primary_name} error: {primary_error}. "
+                    f"{fallback_name} error: {fallback_error}"
+                ) from fallback_error
+
+    def _validate_against_schema(self, data: Any, schema: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate that ``data`` conforms to ``schema``, raising
+        :class:`SchemaViolationError` (never a capability-mismatch signal) if not.
+        """
+        try:
+            jsonschema.validate(instance=data, schema=schema)
+        except jsonschema.ValidationError as e:
+            raise SchemaViolationError(
+                f"{self.model_name} output does not conform to the requested schema "
+                f"at {'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
+            ) from e
+        return cast(Dict[str, Any], data)
 
 
 @dataclass

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/test_generate_object_validation.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/test_generate_object_validation.py
@@ -1,0 +1,89 @@
+# type: ignore
+"""Tests for ``AnthropicAdapter.generate_object`` output validation (#12722).
+
+Anthropic has no native structured-output method (tool calling only), so
+there's nothing to fall back between -- these tests cover the output-content
+validation added to the single tool-calling path: a correct result, a schema
+violation, a refusal (``stop_reason == "refusal"``), and a truncated response
+(``stop_reason == "max_tokens"``).
+
+"Invalid JSON" isn't reachable here: the Anthropic SDK returns
+``tool_use.input`` as an already-parsed dict, so there's no raw JSON text for
+this adapter to parse (and fail to parse) itself.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from phoenix.evals.llm.adapters.anthropic.adapter import AnthropicAdapter
+from phoenix.evals.llm.types import RefusalError, SchemaViolationError, TruncatedResponseError
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _make_adapter(model: str = "claude-3-sonnet") -> AnthropicAdapter:
+    client = MagicMock()
+    client.__module__ = "anthropic"
+    client.__class__.__name__ = "Anthropic"
+    client.messages.create = MagicMock()
+    return AnthropicAdapter(client=client, model=model)
+
+
+def _tool_use_response(args: dict, stop_reason: str = "tool_use") -> MagicMock:
+    block = MagicMock()
+    block.type = "tool_use"
+    block.input = args
+    response = MagicMock()
+    response.content = [block]
+    response.stop_reason = stop_reason
+    return response
+
+
+def _blocked_response(stop_reason: str) -> MagicMock:
+    """A response with no tool_use block -- e.g. truncated before the tool
+    call completed, or the model refused outright."""
+    response = MagicMock()
+    response.content = []
+    response.stop_reason = stop_reason
+    return response
+
+
+def test_correctly_named_result() -> None:
+    adapter = _make_adapter()
+    adapter.client.messages.create.return_value = _tool_use_response({"label": "yes"})
+
+    result = adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+    assert result == {"label": "yes"}
+
+
+def test_schema_violation_raises_and_is_not_a_capability_mismatch() -> None:
+    """The tool call succeeded but the args don't conform to the schema."""
+    adapter = _make_adapter()
+    adapter.client.messages.create.return_value = _tool_use_response({"label": "maybe"})
+
+    with pytest.raises(SchemaViolationError):
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+
+def test_refusal_raises_refusal_error() -> None:
+    adapter = _make_adapter()
+    adapter.client.messages.create.return_value = _blocked_response("refusal")
+
+    with pytest.raises(RefusalError):
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+
+def test_truncated_response_raises_truncated_error() -> None:
+    adapter = _make_adapter()
+    adapter.client.messages.create.return_value = _blocked_response("max_tokens")
+
+    with pytest.raises(TruncatedResponseError):
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/google/test_generate_object_fallback.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/google/test_generate_object_fallback.py
@@ -1,0 +1,96 @@
+# type: ignore
+"""Tests for ``GoogleGenAIAdapter.generate_object`` AUTO-mode fallback.
+
+Covers the drift fixed by consolidating into ``BaseLLMAdapter._try_with_fallback``
+(#12722): the combined error previously dropped the structured-output error
+entirely, only surfacing the tool-calling error.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from google.genai.errors import ClientError
+
+from phoenix.evals.llm.adapters.google.adapter import GoogleGenAIAdapter
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _make_adapter(model: str = "gemini-1.5-pro") -> GoogleGenAIAdapter:
+    client = MagicMock()
+    client.__module__ = "google.genai"
+    client.model = model
+    client.models = MagicMock()
+    client.chats = MagicMock()
+    # `_check_if_async_client()` returns False (sync) when `aio` is present;
+    # MagicMock auto-creates the attribute, so no extra setup is needed here.
+    return GoogleGenAIAdapter(client=client, model=model)
+
+
+def _structured_output_response(label: str = "yes") -> MagicMock:
+    response = MagicMock()
+    response.text = f'{{"label": "{label}"}}'
+    return response
+
+
+def _tool_calling_response(label: str = "yes") -> MagicMock:
+    part = MagicMock()
+    part.function_call.args = {"label": label}
+    candidate = MagicMock()
+    candidate.content.parts = [part]
+    response = MagicMock()
+    response.candidates = [candidate]
+    return response
+
+
+def _client_error(message: str, code: int = 400) -> ClientError:
+    """Construct a real ``ClientError`` -- the only exception the adapter now
+    treats as a capability-mismatch signal eligible for fallback."""
+    return ClientError(code, {"message": message}, None)
+
+
+def test_auto_falls_back_to_tool_calling_on_structured_output_failure() -> None:
+    adapter = _make_adapter()
+    adapter.client.models.generate_content.side_effect = [
+        _client_error("response_schema not supported"),
+        _tool_calling_response("no"),
+    ]
+
+    result = adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+    assert result == {"label": "no"}
+    assert adapter.client.models.generate_content.call_count == 2
+
+
+def test_auto_combined_error_preserves_both_messages() -> None:
+    """Regression test: the pre-refactor code dropped the structured-output
+    error from the combined message, only including the tool-calling error."""
+    adapter = _make_adapter()
+    adapter.client.models.generate_content.side_effect = [
+        _client_error("STRUCTURED_OUTPUT_MARKER"),
+        _client_error("TOOL_CALLING_MARKER"),
+    ]
+
+    with pytest.raises(ValueError, match="failed with both") as exc_info:
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+    message = str(exc_info.value)
+    assert "STRUCTURED_OUTPUT_MARKER" in message
+    assert "TOOL_CALLING_MARKER" in message
+
+
+def test_auth_error_does_not_trigger_fallback() -> None:
+    """A 401 must propagate directly -- never treated as a capability mismatch."""
+    adapter = _make_adapter()
+    adapter.client.models.generate_content.side_effect = _client_error("invalid API key", code=401)
+
+    with pytest.raises(ClientError):
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+    assert adapter.client.models.generate_content.call_count == 1

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/google/test_output_validation.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/google/test_output_validation.py
@@ -1,0 +1,149 @@
+# type: ignore
+"""Tests for ``GoogleGenAIAdapter.generate_object`` output validation (#12722).
+
+Covers a correctly-shaped result, invalid JSON, a schema violation, a
+refusal (``finish_reason in {"SAFETY", "PROHIBITED_CONTENT", ...}``), and a
+truncated response (``finish_reason == "MAX_TOKENS"``) on the
+structured-output path, plus a schema violation on the tool-calling path.
+None of these are capability-mismatch signals, so none should trigger a
+wasted second request against the other method.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from phoenix.evals.llm.adapters.google.adapter import GoogleGenAIAdapter
+from phoenix.evals.llm.types import (
+    MalformedOutputError,
+    ObjectGenerationMethod,
+    RefusalError,
+    SchemaViolationError,
+    TruncatedResponseError,
+)
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _make_adapter(model: str = "gemini-1.5-pro") -> GoogleGenAIAdapter:
+    client = MagicMock()
+    client.__module__ = "google.genai"
+    client.model = model
+    client.models = MagicMock()
+    client.chats = MagicMock()
+    return GoogleGenAIAdapter(client=client, model=model)
+
+
+def _structured_response(text: str, finish_reason: str = "STOP") -> MagicMock:
+    candidate = MagicMock()
+    candidate.finish_reason = finish_reason
+    response = MagicMock()
+    response.text = text
+    response.candidates = [candidate]
+    return response
+
+
+def _tool_call_response(args: dict, finish_reason: str = "STOP") -> MagicMock:
+    part = MagicMock()
+    part.function_call.args = args
+    candidate = MagicMock()
+    candidate.content.parts = [part]
+    candidate.finish_reason = finish_reason
+    response = MagicMock()
+    response.candidates = [candidate]
+    return response
+
+
+class TestStructuredOutputPath:
+    METHOD = ObjectGenerationMethod.STRUCTURED_OUTPUT
+
+    def test_correctly_named_result(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _structured_response(
+            '{"label": "yes"}'
+        )
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "yes"}
+
+    def test_invalid_json_raises_malformed_output_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _structured_response(
+            "{not valid json"
+        )
+
+        with pytest.raises(MalformedOutputError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_schema_violation_raises_schema_violation_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _structured_response(
+            '{"label": "maybe"}'
+        )
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _structured_response(
+            "", finish_reason="SAFETY"
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _structured_response(
+            '{"label": "y', finish_reason="MAX_TOKENS"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+
+class TestToolCallingPath:
+    METHOD = ObjectGenerationMethod.TOOL_CALLING
+
+    def test_correctly_named_result(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _tool_call_response({"label": "no"})
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "no"}
+
+    def test_schema_violation_raises_schema_violation_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _tool_call_response(
+            {"label": "maybe"}
+        )
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _tool_call_response(
+            {}, finish_reason="PROHIBITED_CONTENT"
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.models.generate_content.return_value = _tool_call_response(
+            {}, finish_reason="MAX_TOKENS"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/langchain/test_generate_object_fallback.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/langchain/test_generate_object_fallback.py
@@ -1,0 +1,86 @@
+# type: ignore
+"""Tests for ``LangChainModelAdapter.generate_object`` AUTO-mode fallback.
+
+Covers the drift fixed by consolidating into ``BaseLLMAdapter._try_with_fallback``
+(#12722): when only one generation method is supported by the underlying
+client, a failure used to be swallowed into a generic "neither ... succeeded"
+``ValueError`` that dropped the real error entirely.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx2
+import pytest
+from openai import BadRequestError
+
+pytest.importorskip("langchain_core")
+
+from phoenix.evals.llm.adapters.langchain.adapter import LangChainModelAdapter  # noqa: E402
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _bad_request(message: str) -> BadRequestError:
+    """A real capability-mismatch signal -- the only kind of error the
+    adapter now treats as eligible for the structured-output/tool-calling
+    fallback."""
+    request = httpx2.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx2.Response(400, request=request)
+    return BadRequestError(message, response=response, body=None)
+
+
+def _make_structured_only_adapter() -> LangChainModelAdapter:
+    client = MagicMock(spec=["invoke", "with_structured_output"])
+    client.__module__ = "langchain_openai"
+    return LangChainModelAdapter(client=client, model="model")
+
+
+def test_only_structured_output_supported_propagates_real_error() -> None:
+    """Regression test: previously this raised a generic 'neither ... succeeded'
+    error instead of the actual failure from with_structured_output()."""
+    adapter = _make_structured_only_adapter()
+    adapter.client.with_structured_output.return_value.invoke.side_effect = RuntimeError(
+        "SCHEMA_REJECTED_MARKER"
+    )
+
+    with pytest.raises(RuntimeError, match="SCHEMA_REJECTED_MARKER"):
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+
+def test_both_supported_falls_back_and_combines_errors_on_double_failure() -> None:
+    client = MagicMock()
+    client.__module__ = "langchain_openai"
+    adapter = LangChainModelAdapter(client=client, model="model")
+    adapter.client.with_structured_output.return_value.invoke.side_effect = _bad_request(
+        "STRUCTURED_OUTPUT_MARKER"
+    )
+    adapter.client.bind_tools.return_value.invoke.side_effect = _bad_request("TOOL_CALLING_MARKER")
+
+    with pytest.raises(ValueError, match="failed with both") as exc_info:
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+    message = str(exc_info.value)
+    assert "STRUCTURED_OUTPUT_MARKER" in message
+    assert "TOOL_CALLING_MARKER" in message
+
+
+def test_non_capability_error_does_not_trigger_fallback() -> None:
+    """A rate-limit-shaped error (not BadRequestError) must propagate
+    directly instead of wasting a second request against tool calling."""
+    client = MagicMock()
+    client.__module__ = "langchain_openai"
+    adapter = LangChainModelAdapter(client=client, model="model")
+    adapter.client.with_structured_output.return_value.invoke.side_effect = RuntimeError(
+        "TRANSIENT_ERROR"
+    )
+
+    with pytest.raises(RuntimeError, match="TRANSIENT_ERROR"):
+        adapter.generate_object("test prompt", SIMPLE_SCHEMA)
+
+    adapter.client.bind_tools.return_value.invoke.assert_not_called()

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/langchain/test_output_validation.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/langchain/test_output_validation.py
@@ -1,0 +1,106 @@
+# type: ignore
+"""Tests for ``LangChainModelAdapter.generate_object`` output validation (#12722).
+
+LangChain's ``with_structured_output``/``bind_tools`` already hand back a
+parsed dict (or an ``AIMessage`` whose ``tool_calls[i]["args"]`` is parsed) --
+there's no raw JSON text for this adapter to parse itself, so "invalid JSON"
+isn't reachable here the way it is for OpenAI/LiteLLM/Google. What *is*
+covered: a correctly-shaped result, a schema violation on both paths, and
+best-effort refusal/truncation detection on the tool-calling path via
+``response_metadata`` (populated for OpenAI/Anthropic-backed models).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from phoenix.evals.llm.adapters.langchain.adapter import LangChainModelAdapter  # noqa: E402
+from phoenix.evals.llm.types import (  # noqa: E402
+    ObjectGenerationMethod,
+    RefusalError,
+    SchemaViolationError,
+    TruncatedResponseError,
+)
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _make_adapter() -> LangChainModelAdapter:
+    client = MagicMock()
+    client.__module__ = "langchain_openai"
+    return LangChainModelAdapter(client=client, model="model")
+
+
+def _tool_call_ai_message(args: dict, finish_reason: str = "stop") -> MagicMock:
+    response = MagicMock()
+    response.response_metadata = {"finish_reason": finish_reason}
+    response.tool_calls = [{"name": "extract_structured_data", "args": args}]
+    return response
+
+
+class TestStructuredOutputPath:
+    METHOD = ObjectGenerationMethod.STRUCTURED_OUTPUT
+
+    def test_correctly_named_result(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.with_structured_output.return_value.invoke.return_value = {"label": "yes"}
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "yes"}
+
+    def test_schema_violation_raises_schema_violation_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.with_structured_output.return_value.invoke.return_value = {"label": "maybe"}
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+
+class TestToolCallingPath:
+    METHOD = ObjectGenerationMethod.TOOL_CALLING
+
+    def test_correctly_named_result(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.bind_tools.return_value.invoke.return_value = _tool_call_ai_message(
+            {"label": "no"}
+        )
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "no"}
+
+    def test_schema_violation_raises_schema_violation_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.bind_tools.return_value.invoke.return_value = _tool_call_ai_message(
+            {"label": "maybe"}
+        )
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.bind_tools.return_value.invoke.return_value = _tool_call_ai_message(
+            {"label": "no"}, finish_reason="content_filter"
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.bind_tools.return_value.invoke.return_value = _tool_call_ai_message(
+            {"label": "no"}, finish_reason="length"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/litellm/test_adapter.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/litellm/test_adapter.py
@@ -42,6 +42,8 @@ def _make_structured_output_response(label: str = "yes") -> MagicMock:
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = json.dumps({"label": label})
+    response.choices[0].message.refusal = None
+    response.choices[0].finish_reason = "stop"
     return response
 
 
@@ -49,6 +51,8 @@ def _make_tool_calling_response(label: str = "yes") -> MagicMock:
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = None
+    response.choices[0].message.refusal = None
+    response.choices[0].finish_reason = "tool_calls"
     tool_call = MagicMock()
     tool_call.function.arguments = json.dumps({"label": label})
     response.choices[0].message.tool_calls = [tool_call]

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/litellm/test_output_validation.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/litellm/test_output_validation.py
@@ -1,0 +1,166 @@
+# type: ignore
+"""Tests for ``LiteLLMAdapter.generate_object`` output validation (#12722).
+
+Same shape as the OpenAI adapter's coverage -- LiteLLM proxies OpenAI-format
+responses -- covering a correctly-shaped result, invalid JSON, a schema
+violation, a refusal, and a truncated response, none of which should trigger
+a wasted second request against the other method.
+"""
+
+import json
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from phoenix.evals.llm.adapters.litellm.adapter import LiteLLMAdapter
+from phoenix.evals.llm.adapters.litellm.client import LiteLLMClient
+from phoenix.evals.llm.types import (
+    MalformedOutputError,
+    ObjectGenerationMethod,
+    RefusalError,
+    SchemaViolationError,
+    TruncatedResponseError,
+)
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _structured_response(
+    content: Optional[str], finish_reason: str = "stop", refusal: Optional[str] = None
+) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    response.choices[0].message.refusal = refusal
+    response.choices[0].finish_reason = finish_reason
+    return response
+
+
+def _tool_call_response(
+    arguments: str, finish_reason: str = "tool_calls", refusal: Optional[str] = None
+) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = None
+    response.choices[0].message.refusal = refusal
+    response.choices[0].finish_reason = finish_reason
+    tool_call = MagicMock()
+    tool_call.function.arguments = arguments
+    response.choices[0].message.tool_calls = [tool_call]
+    return response
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch, model: str = "gpt-4o") -> LiteLLMAdapter:
+    client = LiteLLMClient(provider="openai", model=model)
+    adapter = LiteLLMAdapter(client, model)
+    completion_mock = MagicMock()
+    monkeypatch.setattr(adapter._litellm, "completion", completion_mock)
+    adapter._completion_mock = completion_mock  # stash for test access
+    return adapter
+
+
+class TestStructuredOutputPath:
+    METHOD = ObjectGenerationMethod.STRUCTURED_OUTPUT
+
+    def test_correctly_named_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _structured_response(json.dumps({"label": "yes"}))
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "yes"}
+
+    def test_invalid_json_raises_malformed_output_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _structured_response("{not valid json")
+
+        with pytest.raises(MalformedOutputError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_schema_violation_raises_schema_violation_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _structured_response(json.dumps({"label": "maybe"}))
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _structured_response(
+            None, refusal="I can't help with that."
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _structured_response(
+            '{"label": "y', finish_reason="length"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+
+class TestToolCallingPath:
+    METHOD = ObjectGenerationMethod.TOOL_CALLING
+
+    def test_correctly_named_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _tool_call_response(json.dumps({"label": "no"}))
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "no"}
+
+    def test_invalid_json_raises_malformed_output_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _tool_call_response("{not valid json")
+
+        with pytest.raises(MalformedOutputError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_schema_violation_raises_schema_violation_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _tool_call_response(json.dumps({"label": "maybe"}))
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _tool_call_response(
+            json.dumps({"label": "no"}), refusal="I can't help with that."
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _make_adapter(monkeypatch)
+        adapter._completion_mock.return_value = _tool_call_response(
+            '{"label": "n', finish_reason="length"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/openai/test_adapter.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/openai/test_adapter.py
@@ -54,6 +54,8 @@ def _make_structured_output_response(label: str = "yes") -> MagicMock:
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = json.dumps({"label": label})
+    response.choices[0].message.refusal = None
+    response.choices[0].finish_reason = "stop"
     return response
 
 
@@ -62,6 +64,8 @@ def _make_tool_calling_response(label: str = "yes") -> MagicMock:
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = None
+    response.choices[0].message.refusal = None
+    response.choices[0].finish_reason = "tool_calls"
     tool_call = MagicMock()
     tool_call.function.arguments = json.dumps({"label": label})
     response.choices[0].message.tool_calls = [tool_call]

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/openai/test_output_validation.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/openai/test_output_validation.py
@@ -1,0 +1,164 @@
+# type: ignore
+"""Tests for ``OpenAIAdapter.generate_object`` output validation (#12722).
+
+Covers the shared classification the fallback helper now enforces: a
+correctly-shaped result, invalid JSON, a schema violation, a refusal
+(``message.refusal``), and a truncated response (``finish_reason ==
+"length"``) -- none of which are capability-mismatch signals, so none of
+them should trigger a wasted second request against the other method.
+"""
+
+import json
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from phoenix.evals.llm.adapters.openai.adapter import OpenAIAdapter
+from phoenix.evals.llm.types import (
+    MalformedOutputError,
+    ObjectGenerationMethod,
+    RefusalError,
+    SchemaViolationError,
+    TruncatedResponseError,
+)
+
+SIMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string", "enum": ["yes", "no"]},
+    },
+    "required": ["label"],
+}
+
+
+def _make_adapter(model: str = "gpt-4o") -> OpenAIAdapter:
+    client = MagicMock()
+    client.__module__ = "openai"
+    client.__class__.__name__ = "OpenAI"
+    client.model = model
+    client.chat.completions.create = MagicMock()
+    return OpenAIAdapter(client, model)
+
+
+def _structured_response(
+    content: Optional[str], finish_reason: str = "stop", refusal: Optional[str] = None
+) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    response.choices[0].message.refusal = refusal
+    response.choices[0].finish_reason = finish_reason
+    return response
+
+
+def _tool_call_response(
+    arguments: str, finish_reason: str = "tool_calls", refusal: Optional[str] = None
+) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = None
+    response.choices[0].message.refusal = refusal
+    response.choices[0].finish_reason = finish_reason
+    tool_call = MagicMock()
+    tool_call.function.arguments = arguments
+    response.choices[0].message.tool_calls = [tool_call]
+    return response
+
+
+class TestStructuredOutputPath:
+    METHOD = ObjectGenerationMethod.STRUCTURED_OUTPUT
+
+    def test_correctly_named_result(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _structured_response(
+            json.dumps({"label": "yes"})
+        )
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "yes"}
+
+    def test_invalid_json_raises_malformed_output_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _structured_response(
+            "{not valid json"
+        )
+
+        with pytest.raises(MalformedOutputError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_schema_violation_raises_schema_violation_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _structured_response(
+            json.dumps({"label": "maybe"})
+        )
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _structured_response(
+            None, refusal="I can't help with that."
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _structured_response(
+            '{"label": "y', finish_reason="length"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+
+class TestToolCallingPath:
+    METHOD = ObjectGenerationMethod.TOOL_CALLING
+
+    def test_correctly_named_result(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _tool_call_response(
+            json.dumps({"label": "no"})
+        )
+
+        result = adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+        assert result == {"label": "no"}
+
+    def test_invalid_json_raises_malformed_output_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _tool_call_response("{not valid json")
+
+        with pytest.raises(MalformedOutputError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_schema_violation_raises_schema_violation_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _tool_call_response(
+            json.dumps({"label": "maybe"})
+        )
+
+        with pytest.raises(SchemaViolationError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_refusal_raises_refusal_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _tool_call_response(
+            json.dumps({"label": "no"}), refusal="I can't help with that."
+        )
+
+        with pytest.raises(RefusalError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)
+
+    def test_truncated_response_raises_truncated_error(self) -> None:
+        adapter = _make_adapter()
+        adapter.client.chat.completions.create.return_value = _tool_call_response(
+            '{"label": "n', finish_reason="length"
+        )
+
+        with pytest.raises(TruncatedResponseError):
+            adapter.generate_object("test prompt", SIMPLE_SCHEMA, method=self.METHOD)

--- a/uv.lock
+++ b/uv.lock
@@ -943,6 +943,7 @@ version = "3.6.0"
 source = { editable = "packages/phoenix-evals" }
 dependencies = [
     { name = "jsonpath-ng" },
+    { name = "jsonschema" },
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
     { name = "opentelemetry-api" },
@@ -981,6 +982,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'test'" },
     { name = "jsonpath-ng" },
+    { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "litellm", marker = "python_full_version < '3.14' and extra == 'dev'", specifier = ">=1.83.14" },
     { name = "litellm", marker = "python_full_version < '3.14' and extra == 'test'", specifier = ">=1.83.14" },
     { name = "nest-asyncio", marker = "extra == 'test'" },


### PR DESCRIPTION
Closes #12722.

### Summary

This started as a small dedupe refactor for #12722 but review turned up bigger issues  how fallback decides to retry. 

### The problem

Four adapters (OpenAI, Google, LiteLLM, LangChain) each had their own copy of the same try-structured output then fall back to tool calling logic, with subtle differences. Some of them decided to retry on any error, not just a real capability mismatch, so a rate limit or auth failure could trigger a wasted second request. And none of them checked that the models output actually matched the schema it was asked for.

### The fix

Pulled the retry logic into one shared helper on the base adapter class. It now takes a predicate function that decides what counts as a genuine capability mismatch  only that triggers a retry, everything else (auth, rate limit, timeout, refusal, truncated response, bad JSON) fails straight through. Added a small hierarchy of typed errors (refusal, truncation, malformed JSON, schema violation) so callers get a clear reason instead of a generic exception. Every adapter now validates its output against the schema before returning it. 

### Bugs found along the way

Googles old code caught any exception as grounds to retry, including a 401/403, which makes no sense to retry against a different method. Also found Google was dropping half the error message when both methods failed, and LangChain was straight up swallowing the real exception and replacing it with a useless generic one when only one method was available.

### Testing

Ran the full evals test suite  379 passing, two pre-existing failures unrelated to this (missing optional langchain community package, confirmed via git stash). Added dedicated test files per adapter hitting five cases: good result, bad JSON, schema violation, refusal, truncated response  wherever that case is actually reachable for that adapter. 