### PR TITLE
chore: quiet the largest sources of unit-test warnings

### DIFF
--- a/src/phoenix/datetime_utils.py
+++ b/src/phoenix/datetime_utils.py
@@ -5,7 +5,6 @@ import pandas as pd
 from pandas import Timestamp, to_datetime
 from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
-    is_datetime64tz_dtype,
     is_numeric_dtype,
     is_object_dtype,
 )
@@ -44,7 +43,7 @@ def normalize_timestamps(
     """
     if is_numeric_dtype(timestamps):
         return to_datetime(timestamps, unit="s", utc=True)
-    if is_datetime64tz_dtype(timestamps):
+    if isinstance(timestamps.dtype, pd.DatetimeTZDtype):
         return timestamps.dt.tz_convert(timezone.utc)
     if is_datetime64_any_dtype(timestamps):
         return timestamps.dt.tz_localize(

--- a/src/phoenix/db/alembic.ini
+++ b/src/phoenix/db/alembic.ini
@@ -13,6 +13,9 @@ script_location = migrations
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
+# Separator for prepend_sys_path and version_locations. Without it Alembic warns
+# and falls back to splitting on spaces, commas, and colons.
+path_separator = os
 prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file

--- a/src/phoenix/db/types/db_helper_types.py
+++ b/src/phoenix/db/types/db_helper_types.py
@@ -35,6 +35,13 @@ class Undefined:
             cls._instance = super().__new__(cls)
         return cls._instance
 
+    def __repr__(self) -> str:
+        # Pydantic embeds this in "Default value ... is not JSON serializable"
+        # when generating the OpenAPI schema. The default object address made
+        # every emission textually unique, so pytest could not deduplicate them
+        # and one warning appeared once per worker per route model.
+        return "UNDEFINED"
+
     def __bool__(self) -> bool:
         return False
 

--- a/tests/unit/trace/dsl/test_query.py
+++ b/tests/unit/trace/dsl/test_query.py
@@ -208,7 +208,8 @@ async def test_default_project(
         }
     ).set_index("context.span_id")
     async with db() as session:
-        actual = await session.run_sync(sq, root_spans_only=True)
+        with pytest.warns(DeprecationWarning, match="root_spans_only"):
+            actual = await session.run_sync(sq, root_spans_only=True)
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -232,7 +233,8 @@ async def test_root_spans_only(
         }
     ).set_index("context.span_id")
     async with db() as session:
-        actual = await session.run_sync(sq, project_name="abc", root_spans_only=True)
+        with pytest.warns(DeprecationWarning, match="root_spans_only"):
+            actual = await session.run_sync(sq, project_name="abc", root_spans_only=True)
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),

--- a/tests/unit/trace/test_projects.py
+++ b/tests/unit/trace/test_projects.py
@@ -1,15 +1,22 @@
+import pytest
 from openinference.semconv.resource import ResourceAttributes
 from opentelemetry.sdk.trace import ReadableSpan
 
 from phoenix.trace import using_project
+
+# using_project moved to openinference-instrumentation as dangerously_using_project.
+# These tests cover the deprecated shim until it is removed, so the deprecation is
+# asserted here rather than left to leak into the warnings summary.
+_DEPRECATION_MATCH = "dangerously_using_project"
 
 
 def test_enable_tracing_can_dynamically_modify_resource_project() -> None:
     # all spans created while managed by `using_project` will have their project name
     # dynamically overridden
     pre_override = ReadableSpan(name="pre-override")
-    with using_project(project_name="override-project"):
-        with_override = ReadableSpan(name="override")
+    with pytest.warns(DeprecationWarning, match=_DEPRECATION_MATCH):
+        with using_project(project_name="override-project"):
+            with_override = ReadableSpan(name="override")
     post_override = ReadableSpan(name="post-override")
     assert ResourceAttributes.PROJECT_NAME not in pre_override.resource.attributes
     assert with_override.resource.attributes[ResourceAttributes.PROJECT_NAME] == "override-project"
@@ -17,11 +24,12 @@ def test_enable_tracing_can_dynamically_modify_resource_project() -> None:
 
 
 def test_nested_project_overrides() -> None:
-    with using_project(project_name="project1"):
-        with_override = ReadableSpan(name="override")
-        with using_project(project_name="project2"):
-            nested_override = ReadableSpan(name="nested-override")
-        post_nested_override = ReadableSpan(name="post-nested-override")
+    with pytest.warns(DeprecationWarning, match=_DEPRECATION_MATCH):
+        with using_project(project_name="project1"):
+            with_override = ReadableSpan(name="override")
+            with using_project(project_name="project2"):
+                nested_override = ReadableSpan(name="nested-override")
+            post_nested_override = ReadableSpan(name="post-nested-override")
     assert with_override.resource.attributes[ResourceAttributes.PROJECT_NAME] == "project1"
     assert nested_override.resource.attributes[ResourceAttributes.PROJECT_NAME] == "project2"
     assert post_nested_override.resource.attributes[ResourceAttributes.PROJECT_NAME] == "project1"


### PR DESCRIPTION
Part of #15837 - four of the items on that list. I took the ones that are unambiguous and left the two the issue poses as questions.

src/phoenix/datetime_utils.py: is_datetime64tz_dtype is deprecated in pandas, replaced with isinstance(dtype, pd.DatetimeTZDtype) as the deprecation message suggests. This is the big one - 39 of the 54 warnings in the slice below came from that single line.

src/phoenix/db/alembic.ini: added path_separator = os next to the existing version_path_separator, so alembic stops warning it's falling back to splitting prepend_sys_path on spaces, commas and colons.

Undefined: gave the sentinel a stable __repr__. Pydantic embeds the value in "Default value <...Undefined object at 0x...> is not JSON serializable" during OpenAPI generation, and the object address made every emission textually unique, so pytest couldn't deduplicate them and the same warning showed up once per route model per xdist worker. It reads UNDEFINED now.

tests/unit/trace/test_projects.py and tests/unit/trace/dsl/test_query.py both exercise deprecated APIs on purpose (using_project, root_spans_only). The deprecation is asserted with pytest.warns now instead of leaking into the summary, which is what the parametrized root_spans_only test in the same file already does.

Measured over tests/unit/db, tests/unit/trace and tests/unit/utilities, 2,109 tests: 51 warnings before, 6 after, with 1743 passed / 30 failed / 336 skipped identical either way. Those 30 failures are missing optional aws/azure dev dependencies in my environment and reproduce on main. ruff clean.

The six left are two third-party ldap3 deprecations, the ProjectTraceRetentionPolicy autoflush SAWarning, and the three expression-based index reflection SAWarnings. The last two are the items the issue frames as decisions - where the policy should be added to the session, and whether that reflection is wanted at all. The reflection ones come from inside alembic's migration path rather than the test, so filtering at the call site means suppressing them for real users too, which felt like your call. Happy to take either as a follow-up.

I also left the test_trace_dataset.py UserWarning item - it already wraps the call in pytest.warns, so the leak has a different cause than the issue assumes and I didn't want to guess.