### PR TITLE
test: remove sub-millisecond flake in latency quantile assertions

### DIFF
--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -5667,9 +5667,9 @@ async def test_latency_quantile_with_filters_returns_accurate_percentiles(
         llm_span_session = await _add_project_session(
             session, project, session_id="latency-llm-session"
         )
+        start_time = datetime.now(timezone.utc).replace(microsecond=0)
         llm_span_latencies_ms = [100, 200, 300]
         for latency_ms in llm_span_latencies_ms:
-            start_time = datetime.now(timezone.utc)
             trace = await _add_trace(
                 session,
                 project,
@@ -5691,7 +5691,6 @@ async def test_latency_quantile_with_filters_returns_accurate_percentiles(
         )
         chain_span_latencies_ms = [400, 500, 600]
         for latency_ms in chain_span_latencies_ms:
-            start_time = datetime.now(timezone.utc)
             trace = await _add_trace(
                 session,
                 project,


### PR DESCRIPTION
## Problem

`test_latency_quantile_with_filters_returns_accurate_percentiles[sqlite]` is flaky at roughly
**1 run in 465**. It last failed on `main` in
[run 33807953504](https://github.com/Arize-ai/phoenix/actions/runs/33807953504/job/100822849078):

```
>       assert response_llm_span_filter.data["project"]["latencyMsQuantile"] == 200.0
E       assert 201.0 == 200.0
```

## Cause

The test built each trace from `datetime.now(timezone.utc)` — microsecond precision — with
`end_time = start_time + timedelta(milliseconds=N)`, then asserted the p50 was exactly `200.0` /
`500.0` ms.

`Trace.latency_ms` on SQLite compiles to (`src/phoenix/db/models.py:1078-1089`):

```sql
round((unixepoch(end_time,'subsec') - unixepoch(start_time,'subsec')) * 1000, 1)
```

SQLite quantizes stored timestamps to whole milliseconds. Usually both endpoints round the same
direction and the delta survives, but at the half-millisecond boundary they round **opposite**
ways:

```
'2026-09-03 21:29:41.799500' -> unixepoch subsec 1788470981.800   (up)
'2026-09-03 21:29:41.999500' -> unixepoch subsec 1788470981.999   (down)
```

Those two are exactly 200.000 ms apart; SQLite reports `199.0`. Shift the pair one microsecond
earlier (`.799499` → `.999499`) and it reports the correct `200.0`.

Sweeping all 1,000,000 microsecond values for a 200 ms interval: 999,000 give `200.0`, 500 give
`199.0`, 500 give `201.0` — **0.1% of start times are off by ±1 ms**. Monte-Carlo over this test's
data shape (two p50s over three latencies each) puts the run failure rate at 43/20000 = **0.215%**.

Postgres was never affected: `extract(EPOCH …)` there is exact numeric, which is why only the
`[sqlite]` param failed.

## Fix

Hoist a single whole-second `start_time` out of both loops. Removing the sub-millisecond component
makes both endpoints quantize identically, so the latencies are exact and the equality assertions
hold. Any microsecond value that is a multiple of 1000 works — it is the distance from the half-ms
boundary that matters, so `microsecond=500` would *not* be safe.

There is no worthwhile product-side change: `julianday` carries the same quantization, so ±1 ms is
inherent to computing latency through SQLite's date functions.

## Verification

- Negative control — pinning the start to the known-bad `…41.799500` reproduces the failure exactly:
  `assert 199.0 == 200.0`. Restoring the fix turns it green.
- 360,000 whole-millisecond start times × 6 intervals through SQLite: **zero mismatches**.
- `tests/unit/server/api/types/test_Project.py`: 164 passed, 164 skipped (postgres).
