### PR TITLE
feat(evals): deprecate DocumentRelevanceEvaluator in favor of RetrievalRelevanceEvaluator

### DIFF
--- a/js/packages/phoenix-evals/README.md
+++ b/js/packages/phoenix-evals/README.md
@@ -100,7 +100,7 @@ All pre-built evaluators are available from the `@arizeai/phoenix-evals/llm` mod
 | Faithfulness           | `createFaithfulnessEvaluator`         | Detects hallucinations — checks if the output is grounded in the provided context |
 | Conciseness            | `createConcisenessEvaluator`          | Evaluates whether the response is appropriately concise                           |
 | Correctness            | `createCorrectnessEvaluator`          | Checks if the output is factually correct given the input                         |
-| Document Relevance     | `createDocumentRelevanceEvaluator`    | Measures how relevant a retrieved document is to the query                        |
+| Document Relevance     | `createDocumentRelevanceEvaluator`    | **Deprecated** — use `createRetrievalRelevanceEvaluator`; pass the document as `context` |
 | Refusal                | `createRefusalEvaluator`              | Detects whether the model refused to answer                                       |
 | Tool Invocation        | `createToolInvocationEvaluator`       | Evaluates whether the correct tool was invoked with the right arguments           |
 | Tool Selection         | `createToolSelectionEvaluator`        | Checks whether the right tool was selected for the task                           |

--- a/js/packages/phoenix-evals/src/llm/createDocumentRelevanceEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/createDocumentRelevanceEvaluator.ts
@@ -18,6 +18,9 @@ export interface DocumentRelevanceEvaluatorArgs<
 
 /**
  * A record to be evaluated by the document relevance evaluator.
+ *
+ * @deprecated Use the retrieval relevance evaluator's record shape instead, which
+ * names this field `context` rather than `documentText`.
  */
 export interface DocumentRelevanceEvaluationRecord {
   input: string;
@@ -27,6 +30,13 @@ export interface DocumentRelevanceEvaluationRecord {
 
 /**
  * Creates a document relevance evaluator function.
+ *
+ * @deprecated Use {@link createRetrievalRelevanceEvaluator} instead. It covers both
+ * single-document and holistic retrieval evaluation, and the documentation has
+ * recommended it since the Document Relevance page was removed. When migrating, the
+ * input field `documentText` becomes `context` and the negative label `unrelated`
+ * becomes `irrelevant`. Per-document evaluation is still possible: pass a single
+ * document as `context` and call the evaluator once per document.
  *
  * This function returns an evaluator that determines whether a given document text
  * is relevant to a provided input question. The evaluator uses a classification model

--- a/packages/phoenix-evals/README.md
+++ b/packages/phoenix-evals/README.md
@@ -67,7 +67,7 @@ The `phoenix.evals.metrics` module provides ready-to-use evaluators for common t
 | Faithfulness | `FaithfulnessEvaluator` | Detects hallucinations — checks if output is grounded in context |
 | Conciseness | `ConcisenessEvaluator` | Evaluates whether the response is appropriately concise |
 | Correctness | `CorrectnessEvaluator` | Checks if the output is factually correct |
-| Document Relevance | `DocumentRelevanceEvaluator` | Measures how relevant a retrieved document is to a query |
+| Document Relevance | `DocumentRelevanceEvaluator` | **Deprecated** — use `RetrievalRelevanceEvaluator`; pass the document as `context` |
 | Refusal | `RefusalEvaluator` | Detects whether the model refused to answer |
 | Tool Invocation | `ToolInvocationEvaluator` | Checks whether the correct tool was called with the right arguments |
 | Tool Selection | `ToolSelectionEvaluator` | Evaluates whether the right tool was selected for the task |

--- a/packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -14,6 +15,19 @@ class DocumentRelevanceEvaluator(ClassificationEvaluator):
     """
     A specialized evaluator for determining document relevance to a given
     question.
+
+    .. deprecated::
+        Use :class:`~phoenix.evals.metrics.retrieval_relevance.RetrievalRelevanceEvaluator`
+        instead. It covers both single-document and holistic retrieval evaluation, and the
+        documentation has recommended it since the Document Relevance page was removed.
+
+        Migrating:
+
+        - the input field ``document_text`` becomes ``context``
+        - the negative label ``unrelated`` becomes ``irrelevant``
+
+        Per-document evaluation is still possible: pass a single document as ``context``
+        and call the evaluator once per document.
 
     Args:
         llm (LLM): The LLM instance to use for the evaluation.
@@ -66,6 +80,13 @@ class DocumentRelevanceEvaluator(ClassificationEvaluator):
         llm: LLM,
         **kwargs: Any,
     ):
+        warnings.warn(
+            "DocumentRelevanceEvaluator is deprecated; use RetrievalRelevanceEvaluator "
+            "instead. Pass the document as 'context' rather than 'document_text', and "
+            "note the negative label is 'irrelevant' rather than 'unrelated'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             name=self.NAME,
             llm=llm,

--- a/packages/phoenix-evals/tests/phoenix/evals/metrics/test_classification_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/metrics/test_classification_evaluators.py
@@ -7,6 +7,8 @@ Covers:
 - kwargs forwarding (e.g. temperature)
 """
 
+import warnings
+
 import pytest
 
 from phoenix.evals.llm.prompts import PromptTemplate
@@ -73,6 +75,10 @@ ALL_EVALUATORS = [
         DocumentRelevanceEvaluator,
         {"input": "Q", "document_text": "D"},
         id="DocumentRelevanceEvaluator",
+        # Deprecated in favour of RetrievalRelevanceEvaluator; still covered here
+        # until it is removed. The deprecation itself is asserted by
+        # test_document_relevance_evaluator_warns_deprecated below.
+        marks=pytest.mark.filterwarnings("ignore::DeprecationWarning"),
     ),
     pytest.param(
         RefusalEvaluator,
@@ -164,3 +170,16 @@ class TestKwargsForwarding:
         llm = MockLLM()
         ev = EvaluatorClass(llm=llm, temperature=0.5)
         assert ev.invocation_parameters.get("temperature") == 0.5
+
+
+def test_document_relevance_evaluator_warns_deprecated() -> None:
+    """DocumentRelevanceEvaluator points callers at RetrievalRelevanceEvaluator."""
+    with pytest.warns(DeprecationWarning, match="RetrievalRelevanceEvaluator"):
+        DocumentRelevanceEvaluator(llm=MockLLM())
+
+
+def test_retrieval_relevance_evaluator_is_not_deprecated() -> None:
+    """The replacement must not warn, or the deprecation is pointing nowhere useful."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        RetrievalRelevanceEvaluator(llm=MockLLM())


### PR DESCRIPTION
Part of #15873.

Phoenix exports two overlapping relevance evaluators. RetrievalRelevanceEvaluator is the newer one, covers both single-document and holistic retrieval evaluation, and is what the docs have recommended since the Document Relevance page was removed in #14933 - but the older API was never formally deprecated, so callers still had two choices with nothing saying which to use.

DocumentRelevanceEvaluator (Python) and createDocumentRelevanceEvaluator (TypeScript) are marked deprecated now, with the migration inline rather than only in a changelog, since the field and label names differ. The input field document_text / documentText becomes context, and the negative label unrelated becomes irrelevant.

I checked both against the generated configs rather than taking them from the issue:

```
document_relevance   choices: {'relevant': 1.0, 'unrelated': 0.0}
retrieval_relevance  choices: {'relevant': 1.0, 'irrelevant': 0.0}
```

The guidance also says explicitly that per-document evaluation still works on the replacement by passing a single document as context, so the deprecation doesn't read as losing a capability.

Touched the Python class (runtime DeprecationWarning plus docstring), the TS factory and its record interface (@deprecated JSDoc), and the evaluator table in both package READMEs.

The deprecated class stays in the shared parametrized evaluator list so it keeps its coverage until removal, but with a filterwarnings mark so the new warning doesn't leak into the warnings summary. I have #15921 open to reduce those and didn't want this adding five back. Two tests assert the behaviour directly instead of relying on the mark: that the old class warns and names the replacement, and that the replacement doesn't warn, so the deprecation points somewhere useful.

packages/phoenix-evals: 83 passed, 0 warnings. ruff clean.

The TypeScript change is JSDoc only, no code path touched. I couldn't run the JS suite - pnpm isn't available in my environment - so that side is worth a look in CI.

Not included: the removal release. The issue asks for one to be chosen, and that's your call, so no version is named anywhere - not in the warning text, the docstrings or the JSDoc. Tell me which release and I'll add it here along with the changelog entries.

I also left the README usage examples on the old API rather than rewriting them, since converting those means changing documentText to context in runnable sample code and that felt like it should ride along with the version decision.