### PR TITLE
chore(deps): bump strawberry-graphql to 0.327.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "starlette>=0.37.0",
   "uvicorn",
   "psutil",
-  "strawberry-graphql==0.320.4",
+  "strawberry-graphql==0.327.0",
   "pyarrow",
   "typing-extensions>=4.6",
   "scipy",
@@ -153,7 +153,7 @@ dev = [
   "requests",  # this is needed to type-check third-party packages
   "responses",
   "respx>=0.22.0",
-  "strawberry-graphql[opentelemetry,cli]==0.320.4",  # cli extra provides typer for `strawberry export-schema` (schema-graphql); previously satisfied transitively via huggingface-hub, which dropped typer in 1.22.0
+  "strawberry-graphql[opentelemetry,cli]==0.327.0",  # cli extra provides typer for `strawberry export-schema` (schema-graphql); previously satisfied transitively via huggingface-hub, which dropped typer in 1.22.0
   "syrupy",
   "tenacity",
   "tiktoken",
@@ -234,7 +234,7 @@ container = [
   "opentelemetry-instrumentation-sqlalchemy==0.64b0",
   "opentelemetry-instrumentation-grpc==0.64b0",
   "py-grpc-prometheus",
-  "strawberry-graphql[opentelemetry]==0.320.4",
+  "strawberry-graphql[opentelemetry]==0.327.0",
   "uvloop; platform_system != 'Windows'",
   "aioboto3",
   "aiobotocore>=3.2.0",  # first release whose botocore floor includes Converse ToolSpecification "strict"; older botocore rejects it client-side

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -19,7 +19,7 @@ py-grpc-prometheus
 pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.34.0
 pypistats  # this is needed to type-check third-party packages
 requests  # this is needed to type-check third-party packages
-strawberry-graphql[opentelemetry]==0.319.0
+strawberry-graphql[opentelemetry]==0.327.0
 tenacity
 types-aiobotocore-bedrock-runtime
 types-aiobotocore-rds

--- a/src/phoenix/server/api/types/TimeSeries.py
+++ b/src/phoenix/server/api/types/TimeSeries.py
@@ -18,7 +18,7 @@ class TimeSeriesDataPoint:
     """The value of the data point"""
     value: Optional[float] = strawberry.field(default=GqlValueMediator())
 
-    def __lt__(self, other: "TimeSeriesDataPoint") -> bool:  # type: ignore
+    def __lt__(self, other: "TimeSeriesDataPoint") -> bool:
         return self.timestamp < other.timestamp
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -780,8 +780,8 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46,<3" },
     { name = "sqlglot", specifier = "==30.17.0" },
     { name = "starlette", specifier = ">=0.37.0" },
-    { name = "strawberry-graphql", specifier = "==0.320.4" },
-    { name = "strawberry-graphql", extras = ["opentelemetry"], marker = "extra == 'container'", specifier = "==0.320.4" },
+    { name = "strawberry-graphql", specifier = "==0.327.0" },
+    { name = "strawberry-graphql", extras = ["opentelemetry"], marker = "extra == 'container'", specifier = "==0.327.0" },
     { name = "tqdm" },
     { name = "types-aiobotocore-bedrock-runtime", marker = "extra == 'aws'", specifier = ">=3.6.0" },
     { name = "types-aiobotocore-bedrock-runtime", marker = "extra == 'container'", specifier = ">=3.6.0" },
@@ -871,7 +871,7 @@ dev = [
     { name = "responses" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.15.2" },
-    { name = "strawberry-graphql", extras = ["opentelemetry", "cli"], specifier = "==0.320.4" },
+    { name = "strawberry-graphql", extras = ["opentelemetry", "cli"], specifier = "==0.327.0" },
     { name = "syrupy" },
     { name = "tenacity" },
     { name = "tiktoken" },
@@ -8120,7 +8120,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.320.4"
+version = "0.327.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -8129,9 +8129,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/6b3f0ce8d1f77f89446aff8ccaa3f875b23a082111b903a7adc261f99645/strawberry_graphql-0.320.4.tar.gz", hash = "sha256:cd02eb963c63b84a89007c2784704327924d826ca8f4f172e8386701f839416b", size = 229798, upload-time = "2026-07-09T09:29:57.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/4c/ad2dab90469a2ce214736be5b31c7a788588ccc44cf61b30192b46740535/strawberry_graphql-0.327.0.tar.gz", hash = "sha256:b441199ba607aa51feb166b02d018ed74176f94d1a33e55b691509a377d99757", size = 243389, upload-time = "2026-08-31T22:28:49.209Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/ba/ab8323bed6ddc12c218c0e38d9bee02b10fbc6f03da6a05b5af1cf250572/strawberry_graphql-0.320.4-py3-none-any.whl", hash = "sha256:79a0172ecb372cd1855a199b78668629dc7c6e54276554d459ff51678385e389", size = 332789, upload-time = "2026-07-09T09:29:56.186Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ba/61361c52ea79928b3fdc9f322554e28b84f3c10b25ba81cc99420813e742/strawberry_graphql-0.327.0-py3-none-any.whl", hash = "sha256:756d292f9327cb88cf08407a754bce2abb1066fb035ceafc200d590daaeb5298", size = 347298, upload-time = "2026-08-31T22:28:47.518Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps `strawberry-graphql` from 0.320.4 to 0.327.0, and brings `requirements/type-check.txt` up from 0.319.0 where it had drifted behind the `pyproject.toml` pins.

### The one source change

0.324.5 corrected the `dataclass_transform` ordering metadata on strawberry's decorators to match their runtime behavior — they do not generate ordering methods by default. `TimeSeriesDataPoint` defines its own `__lt__`, which mypy previously flagged as conflicting with a generated one, so the `# type: ignore` there is now unused and is removed.

### Schema is unchanged

`js/app/schema.graphql` regenerates byte-identical. Worth calling out because 0.326.0 added custom schema directives to introspection and SDL, and this schema uses `strawberry.input(one_of=True)` in about ten places — those resolve to GraphQL's built-in `@oneOf`, which is not printed.

### Other changes in the range, checked and unaffected

- No `strawberry.extensions.Extension` alias (removed in 0.322.0)
- No `ParserCache` / `ValidationCache` (0.327.0 bounds their default `maxsize`)
- No synchronous `has_permission` returning an awaitable (0.326.1 makes that fail closed)
- No `strawberry.field()` nested inside an inner `Annotated` (0.324.3 now rejects it at schema build)

### Verification

- `make typecheck-python` — clean, 1085 files
- `make format-python` / `make lint-python` — clean
- `uv run pytest tests/unit` — 8898 passed, no new failures
- `uv lock --upgrade-package strawberry-graphql` re-resolves to exactly this lockfile under the default three-day `exclude-newer` window

The one failing unit test and the errors from `make typecheck-python-ty` reproduce identically on 0.320.4 with the same working tree, so both are pre-existing on `main` and unrelated to this bump.

`make relay-build` was not run — the local pnpm install is broken in a way unrelated to this change. Since the schema is byte-identical the Relay artifacts cannot change, and CI regenerates them regardless.

0.327.2 is available; the only behavioral delta past 0.327.0 is a legacy `graphql-ws` subscription-slot fix. Happy to go there instead if preferred.
