### PR TITLE
chore(agents): remove stale RFC notes from UI code mode tool docs

### DIFF
--- a/js/app/src/agent/uiOperations/executeBrowserActionTool.ts
+++ b/js/app/src/agent/uiOperations/executeBrowserActionTool.ts
@@ -501,9 +501,6 @@ export function parseExecuteBrowserActionRunOutput(
  * state-changing call from a script that did not carry `write_description`
  * is refused by dispatch with `APPROVAL_REQUIRED`, telling the model to
  * re-issue the call with one. Bypass edit mode skips the gate entirely.
- *
- * RFC note: not yet listed in `toolRegistry.ts` — inert until the rollout
- * capability lands.
  */
 export const executeBrowserActionTool = defineTool<ExecuteBrowserActionInput>({
   name: EXECUTE_BROWSER_ACTION_TOOL_NAME,

--- a/js/app/src/agent/uiOperations/searchBrowserActionsTool.ts
+++ b/js/app/src/agent/uiOperations/searchBrowserActionsTool.ts
@@ -29,9 +29,6 @@ function parseSearchUIInput(input: unknown): SearchUIInput | null {
  * (see {@link searchUIOperations}), so one call per conversation suffices —
  * the output says so explicitly to stop the model from re-searching with
  * reworded queries.
- *
- * RFC note: not yet listed in `toolRegistry.ts` — inert until the rollout
- * capability lands.
  */
 export const searchBrowserActionsTool = defineTool<SearchUIInput>({
   name: SEARCH_BROWSER_ACTIONS_TOOL_NAME,


### PR DESCRIPTION
## Summary

Both `execute_browser_action` and `search_browser_actions` are registered in `toolRegistry.ts` and shipped, but their JSDoc still ended with:

> RFC note: not yet listed in `toolRegistry.ts` — inert until the rollout capability lands.

This removes that paragraph from both tool docblocks. Comment-only change, 6 lines deleted, no behavior change.

A repo-wide search for related pre-rollout wording ("rollout capability", "inert until", "not yet listed", etc.) found no other hits. Remaining `RFC` mentions are real IETF RFCs in `src/phoenix/server/app.py` and were left alone.

## Verification

- `oxfmt --check` passes on both files.
- Pre-commit hooks (oxfmt, oxlint) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)