### PR TITLE
fix(mcp/sql): make AnalyticsSqlError a real exception

### DIFF
--- a/src/phoenix/server/mcp/sql/errors.py
+++ b/src/phoenix/server/mcp/sql/errors.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import Enum
 
 
@@ -24,12 +23,20 @@ class ErrorCode(str, Enum):
     EXECUTION_ERROR = "execution_error"
 
 
-@dataclass(frozen=True)
 class AnalyticsSqlError(Exception):
-    code: ErrorCode
-    message: str
-    identifiers: tuple[str, ...] = ()
-    admission_detail: str = ""
+    def __init__(
+        self,
+        *,
+        code: ErrorCode,
+        message: str,
+        identifiers: tuple[str, ...] = (),
+        admission_detail: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.identifiers = identifiers
+        self.admission_detail = admission_detail
 
 
 # The spelling that answers the same question on the backend where the refused


### PR DESCRIPTION
`AnalyticsSqlError` was a frozen dataclass subclassing `Exception`. A frozen dataclass generates a `__setattr__` that refuses **every** attribute when `type(self) is cls` — including the ones the exception protocol writes.

`contextlib._AsyncGeneratorContextManager.__aexit__` assigns `exc.__traceback__ = traceback` as an exception leaves an `async with`. The backend errors `_execute_postgres` raises — plan resolution, plan gate, timeout, stream — are all raised after it opens `async with db.read()`, so on the way out that assignment raised `FrozenInstanceError` in place of the error. `FrozenInstanceError` is not caught by the `except AnalyticsSqlError` in `tools.py`, so FastMCP re-wrapped it as a generic `ToolError`: the caller got a transport-level failure instead of an `ExecuteSqlErrorEnvelope` carrying the `code`, `message` and `identifiers` the surface had already prepared. Refusals raised before that line, such as the pyformat guard, were never affected.

## Why the nightly caught it and PR CI didn't

CPython added that assignment in **3.11**. PR CI runs the PostgreSQL unit tests on **3.10 only** (`python-CI.yml`), so the whole matrix sat on the one version where `__aexit__` doesn't perform the write. The scheduled all-platforms workflow is the only place PostgreSQL runs on ≥3.11, and it failed there at 3.14: `unit/server/mcp/sql/test_liveness.py::test_the_same_collision_is_refused_by_postgresql` — https://github.com/Arize-ai/phoenix/actions/runs/33794669691/job/100779382954

```
E   asyncpg.exceptions.AmbiguousColumnError: column reference "user_id" is ambiguous
...
contextlib.py:268: in __aexit__
    exc.__traceback__ = traceback
E   dataclasses.FrozenInstanceError: cannot assign to field '__traceback__'
```

Postgres detected the ambiguity correctly; the error was destroyed on its way out.

SQLite was unaffected for two independent reasons: `_execute_sqlite_file` opens its own `sqlean` connection and never enters `db.read()`, and `resolve_sqlite_db_path` — the one SQLite site that does — builds its `AnalyticsSqlError` in an `except` clause outside the context manager, so only the SQLAlchemy error crosses it.

## The change

The decorator goes rather than its flags, because the generated machinery is what doesn't fit `BaseException`:

```python
class AnalyticsSqlError(Exception):
    def __init__(
        self,
        *,
        code: ErrorCode,
        message: str,
        identifiers: tuple[str, ...] = (),
        admission_detail: str = "",
    ) -> None:
        super().__init__(message)
        self.code = code
        self.message = message
        self.identifiers = identifiers
        self.admission_detail = admission_detail
```

Tuning the decorator to `eq=False` would have fixed the crash, but it leaves a second, quieter defect in place: a dataclass `__init__` never calls `Exception.__init__`, so `args` stayed empty and `str(exc)` returned `''`. Every construction site in the repo passes keywords (all 40, AST-verified), so that was unconditional — the message was absent from tracebacks and from any `"%s"` of the error. It's visible in the failure above, where our exception renders as a bare class name one line below asyncpg's, which carries its message:

```
E   asyncpg.exceptions.AmbiguousColumnError: column reference "user_id" is ambiguous
E               phoenix.server.mcp.sql.errors.AnalyticsSqlError
```

`super().__init__(message)` restores it. Identity equality and hashing come back from `Exception` rather than from a decorator flag, and there is no longer a `frozen`/`eq`/`__hash__` decision to get wrong.

| | `str(exc)` | `__traceback__` assignable |
| --- | --- | --- |
| `frozen=True` (before) | `''` | **no** |
| `@dataclass` / `eq=False` | `''` | yes |
| plain exception (this PR) | the message | yes |

Keyword-only matches all 40 existing call sites, and every consumer reads `.code` / `.message` / `.identifiers`, including `ExecuteSqlErrorEnvelope.from_error`. The dataclass `__repr__` is the one thing given up; with `str()` working the message now lands on the exception line itself, where a reader looks first.

`AnalyticsSqlError` was the only frozen dataclass inheriting from an exception in the repo, so no broader fix applies.

## Verification

- Reproduced the version boundary directly: an `AnalyticsSqlError` crossing an `@asynccontextmanager` survives on 3.9/3.10 and becomes `FrozenInstanceError` on 3.11 through 3.14.
- Confirmed the SQLite exemption empirically by monkeypatching 3.10's `contextlib` to add the 3.11 line. A positive control (an `AnalyticsSqlError` raised inside a bare `@asynccontextmanager`) fails under the patch; `test_a_name_offered_by_both_a_table_and_a_derived_relation_is_refused_by_the_engine` passes, so nothing on the SQLite path unwinds through a generator-based context manager.
- `tests/unit/server/mcp/sql/` + `tests/unit/server/test_mcp_sql_tools.py`: 2014 passed, 456 skipped (SQLite).
- `ruff format`, `ruff check`, `mypy` clean over `src/phoenix/server/mcp/sql/`.

## Known gap

There is no regression test. The only coverage is the liveness test above, which is `postgres_only` and therefore runs on Python 3.10 in PR CI — the version where `contextlib` does not perform the assignment. A reintroduction of the dataclass would pass PR CI and be caught only by the nightly, after merge. A version-independent guard would be two lines:

```python
def test_analytics_sql_error_carries_its_message_and_accepts_a_traceback() -> None:
    error = AnalyticsSqlError(code=ErrorCode.EXECUTION_ERROR, message="failed")
    assert str(error) == "failed"
    error.__traceback__ = None
```

Happy to add it if reviewers want the guard.
