### PR TITLE
chore(deps): resolve @fastify/static and @opentelemetry/core advisories under scripts/

### DIFF
--- a/scripts/docker/devops/oidc-server/package.json
+++ b/scripts/docker/devops/oidc-server/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@fastify/cors": "^11.3.0",
     "@fastify/formbody": "^8.0.2",
-    "@fastify/static": "^9.3.0",
+    "@fastify/static": "^10.1.3",
     "fastify": "^5.10.0",
     "jose": "^6.2.3",
     "pg": "^8.22.0",

--- a/scripts/docker/devops/oidc-server/src/server.ts
+++ b/scripts/docker/devops/oidc-server/src/server.ts
@@ -96,11 +96,11 @@ async function setupPlugins() {
       root: staticPath,
       prefix: "/",
       decorateReply: false,
-      setHeaders: (res, pathname) => {
+      setHeaders: (reply, pathname) => {
         if (pathname.endsWith(".html")) {
-          res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-          res.setHeader("Pragma", "no-cache");
-          res.setHeader("Expires", "0");
+          reply.header("Cache-Control", "no-cache, no-store, must-revalidate");
+          reply.header("Pragma", "no-cache");
+          reply.header("Expires", "0");
         }
       },
     });

--- a/scripts/docker/devops/smtp-server/package.json
+++ b/scripts/docker/devops/smtp-server/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.3.0",
-    "@fastify/static": "^9.3.0",
+    "@fastify/static": "^10.1.3",
     "fastify": "^5.10.0",
     "mailparser": "^3.9.14",
     "smtp-server": "^3.19.2",

--- a/scripts/ts-span-generator/package-lock.json
+++ b/scripts/ts-span-generator/package-lock.json
@@ -87,23 +87,23 @@
       }
     },
     "node_modules/@arizeai/openinference-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-core/-/openinference-core-2.5.0.tgz",
-      "integrity": "sha512-fGzNaMGp62JTRXjEJj6K5Je69C1/z/6wdfBdoxvHFDAEj4qIhgvWmi3y1loLmzi6e/NjeUbUdYeQcNap/05vFQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-core/-/openinference-core-2.6.1.tgz",
+      "integrity": "sha512-AemLjCu2mZqBevyC7o8cLpuskDDE3IicEqGsGE4iZgzYoklCHBadDVYxv4TTK8yNRMwzXvbly7V983IWOsTTfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arizeai/openinference-semantic-conventions": "2.6.0",
+        "@arizeai/openinference-semantic-conventions": "2.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.8.0"
       }
     },
     "node_modules/@arizeai/openinference-genai": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-genai/-/openinference-genai-0.3.2.tgz",
-      "integrity": "sha512-l2U69890wXOsTtwxWFuEr+9KYfZoMBXoyGaZFePLeo0lbLRKm9YYVl8SAu3zw3LPjSQ73L0DQX+IkrfUkaB6YQ==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-genai/-/openinference-genai-0.3.6.tgz",
+      "integrity": "sha512-5EqDEhu/jcD6X5o1HR39lZWoAoqUWR4tSrozdcO0HFoBp+WgEK5zqNGQEhNujkF3sbEi7kuLFP16S285Y4AMHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arizeai/openinference-semantic-conventions": "2.6.0"
+        "@arizeai/openinference-semantic-conventions": "2.8.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0",
@@ -111,21 +111,21 @@
       }
     },
     "node_modules/@arizeai/openinference-semantic-conventions": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-semantic-conventions/-/openinference-semantic-conventions-2.6.0.tgz",
-      "integrity": "sha512-0J1h97WG8K7cVVAtUKa7Tdv49yt0xZ+tebHcBzhSOdjJN5SWoc4CsoGadjO6G/nf+W4qYtRzraBOWKm7/20cyA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-semantic-conventions/-/openinference-semantic-conventions-2.8.0.tgz",
+      "integrity": "sha512-2Ep10THclKGfAY+Iu9ojhjTuKZpnPZ185O2bI+l2fyOT4ODBWJzjE9iRweeLqNaRPHdxCAZWGTjdXTf3Z67Kgg==",
       "license": "Apache-2.0"
     },
     "node_modules/@arizeai/openinference-vercel": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-vercel/-/openinference-vercel-3.1.3.tgz",
-      "integrity": "sha512-vwptUFMg95XnbYDGlK7yzPsN7DORXotRzQMj5JL5Lwrx/8+fqLHZPeeRfEXtmPvIiFTSrEdTVEag0CA8PLzijw==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-vercel/-/openinference-vercel-3.1.10.tgz",
+      "integrity": "sha512-1SzxjL/3dIHfkd712nkWxQHRV+l78p6XtqyG0IZAsZcrChrn/ZHmQY6trdJZYUUSGiLm8njLRQEYlRgInqPBbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arizeai/openinference-core": "2.5.0",
-        "@arizeai/openinference-genai": "0.3.2",
-        "@arizeai/openinference-semantic-conventions": "2.6.0",
-        "@opentelemetry/core": "^1.30.1",
+        "@arizeai/openinference-core": "2.6.1",
+        "@arizeai/openinference-genai": "0.3.6",
+        "@arizeai/openinference-semantic-conventions": "2.8.0",
+        "@opentelemetry/core": "^2.8.0",
         "@opentelemetry/semantic-conventions": ">=1.41.1 <2.0.0"
       },
       "engines": {
@@ -136,30 +136,6 @@
         "@opentelemetry/api": ">=1.7.0 <2.0.0",
         "@opentelemetry/semantic-conventions": ">=1.41.1 <2.0.0",
         "ai": "^7.0.0"
-      }
-    },
-    "node_modules/@arizeai/openinference-vercel/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@arizeai/openinference-vercel/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@arizeai/phoenix-config": {


### PR DESCRIPTION
Resolves the 5 open Dependabot alerts on `main` (2 high, 3 moderate).

## `@fastify/static`

The oidc-server and smtp-server dev containers were on `^9.3.0`, affected by both advisories:

| Advisory | Severity | Affected | Patched |
| --- | --- | --- | --- |
| [GHSA-83w8-p2f5-377r](https://github.com/advisories/GHSA-83w8-p2f5-377r) — route guard bypass via path traversal | High | `<= 10.1.0` | 10.1.1 |
| [GHSA-8pvw-jcv7-9cmj](https://github.com/advisories/GHSA-8pvw-jcv7-9cmj) — authorization bypass via non-canonical URL paths | Moderate | `<= 10.1.1` | 10.1.2 |

Both manifests move to `^10.1.3`. The pnpm lockfiles under `scripts/docker/devops/` are intentionally untracked (see the SBOM-scanner note in the oidc-server Dockerfile) and the Dockerfiles run plain `pnpm install`, so the manifest bump is the whole fix. Both were regenerated locally to confirm they resolve `@fastify/static@10.1.3` with no v9 remaining.

**v10 required one code change.** Its only breaking change is that `setHeaders` now receives a `FastifyReply` instead of a raw `ServerResponse`, so oidc-server's no-cache callback moves from `res.setHeader(…)` to `reply.header(…)`. smtp-server does not use `setHeaders`.

v10 additionally lets `setHeaders` override the headers `@fastify/send` writes. Under v9 the oidc-server no-cache headers on `.html` were being replaced by `Cache-Control: public, max-age=0`; they now take effect. That is the intended direction of the upstream fix, not a regression.

## `@opentelemetry/core`

`scripts/ts-span-generator/package-lock.json` carried a nested `@opentelemetry/core@1.30.1`, affected by [GHSA-8988-4f7v-96qf](https://github.com/advisories/GHSA-8988-4f7v-96qf) (unbounded memory allocation in W3C Baggage propagation, patched in 2.8.0). It came in solely through `@arizeai/openinference-vercel@3.1.3`, which pinned `^1.30.1`.

`openinference-vercel` 3.1.7+ moved to `@opentelemetry/core` `^2.8.0`, and the manifest's `@arizeai/phoenix-otel@^2.1.0` already permits `openinference-vercel ^3.1.0` — so a lockfile refresh was sufficient and no manifest change was needed. It now resolves 3.1.10; the nested `core@1.30.1` entry is gone and every remaining `@opentelemetry/core` in the lockfile is `>= 2.9.0` (installs dedupe to a single 2.10.0).

## Verification

- `tsc --noEmit` passes in oidc-server, smtp-server, and ts-span-generator. It failed on exactly the three `res.setHeader` lines before the edit and passes after.
- `oxfmt --check` and `oxlint` pass in both servers.
- A `fastify.inject` harness run against the real v10 install with the rewritten callback: `.html` receives all three no-cache headers, `.js` receives none of them, and `/..%2f..%2fetc%2fpasswd` returns 404.

## Out of scope

`js/pnpm-lock.yaml` also carries an `@opentelemetry/core@1.30.1` (line 2992), almost certainly the same `openinference-vercel` path via `js/packages/phoenix-otel`. It is not one of the five alerts and is left untouched here.
