### PR TITLE
fix(kustomize): make the auth overlay buildable and drop the stale working dir

### DIFF
--- a/.github/workflows/kustomize-ci.yml
+++ b/.github/workflows/kustomize-ci.yml
@@ -1,0 +1,47 @@
+name: Kustomize CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "kustomize/**"
+      - ".github/workflows/kustomize-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "kustomize/**"
+  workflow_dispatch:
+
+concurrency:
+  group: kustomize-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  kustomize-build:
+    name: Kustomize Overlays Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # kubectl ships with the ubuntu-latest runner image and embeds kustomize,
+      # so this matches what `kubectl apply -k` does for a user.
+      - name: Build every overlay
+        run: |
+          set -euo pipefail
+          rc=0
+          for dir in kustomize/*/; do
+            [ -f "${dir}kustomization.yaml" ] || continue
+            echo "::group::kubectl kustomize ${dir}"
+            if ! kubectl kustomize "${dir}"; then
+              echo "::error file=${dir}kustomization.yaml::overlay failed to build"
+              rc=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $rc

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,10 +1,27 @@
 This directory contains a set of manifests and overlays that describe our various Kubernetes deployment options.
 These deployments can be invoked from the repository root.
 
-Examples:
+## Base
 
 ```shell
 kubectl apply -k kustomize/base
 ```
 
-will yield a single node deployment of Phoenix with PostgreSQL
+will yield a single node deployment of Phoenix with PostgreSQL.
+
+Phoenix stores its data in PostgreSQL, so no persistent volume is mounted for Phoenix
+itself and `PHOENIX_WORKING_DIR` is deliberately left unset — Phoenix only runs without
+local storage when a PostgreSQL connection string is set *and* no working directory is
+configured. PostgreSQL keeps its own volume claim.
+
+## Auth
+
+```shell
+# Phoenix reads its signing key from a secret; create it once before applying the overlay.
+kubectl create secret generic phoenix-secret \
+  --from-literal=secret-key="$(openssl rand -hex 32)"
+
+kubectl apply -k kustomize/auth
+```
+
+will yield the same deployment with authentication enabled.

--- a/kustomize/auth/kustomization.yaml
+++ b/kustomize/auth/kustomization.yaml
@@ -1,5 +1,8 @@
-bases:
-  - ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 
-patchesStrategicMerge:
-  - patches.yaml
+resources:
+  - ../base
+
+patches:
+  - path: patches.yaml

--- a/kustomize/auth/patches.yaml
+++ b/kustomize/auth/patches.yaml
@@ -10,13 +10,11 @@ spec:
         env:
         - name: PHOENIX_ENABLE_AUTH
           value: "true"
-        # When enabling Auth, you must provide a secret
-        # For example, set a Kubernetes Secret with:
-        # kubectl create secret generic phoenix-secret --from-literal=secret-key='[YOUR-SECRET]'
-        # then use 
-        #  valueFrom:
-        #    secretKeyRef:
-        #      name: phoenix-secret
-        #      key: secret-key
+        # Enabling auth requires a secret. Create it before applying this overlay:
+        #   kubectl create secret generic phoenix-secret \
+        #     --from-literal=secret-key="$(openssl rand -hex 32)"
         - name: PHOENIX_SECRET
-          value:  "3413f9a7735bb780c6b8e4db7d946a492b64d26112a955cdea6a797f4c833593"
+          valueFrom:
+            secretKeyRef:
+              name: phoenix-secret
+              key: secret-key

--- a/kustomize/base/phoenix.yaml
+++ b/kustomize/base/phoenix.yaml
@@ -1,3 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: phoenix
+  name: phoenix
+spec:
+  ports:
+  - name: phoenix-app
+    port: 6006
+    protocol: TCP
+    targetPort: 6006
+  - name: phoenix-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: phoenix-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: phoenix
+  type: ClusterIP
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -7,6 +31,7 @@ spec:
     selector:
         matchLabels:
             app: phoenix
+    serviceName: phoenix
     template:
         metadata:
             annotations:
@@ -24,8 +49,6 @@ spec:
                   command:
                       - python
                   env:
-                      - name: PHOENIX_WORKING_DIR
-                        value: /mnt/data
                       - name: PHOENIX_PORT
                         value: "6006"
                       - name: PHOENIX_SQL_DATABASE_URL


### PR DESCRIPTION
Fixes #7119.

kustomize/auth can't be applied at all right now:

```
$ kustomize build kustomize/auth
Error: accumulating resources from '../../base': evalsymlink failure on '<repo>/base': no such file or directory
```

Two things wrong in that file: `../../base` points at `<repo>/base` instead of `kustomize/base`, and `bases:`/`patchesStrategicMerge:` were both removed in kustomize v5, which is what current kubectl -k embeds. Rewrote it with apiVersion/kind, `resources: [../base]` and `patches:`.

The base overlay had a quieter problem. #7697 removed Phoenix's volume but left PHOENIX_WORKING_DIR=/mnt/data behind, pointing at a mount that no longer exists. That variable isn't inert - _no_local_storage() in src/phoenix/config.py only returns True when a Postgres URL is set and PHOENIX_WORKING_DIR is unset, so setting it opts the deployment out of exactly the mode this issue asks for. Removed it.

Schema validation turned up a third thing: the phoenix StatefulSet has no spec.serviceName, which is required through k8s 1.33 (optional from 1.34), and there was no Service for phoenix at all, only for postgres. So kubectl apply -k kustomize/base gets rejected on most clusters. Added a ClusterIP Service and serviceName, following the shape postgres.yaml already uses in the same directory, with port names matching the Helm chart.

auth/patches.yaml also had a hardcoded PHOENIX_SECRET, so anyone applying the overlay was signing JWTs with a value published in this repo. It reads from a secretKeyRef now, which is what the file's own comment already told people to do. README documents the one-time kubectl create secret step.

Added .github/workflows/kustomize-ci.yml, modelled on helm-ci.yml, that builds every overlay with kubectl kustomize. Nothing was validating these, which is how a hard build failure ended up on main. I checked it catches this regression - putting the old bases: file back makes it exit 1.

Testing: both overlays build clean with kustomize 5.8.1 and no warnings, and validate under kubeconform -strict on k8s 1.27, 1.29, 1.31, 1.33 and 1.34 (10/10). I also assert on the rendered output - that the auth patch applies, PHOENIX_ENABLE_AUTH is true, the secret is a secretKeyRef with no literal, the Postgres URL survives, and there's no /mnt/data or dangling volumeMounts left.

One thing I left alone: docs/phoenix/self-hosting/features/authentication.mdx:36 uses that same secret string as the example value. It's illustrative rather than applied config so I didn't touch it, but it is the literal value someone might paste into production. Can change it here or separately if you want.