### PR TITLE
fix(client): narrow the env-file ownership check on sys.platform

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/utils/config.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/config.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import stat as stat_module
+import sys
 from pathlib import Path
 from typing import Iterable, Literal, NamedTuple, Optional, overload
 
@@ -102,8 +103,12 @@ def _is_env_file_discovery_enabled() -> bool:
 
 def _is_trusted_env_file_stat(stat: os.stat_result) -> bool:
     """Whether the stat describes a regular file owned by the current user."""
-    is_owned_by_current_user = not hasattr(os, "getuid") or stat.st_uid == os.getuid()
-    return stat_module.S_ISREG(stat.st_mode) and is_owned_by_current_user
+    if not stat_module.S_ISREG(stat.st_mode):
+        return False
+    if sys.platform == "win32" or not hasattr(os, "getuid"):
+        # Without POSIX file ownership ``st_uid`` carries no information.
+        return True
+    return stat.st_uid == os.getuid()
 
 
 def _find_env_file(start_dir: Path) -> Optional[Path]:

--- a/packages/phoenix-client/tests/client/utils/test_config.py
+++ b/packages/phoenix-client/tests/client/utils/test_config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
@@ -336,7 +337,7 @@ class TestEnvFileDiscovery:
     def test_file_owned_by_another_user_is_ignored(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        if not hasattr(os, "getuid"):
+        if sys.platform == "win32" or not hasattr(os, "getuid"):
             pytest.skip("file ownership is not available on this platform")
         env_file = tmp_path / ".env.phoenix"
         env_file.write_text("PHOENIX_API_KEY=untrusted\n")
@@ -346,7 +347,7 @@ class TestEnvFileDiscovery:
             stat = real_stat(path, follow_symlinks=follow_symlinks)
             if path == env_file:
                 values = list(stat)
-                values[4] = os.getuid() + 1
+                values[4] = stat.st_uid + 1
                 return os.stat_result(values)
             return stat
 


### PR DESCRIPTION
## Why

The Phoenix Client Windows legs of the **Python All Platforms** workflow have been failing on `main` ([run 33807953504](https://github.com/Arize-ai/phoenix/actions/runs/33807953504/job/100822849073)) with six pyright errors:

```
src\phoenix\client\utils\config.py:105:5  - error: Type of "is_owned_by_current_user" is partially unknown
src\phoenix\client\utils\config.py:105:76 - error: Type of "getuid" is unknown
src\phoenix\client\utils\config.py:105:79 - error: "getuid" is not a known attribute of module "os"
src\phoenix\client\utils\config.py:106:12 - error: Return type, "Unknown | bool", is partially unknown
tests\client\utils\test_config.py:349:29  - error: Type of "getuid" is unknown
tests\client\utils\test_config.py:349:32  - error: "getuid" is not a known attribute of module "os"
```

typeshed declares `os.getuid` inside `if sys.platform != "win32":`, and pyright's `pythonPlatform` defaults to the host OS, so on the Windows runner the attribute simply does not exist in the stub. `hasattr(os, "getuid")` is a runtime check pyright does not narrow on, so it buys nothing there. `pyright .` is `commands[1]` of the `phoenix_client` tox env, so the job died before `mypy` and `pytest` ever ran.

This landed on `main` unnoticed because Windows pyright only runs in the scheduled/dispatch **Python All Platforms** workflow, not in per-PR CI.

## What

Front both checks with a `sys.platform` comparison, which pyright evaluates statically and skips diagnostics inside the dead branch:

- `config.py` — `_is_trusted_env_file_stat` returns early on a non-regular file, returns `True` when there is no POSIX ownership to check, and otherwise compares `st_uid` to `os.getuid()`.
- `test_config.py` — the skip guard gains the same `sys.platform` term; since `pytest.skip` is annotated `-> NoReturn`, the rest of the test (including the nested `stat_with_foreign_owner`) is unreachable under Windows analysis. The foreign uid is now derived from the real `stat.st_uid` rather than a second `os.getuid()` call, which removes the reference outright instead of relying on that narrowing to propagate into the closure.

The `hasattr` guard is deliberately kept as the second term of the `or`. It is what makes the check portable to a non-`win32` platform that also lacks `getuid`; dropping it would let `AttributeError` escape `_find_env_file`, which only catches `OSError`. Pyright is happy with it in that position — `hasattr(os, "getuid")` is a plain call with a string literal, not an attribute access.

No behavior change on any platform.

The identical pattern at `packages/phoenix-otel/src/phoenix/otel/settings.py:77` is left alone — the `phoenix_otel` tox env runs `mypy .` and no pyright, mypy *does* narrow on `hasattr`, and all eight Phoenix OTel Windows/macOS jobs passed in the same run.

## Verification

With the CI-pinned pyright (1.1.394) and `mypy --strict`, against the two changed files:

| tool | Windows | Linux | Darwin |
| --- | --- | --- | --- |
| `pyright --pythonplatform` | 0 errors | 0 errors | 0 errors |
| `mypy --strict --platform` | clean | clean | clean |

`pytest tests/client/utils/test_config.py` — 63 passed. `ruff check` and `ruff format --check` clean.

Other legs of that run also failed, for causes checked and unrelated to this change: the macOS 3.14 unit tests on `test_Project.py::test_latency_quantile_with_filters_returns_accurate_percentiles`, and the Windows integration tests on the job's 30-minute timeout. Neither is addressed here.
