### PR TITLE
fix(agents): stop retrying GitHub calls after an authorization failure

### DIFF
--- a/src/phoenix/server/agents/capabilities/github_mcp.py
+++ b/src/phoenix/server/agents/capabilities/github_mcp.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import httpx
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, ToolFailed
 from pydantic_ai.mcp import CallToolFunc, MCPToolset, ToolResult
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import (
@@ -36,6 +36,10 @@ logger = logging.getLogger(__name__)
 # entry points; writes are approval-gated below.
 GITHUB_READ_TOOLS = frozenset({"issue_read", "list_issues", "search_issues"})
 GITHUB_WRITE_TOOLS = frozenset({"issue_write"})
+
+# Authorization failures the turn cannot resolve on its own: the token is bound
+# when the toolset is built, so a retry re-sends the same credential.
+_NON_RETRYABLE_STATUS_CODES = frozenset({401, 403})
 GITHUB_TOOL_ALLOWLIST = GITHUB_READ_TOOLS | GITHUB_WRITE_TOOLS
 
 # Appended when the write tools are filtered out, so the model knows the
@@ -112,15 +116,27 @@ async def _call_tool_with_sanitized_errors(
 
     Raw httpx/MCP transport exception text can embed request headers — and so
     the bearer token — which must never reach the model or a tool span.
+
+    Authorization failures are terminal rather than retryable: the turn's token
+    is fixed when the toolset is built, so repeating the call re-sends the same
+    credential and fails identically. `ToolFailed` reports the failure to the
+    model without a retry prompt and without consuming the retry budget, so the
+    model relays it to the user instead of reissuing the request.
     """
     try:
         return await call_tool(name, args)
     except ModelRetry:
         raise
     except httpx.HTTPStatusError as exc:
-        raise ModelRetry(
-            f"GitHub MCP request failed with HTTP {exc.response.status_code}"
-        ) from None
+        status_code = exc.response.status_code
+        if status_code in _NON_RETRYABLE_STATUS_CODES:
+            raise ToolFailed(
+                f"GitHub MCP request failed with HTTP {status_code}: the credential in "
+                "use is not authorized for this operation. Tell the user to check that "
+                "their GitHub token is valid and has the required scope and repository "
+                "access, and do not retry until they confirm it changed."
+            ) from None
+        raise ModelRetry(f"GitHub MCP request failed with HTTP {status_code}") from None
     except httpx.HTTPError as exc:
         raise ModelRetry(f"GitHub MCP request failed: {type(exc).__name__}") from None
 

--- a/src/phoenix/server/agents/capabilities/github_mcp.py
+++ b/src/phoenix/server/agents/capabilities/github_mcp.py
@@ -36,9 +36,6 @@ logger = logging.getLogger(__name__)
 # entry points; writes are approval-gated below.
 GITHUB_READ_TOOLS = frozenset({"issue_read", "list_issues", "search_issues"})
 GITHUB_WRITE_TOOLS = frozenset({"issue_write"})
-
-# Authorization failures the turn cannot resolve on its own: the token is bound
-# when the toolset is built, so a retry re-sends the same credential.
 _NON_RETRYABLE_STATUS_CODES = frozenset({401, 403})
 GITHUB_TOOL_ALLOWLIST = GITHUB_READ_TOOLS | GITHUB_WRITE_TOOLS
 
@@ -116,12 +113,6 @@ async def _call_tool_with_sanitized_errors(
 
     Raw httpx/MCP transport exception text can embed request headers — and so
     the bearer token — which must never reach the model or a tool span.
-
-    Authorization failures are terminal rather than retryable: the turn's token
-    is fixed when the toolset is built, so repeating the call re-sends the same
-    credential and fails identically. `ToolFailed` reports the failure to the
-    model without a retry prompt and without consuming the retry budget, so the
-    model relays it to the user instead of reissuing the request.
     """
     try:
         return await call_tool(name, args)
@@ -132,9 +123,8 @@ async def _call_tool_with_sanitized_errors(
         if status_code in _NON_RETRYABLE_STATUS_CODES:
             raise ToolFailed(
                 f"GitHub MCP request failed with HTTP {status_code}: the credential in "
-                "use is not authorized for this operation. Tell the user to check that "
-                "their GitHub token is valid and has the required scope and repository "
-                "access, and do not retry until they confirm it changed."
+                "use is not authorized for this operation. The user may need to check that "
+                "their GitHub token is valid and has the required scope and repository access."
             ) from None
         raise ModelRetry(f"GitHub MCP request failed with HTTP {status_code}") from None
     except httpx.HTTPError as exc:

--- a/tests/unit/server/agents/capabilities/test_github_mcp.py
+++ b/tests/unit/server/agents/capabilities/test_github_mcp.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import httpx
 import pytest
 from pydantic import SecretStr
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, ToolFailed
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets import ApprovalRequiredToolset, FilteredToolset
 
@@ -121,21 +121,49 @@ class TestDegradeOnConnectFailure:
 
 
 class TestErrorSanitization:
-    async def test_http_status_error_reduces_to_status_code(self) -> None:
+    @staticmethod
+    def _failing_call(status_code: int) -> Any:
         async def call_tool(name: str, args: dict[str, Any], **_: Any) -> Any:
             request = httpx.Request(
                 "POST", "https://example.com/mcp/", headers={"Authorization": f"Bearer {_TOKEN}"}
             )
             raise httpx.HTTPStatusError(
-                f"401 for url with Authorization: Bearer {_TOKEN}",
+                f"{status_code} for url with Authorization: Bearer {_TOKEN}",
                 request=request,
-                response=httpx.Response(401, request=request),
+                response=httpx.Response(status_code, request=request),
             )
 
+        return call_tool
+
+    @pytest.mark.parametrize("status_code", [500, 502, 429])
+    async def test_retryable_http_status_error_reduces_to_status_code(
+        self, status_code: int
+    ) -> None:
         with pytest.raises(ModelRetry) as exc_info:
-            await _call_tool_with_sanitized_errors(Mock(), call_tool, "issue_read", {})
+            await _call_tool_with_sanitized_errors(
+                Mock(), self._failing_call(status_code), "issue_read", {}
+            )
         assert _TOKEN not in str(exc_info.value)
-        assert "401" in str(exc_info.value)
+        assert str(status_code) in str(exc_info.value)
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    async def test_authorization_failure_is_terminal_not_retryable(self, status_code: int) -> None:
+        """An auth failure must not come back as a retry prompt.
+
+        The turn's token is bound when the toolset is built, so retrying re-sends
+        the same credential; the assistant previously reissued identical
+        `issue_write` calls after a 403 instead of telling the user to fix the token.
+        """
+        with pytest.raises(ToolFailed) as exc_info:
+            await _call_tool_with_sanitized_errors(
+                Mock(), self._failing_call(status_code), "issue_write", {}
+            )
+        message = str(exc_info.value)
+        assert _TOKEN not in message
+        assert str(status_code) in message
+        assert "not authorized" in message
+        # ToolFailed is not a ModelRetry, so the retry budget is untouched.
+        assert not isinstance(exc_info.value, ModelRetry)
 
     async def test_transport_error_reduces_to_class_name(self) -> None:
         async def call_tool(name: str, args: dict[str, Any], **_: Any) -> Any:

--- a/tests/unit/server/agents/capabilities/test_github_mcp.py
+++ b/tests/unit/server/agents/capabilities/test_github_mcp.py
@@ -148,12 +148,6 @@ class TestErrorSanitization:
 
     @pytest.mark.parametrize("status_code", [401, 403])
     async def test_authorization_failure_is_terminal_not_retryable(self, status_code: int) -> None:
-        """An auth failure must not come back as a retry prompt.
-
-        The turn's token is bound when the toolset is built, so retrying re-sends
-        the same credential; the assistant previously reissued identical
-        `issue_write` calls after a 403 instead of telling the user to fix the token.
-        """
         with pytest.raises(ToolFailed) as exc_info:
             await _call_tool_with_sanitized_errors(
                 Mock(), self._failing_call(status_code), "issue_write", {}
@@ -162,7 +156,6 @@ class TestErrorSanitization:
         assert _TOKEN not in message
         assert str(status_code) in message
         assert "not authorized" in message
-        # ToolFailed is not a ModelRetry, so the retry budget is untouched.
         assert not isinstance(exc_info.value, ModelRetry)
 
     async def test_transport_error_reduces_to_class_name(self) -> None:


### PR DESCRIPTION
Addresses the retry half of #15808. The credential redaction half is a bigger change and isn't here.

_call_tool_with_sanitized_errors turns every HTTP failure from the GitHub MCP toolset into ModelRetry, which is pydantic-ai's signal to prompt the model to try again:

```python
except httpx.HTTPStatusError as exc:
    raise ModelRetry(f"GitHub MCP request failed with HTTP {exc.response.status_code}") from None
```

For 401 and 403 that retry can't succeed. The turn's token is bound when the toolset is built - as the module docstring says, it carries the turn's resolved token as transport auth - so the retry re-sends the same credential. The trace audit in #15808 caught it: 20 of 22 issue_write spans ended ERROR, with multiple traces carrying two failed calls for the same payload.

pydantic-ai already has the distinction and points right at it. ModelRetry's docstring says "For a terminal failure the model should see but not retry, raise ToolFailed instead", and ToolFailed is documented for "a definitive upstream error" where you want the model to "adapt rather than try the same call again" - it doesn't prepend retry instructions and doesn't consume the retry budget.

So 401 and 403 raise ToolFailed now, everything else stays ModelRetry. The message tells the model to have the user check the token's scope and repo access rather than reissuing. It names only the status code, which keeps the property the function exists for - no part of an httpx error, which can echo the Authorization header, reaches the model or a tool span. The tests assert the token doesn't appear in either path.

ToolFailed is in pydantic-ai-slim 2.34.0, the declared floor in pyproject.toml. I installed that exact version and confirmed the import, so no dependency change needed.

The new test fails against the current code with ModelRetry: GitHub MCP request failed with HTTP 401 (and 403).

test_github_mcp.py: 14 passed. tests/unit/server/agents/: 504 passed. ruff and mypy clean.

The existing test_http_status_error_reduces_to_status_code asserted 401 -> ModelRetry, which is the behaviour being corrected. It's now parametrized over retryable codes (500/502/429) and paired with a new test over 401/403, so both branches stay covered.

Two things from the issue I didn't do. Credential detection and redaction in assistant input needs a detector for credential-like strings in free text, which server/redaction.py doesn't provide (it's reversible encryption for values Phoenix already knows are secrets), and it carries product decisions about what to detect and where to warn. And marking the toolset unavailable after an auth failure, the way a connect failure already degrades the run, would structurally prevent further calls in the same turn but changes the capability's lifecycle rather than one error branch. Happy to add either.