### PR TITLE
fix(db): enforce one span_costs row per span

### DIFF
--- a/src/phoenix/db/ddl/postgresql_schema.sql
+++ b/src/phoenix/db/ddl/postgresql_schema.sql
@@ -343,7 +343,7 @@ CREATE TABLE public.span_costs (
 
 CREATE INDEX ix_span_costs_model_id_span_start_time ON public.span_costs
     USING btree (model_id, span_start_time);
-CREATE INDEX ix_span_costs_span_rowid ON public.span_costs
+CREATE UNIQUE INDEX ix_span_costs_span_rowid ON public.span_costs
     USING btree (span_rowid);
 CREATE INDEX ix_span_costs_span_start_time ON public.span_costs
     USING btree (span_start_time);

--- a/src/phoenix/db/ddl/sqlite_schema.sql
+++ b/src/phoenix/db/ddl/sqlite_schema.sql
@@ -325,7 +325,7 @@ CREATE TABLE span_costs (
 
 CREATE INDEX ix_span_costs_model_id_span_start_time ON span_costs
     (model_id, span_start_time);
-CREATE INDEX ix_span_costs_span_rowid ON span_costs (span_rowid);
+CREATE UNIQUE INDEX ix_span_costs_span_rowid ON span_costs (span_rowid);
 CREATE INDEX ix_span_costs_span_start_time ON span_costs (span_start_time);
 CREATE INDEX ix_span_costs_trace_rowid ON span_costs (trace_rowid);
 

--- a/src/phoenix/db/migrations/versions/c3f8a1d24b70_unique_span_costs_span_rowid.py
+++ b/src/phoenix/db/migrations/versions/c3f8a1d24b70_unique_span_costs_span_rowid.py
@@ -1,0 +1,65 @@
+"""enforce one span_costs row per span
+
+Revision ID: c3f8a1d24b70
+Revises: 4aad9107d196
+Create Date: 2026-09-03 00:00:00.000000
+
+`Span.span_cost` is a scalar relationship, so at most one `span_costs` row may
+exist per span, but `span_costs.span_rowid` carried a plain index rather than a
+unique one. Duplicates therefore multiply any join against `span_costs`, which
+inflates cost and token aggregates and can skew span counts and pagination.
+
+Any duplicates already present are collapsed before the unique index is created,
+keeping the highest `id` for each span -- the most recently written row, which
+reflects the latest cost calculation. Dependent `span_cost_details` rows are
+removed by the existing ON DELETE CASCADE.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3f8a1d24b70"
+down_revision: Union[str, None] = "4aad9107d196"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "ix_span_costs_span_rowid"
+
+
+def upgrade() -> None:
+    # Collapse duplicates before the unique index is built, otherwise creating
+    # it would fail on any database that already has them.
+    #
+    # The child rows are removed explicitly rather than leaning on the
+    # ON DELETE CASCADE: SQLite only enforces foreign keys when
+    # PRAGMA foreign_keys is ON, and it is off by default on the connection
+    # Alembic migrates with, which would otherwise leave orphaned
+    # span_cost_details behind.
+    op.execute(
+        """
+        DELETE FROM span_cost_details
+        WHERE span_cost_id IN (
+            SELECT id FROM span_costs
+            WHERE id NOT IN (
+                SELECT MAX(id) FROM span_costs GROUP BY span_rowid
+            )
+        )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM span_costs
+        WHERE id NOT IN (
+            SELECT MAX(id) FROM span_costs GROUP BY span_rowid
+        )
+        """
+    )
+    op.drop_index(_INDEX_NAME, table_name="span_costs")
+    op.create_index(_INDEX_NAME, "span_costs", ["span_rowid"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX_NAME, table_name="span_costs")
+    op.create_index(_INDEX_NAME, "span_costs", ["span_rowid"], unique=False)

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2866,7 +2866,11 @@ class SpanCost(HasId):
     span_rowid: Mapped[int] = mapped_column(
         ForeignKey("spans.id", ondelete="CASCADE"),
         nullable=False,
+        # Span.span_cost is a scalar relationship, so at most one cost row may
+        # exist per span. A unique index enforces that invariant in the database
+        # rather than relying on every writer to preserve it.
         index=True,
+        unique=True,
     )
     trace_rowid: Mapped[int] = mapped_column(
         ForeignKey("traces.id", ondelete="CASCADE"),


### PR DESCRIPTION
Closes #15754.

Span.span_cost is modelled and used as a scalar relationship, but span_costs.span_rowid only has a plain index in both dialects, so nothing stops a second cost row being written for the same span.

That isn't cosmetic - any join against span_costs multiplies the duplicate, so cost and token totals over-report and span counts and pagination drift. On a migrated database with three duplicate rows for one span, SUM(total_cost) came out at 4.5 against a true 2.5; after the migration it's 2.5.

The current writer avoids duplicates by calculating cost only after a span inserts successfully, but that's a property of one code path rather than an invariant, and it doesn't survive retries, imports or direct database writes.

So: make the existing ix_span_costs_span_rowid unique, collapsing any duplicates first and keeping the highest id per span as the most recent calculation.

I used a unique index rather than a UniqueConstraint on purpose - SQLite can't ADD CONSTRAINT, so a constraint means a full table rebuild through batch_alter_table, which is expensive on a large span_costs. Swapping an index is cheap on both. That does differ from SpanCostDetail, which uses a UniqueConstraint, so say the word if you'd rather have the uq_ name (it would also let insert_on_conflict target it by constraint name).

The migration deletes the dependent span_cost_details rows explicitly instead of relying on ON DELETE CASCADE. SQLite only enforces foreign keys when PRAGMA foreign_keys is on, and it's off on the connection alembic migrates with, so the cascade doesn't fire and you're left with orphans. I only caught that because the test planted duplicates that had children - the first version of the migration silently orphaned them.

Testing, against a SQLite database migrated through the full chain and an ephemeral PostgreSQL 16.2:

- alembic upgrade head from scratch on both, index reports unique
- duplicates planted at 4aad9107d196 then upgraded: collapsed to one row, highest id kept, aggregate corrected
- orphaned span_cost_details removed, the surviving row's detail kept, no orphans left
- duplicate insert after upgrade raises IntegrityError
- downgrade -1 restores a non-unique index and lands on 4aad9107d196, re-upgrade clean
- scripts/ddl validators pass on both dialects, compare_schemas reports parity
- tests/unit/db: 390 passed

Both DDL assets were regenerated with scripts/ddl/generate_ddl_{postgresql,sqlite}.py against ephemeral databases rather than hand-edited, which is why the diff is one line per dialect.

One thing I didn't change: SpanCostCalculator._insert_costs uses session.add_all. With the index unique a conflicting row would now raise instead of silently duplicating, and since the batch is one transaction a single conflict drops the whole batch rather than one row. Shouldn't happen given how the writer is driven, and failing loudly is arguably the point, but I'm happy to make it conflict-tolerant here or separately - insert_on_conflict already exists.