### PR TITLE
fix(cost): keep image generation models in the cost manifest and add gpt-image-2.5

### DIFF
--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -180,6 +180,31 @@ def _tier_customization(
     )
 
 
+OUTPUT_RATE_FIELDS: tuple[str, ...] = (
+    "output_cost_per_token",
+    "output_cost_per_image_token",
+)
+
+
+def _output_rate_field(model_info: dict[str, Any]) -> Optional[str]:
+    """
+    Resolve which LiteLLM field prices Phoenix's ``output`` token type.
+
+    Phoenix bills every completion token that has no more specific price at the ``output``
+    rate, and the cost calculator requires that rate whenever any completion price is
+    configured. LiteLLM publishes a text rate (``output_cost_per_token``) for chat models,
+    but image generation models such as gpt-image-2 emit only image tokens and carry just
+    ``output_cost_per_image_token``. Prefer the text rate when published and fall back to
+    the image-token rate otherwise. The image-token rate is always emitted as an explicit
+    ``image`` price as well, so instrumentation that reports image tokens separately bills
+    them exactly regardless of which field backs ``output``.
+    """
+    for field in OUTPUT_RATE_FIELDS:
+        if _is_positive_number(model_info.get(field)):
+            return field
+    return None
+
+
 def _is_positive_number(value: Any) -> bool:
     try:
         return float(value) > 0
@@ -190,13 +215,8 @@ def _is_positive_number(value: Any) -> bool:
 def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
     models_with_pricing = []
     for model_id, model_info in data.items():
-        # Both an input and an output rate are required for pricing. Image generation
-        # models (e.g. gpt-image-2) bill their output exclusively as image tokens and
-        # LiteLLM publishes that rate as ``output_cost_per_image_token`` without an
-        # ``output_cost_per_token``, so accept either as the output rate.
-        if "input_cost_per_token" in model_info and (
-            "output_cost_per_token" in model_info or "output_cost_per_image_token" in model_info
-        ):
+        # Both an input and an output rate are required for pricing.
+        if "input_cost_per_token" in model_info and _output_rate_field(model_info) is not None:
             models_with_pricing.append(model_id)
 
     filtered_model_ids = filter_models(models_with_pricing)
@@ -223,20 +243,13 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                 )
             )
 
-        # Image generation models have no plain output rate: every output token is an
-        # image token, so fall back to the image token rate for the "output" price that
-        # the cost calculator requires as the completion default.
-        if output_cost := float(
-            model_info.get("output_cost_per_token")
-            or model_info.get("output_cost_per_image_token")
-            or 0
-        ):
+        if (output_field := _output_rate_field(model_info)) is not None:
             token_prices.append(
                 TokenPrice(
                     token_type="output",
-                    base_rate=output_cost,
+                    base_rate=float(model_info[output_field]),
                     is_prompt=False,
-                    customization=_tier_customization(model_info, "output_cost_per_token"),
+                    customization=_tier_customization(model_info, output_field),
                 )
             )
 

--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -190,9 +190,13 @@ def _is_positive_number(value: Any) -> bool:
 def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
     models_with_pricing = []
     for model_id, model_info in data.items():
-        if (
-            "input_cost_per_token" in model_info and "output_cost_per_token" in model_info
-        ):  # both are required for pricing
+        # Both an input and an output rate are required for pricing. Image generation
+        # models (e.g. gpt-image-2) bill their output exclusively as image tokens and
+        # LiteLLM publishes that rate as ``output_cost_per_image_token`` without an
+        # ``output_cost_per_token``, so accept either as the output rate.
+        if "input_cost_per_token" in model_info and (
+            "output_cost_per_token" in model_info or "output_cost_per_image_token" in model_info
+        ):
             models_with_pricing.append(model_id)
 
     filtered_model_ids = filter_models(models_with_pricing)
@@ -219,7 +223,14 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                 )
             )
 
-        if output_cost := float(model_info.get("output_cost_per_token", 0)):
+        # Image generation models have no plain output rate: every output token is an
+        # image token, so fall back to the image token rate for the "output" price that
+        # the cost calculator requires as the completion default.
+        if output_cost := float(
+            model_info.get("output_cost_per_token")
+            or model_info.get("output_cost_per_image_token")
+            or 0
+        ):
             token_prices.append(
                 TokenPrice(
                     token_type="output",
@@ -265,6 +276,24 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                 TokenPrice(
                     token_type="audio",
                     base_rate=output_audio_cost,
+                    is_prompt=False,
+                )
+            )
+
+        if input_image_cost := float(model_info.get("input_cost_per_image_token", 0)):
+            token_prices.append(
+                TokenPrice(
+                    token_type="image",
+                    base_rate=input_image_cost,
+                    is_prompt=True,
+                )
+            )
+
+        if output_image_cost := float(model_info.get("output_cost_per_image_token", 0)):
+            token_prices.append(
+                TokenPrice(
+                    token_type="image",
+                    base_rate=output_image_cost,
                     is_prompt=False,
                 )
             )

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -1861,33 +1861,6 @@
       ]
     },
     {
-      "name": "gemini-3.8-flash",
-      "name_pattern": "gemini-3\\.8-flash",
-      "source": "litellm",
-      "token_prices": [
-        {
-          "base_rate": 7.5e-7,
-          "is_prompt": true,
-          "token_type": "input"
-        },
-        {
-          "base_rate": 3.75e-6,
-          "is_prompt": false,
-          "token_type": "output"
-        },
-        {
-          "base_rate": 7.5e-8,
-          "is_prompt": true,
-          "token_type": "cache_read"
-        },
-        {
-          "base_rate": 3.75e-6,
-          "is_prompt": false,
-          "token_type": "reasoning"
-        }
-      ]
-    },
-    {
       "name": "gemini-exp-1206",
       "name_pattern": "gemini-exp-1206",
       "source": "litellm",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -18,6 +18,38 @@
       ]
     },
     {
+      "name": "chatgpt-image-latest",
+      "name_pattern": "chatgpt-image-latest",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00004,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 0.00001,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00004,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
       "name": "claude-3-7-sonnet-20250219",
       "name_pattern": "claude-3.7-sonnet-20250219|anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219",
       "source": "litellm",
@@ -1115,6 +1147,11 @@
           "token_type": "audio"
         },
         {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
+        },
+        {
           "base_rate": 2.5e-6,
           "is_prompt": false,
           "token_type": "reasoning"
@@ -1460,6 +1497,11 @@
           "base_rate": 0.000012,
           "is_prompt": false,
           "token_type": "output"
+        },
+        {
+          "base_rate": 0.00012,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -1477,6 +1519,11 @@
           "base_rate": 0.000012,
           "is_prompt": false,
           "token_type": "output"
+        },
+        {
+          "base_rate": 0.00012,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -1534,6 +1581,11 @@
           "base_rate": 3e-6,
           "is_prompt": false,
           "token_type": "output"
+        },
+        {
+          "base_rate": 0.00006,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -1551,6 +1603,11 @@
           "base_rate": 3e-6,
           "is_prompt": false,
           "token_type": "output"
+        },
+        {
+          "base_rate": 0.00006,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -1605,6 +1662,11 @@
           "base_rate": 2.5e-8,
           "is_prompt": true,
           "token_type": "cache_read"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -1664,6 +1726,11 @@
           "base_rate": 0.000012,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 1e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -1861,6 +1928,33 @@
       ]
     },
     {
+      "name": "gemini-3.8-flash",
+      "name_pattern": "gemini-3\\.8-flash",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 7.5e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 3.75e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 7.5e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-6,
+          "is_prompt": false,
+          "token_type": "reasoning"
+        }
+      ]
+    },
+    {
       "name": "gemini-exp-1206",
       "name_pattern": "gemini-exp-1206",
       "source": "litellm",
@@ -1980,6 +2074,11 @@
           "base_rate": 0.000012,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 3e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -4882,6 +4981,70 @@
       ]
     },
     {
+      "name": "gpt-image-1",
+      "name_pattern": "gpt-image-1",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00004,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 0.00001,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00004,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-1-mini",
+      "name_pattern": "gpt-image-1-mini",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 2e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 2e-7,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 2.5e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
       "name": "gpt-image-1.5",
       "name_pattern": "gpt-image-1\\.5",
       "source": "litellm",
@@ -4900,6 +5063,16 @@
           "base_rate": 1.25e-6,
           "is_prompt": true,
           "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.000032,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -4922,6 +5095,208 @@
           "base_rate": 1.25e-6,
           "is_prompt": true,
           "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.000032,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-2",
+      "name_pattern": "gpt-image-2",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-2-2026-04-21",
+      "name_pattern": "gpt-image-2-2026-04-21",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-2.5-flare",
+      "name_pattern": "gpt-image-2\\.5-flare",
+      "source": "manual",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-2.5-flare-2026-09-08",
+      "name_pattern": "gpt-image-2\\.5-flare-2026-09-08",
+      "source": "manual",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-2.5-sunburst",
+      "name_pattern": "gpt-image-2\\.5-sunburst",
+      "source": "manual",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
+        }
+      ]
+    },
+    {
+      "name": "gpt-image-2.5-sunburst-2026-09-08",
+      "name_pattern": "gpt-image-2\\.5-sunburst-2026-09-08",
+      "source": "manual",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 1.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 8e-6,
+          "is_prompt": true,
+          "token_type": "image"
+        },
+        {
+          "base_rate": 0.00003,
+          "is_prompt": false,
+          "token_type": "image"
         }
       ]
     },
@@ -4954,6 +5329,11 @@
           "base_rate": 0.000064,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -4986,6 +5366,11 @@
           "base_rate": 0.000064,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -5018,6 +5403,11 @@
           "base_rate": 0.000064,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -5050,6 +5440,11 @@
           "base_rate": 0.000064,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -5082,6 +5477,11 @@
           "base_rate": 0.00002,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 8e-7,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -5114,6 +5514,11 @@
           "base_rate": 0.000064,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -5173,6 +5578,11 @@
           "base_rate": 0.00002,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 8e-7,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },
@@ -5205,6 +5615,11 @@
           "base_rate": 0.00002,
           "is_prompt": false,
           "token_type": "audio"
+        },
+        {
+          "base_rate": 8e-7,
+          "is_prompt": true,
+          "token_type": "image"
         }
       ]
     },

--- a/tests/unit/server/cost_tracking/test_model_cost_manifest.py
+++ b/tests/unit/server/cost_tracking/test_model_cost_manifest.py
@@ -78,3 +78,35 @@ def test_flagship_models_carry_threshold_based_tier_rates(
     assert customization["key"] == "llm.token_count.prompt"
     assert customization["threshold"] == pytest.approx(threshold, rel=1e-9)
     assert customization["new_rate"] == pytest.approx(elevated_rate, rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    "model_name, input_rate, output_rate, image_input_rate, image_output_rate",
+    [
+        # LiteLLM prices image generation output only as ``output_cost_per_image_token``;
+        # the sync must fall back to that rate rather than dropping the model.
+        ("gpt-image-2", 5e-6, 3e-5, 8e-6, 3e-5),
+        ("gpt-image-1", 5e-6, 4e-5, 1e-5, 4e-5),
+        ("gpt-image-1-mini", 2e-6, 8e-6, 2.5e-6, 8e-6),
+        # Manually maintained until LiteLLM publishes them (released 2026-09-08).
+        ("gpt-image-2.5-flare", 5e-6, 3e-5, 8e-6, 3e-5),
+        ("gpt-image-2.5-sunburst", 5e-6, 3e-5, 8e-6, 3e-5),
+    ],
+)
+def test_image_generation_models_carry_output_and_image_token_rates(
+    models_by_name: dict[str, dict[str, Any]],
+    model_name: str,
+    input_rate: float,
+    output_rate: float,
+    image_input_rate: float,
+    image_output_rate: float,
+) -> None:
+    assert model_name in models_by_name, f"missing model entry: {model_name}"
+    prices = {
+        (price["token_type"], price["is_prompt"]): price["base_rate"]
+        for price in models_by_name[model_name]["token_prices"]
+    }
+    assert prices[("input", True)] == pytest.approx(input_rate, rel=1e-9)
+    assert prices[("output", False)] == pytest.approx(output_rate, rel=1e-9)
+    assert prices[("image", True)] == pytest.approx(image_input_rate, rel=1e-9)
+    assert prices[("image", False)] == pytest.approx(image_output_rate, rel=1e-9)


### PR DESCRIPTION
Started as the automated LiteLLM pricing sync for 2026-09-03; extended to fix why that sync was dropping image models.

## Problem

- LiteLLM prices image generation output solely as `output_cost_per_image_token`. The sync required a plain `output_cost_per_token`, so it dropped `gpt-image-2` (and its dated snapshot) as soon as LiteLLM changed that entry, and had never picked up `gpt-image-1`, `gpt-image-1-mini`, or `chatgpt-image-latest`.
- `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` (released 2026-09-08) are not in LiteLLM yet.

## Changes

- `sync_models.py`: resolve the LiteLLM field backing Phoenix's `output` rate in one documented helper (`_output_rate_field`). Prefer the text rate; fall back to the image-token rate for models that emit only image tokens. The same field drives eligibility, the base rate, and the tier-customization lookup.
- Emit explicit `image` token-type rows (prompt and completion) from `input_cost_per_image_token` / `output_cost_per_image_token`, so instrumentation that reports image tokens separately bills them exactly.
- Manifest regenerated against current LiteLLM data on top of `main`. Restores `gpt-image-2`, adds `gpt-image-1`, `gpt-image-1-mini`, `chatgpt-image-latest`.
- Adds `gpt-image-2.5-flare`, `gpt-image-2.5-sunburst`, and their `-2026-09-08` snapshots as `source: manual` (OpenAI: $5/M text input, $1.25/M cached, $8/M image input, $30/M image output). Once LiteLLM publishes them the sync updates prices but keeps the entries.
- Regression test asserting image models carry `output` and `image` rates.

## Verification

Ran the real `SpanCostDetailsCalculator` against the shipped manifest for `gpt-image-2` (1000 completion tokens) across the shapes instrumentation can produce:

| instrumentation reports | breakdown | total |
| --- | --- | --- |
| `completion=1000`, `completion_details.image=1000` | image 1000 tok | $0.030000 |
| `completion=1000` only | output 1000 tok | $0.030000 |
| `completion=1000`, `completion_details.image=600` | image 600 + output 400 | $0.030000 |
| `completion_details.image=1000` only | image 1000 tok | $0.030000 |

All four agree, and there is no double counting — phase 2 of the calculator subtracts the detailed counts from the aggregate, so the `output` row only picks up the remainder.

Manifest audit: 354 models, none dropped relative to `main`, no model has completion prices without an `output` row, and no model has a zero `output` rate. `tests/unit/server/cost_tracking/` passes (347 tests).

## Known limitation: models publishing both output rates

`gpt-image-1.5` and `gpt-image-1.5-2025-12-16` publish a text output rate ($10/M) *and* an image output rate ($32/M). `_output_rate_field` prefers the text rate, since the sync cannot know which kind of token a span will report. So for these two models:

- with `completion_details.image` reported → $0.032/1K, correct
- with only `llm.token_count.completion` reported → $0.010/1K, a 3.2x under-bill

For the image-only models (`gpt-image-2`, `gpt-image-1`, `gpt-image-1-mini`, `chatgpt-image-latest`, `gpt-image-2.5-*`) the two rates are identical, so the reported shape does not matter — that is the assumption the helper's docstring rests on, and it holds for every manifest entry except the two `gpt-image-1.5` ones.

This gap predates this PR (on `main` those models had no `image` rows at all) and is not fixable in the sync script. Follow-up: confirm the OpenAI instrumentation populates `completion_details.image` for the image endpoints.

## Note

Hand-added manifest entries must use `source: manual`. The weekday sync prunes any `source: litellm` model that LiteLLM does not list, which is how `gemini-3.8-flash` was removed by the original bot commit here.
