### PR TITLE
fix(model-pricing): sync minimax pricing from LiteLLM

### DIFF
--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -58,6 +58,7 @@ class ModelCostManifest(BaseModel):
 PROVIDER_PREFIXES: dict[str, str | None] = {
     "cerebras/": "cerebras",
     "groq/": "groq",
+    "minimax/": "minimax",
     "moonshot/": None,
     "perplexity/": None,
     "together_ai/": "together",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -6036,6 +6036,187 @@
       ]
     },
     {
+      "name": "minimax/MiniMax-M2",
+      "name_pattern": "MiniMax-M2",
+      "source": "litellm",
+      "provider": "minimax",
+      "token_prices": [
+        {
+          "base_rate": 3e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 1.2e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 3e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-7,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
+      "name": "minimax/MiniMax-M2.1",
+      "name_pattern": "MiniMax-M2\\.1",
+      "source": "litellm",
+      "provider": "minimax",
+      "token_prices": [
+        {
+          "base_rate": 3e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 1.2e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 3e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-7,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
+      "name": "minimax/MiniMax-M2.1-lightning",
+      "name_pattern": "MiniMax-M2\\.1-lightning",
+      "source": "litellm",
+      "provider": "minimax",
+      "token_prices": [
+        {
+          "base_rate": 3e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 2.4e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 3e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-7,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
+      "name": "minimax/MiniMax-M2.5",
+      "name_pattern": "MiniMax-M2\\.5",
+      "source": "litellm",
+      "provider": "minimax",
+      "token_prices": [
+        {
+          "base_rate": 3e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 1.2e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 3e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-7,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
+      "name": "minimax/MiniMax-M2.5-lightning",
+      "name_pattern": "MiniMax-M2\\.5-lightning",
+      "source": "litellm",
+      "provider": "minimax",
+      "token_prices": [
+        {
+          "base_rate": 3e-7,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 2.4e-6,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 3e-8,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 3.75e-7,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
+      "name": "minimax/MiniMax-M3",
+      "name_pattern": "MiniMax-M3",
+      "source": "litellm",
+      "provider": "minimax",
+      "token_prices": [
+        {
+          "base_rate": 3e-7,
+          "is_prompt": true,
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 512000.0,
+            "new_rate": 6e-7
+          }
+        },
+        {
+          "base_rate": 1.2e-6,
+          "is_prompt": false,
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 512000.0,
+            "new_rate": 2.4e-6
+          }
+        },
+        {
+          "base_rate": 6e-8,
+          "is_prompt": true,
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 512000.0,
+            "new_rate": 1.2e-7
+          }
+        }
+      ]
+    },
+    {
       "name": "moonshot/kimi-k2-0711-preview",
       "name_pattern": "kimi-k2-0711-preview",
       "source": "litellm",

--- a/tests/unit/server/cost_tracking/test_model_cost_manifest.py
+++ b/tests/unit/server/cost_tracking/test_model_cost_manifest.py
@@ -47,6 +47,9 @@ def models_by_name(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
         ("gpt-5.4", "output", 272_000, 1.5e-5, 2.25e-5),
         ("gpt-5.5", "input", 272_000, 5e-6, 1e-5),
         ("gpt-5.5", "output", 272_000, 3e-5, 4.5e-5),
+        ("minimax/MiniMax-M3", "input", 512_000, 3e-7, 6e-7),
+        ("minimax/MiniMax-M3", "output", 512_000, 1.2e-6, 2.4e-6),
+        ("minimax/MiniMax-M3", "cache_read", 512_000, 6e-8, 1.2e-7),
     ],
 )
 def test_flagship_models_carry_threshold_based_tier_rates(


### PR DESCRIPTION
resolves #15592

- Adds "minimax/" to PROVIDER_PREFIXES so the LiteLLM sync picks uo first-party minimax/* models (M2, M2.1, M2.5, lightning variants, M3).
- M3's 512k tier is captured as a threshold_based customization. 
- Regenerated manifest + regression tests.