### PR TITLE
feat(sandbox): expose the guest type checker through MontyRuntime

### DIFF
--- a/src/phoenix/server/monty_runtime.py
+++ b/src/phoenix/server/monty_runtime.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
 if TYPE_CHECKING:
-    from pydantic_monty import AsyncMonty, PrintCallback, ResourceLimits
+    from pydantic_monty import AsyncMonty, PrintCallback, ResourceLimits, TypeCheckFormat
 
 logger = logging.getLogger(__name__)
 
@@ -172,10 +172,18 @@ class MontyRuntime:
         inputs: Optional[dict[str, Any]],
         external_functions: Optional[dict[str, Callable[..., Any]]],
         print_callback: Optional["PrintCallback"],
+        type_check: bool,
+        type_check_format: Optional["TypeCheckFormat"],
     ) -> Any:
         async with AsyncExitStack() as stack:
             try:
-                session = await stack.enter_async_context(pool.checkout(limits=limits))
+                session = await stack.enter_async_context(
+                    pool.checkout(
+                        limits=limits,
+                        type_check=type_check,
+                        type_check_format=type_check_format,
+                    )
+                )
             except TimeoutError as exc:
                 raise MontyBusy("No Monty worker became available") from exc
             except RuntimeError as exc:
@@ -198,6 +206,8 @@ class MontyRuntime:
         inputs: Optional[dict[str, Any]],
         external_functions: Optional[dict[str, Callable[..., Any]]],
         print_callback: Optional["PrintCallback"],
+        type_check: bool,
+        type_check_format: Optional["TypeCheckFormat"],
     ) -> Any:
         slots = self._consumer_slots[consumer]
         try:
@@ -213,6 +223,8 @@ class MontyRuntime:
                 inputs=inputs,
                 external_functions=external_functions,
                 print_callback=print_callback,
+                type_check=type_check,
+                type_check_format=type_check_format,
             )
         finally:
             slots.release()
@@ -227,6 +239,8 @@ class MontyRuntime:
         external_functions: Optional[dict[str, Callable[..., Any]]] = None,
         print_callback: Optional["PrintCallback"] = None,
         total_timeout: Optional[float] = None,
+        type_check: bool = False,
+        type_check_format: Optional["TypeCheckFormat"] = None,
     ) -> Any:
         """Execute one isolated block and return its trailing value.
 
@@ -234,6 +248,14 @@ class MontyRuntime:
         by ``checkout_timeout``. Guest duration in ``limits`` counts only guest
         execution, while ``request_timeout`` bounds one silent worker turn and
         ``total_timeout`` optionally bounds the complete call.
+
+        ``type_check`` runs the worker's type checker over ``code`` before
+        executing it, raising ``MontyTypingError`` instead of running. It is a
+        guest-code error like ``MontySyntaxError``, not a ``MontyServiceError``,
+        so callers report it rather than retrying. Names supplied through
+        ``inputs`` are undefined to the checker, so code referencing them must
+        be fed unchecked. ``type_check_format`` selects the diagnostic
+        rendering; ``None`` gives the multi-line ``full`` form.
         """
         if self._closed:
             raise MontyShuttingDown("Monty runtime is shutting down")
@@ -248,6 +270,8 @@ class MontyRuntime:
                 external_functions=external_functions,
                 print_callback=print_callback,
                 total_timeout=total_timeout,
+                type_check=type_check,
+                type_check_format=type_check_format,
             )
         finally:
             self._active_executions -= 1
@@ -264,6 +288,8 @@ class MontyRuntime:
         external_functions: Optional[dict[str, Callable[..., Any]]],
         print_callback: Optional["PrintCallback"],
         total_timeout: Optional[float],
+        type_check: bool,
+        type_check_format: Optional["TypeCheckFormat"],
     ) -> Any:
         pydantic_monty = import_monty()
         execution = self._acquire_and_feed(
@@ -273,6 +299,8 @@ class MontyRuntime:
             inputs=inputs,
             external_functions=external_functions,
             print_callback=print_callback,
+            type_check=type_check,
+            type_check_format=type_check_format,
         )
         try:
             if total_timeout is None:

--- a/tests/unit/server/test_mcp_code_mode.py
+++ b/tests/unit/server/test_mcp_code_mode.py
@@ -7,6 +7,7 @@ containment.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import textwrap
 from contextlib import asynccontextmanager
@@ -14,13 +15,13 @@ from typing import Any, AsyncIterator
 
 import pytest
 from fastmcp.exceptions import ToolError
-from pydantic_monty import MontyError, MontyRuntimeError, MontySyntaxError
+from pydantic_monty import MontyError, MontyRuntimeError, MontySyntaxError, MontyTypingError
 
 from phoenix.server.mcp_code_mode import (
     DEFAULT_LIMITS,
     MontyPoolSandboxProvider,
 )
-from phoenix.server.monty_runtime import MontyRuntime, MontyShuttingDown
+from phoenix.server.monty_runtime import MontyRuntime, MontyServiceError, MontyShuttingDown
 
 # Faults the native interpreter in-process; depth is a runtime value, invisible
 # to any check on the source.
@@ -434,6 +435,8 @@ async def test_dropped_pool_during_shutdown_reports_a_tool_error() -> None:
             inputs=None,
             external_functions=None,
             print_callback=None,
+            type_check=False,
+            type_check_format=None,
         )
 
 
@@ -595,3 +598,26 @@ def test_partial_consumer_limits_merge_with_defaults() -> None:
 def test_unknown_consumer_limit_is_rejected() -> None:
     with pytest.raises(ValueError, match="Unknown Monty consumers"):
         MontyRuntime(consumer_limits={"unknown": 1})  # type: ignore[dict-item]
+
+
+async def test_type_check_rejects_before_executing() -> None:
+    """``type_check`` asks the worker's checker for a verdict instead of running the code."""
+    runtime = MontyRuntime(consumer_limits={"mcp": 1})
+    try:
+        with pytest.raises(MontyTypingError) as exc_info:
+            await runtime.run(
+                "'a' + 1",
+                consumer="mcp",
+                limits=None,
+                type_check=True,
+                type_check_format="json",
+            )
+        # A guest error, so callers report it rather than retrying the runtime.
+        assert not isinstance(exc_info.value, MontyServiceError)
+        diagnostics = json.loads(str(exc_info.value))
+        assert [d["code"] for d in diagnostics] == ["unsupported-operator"]
+
+        # The same source runs when no verdict is requested.
+        assert await runtime.run("40 + 2", consumer="mcp", limits=None) == 42
+    finally:
+        await runtime.aclose()


### PR DESCRIPTION
pydantic-monty 0.0.21 renders type-checker diagnostics in compact and machine-readable forms (`type_check_format`, new in 0.0.20). `MontyRuntime.run` gains keyword-only `type_check` and `type_check_format`, threaded through to `pool.checkout(...)`. **No caller enables them, so behavior is unchanged.** A diagnostic carries a code, a line and a column, which is what an advisory editor warning needs.

## Why authoring-time validation does not use it

Two earlier versions of this PR did, and both were wrong. The evidence is worth recording, because "type-check the evaluator before saving it" is an obvious idea that does not survive contact with this checker.

**The checker rejects names the guest resolves.** Sweeping every public builtin against a live worker found 16 that the guest evaluates but the checker calls `unresolved-reference`: `map`, `filter`, `getattr`, `hasattr`, `setattr`, `open`, `vars`, `staticmethod`, `super`, and `ImportError`, `ModuleNotFoundError`, `PermissionError`, `FileNotFoundError`, `FileExistsError`, `IsADirectoryError`, `NotADirectoryError`, `UnboundLocalError`, `UnicodeDecodeError`, `UnicodeEncodeError`. These all run and would all have been refused:

```python
def evaluate(output):
    return {'score': sum(map(len, output.split()))}          # runs -> {'score': 6}

def evaluate(output):
    try:
        import json
    except ModuleNotFoundError:                               # runs -> {'score': 1}
        return {'score': 0}
    return {'score': 1}
```

**It also rejects type-compatibility idioms Python does not enforce.** An annotated parameter defaulting to `None` — the common pre-`Optional` style — fails `invalid-parameter-default` while running correctly. And leaving the same parameter unannotated makes it dynamic, so the equivalent broken code passes either way. Gating on this penalises authors who annotate without establishing that a saved evaluator works.

**Where it is accurate, it is redundant.** `unresolved-import` produced no false positives across 311 CPython names and 30 module imports — but executing the authored source already catches every one of those, because imports run at module level during validation. Execution catches strictly more: `from dataclasses import asdict` passes the checker and fails at runtime.

So executing the authored source remains the only check that decides a save. The checker's value is reporting, not gating — which points at advisory editor warnings, a separate piece of work needing a non-blocking field on the payload.

## Behavior notes

`type_check` runs the checker in the worker ahead of execution and raises `MontyTypingError` instead of running the code. That is a guest error, not a `MontyServiceError`, so a caller reports it rather than retrying the runtime; the test asserts that classification, since getting it wrong would turn author mistakes into infrastructure retries.

Names supplied through `inputs=` are undefined to the checker, so code referencing them must be fed unchecked — which is why the evaluator execution harness, which appends `evaluate(**_inputs)`, could not be checked as-run even if gating were desirable.

Internal signatures in the threading chain take the parameters without defaults, so a missed pass-through is a type error rather than a silently unchecked feed.

## Verification

292 passed across `tests/unit/server/test_mcp_code_mode.py` and `tests/unit/server/sandbox/`; mypy and ruff clean. The new test asserts the checker's verdict arrives as JSON with the expected diagnostic code, that it is not a service error, and that the same source runs when no verdict is requested.
