### PR TITLE
docs(sandbox): name what Monty's guest can import

### DIFF
--- a/src/phoenix/server/sandbox/monty_backend.py
+++ b/src/phoenix/server/sandbox/monty_backend.py
@@ -156,10 +156,26 @@ class MontyAdapter(SandboxAdapter[MontyConfig, NoCredentials, MontyDeployment]):
     display_name = "Monty"
     hosting_type = "local"
     language_dialect = "restricted"
+    #: Modules an evaluator author can import, named in ``runtime_notes`` below and held
+    #: to a live worker in the backend tests. The guest exposes more, but only these are
+    #: advertised, so only these are guaranteed.
+    IMPORTABLE_MODULES = (
+        "json",
+        "re",
+        "math",
+        "datetime",
+        "pathlib",
+        "typing",
+        "collections",
+        "itertools",
+        "dataclasses",
+    )
     runtime_notes = (
         "Restricted Python running in isolated worker subprocesses. A limited standard library "
-        "is importable, while filesystem, network, environment, subprocess, and third-party "
-        "package access are blocked."
+        f"is importable — {', '.join(IMPORTABLE_MODULES)} — each exposing a subset of its "
+        "CPython API, while filesystem, network, environment, subprocess, and third-party "
+        "package access are blocked. Decorated functions and plain classes are supported; "
+        "class inheritance, metaclasses, and method decorators are not."
     )
     config_model = MontyConfig
     credentials_model = NoCredentials

--- a/tests/unit/server/api/test_capability_advertisement.py
+++ b/tests/unit/server/api/test_capability_advertisement.py
@@ -6,6 +6,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.models import SandboxBackendType
 from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA
+from phoenix.server.sandbox.monty_backend import MontyAdapter
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -103,6 +104,10 @@ async def test_monty_advertises_restricted_python(
     assert "worker subprocesses" in runtime_notes
     assert "limited standard library" in runtime_notes
     assert "class definitions" not in runtime_notes
+    # The advertisement is built from MontyAdapter.IMPORTABLE_MODULES, and
+    # test_monty_backend.py imports from each of those in a live worker.
+    for module_name in MontyAdapter.IMPORTABLE_MODULES:
+        assert module_name in runtime_notes
 
 
 async def test_sandbox_config_secret_ref_env_var_round_trips(

--- a/tests/unit/server/sandbox/test_monty_backend.py
+++ b/tests/unit/server/sandbox/test_monty_backend.py
@@ -78,6 +78,73 @@ async def test_validate_code_runs_in_worker(runtime: MontyRuntime) -> None:
     assert "ModuleNotFoundError" in error
 
 
+#: A representative API per advertised module. Each module exposes a subset of its
+#: CPython contents, so importing the module proves less than importing from it. Keyed
+#: by ``MontyAdapter.IMPORTABLE_MODULES``, which the advertisement is built from, so a
+#: module added to the notes has no entry here and fails rather than going untested.
+_REPRESENTATIVE_API = {
+    "json": "from json import loads, dumps",
+    "re": "from re import search, match",
+    "math": "from math import sqrt",
+    "datetime": "from datetime import date, timezone",
+    "pathlib": "from pathlib import Path",
+    "typing": "from typing import Optional",
+    "collections": "from collections import Counter, defaultdict, deque, namedtuple",
+    "itertools": "from itertools import chain, islice, pairwise",
+    "dataclasses": "from dataclasses import dataclass",
+}
+
+
+@pytest.mark.parametrize("module_name", MontyAdapter.IMPORTABLE_MODULES)
+async def test_advertised_modules_are_importable_in_the_guest(
+    module_name: str, runtime: MontyRuntime
+) -> None:
+    assert (
+        await runtime.run(
+            f"{_REPRESENTATIVE_API[module_name]}\n'imported'",
+            consumer="validation",
+            limits=None,
+        )
+        == "imported"
+    )
+
+
+async def test_guest_rejects_inheritance_and_method_decorators(
+    runtime: MontyRuntime,
+) -> None:
+    """Decorators apply to functions, not methods; classes cannot inherit."""
+    adapter = MontyAdapter()
+
+    supported = await adapter.validate_code(
+        MontyConfig(),
+        "def double(func):\n"
+        "    def inner(value):\n"
+        "        return func(value) * 2\n"
+        "    return inner\n"
+        "@double\n"
+        "def scale(value):\n"
+        "    return value\n"
+        "class Scorer:\n"
+        "    def score(self, value):\n"
+        "        return scale(value)\n"
+        "def evaluate(output):\n"
+        "    return {'score': Scorer().score(output)}\n",
+        runtime=SandboxRuntimeContext(monty=runtime),
+    )
+    assert supported is None
+
+    for unsupported, expected in (
+        ("class Base:\n    pass\nclass Child(Base):\n    pass\n", "inheritance"),
+        ("class Scorer:\n    @property\n    def score(self):\n        return 1\n", "decorators"),
+    ):
+        error = await adapter.validate_code(
+            MontyConfig(),
+            f"{unsupported}def evaluate(output):\n    return output",
+            runtime=SandboxRuntimeContext(monty=runtime),
+        )
+        assert error is not None and expected in error
+
+
 async def test_validate_code_reports_unavailable_runtime(runtime: MontyRuntime) -> None:
     runtime.run = AsyncMock(side_effect=MontyBusy("validation capacity is busy"))  # type: ignore[method-assign]
 


### PR DESCRIPTION
`MontyAdapter.runtime_notes` is the only place Phoenix describes the restricted Python dialect to an evaluator author — it reaches the UI through `sandboxBackends.runtimeNotes`. It named nothing importable, so when #15902 brought `collections`, `itertools`, and `dataclasses` into the sandbox, nobody writing an evaluator had any way to learn that.

The notes are now built from `MontyAdapter.IMPORTABLE_MODULES`, so a module cannot be advertised without the backend test importing from it in a live worker:

> Restricted Python running in isolated worker subprocesses. A limited standard library is importable — json, re, math, datetime, pathlib, typing, collections, itertools, dataclasses — each exposing a subset of its CPython API, while filesystem, network, environment, subprocess, and third-party package access are blocked. Decorated functions and plain classes are supported; class inheritance, metaclasses, and method decorators are not.

Two things in that wording are deliberate, and both came from running code against a live worker rather than from release notes.

**"a subset of its CPython API"** — the module names alone would read as standard-library compatibility, and the implementations are partial. `dataclasses.asdict`, `dataclasses.field`, `pathlib.PurePosixPath`, `collections.OrderedDict`, and `itertools.groupby` are all absent. `from dataclasses import dataclass` works; `from dataclasses import asdict` raises `ImportError`.

**"method decorators are not"** — decorators apply to module-level functions only. A decorator on a method, `@property` and `@staticmethod` included, raises `NotImplementedError: The monty syntax parser does not yet support method decorators`. Plain classes with plain methods are fine; any base class at all — even `object` — fails, which is also why `abc` is unavailable (it is not importable).

Tests hold each claim to a real worker so the notes cannot drift from the guest. The module test imports a representative API from each advertised module rather than the bare module, because importing `dataclasses` proves nothing about `asdict` — that gap is exactly what the earlier draft of these notes got wrong.

Verified on this branch: 71 passed / 10 skipped across `test_monty_backend.py`, `test_capability_advertisement.py`, and `test_mcp_code_mode.py`; mypy and ruff clean.

No behavior change — documentation and tests only.
