### PR TITLE
feat(client): add error and latency filters to get_traces in python and typescript clients

### DIFF
--- a/.github/workflows/check-card-links.yml
+++ b/.github/workflows/check-card-links.yml
@@ -43,7 +43,7 @@ jobs:
           path: ${{ steps.run-check.outputs.summary_path }}
 
       - name: Delete previous card links comment
-        if: ${{ github.event_name == 'pull_request' && always() }}
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
@@ -64,7 +64,7 @@ jobs:
             }
 
       - name: Comment on PR with summary
-        if: ${{ github.event_name == 'pull_request' && always() }}
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           SUMMARY_PATH: ${{ steps.run-check.outputs.summary_path }}

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/traces.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/traces.mdx
@@ -29,7 +29,7 @@ The traces module provides trace retrieval, project transfer, and trace-level an
 
 ## Retrieve Traces
 
-Use `getTraces` when you want trace-centric pagination by project, optional inline spans, or filtering by session.
+Use `getTraces` when you want trace-centric pagination by project, optional inline spans, or filtering by session, error status, or latency.
 
 ```ts
 import { getTraces } from "@arizeai/phoenix-client/traces";
@@ -60,6 +60,18 @@ console.log(result.nextCursor);
 - `cursor`
 - `includeSpans`
 - `sessionId`
+- `error`
+- `minLatencyMs`
+- `maxLatencyMs`
+
+```ts
+// Slow traces that contain at least one errored span
+const slowFailures = await getTraces({
+  project: { projectName: "support-bot" },
+  error: true,
+  minLatencyMs: 1000,
+});
+```
 
 ### Notes
 
@@ -67,6 +79,7 @@ console.log(result.nextCursor);
 - Use the returned `nextCursor` to continue pagination
 - Set `includeSpans` when you need a trace-centric fetch that also contains span details
 - `project` accepts `{ project }`, `{ projectId }`, or `{ projectName }`
+- `error`, `minLatencyMs`, and `maxLatencyMs` require Phoenix server >= 20.8.0; `error: false` selects traces with no errored spans
 
 ## Move Traces To Another Project
 

--- a/js/.changeset/tidy-pugs-shave.md
+++ b/js/.changeset/tidy-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `error`, `minLatencyMs`, and `maxLatencyMs` filters to `getTraces`, matching the query parameters on `GET /v1/projects/{id}/traces` (requires Phoenix server >= 20.8.0).

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -421,6 +421,13 @@ const sessionTraces = await getTraces({
   project: { projectName: "my-project" },
   sessionId: "my-session-id",
 });
+
+// Filter by error status and latency (requires Phoenix server >= 20.8.0)
+const slowFailures = await getTraces({
+  project: { projectName: "my-project" },
+  error: true,
+  minLatencyMs: 1000,
+});
 ```
 
 | Parameter      | Type                           | Description                                |
@@ -434,6 +441,9 @@ const sessionTraces = await getTraces({
 | `cursor`       | `string \| null`               | Pagination cursor                          |
 | `includeSpans` | `boolean`                      | Include full span details for each trace   |
 | `sessionId`    | `string \| string[] \| null`   | Filter traces by session identifier(s)     |
+| `error`        | `boolean \| null`              | Only traces with (`true`) or without (`false`) errored spans |
+| `minLatencyMs` | `number \| null`               | Inclusive lower bound on trace latency (ms) |
+| `maxLatencyMs` | `number \| null`               | Inclusive upper bound on trace latency (ms) |
 
 ### Pagination
 

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -430,20 +430,20 @@ const slowFailures = await getTraces({
 });
 ```
 
-| Parameter      | Type                           | Description                                |
-| -------------- | ------------------------------ | ------------------------------------------ |
-| `project`      | `ProjectIdentifier`            | The project (by name or ID) — **required** |
-| `startTime`    | `Date \| string \| null`       | Inclusive lower bound on trace start time  |
-| `endTime`      | `Date \| string \| null`       | Exclusive upper bound on trace start time  |
-| `sort`         | `"start_time" \| "latency_ms"` | Sort field                                 |
-| `order`        | `"asc" \| "desc"`              | Sort direction                             |
-| `limit`        | `number`                       | Maximum number of traces to return         |
-| `cursor`       | `string \| null`               | Pagination cursor                          |
-| `includeSpans` | `boolean`                      | Include full span details for each trace   |
-| `sessionId`    | `string \| string[] \| null`   | Filter traces by session identifier(s)     |
+| Parameter      | Type                           | Description                                                  |
+| -------------- | ------------------------------ | ------------------------------------------------------------ |
+| `project`      | `ProjectIdentifier`            | The project (by name or ID) — **required**                   |
+| `startTime`    | `Date \| string \| null`       | Inclusive lower bound on trace start time                    |
+| `endTime`      | `Date \| string \| null`       | Exclusive upper bound on trace start time                    |
+| `sort`         | `"start_time" \| "latency_ms"` | Sort field                                                   |
+| `order`        | `"asc" \| "desc"`              | Sort direction                                               |
+| `limit`        | `number`                       | Maximum number of traces to return                           |
+| `cursor`       | `string \| null`               | Pagination cursor                                            |
+| `includeSpans` | `boolean`                      | Include full span details for each trace                     |
+| `sessionId`    | `string \| string[] \| null`   | Filter traces by session identifier(s)                       |
 | `error`        | `boolean \| null`              | Only traces with (`true`) or without (`false`) errored spans |
-| `minLatencyMs` | `number \| null`               | Inclusive lower bound on trace latency (ms) |
-| `maxLatencyMs` | `number \| null`               | Inclusive upper bound on trace latency (ms) |
+| `minLatencyMs` | `number \| null`               | Inclusive lower bound on trace latency (ms)                  |
+| `maxLatencyMs` | `number \| null`               | Inclusive upper bound on trace latency (ms)                  |
 
 ### Pagination
 

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -98,6 +98,16 @@ export const LIST_PROJECT_TRACES: RouteRequirement = {
   minServerVersion: [13, 15, 0],
 };
 
+export const GET_TRACES_FILTERS: ParameterRequirement = {
+  kind: "parameter",
+  parameterName: "error",
+  parameterLocation: "query",
+  route: "GET /v1/projects/{id}/traces",
+  minServerVersion: [20, 8, 0],
+  description:
+    "The 'error', 'min_latency_ms', and 'max_latency_ms' query parameters on GET /v1/projects/{id}/traces",
+};
+
 export const TRANSFER_TRACES: RouteRequirement = {
   kind: "route",
   method: "POST",
@@ -234,6 +244,7 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   GET_SPANS_FILTERS,
   GET_SPANS_BY_ATTRIBUTE,
   LIST_PROJECT_TRACES,
+  GET_TRACES_FILTERS,
   TRANSFER_TRACES,
   DATASET_UPLOAD_EXAMPLE_IDS,
   ADD_TRACE_NOTE_IDENTIFIER,

--- a/js/packages/phoenix-client/src/traces/getTraces.ts
+++ b/js/packages/phoenix-client/src/traces/getTraces.ts
@@ -1,6 +1,9 @@
 import type { operations } from "../__generated__/api/v1";
 import { createClient } from "../client";
-import { LIST_PROJECT_TRACES } from "../constants/serverRequirements";
+import {
+  GET_TRACES_FILTERS,
+  LIST_PROJECT_TRACES,
+} from "../constants/serverRequirements";
 import type { ClientFn } from "../types/core";
 import type { ProjectIdentifier } from "../types/projects";
 import { resolveProjectIdentifier } from "../types/projects";
@@ -28,6 +31,112 @@ export interface GetTracesParams extends ClientFn {
   includeSpans?: boolean;
   /** Filter traces by session identifier(s) (session_id strings or GlobalIDs) */
   sessionId?: string | string[] | null;
+  /**
+   * Filter by trace error status. `true` returns only traces containing at
+   * least one errored span, `false` only traces with no errored spans.
+   * Omit to leave traces unfiltered by error status.
+   *
+   * @requires Phoenix server >= 20.8.0
+   */
+  error?: boolean | null;
+  /**
+   * Inclusive lower bound on trace latency in milliseconds.
+   *
+   * @requires Phoenix server >= 20.8.0
+   */
+  minLatencyMs?: number | null;
+  /**
+   * Inclusive upper bound on trace latency in milliseconds.
+   *
+   * @requires Phoenix server >= 20.8.0
+   */
+  maxLatencyMs?: number | null;
+}
+
+/**
+ * Reject latency bounds the server would reject (negatives) or that can never
+ * match a trace (an inverted range), so callers get a clear error instead of a
+ * 422 or a silently empty page.
+ */
+function validateLatencyBounds({
+  minLatencyMs,
+  maxLatencyMs,
+}: Pick<GetTracesParams, "minLatencyMs" | "maxLatencyMs">): void {
+  if (minLatencyMs != null && minLatencyMs < 0) {
+    throw new Error(`minLatencyMs must be non-negative, got ${minLatencyMs}`);
+  }
+  if (maxLatencyMs != null && maxLatencyMs < 0) {
+    throw new Error(`maxLatencyMs must be non-negative, got ${maxLatencyMs}`);
+  }
+  if (
+    minLatencyMs != null &&
+    maxLatencyMs != null &&
+    minLatencyMs > maxLatencyMs
+  ) {
+    throw new Error(
+      `minLatencyMs (${minLatencyMs}) must not exceed maxLatencyMs (${maxLatencyMs})`
+    );
+  }
+}
+
+type ListProjectTracesQuery = NonNullable<
+  operations["listProjectTraces"]["parameters"]["query"]
+>;
+
+/**
+ * Translate the camelCase parameters into the endpoint's snake_case query,
+ * omitting anything the caller left unset so the server applies its defaults.
+ */
+function buildQuery({
+  cursor,
+  limit = 100,
+  startTime,
+  endTime,
+  sort,
+  order,
+  includeSpans,
+  sessionId,
+  error,
+  minLatencyMs,
+  maxLatencyMs,
+}: Omit<GetTracesParams, "client" | "project">): ListProjectTracesQuery {
+  const query: ListProjectTracesQuery = { limit };
+  if (cursor) {
+    query.cursor = cursor;
+  }
+  if (startTime) {
+    query.start_time =
+      startTime instanceof Date ? startTime.toISOString() : startTime;
+  }
+  if (endTime) {
+    query.end_time = endTime instanceof Date ? endTime.toISOString() : endTime;
+  }
+  if (sort) {
+    query.sort = sort;
+  }
+  if (order) {
+    query.order = order;
+  }
+  if (includeSpans) {
+    query.include_spans = true;
+  }
+  if (sessionId) {
+    query.session_identifier = Array.isArray(sessionId)
+      ? sessionId
+      : [sessionId];
+  }
+  // `error: false` is a meaningful filter (traces with no errored spans), so
+  // send the parameter whenever it was set rather than only when truthy.
+  if (error != null) {
+    query.error = error;
+  }
+  if (minLatencyMs != null) {
+    query.min_latency_ms = minLatencyMs;
+  }
+  if (maxLatencyMs != null) {
+    query.max_latency_ms = maxLatencyMs;
+  }
+  return query;
 }
 
 export type GetTracesResponse =
@@ -81,60 +190,30 @@ export type GetTracesResult = {
  *   });
  *   cursor = result.nextCursor || undefined;
  * } while (cursor);
+ *
+ * // Only slow traces that errored
+ * const slowFailures = await getTraces({
+ *   client,
+ *   project: { projectName: "my-project" },
+ *   error: true,
+ *   minLatencyMs: 1000,
+ * });
  * ```
  */
 export async function getTraces({
   client: _client,
   project,
-  cursor,
-  limit = 100,
-  startTime,
-  endTime,
-  sort,
-  order,
-  includeSpans,
-  sessionId,
+  ...params
 }: GetTracesParams): Promise<GetTracesResult> {
+  const { error: errorFilter, minLatencyMs, maxLatencyMs } = params;
   const client = _client ?? createClient();
+  validateLatencyBounds({ minLatencyMs, maxLatencyMs });
   await ensureServerCapability({ client, requirement: LIST_PROJECT_TRACES });
+  if (errorFilter != null || minLatencyMs != null || maxLatencyMs != null) {
+    await ensureServerCapability({ client, requirement: GET_TRACES_FILTERS });
+  }
   const projectIdentifier = resolveProjectIdentifier(project);
-
-  const params: NonNullable<
-    operations["listProjectTraces"]["parameters"]["query"]
-  > = {
-    limit,
-  };
-
-  if (cursor) {
-    params.cursor = cursor;
-  }
-
-  if (startTime) {
-    params.start_time =
-      startTime instanceof Date ? startTime.toISOString() : startTime;
-  }
-
-  if (endTime) {
-    params.end_time = endTime instanceof Date ? endTime.toISOString() : endTime;
-  }
-
-  if (sort) {
-    params.sort = sort;
-  }
-
-  if (order) {
-    params.order = order;
-  }
-
-  if (includeSpans) {
-    params.include_spans = true;
-  }
-
-  if (sessionId) {
-    params.session_identifier = Array.isArray(sessionId)
-      ? sessionId
-      : [sessionId];
-  }
+  const query = buildQuery(params);
 
   const { data, error } = await client.GET(
     "/v1/projects/{project_identifier}/traces",
@@ -143,7 +222,7 @@ export async function getTraces({
         path: {
           project_identifier: projectIdentifier,
         },
-        query: params,
+        query,
       },
     }
   );

--- a/js/packages/phoenix-client/test/traces/getTraces.test.ts
+++ b/js/packages/phoenix-client/test/traces/getTraces.test.ts
@@ -117,4 +117,93 @@ describe("getTraces", () => {
       expect(receivedSessionIdentifiers).toEqual([]);
     });
   });
+
+  describe("error and latency filters", () => {
+    const captureQuery = (received: Record<string, string | null>) =>
+      http.get(
+        "/v1/projects/{project_identifier}/traces",
+        ({ query, response }) => {
+          received.error = query.get("error");
+          received.min_latency_ms = query.get("min_latency_ms");
+          received.max_latency_ms = query.get("max_latency_ms");
+          return response(200).json({ next_cursor: null, data: [] });
+        }
+      );
+
+    it("should send error=true", async () => {
+      const received: Record<string, string | null> = {};
+      server.use(captureQuery(received));
+
+      await getTraces({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+        error: true,
+      });
+
+      expect(received.error).toBe("true");
+    });
+
+    it("should send error=false rather than dropping it as falsy", async () => {
+      const received: Record<string, string | null> = {};
+      server.use(captureQuery(received));
+
+      await getTraces({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+        error: false,
+      });
+
+      expect(received.error).toBe("false");
+    });
+
+    it("should send latency bounds, including a zero lower bound", async () => {
+      const received: Record<string, string | null> = {};
+      server.use(captureQuery(received));
+
+      await getTraces({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+        minLatencyMs: 0,
+        maxLatencyMs: 5000,
+      });
+
+      expect(received.min_latency_ms).toBe("0");
+      expect(received.max_latency_ms).toBe("5000");
+    });
+
+    it("should not send the filters when they are omitted", async () => {
+      const received: Record<string, string | null> = {};
+      server.use(captureQuery(received));
+
+      await getTraces({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+      });
+
+      expect(received.error).toBeNull();
+      expect(received.min_latency_ms).toBeNull();
+      expect(received.max_latency_ms).toBeNull();
+    });
+
+    it("should reject negative latency bounds", async () => {
+      await expect(
+        getTraces({
+          client: createTestClient(),
+          project: { projectName: "test-project" },
+          minLatencyMs: -1,
+        })
+      ).rejects.toThrow(/non-negative/);
+    });
+
+    it("should reject an inverted latency range", async () => {
+      await expect(
+        getTraces({
+          client: createTestClient(),
+          project: { projectName: "test-project" },
+          minLatencyMs: 500,
+          maxLatencyMs: 100,
+        })
+      ).rejects.toThrow(/must not exceed/);
+    });
+  });
 });

--- a/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
+++ b/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
@@ -70,6 +70,17 @@ LIST_PROJECT_TRACES = RouteRequirement(
     min_server_version=Version(13, 15, 0),
 )
 
+GET_TRACES_FILTERS = ParameterRequirement(
+    parameter_name="error",
+    parameter_location="query",
+    route="GET /v1/projects/{id}/traces",
+    min_server_version=Version(20, 8, 0),
+    description=(
+        "The 'error', 'min_latency_ms', and 'max_latency_ms' query parameters "
+        "on GET /v1/projects/{id}/traces"
+    ),
+)
+
 DATASET_UPLOAD_EXAMPLE_IDS = ParameterRequirement(
     parameter_name="example_ids",
     parameter_location="body",

--- a/packages/phoenix-client/src/phoenix/client/resources/traces/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/traces/__init__.py
@@ -14,7 +14,10 @@ from typing import (
 import httpx
 
 from phoenix.client.__generated__ import v1
-from phoenix.client.constants.server_requirements import LIST_PROJECT_TRACES
+from phoenix.client.constants.server_requirements import (
+    GET_TRACES_FILTERS,
+    LIST_PROJECT_TRACES,
+)
 from phoenix.client.utils.annotation_helpers import (
     _chunk_trace_annotations_dataframe,  # pyright: ignore[reportPrivateUsage]
     _create_trace_annotation,  # pyright: ignore[reportPrivateUsage]
@@ -32,6 +35,66 @@ InsertedTraceAnnotation = v1.InsertedTraceAnnotation
 TraceAnnotationData = v1.TraceAnnotationData
 AnnotateTracesRequestBody = v1.AnnotateTracesRequestBody
 AnnotateTracesResponseBody = v1.AnnotateTracesResponseBody
+
+_TraceQueryParams = dict[str, Union[int, float, str, bool, Sequence[str]]]
+
+
+def _validate_latency_bounds(
+    min_latency_ms: Optional[float],
+    max_latency_ms: Optional[float],
+) -> None:
+    """Reject latency bounds the server would reject or that select nothing."""
+    if min_latency_ms is not None and min_latency_ms < 0:
+        raise ValueError(f"min_latency_ms must be non-negative, got {min_latency_ms}")
+    if max_latency_ms is not None and max_latency_ms < 0:
+        raise ValueError(f"max_latency_ms must be non-negative, got {max_latency_ms}")
+    if (
+        min_latency_ms is not None
+        and max_latency_ms is not None
+        and min_latency_ms > max_latency_ms
+    ):
+        raise ValueError(
+            f"min_latency_ms ({min_latency_ms}) must not exceed max_latency_ms ({max_latency_ms})"
+        )
+
+
+def _build_trace_query_params(
+    *,
+    start_time: Optional[datetime],
+    end_time: Optional[datetime],
+    sort: Optional[str],
+    order: Optional[str],
+    include_spans: bool,
+    session_id: Optional[Union[str, Sequence[str]]],
+    error: Optional[bool],
+    min_latency_ms: Optional[float],
+    max_latency_ms: Optional[float],
+) -> _TraceQueryParams:
+    """Build the query params shared by every page of a ``get_traces`` request."""
+    params: _TraceQueryParams = {}
+    if start_time:
+        params["start_time"] = start_time.isoformat()
+    if end_time:
+        params["end_time"] = end_time.isoformat()
+    if sort:
+        params["sort"] = sort
+    if order:
+        params["order"] = order
+    if include_spans:
+        params["include_spans"] = True
+    if session_id:
+        params["session_identifier"] = (
+            [session_id] if isinstance(session_id, str) else list(session_id)
+        )
+    # `error=False` is a meaningful filter (traces with no errored spans), so send
+    # the parameter whenever it was set rather than only when truthy.
+    if error is not None:
+        params["error"] = error
+    if min_latency_ms is not None:
+        params["min_latency_ms"] = min_latency_ms
+    if max_latency_ms is not None:
+        params["max_latency_ms"] = max_latency_ms
+    return params
 
 
 class Traces:
@@ -346,6 +409,9 @@ class Traces:
         order: Optional[Literal["asc", "desc"]] = None,
         include_spans: bool = False,
         session_id: Optional[Union[str, Sequence[str]]] = None,
+        error: Optional[bool] = None,
+        min_latency_ms: Optional[float] = None,
+        max_latency_ms: Optional[float] = None,
         limit: int = 100,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.TraceData]:
@@ -365,6 +431,14 @@ class Traces:
                 If you experience performance issues, consider fetching spans separately.
             session_id (Optional[Union[str, Sequence[str]]]): Filter by one or more
                 session IDs or GlobalIDs. Can be a single string or a sequence of strings.
+            error (Optional[bool]): If True, only return traces containing at least one
+                errored span. If False, only return traces with no errored spans. If
+                None (default), traces are not filtered by error status.
+                Requires Phoenix server >= 20.8.0.
+            min_latency_ms (Optional[float]): Inclusive lower bound on trace latency in
+                milliseconds. Requires Phoenix server >= 20.8.0.
+            max_latency_ms (Optional[float]): Inclusive upper bound on trace latency in
+                milliseconds. Requires Phoenix server >= 20.8.0.
             limit (int): Maximum number of traces to return. Defaults to 100.
             timeout (Optional[int]): Request timeout in seconds.
 
@@ -373,6 +447,8 @@ class Traces:
 
         Raises:
             httpx.HTTPStatusError: If the API returns an error response.
+            ValueError: If ``min_latency_ms`` or ``max_latency_ms`` is negative, or if
+                ``min_latency_ms`` exceeds ``max_latency_ms``.
 
         Example::
 
@@ -383,27 +459,33 @@ class Traces:
                 project_identifier="my-project",
                 limit=50,
             )
+
+            # Only slow traces that errored
+            slow_failures = client.traces.get_traces(
+                project_identifier="my-project",
+                error=True,
+                min_latency_ms=1000,
+            )
         """
+        _validate_latency_bounds(min_latency_ms, max_latency_ms)
         self._guard.require(LIST_PROJECT_TRACES)
+        if error is not None or min_latency_ms is not None or max_latency_ms is not None:
+            self._guard.require(GET_TRACES_FILTERS)
         all_traces: list[v1.TraceData] = []
         cursor: Optional[str] = None
         page_size = min(100, limit)
 
-        base_params: dict[str, Union[int, str, bool, Sequence[str]]] = {}
-        if start_time:
-            base_params["start_time"] = start_time.isoformat()
-        if end_time:
-            base_params["end_time"] = end_time.isoformat()
-        if sort:
-            base_params["sort"] = sort
-        if order:
-            base_params["order"] = order
-        if include_spans:
-            base_params["include_spans"] = True
-        if session_id:
-            base_params["session_identifier"] = (
-                [session_id] if isinstance(session_id, str) else list(session_id)
-            )
+        base_params = _build_trace_query_params(
+            start_time=start_time,
+            end_time=end_time,
+            sort=sort,
+            order=order,
+            include_spans=include_spans,
+            session_id=session_id,
+            error=error,
+            min_latency_ms=min_latency_ms,
+            max_latency_ms=max_latency_ms,
+        )
 
         while len(all_traces) < limit:
             remaining = limit - len(all_traces)
@@ -742,6 +824,9 @@ class AsyncTraces:
         order: Optional[Literal["asc", "desc"]] = None,
         include_spans: bool = False,
         session_id: Optional[Union[str, Sequence[str]]] = None,
+        error: Optional[bool] = None,
+        min_latency_ms: Optional[float] = None,
+        max_latency_ms: Optional[float] = None,
         limit: int = 100,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.TraceData]:
@@ -761,6 +846,14 @@ class AsyncTraces:
                 If you experience performance issues, consider fetching spans separately.
             session_id (Optional[Union[str, Sequence[str]]]): Filter by one or more
                 session IDs or GlobalIDs. Can be a single string or a sequence of strings.
+            error (Optional[bool]): If True, only return traces containing at least one
+                errored span. If False, only return traces with no errored spans. If
+                None (default), traces are not filtered by error status.
+                Requires Phoenix server >= 20.8.0.
+            min_latency_ms (Optional[float]): Inclusive lower bound on trace latency in
+                milliseconds. Requires Phoenix server >= 20.8.0.
+            max_latency_ms (Optional[float]): Inclusive upper bound on trace latency in
+                milliseconds. Requires Phoenix server >= 20.8.0.
             limit (int): Maximum number of traces to return. Defaults to 100.
             timeout (Optional[int]): Request timeout in seconds.
 
@@ -769,6 +862,8 @@ class AsyncTraces:
 
         Raises:
             httpx.HTTPStatusError: If the API returns an error response.
+            ValueError: If ``min_latency_ms`` or ``max_latency_ms`` is negative, or if
+                ``min_latency_ms`` exceeds ``max_latency_ms``.
 
         Example::
 
@@ -779,27 +874,33 @@ class AsyncTraces:
                 project_identifier="my-project",
                 limit=50,
             )
+
+            # Only slow traces that errored
+            slow_failures = await client.traces.get_traces(
+                project_identifier="my-project",
+                error=True,
+                min_latency_ms=1000,
+            )
         """
+        _validate_latency_bounds(min_latency_ms, max_latency_ms)
         await self._guard.require(LIST_PROJECT_TRACES)
+        if error is not None or min_latency_ms is not None or max_latency_ms is not None:
+            await self._guard.require(GET_TRACES_FILTERS)
         all_traces: list[v1.TraceData] = []
         cursor: Optional[str] = None
         page_size = min(100, limit)
 
-        base_params: dict[str, Union[int, str, bool, Sequence[str]]] = {}
-        if start_time:
-            base_params["start_time"] = start_time.isoformat()
-        if end_time:
-            base_params["end_time"] = end_time.isoformat()
-        if sort:
-            base_params["sort"] = sort
-        if order:
-            base_params["order"] = order
-        if include_spans:
-            base_params["include_spans"] = True
-        if session_id:
-            base_params["session_identifier"] = (
-                [session_id] if isinstance(session_id, str) else list(session_id)
-            )
+        base_params = _build_trace_query_params(
+            start_time=start_time,
+            end_time=end_time,
+            sort=sort,
+            order=order,
+            include_spans=include_spans,
+            session_id=session_id,
+            error=error,
+            min_latency_ms=min_latency_ms,
+            max_latency_ms=max_latency_ms,
+        )
 
         while len(all_traces) < limit:
             remaining = limit - len(all_traces)

--- a/packages/phoenix-client/tests/client/resources/traces/test_traces.py
+++ b/packages/phoenix-client/tests/client/resources/traces/test_traces.py
@@ -112,6 +112,96 @@ class TestGetTraces:
         )
         assert len(traces) == 1
 
+    def test_error_true_param(self) -> None:
+        transport = _make_handler(expected_params={"error": ["true"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        traces = Traces(client).get_traces(
+            project_identifier="my-project",
+            error=True,
+        )
+        assert len(traces) == 1
+
+    def test_error_false_is_sent(self) -> None:
+        # `error=False` selects traces with no errored spans, so it must reach the
+        # server rather than being dropped as a falsy value.
+        transport = _make_handler(expected_params={"error": ["false"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        traces = Traces(client).get_traces(
+            project_identifier="my-project",
+            error=False,
+        )
+        assert len(traces) == 1
+
+    def test_error_omitted_by_default(self) -> None:
+        received: dict[str, list[str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            received.update(parse_qs(urlparse(str(request.url)).query))
+            return httpx.Response(200, json={"data": [_make_trace()], "next_cursor": None})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        Traces(client).get_traces(project_identifier="my-project")
+        assert "error" not in received
+        assert "min_latency_ms" not in received
+        assert "max_latency_ms" not in received
+
+    def test_latency_params(self) -> None:
+        transport = _make_handler(
+            expected_params={"min_latency_ms": ["100.0"], "max_latency_ms": ["5000.0"]}
+        )
+        client = httpx.Client(transport=transport, base_url="http://test")
+        traces = Traces(client).get_traces(
+            project_identifier="my-project",
+            min_latency_ms=100.0,
+            max_latency_ms=5000.0,
+        )
+        assert len(traces) == 1
+
+    def test_zero_min_latency_is_sent(self) -> None:
+        transport = _make_handler(expected_params={"min_latency_ms": ["0.0"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        traces = Traces(client).get_traces(
+            project_identifier="my-project",
+            min_latency_ms=0.0,
+        )
+        assert len(traces) == 1
+
+    @pytest.mark.parametrize(
+        "min_latency_ms,max_latency_ms",
+        [
+            pytest.param(-1.0, None, id="negative-min"),
+            pytest.param(None, -1.0, id="negative-max"),
+            pytest.param(500.0, 100.0, id="min-exceeds-max"),
+        ],
+    )
+    def test_invalid_latency_bounds_rejected(
+        self,
+        min_latency_ms: float | None,
+        max_latency_ms: float | None,
+    ) -> None:
+        transport = _make_handler()
+        client = httpx.Client(transport=transport, base_url="http://test")
+        with pytest.raises(ValueError):
+            Traces(client).get_traces(
+                project_identifier="my-project",
+                min_latency_ms=min_latency_ms,
+                max_latency_ms=max_latency_ms,
+            )
+
+    def test_filters_persist_across_pages(self) -> None:
+        transport = _make_handler(
+            expected_params={"error": ["true"], "min_latency_ms": ["100.0"]},
+            pages=3,
+        )
+        client = httpx.Client(transport=transport, base_url="http://test")
+        traces = Traces(client).get_traces(
+            project_identifier="my-project",
+            error=True,
+            min_latency_ms=100.0,
+            limit=300,
+        )
+        assert len(traces) == 3
+
     def test_pagination(self) -> None:
         transport = _make_handler(pages=3)
         client = httpx.Client(transport=transport, base_url="http://test")
@@ -149,3 +239,32 @@ class TestAsyncGetTraces:
             limit=300,
         )
         assert len(traces) == 3
+
+    @pytest.mark.anyio
+    async def test_error_and_latency_params(self) -> None:
+        transport = _make_handler(
+            expected_params={
+                "error": ["false"],
+                "min_latency_ms": ["100.0"],
+                "max_latency_ms": ["5000.0"],
+            }
+        )
+        client = httpx.AsyncClient(transport=transport, base_url="http://test")
+        traces = await AsyncTraces(client).get_traces(
+            project_identifier="my-project",
+            error=False,
+            min_latency_ms=100.0,
+            max_latency_ms=5000.0,
+        )
+        assert len(traces) == 1
+
+    @pytest.mark.anyio
+    async def test_invalid_latency_bounds_rejected(self) -> None:
+        transport = _make_handler()
+        client = httpx.AsyncClient(transport=transport, base_url="http://test")
+        with pytest.raises(ValueError):
+            await AsyncTraces(client).get_traces(
+                project_identifier="my-project",
+                min_latency_ms=500.0,
+                max_latency_ms=100.0,
+            )


### PR DESCRIPTION
Advances #12008 and #12011 (both were blocked by #14026, now shipped).

## Problem

#14037 added `error`, `min_latency_ms`, and `max_latency_ms` to `GET /v1/projects/{project_identifier}/traces`, and regenerated the OpenAPI types. But the hand-written client wrappers were not updated, so the new filters were unreachable from either SDK — callers had to page through unfiltered traces and filter locally, which is exactly the over-fetching #14026 set out to remove.

## Change

Expose the three parameters on `Traces.get_traces` / `AsyncTraces.get_traces` (Python) and `getTraces` (TypeScript), following the parameter-gating pattern already established for the `get_spans` filters.

```python
from phoenix.client import Client

client = Client()

# Slow traces that contain at least one errored span
slow_failures = client.traces.get_traces(
    project_identifier="my-project",
    error=True,
    min_latency_ms=1000,
)

# Traces with no errored spans, under 500ms
clean_and_fast = client.traces.get_traces(
    project_identifier="my-project",
    error=False,
    max_latency_ms=500,
)
```

```ts
import { getTraces } from "@arizeai/phoenix-client/traces";

const slowFailures = await getTraces({
  project: { projectName: "my-project" },
  error: true,
  minLatencyMs: 1000,
});
```

### Three things worth a reviewer's attention

- **`error: false` is a filter, not an absence of one.** It selects traces with no errored spans, so it is sent whenever set rather than gated on truthiness the way `include_spans` is. A zero latency bound is handled the same way. Both are covered by regression tests in each client.
- **Version gating.** A new `GET_TRACES_FILTERS` capability requirement (>= 20.8.0) is checked only when one of the filters is passed. Without it an older server ignores the unknown query params and returns *unfiltered* traces, which is a worse failure than an explicit error. Version chosen per the existing convention (`version.py` is at 20.7.0, so the next minor).
- **Client-side bound validation.** Negative bounds would 422 at the server, and an inverted range (`min > max`) would silently return an empty page. Both are rejected up front with a message naming the offending value.

The Python query-param building, previously duplicated between the sync and async `get_traces`, is factored into one helper. `getTraces` gets the equivalent extraction — my additions pushed it past the oxlint complexity-20 limit, so the param building moved into a `buildQuery` helper.

## Deliberately out of scope

The CLI half of #12008 / #12011 (`px trace list --error`, `--min-latency`) is not included. `traceListHandler` fetches through a separate `getLastNTraces` helper rather than `getTraces`, so wiring it up is a larger change with its own design questions. Happy to follow up if that shape is wanted.

## Testing

| Check | Result |
| --- | --- |
| `packages/phoenix-client` traces tests | 21 passed (11 new) |
| Full Python client suite | no new failures vs. baseline on the same environment |
| ruff check / format, mypy, pyright (strict) | clean |
| Full TS client suite | 545 passed (6 new) |
| oxlint / oxfmt / `tsc --noEmit` | clean |

Docs: README parameter table, the Mintlify `traces.mdx` page, docstrings on both Python methods, and a changeset for `@arizeai/phoenix-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
