### PR TITLE
docs(skills): record the unit-test startup shortcuts and daemon rules in phoenix-server

### DIFF
--- a/.agents/skills/phoenix-server/SKILL.md
+++ b/.agents/skills/phoenix-server/SKILL.md
@@ -70,6 +70,25 @@ tests/unit/server/api/
   unauthenticated by default — this has been exploited as an SSRF vector. See
   `references/graphql-patterns.md` → "Query vs Mutation".
 
+## Tests
+
+- **Never sleep to wait for a daemon.** Unit-test apps run the server's daemons in the
+  test's event loop, so a fixed sleep ties the outcome to machine load. Patch the daemon's
+  sleep so it parks on an event; the test releases it once and awaits its return to the
+  parked state, with a timeout that fails the test by name (`5df03f271`, #15864). See
+  `references/test-patterns.md` → "Waiting on Daemons".
+- **Any `import phoenix.<anything>` imports the whole server.** The package init pulls in the
+  session module and with it the app, several seconds per process, including pytest plugins
+  and scripts. Keep new imports out of `src/phoenix/__init__.py`.
+- **Unit-test apps take startup shortcuts, most with an opt-out marker.** The conftest
+  memoizes key derivation, the GraphQL schema, routers, and FastAPI's route analysis across
+  apps in a worker, stubs out the docs MCP session, model-cost seeding, and other startup
+  effects no test observes, and seeds each worker's template database with the startup rows.
+  A test whose subject is one of those behaviors must opt out with its marker or it passes
+  against the shortcut. The markers registered in the unit conftest are the authoritative
+  list; the shortcuts arrived in #15864 through #15882. See `references/test-patterns.md` →
+  "Startup Shortcuts".
+
 ## Naming
 
 - **Avoid acronyms and single/double-letter abbreviations for local variables.**

--- a/.agents/skills/phoenix-server/SKILL.md
+++ b/.agents/skills/phoenix-server/SKILL.md
@@ -75,7 +75,7 @@ tests/unit/server/api/
 - **Never sleep to wait for a daemon.** Unit-test apps run the server's daemons in the
   test's event loop, so a fixed sleep ties the outcome to machine load. Patch the daemon's
   sleep so it parks on an event; the test releases it once and awaits its return to the
-  parked state, with a timeout that fails the test by name (`5df03f271`, #15864). See
+  parked state, with a timeout that fails the test by name. See
   `references/test-patterns.md` → "Waiting on Daemons".
 - **Any `import phoenix.<anything>` imports the whole server.** The package init pulls in the
   session module and with it the app, several seconds per process, including pytest plugins
@@ -86,8 +86,7 @@ tests/unit/server/api/
   effects no test observes, and seeds each worker's template database with the startup rows.
   A test whose subject is one of those behaviors must opt out with its marker or it passes
   against the shortcut. The markers registered in the unit conftest are the authoritative
-  list; the shortcuts arrived in #15864 through #15882. See `references/test-patterns.md` →
-  "Startup Shortcuts".
+  list. See `references/test-patterns.md` → "Startup Shortcuts".
 
 ## Naming
 

--- a/.agents/skills/phoenix-server/references/test-patterns.md
+++ b/.agents/skills/phoenix-server/references/test-patterns.md
@@ -9,8 +9,11 @@ make test-python                              # full suite
 uv run pytest path/to/test_file.py -n auto    # specific file, parallel
 uv run pytest path/to/test_file.py -n auto -x # stop on first failure
 uv run pytest path/to/test_file.py -xvs       # verbose, no capture (for debugging)
-uv run pytest path/to/test_file.py --run-postgres  # also run against PostgreSQL
+uv run pytest path/to/test_file.py --db postgresql # run against PostgreSQL instead
 ```
+
+`--db postgresql` needs a PostgreSQL installation; pytest-postgresql finds `pg_ctl` through
+`pg_config`, or takes `--postgresql-exec /path/to/pg_ctl`.
 
 `-n auto` uses pytest-xdist to parallelize across CPU cores. Always use it unless you're
 debugging a specific test and need sequential output.
@@ -173,7 +176,122 @@ async def test_subscription(
                 break
 ```
 
+## Startup Shortcuts
+
+The unit conftest cuts app startup short in every test. Some steps are memoized per xdist
+worker, since each worker is its own process: key derivation, the GraphQL schema, the
+routers, and FastAPI's route analysis. Others are stubbed out because no test observes them
+except deliberately: the docs MCP session, the model-cost seeding, the WASM prefetch, the
+`/mcp` mount, the Monty runtime probe, the agent MCP server, and the agent-session sweeper's
+loop. Each worker's template database also carries the rows the app seeds at startup.
+Worked examples on main: memoized computations in `7376f3fd5` (#15867), `e7faa374b` (#15876),
+`515dd6b7b` (#15880), `c73b0d2ae` (#15878), and `64f6c60bc` (#15881); stubbed effects in
+`5df03f271` (#15864), `1432884d1` (#15865), and `cfe1f883a` (#15866); template seeding in
+`9c0aa95eb` (#15882).
+
+A test whose subject is one of these behaviors opts out with the marker below; without it,
+the test passes against the shortcut. The registrations in the unit conftest's
+`pytest_configure` are the authoritative list.
+
+| Marker | Use it when the test |
+|--------|----------------------|
+| `pristine_db` | seeds from an empty database, or counts rows in a table the app seeds |
+| `seeded_model_costs` | needs the built-in models and their prices in the database |
+| `real_docs_mcp_server` | exercises the docs MCP toolset |
+| `real_agent_mcp_server` | exercises the agent's MCP server derived from the OpenAPI document |
+| `real_monty_runtime_probe` | exercises the Monty runtime startup probe |
+| `real_agent_session_sweeper` | needs the agent-session sweeper's loop to run |
+| `real_key_derivation` | asserts on the PBKDF2 derivation itself |
+| `real_graphql_schema_build` | inspects the schema object the app builds |
+| `real_app_routers` | inspects the router objects the app builds |
+| `real_fastapi_type_adapters` | inspects the pydantic adapters behind route fields |
+| `real_fastapi_dependants` | inspects FastAPI's dependency analysis of routes |
+
+The `/mcp` mount and the WASM prefetch have no marker; the tests that need them patch the
+setting or call the function directly.
+
+### Adding a startup shortcut
+
+- **When.** A step qualifies when it runs during every app's construction or lifespan
+  startup and shows in the setup phase of `--durations`. Work that runs per request, or that
+  most tests assert on, does not qualify.
+- **Memoize or stub.** A pure function of its inputs is memoized per worker, and every test
+  keeps getting the real result: key derivation by secret, the schema by its extension list,
+  a router by its builder's flag. A step whose result depends on anything else, such as
+  environment flags read at construction, is left alone. A side effect no test observes,
+  such as a network session or a seeding pass, is stubbed out, and every test whose subject
+  is that effect opts out; a stub changes behavior, so its safety rests on the opt-outs.
+- **Name the opt-out for the behavior the test needs**: `real_<thing>` for a replaced
+  computation or effect, a data-state name such as `pristine_db` or `seeded_model_costs` for
+  what the database holds. Put the marker on the tests whose subject is that behavior: the
+  ones that assert on the object being built, the rows being seeded, or the session being
+  opened. A test that only uses the result keeps the shortcut.
+- **Patch through an autouse fixture that reads the marker** with
+  `request.node.get_closest_marker`, returns early when it is present, and applies the patch
+  with `monkeypatch` so it is undone per test. Register the marker in `pytest_configure`.
+  Database-state markers are read by the engine fixtures instead.
+- **Never let a cache keep an app alive.** Memoize only what recurs across apps, such as
+  module-level functions and shared routers; a closure built per app is computed fresh.
+  Hand out copies of anything the caller mutates afterwards (`64f6c60bc`, #15881).
+- **Bound a cache whose keys can miss on every app in a normal run**, or it grows for the
+  life of the worker (`c73b0d2ae`, #15878).
+- **Pin the wiring with tests**: two apps in one worker share the object, the marker gives a
+  fresh one, and a second app calls the real builder zero times. When the seam is a private
+  attribute of a dependency, add a test that fails at the first setup if a release moves it
+  (`c73b0d2ae`, #15878).
+
+## Waiting on Daemons
+
+Never `sleep` to give a daemon time to run. Give the test a controller: patch the daemon
+class's sleep method with the controller's bound `park`, release the daemon once, and await
+its return to the parked state. The model-store lifecycle test in `5df03f271` (#15864) and the
+retention tests in #15893 do this.
+
+```python
+class _DaemonController:
+    def __init__(self) -> None:
+        self._release = Event()
+        self._parked = Event()
+
+    async def park(self, *_: Any, **__: Any) -> None:  # bound method, patched in for the sleep
+        self._parked.set()
+        await self._release.wait()
+        self._release.clear()
+
+    async def run_once(self, timeout: float = 30.0) -> None:
+        await self._parked_within(timeout, "the daemon never parked")
+        self._parked.clear()
+        self._release.set()
+        await self._parked_within(timeout, "the cycle did not finish")
+
+    async def _parked_within(self, timeout: float, failure: str) -> None:
+        try:
+            await wait_for(self._parked.wait(), timeout)
+        except asyncio.TimeoutError:
+            pytest.fail(f"{failure} within {timeout:.0f}s")
+```
+
+Two details decide whether this works:
+
+- **The patch must be in place before the app's lifespan starts the daemon**, or the daemon
+  enters its real sleep and the first wait times out. pytest instantiates same-scope fixtures
+  in the order the test requests them, so request the controller fixture before `asgi_app`,
+  or make the fixture that starts the app depend on it.
+- **Know whether the daemon works before it sleeps or after.** A daemon that sleeps first
+  runs one cycle per release. A daemon that works first has finished a cycle by the time it
+  first parks, so await that park on its own before releasing anything.
+
 ## Gotchas
 
 **Fixture scope is per-test** — Each test gets a fresh database transaction that rolls back
 after the test completes. Don't rely on data from a previous test.
+
+**The database arrives seeded** — Unless the test carries `pristine_db`, roles, the system
+user, the default retention policy, the builtin evaluators, and the sandbox providers are
+present before the test starts (`9c0aa95eb`, #15882). Look a role up by name instead of
+inserting it; the name is unique. A `pristine_db` test gets a schema-only database and seeds
+what it needs.
+
+**The client's pytest plugin is blocked** — `-p no:phoenix` in `pyproject.toml` keeps the
+`arize-phoenix-client` plugin out of this suite (`d231b1754`, #15888). Its `phoenix` marker is
+unregistered here: pytest warns about it and nothing records the test.

--- a/.agents/skills/phoenix-server/references/test-patterns.md
+++ b/.agents/skills/phoenix-server/references/test-patterns.md
@@ -184,10 +184,6 @@ routers, and FastAPI's route analysis. Others are stubbed out because no test ob
 except deliberately: the docs MCP session, the model-cost seeding, the WASM prefetch, the
 `/mcp` mount, the Monty runtime probe, the agent MCP server, and the agent-session sweeper's
 loop. Each worker's template database also carries the rows the app seeds at startup.
-Worked examples on main: memoized computations in `7376f3fd5` (#15867), `e7faa374b` (#15876),
-`515dd6b7b` (#15880), `c73b0d2ae` (#15878), and `64f6c60bc` (#15881); stubbed effects in
-`5df03f271` (#15864), `1432884d1` (#15865), and `cfe1f883a` (#15866); template seeding in
-`9c0aa95eb` (#15882).
 
 A test whose subject is one of these behaviors opts out with the marker below; without it,
 the test passes against the shortcut. The registrations in the unit conftest's
@@ -232,20 +228,18 @@ setting or call the function directly.
   Database-state markers are read by the engine fixtures instead.
 - **Never let a cache keep an app alive.** Memoize only what recurs across apps, such as
   module-level functions and shared routers; a closure built per app is computed fresh.
-  Hand out copies of anything the caller mutates afterwards (`64f6c60bc`, #15881).
+  Hand out copies of anything the caller mutates afterwards.
 - **Bound a cache whose keys can miss on every app in a normal run**, or it grows for the
-  life of the worker (`c73b0d2ae`, #15878).
+  life of the worker.
 - **Pin the wiring with tests**: two apps in one worker share the object, the marker gives a
   fresh one, and a second app calls the real builder zero times. When the seam is a private
-  attribute of a dependency, add a test that fails at the first setup if a release moves it
-  (`c73b0d2ae`, #15878).
+  attribute of a dependency, add a test that fails at the first setup if a release moves it.
 
 ## Waiting on Daemons
 
 Never `sleep` to give a daemon time to run. Give the test a controller: patch the daemon
 class's sleep method with the controller's bound `park`, release the daemon once, and await
-its return to the parked state. The model-store lifecycle test in `5df03f271` (#15864) and the
-retention tests in #15893 do this.
+its return to the parked state. The model-store lifecycle test does this.
 
 ```python
 class _DaemonController:
@@ -288,10 +282,9 @@ after the test completes. Don't rely on data from a previous test.
 
 **The database arrives seeded** — Unless the test carries `pristine_db`, roles, the system
 user, the default retention policy, the builtin evaluators, and the sandbox providers are
-present before the test starts (`9c0aa95eb`, #15882). Look a role up by name instead of
-inserting it; the name is unique. A `pristine_db` test gets a schema-only database and seeds
-what it needs.
+present before the test starts. Look a role up by name instead of inserting it; the name is
+unique. A `pristine_db` test gets a schema-only database and seeds what it needs.
 
 **The client's pytest plugin is blocked** — `-p no:phoenix` in `pyproject.toml` keeps the
-`arize-phoenix-client` plugin out of this suite (`d231b1754`, #15888). Its `phoenix` marker is
-unregistered here: pytest warns about it and nothing records the test.
+`arize-phoenix-client` plugin out of this suite. Its `phoenix` marker is unregistered here:
+pytest warns about it and nothing records the test.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,11 +139,12 @@ Commands corresponding to an environment can be executed by running `tox run -e 
 tox run -e unit_tests
 ```
 
-By default, database tests only run against `sqlite`, in order to run database tests against
-a `postgresql` database as well, use the `--run-postgres` flag
+By default, database tests run against `sqlite`. To run them against `postgresql` instead,
+pass `--db postgresql`; pytest-postgresql finds `pg_ctl` through `pg_config`, or takes
+`--postgresql-exec /path/to/pg_ctl`.
 
 ```bash
-tox run -e unit_tests -- --run-postgres
+tox run -e unit_tests -- --db postgresql
 ```
 
 To run unit tests faster using parallel execution:


### PR DESCRIPTION
### What
- `SKILL.md`: a Tests section with three rules. Never sleep to wait for a daemon in a test; any import under the `phoenix` package imports the whole server; unit-test apps take startup shortcuts, most with an opt-out marker, and the markers registered in the unit conftest are the authoritative list.
- `references/test-patterns.md`: which startup steps are memoized and which are stubbed, the marker table, a checklist for adding a shortcut (when a step qualifies, memoize versus stub, how to name and place the opt-out, per-worker state, no cache that keeps an app alive, wiring tests), the daemon controller pattern with the two details that decide whether it works (patch before the app starts; whether the daemon works before or after it sleeps), and the gotchas: the database arrives seeded unless the test carries `pristine_db`, and the client's pytest plugin is blocked.
- `DEVELOPMENT.md` and the reference: the PostgreSQL option is `--db postgresql`; `--run-postgres` does not exist.

### Why
The unit-test startup stack (#15887 through #15881) changed what a unit-test app does at startup and what a test's database contains. A test written against the real behavior needs its marker, and a test that inserts a role by hand collides with the seeded one.

### Notes
- Revised after an independent adversarial review: two pre-existing markers were missing from the table, two shortcuts have no marker and are named as such, the seeded-database gotcha now excludes the pristine path, the controller sketch names the stalled phase on timeout and states the fixture-order requirement, and the checklist distinguishes memoizing a pure function from stubbing an effect.
- The retention tests still sleep after triggering their sweeper; #15893 replaces that with the controller pattern described here.
