### PR TITLE
test(sandbox): decouple the nested-configs assertion from installed extras

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -23,6 +23,10 @@ tenacity
 tiktoken
 typing-extensions
 vcrpy>=8.3
+# Registers the WASM sandbox adapter, whose probe_dependencies imports wasmtime.
+# Without it CI never seeds the default WASM config and never exercises any path
+# behind SANDBOX_ADAPTERS.get("WASM"), which a developer with the extras does.
+wasmtime>=15.0
 pytest-smtpd
 freezegun
 aiosqlite>=0.22.1

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -106,21 +106,45 @@ async def test_sandbox_providers_returns_nested_configs(
         SANDBOX_ADAPTER_METADATA[provider.backend_type].supported_languages
     )
     assert provider_result["enabled"] is True
-    assert provider_result["configs"] == [
-        {
-            "id": str(GlobalID("SandboxConfig", str(sandbox_config.id))),
-            "name": sandbox_config.name.root,
-            "description": sandbox_config.description,
-            "language": sandbox_config.language,
-            "timeout": sandbox_config.timeout,
-            "enabled": sandbox_config.enabled,
-            "config": {
-                "envVars": [],
-                "internetAccess": None,
-                "dependencies": None,
-            },
-        }
-    ]
+
+    # The provider nests exactly its own configs and no other provider's. The
+    # expected ids are read back from the database rather than spelled out,
+    # because the startup seeder adds a default config for every auto-seedable
+    # adapter whose SDK is importable: a developer with the sandbox extras
+    # installed sees rows here that a bare install does not, and naming the
+    # fixture's config as the only element makes the test pass or fail on which
+    # extras happen to be present. Compare sorted lists rather than sets, so a
+    # resolver that emitted a row more than once would still be caught.
+    async with db() as session:
+        config_ids = list(
+            await session.scalars(
+                select(models.SandboxConfig.id).where(
+                    models.SandboxConfig.backend_type == provider.backend_type
+                )
+            )
+        )
+    assert sorted(config["id"] for config in provider_result["configs"]) == sorted(
+        str(GlobalID("SandboxConfig", str(config_id))) for config_id in config_ids
+    )
+
+    fixture_result = next(
+        config
+        for config in provider_result["configs"]
+        if config["id"] == str(GlobalID("SandboxConfig", str(sandbox_config.id)))
+    )
+    assert fixture_result == {
+        "id": str(GlobalID("SandboxConfig", str(sandbox_config.id))),
+        "name": sandbox_config.name.root,
+        "description": sandbox_config.description,
+        "language": sandbox_config.language,
+        "timeout": sandbox_config.timeout,
+        "enabled": sandbox_config.enabled,
+        "config": {
+            "envVars": [],
+            "internetAccess": None,
+            "dependencies": None,
+        },
+    }
 
 
 async def test_sandbox_backends_and_providers_can_be_loaded_together(


### PR DESCRIPTION
`test_sandbox_providers_returns_nested_configs` asserted that the WASM provider's `configs` were exactly the one row its fixture inserts. That holds only when no default WASM config has been seeded, which depends on the environment rather than on anything the test controls.

### Why it depends on the environment

`_try_register_adapter` skips any adapter whose `probe_dependencies` raises `ImportError` (`src/phoenix/server/sandbox/__init__.py:375`), and the Facilitator's `sync_sandbox_default_configs` seeds a default config for every registered auto-seedable adapter.

Of the three auto-seedable adapters, WASM is the only one whose probe imports an optional SDK (`wasmtime`, `src/phoenix/server/sandbox/wasm_backend.py:313`). DENO and MONTY inherit the base no-op probe (`src/phoenix/server/sandbox/types.py:712`) and register unconditionally. Several adapters that are not auto-seedable gate on their SDKs too, but they never seed a default config, so WASM alone decides whether this provider has a seeded row.

An installation carrying `wasmtime` therefore gets a `default-wasm-python` row and the provider legitimately returns two configs, while an installation without it gets one. The tox `unit_tests` environment installs `arize-phoenix` with no extras (`tox.ini:158`), so `wasmtime` was absent in CI — which is why the assertion held there and broke for anyone working with the extras installed.

### The change

The GraphQL nesting was correct throughout; each provider returns exactly its own configs. The test now asserts that the provider returns exactly the configs the database holds for its backend type, which still catches configs leaking across providers and now has real rows from the other providers to catch them against, then locates the fixture's config by id and asserts its rendered shape as before. The comparison is between sorted lists rather than sets, so it still fails a resolver that emits a row more than once, which set membership would hide.

`wasmtime>=15.0` is added to `requirements/unit-tests.txt` so CI registers the WASM adapter and covers the seeding path, rather than passing because the adapter is missing. This also lifts the module-level `pytest.importorskip("wasmtime")` in `tests/unit/server/api/test_wasm_backend.py:12`, so that module runs in CI as well, and `sandboxBackends` reports WASM as `AVAILABLE`/`UNAVAILABLE` there instead of `NOT_INSTALLED`.

### Verification

- The test passes both with the sandbox extras installed, where it previously failed, and with the adapters gated off through `PHOENIX_ALLOWED_SANDBOX_PROVIDERS`, which reproduces the pre-change CI shape
- Full `tests/unit` in the development environment under random ordering: 8899 passed, 0 failed (previously 8898 passed, 1 failed)
- Full `tests/unit` in a Python 3.10 environment built the way tox builds its own — unit-test requirements plus `arize-phoenix` installed with no extras — confirming the WASM adapter registers there and nothing else depends on its absence: 8885 passed, 0 failed
- The other three consumers of the `sandbox_config` fixture plus `test_sync.py`: 203 passed
- Injecting a dataloader that emits each row twice fails the new assertion, confirming multiplicity is still checked
- `make format-python`, `make lint-python`, `make typecheck-python` all clean

### Not addressed here

The `sandbox_config` fixture stores `config={}`, which lacks the discriminator and trips the parse-warning fallback that the asserted `config` dict encodes. Four test files share that fixture, so it is left alone.
