### PR TITLE
deprecate(evals): mark DocumentRelevanceEvaluator deprecated in favor of RetrievalRelevanceEvaluator

### DIFF
--- a/docs/phoenix/evaluation/pre-built-metrics/retrieval-relevance.mdx
+++ b/docs/phoenix/evaluation/pre-built-metrics/retrieval-relevance.mdx
@@ -7,6 +7,17 @@ description: "Evaluate whether externally retrieved information is relevant to t
 
 The **Retrieval Relevance** evaluator determines whether the external information retrieved during a step is relevant to the request it was meant to serve. It is **source-agnostic**: the retrieved information may come from a vector-database / semantic search, a tool or function call, an MCP server, a web search, or a database query. It scores the retrieved information as a whole — holistically, per retrieval step — against the request.
 
+<Warning>
+`DocumentRelevanceEvaluator` (Python) and `createDocumentRelevanceEvaluator` (TypeScript) are deprecated in favor of this evaluator, which covers single-document evaluation as well as holistic, source-agnostic retrieval evaluation. To migrate:
+
+| Old (Document Relevance) | New (Retrieval Relevance) |
+|---------------------------|----------------------------|
+| `document_text` / `documentText` input field | `context` input field |
+| `unrelated` label | `irrelevant` label |
+
+The deprecated evaluators will be removed in a future major version.
+</Warning>
+
 ### When to Use
 
 Use the Retrieval Relevance evaluator when you need to:

--- a/js/.changeset/deprecate-document-relevance-evaluator.md
+++ b/js/.changeset/deprecate-document-relevance-evaluator.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-evals": patch
+---
+
+Deprecate `createDocumentRelevanceEvaluator` in favor of `createRetrievalRelevanceEvaluator`, which covers single-document evaluation as well as holistic, source-agnostic retrieval evaluation. To migrate, rename the `documentText` input field to `context` and update any code that checks for the `unrelated` label to check for `irrelevant` instead. `createDocumentRelevanceEvaluator` will be removed in a future major version.

--- a/js/packages/phoenix-evals/src/llm/createDocumentRelevanceEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/createDocumentRelevanceEvaluator.ts
@@ -18,6 +18,9 @@ export interface DocumentRelevanceEvaluatorArgs<
 
 /**
  * A record to be evaluated by the document relevance evaluator.
+ *
+ * @deprecated Use {@link RetrievalRelevanceEvaluationRecord} instead: rename
+ * `documentText` to `context`. See {@link createDocumentRelevanceEvaluator}.
  */
 export interface DocumentRelevanceEvaluationRecord {
   input: string;
@@ -50,6 +53,12 @@ export interface DocumentRelevanceEvaluationRecord {
  * });
  * console.log(result.label); // "relevant" or "unrelated"
  * ```
+ *
+ * @deprecated Use {@link createRetrievalRelevanceEvaluator} instead, which covers
+ * single-document evaluation as well as holistic, source-agnostic retrieval
+ * evaluation. To migrate: rename the `documentText` input field to `context`, and
+ * update any code that checks for the `unrelated` label to check for `irrelevant`
+ * instead. This function will be removed in a future major version.
  */
 export function createDocumentRelevanceEvaluator<
   RecordType extends Record<string, unknown> =

--- a/packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -14,6 +15,15 @@ class DocumentRelevanceEvaluator(ClassificationEvaluator):
     """
     A specialized evaluator for determining document relevance to a given
     question.
+
+    .. deprecated::
+        ``DocumentRelevanceEvaluator`` is deprecated in favor of
+        :class:`~phoenix.evals.metrics.retrieval_relevance.RetrievalRelevanceEvaluator`,
+        which covers single-document evaluation as well as holistic,
+        source-agnostic retrieval evaluation. To migrate, rename the
+        ``document_text`` input field to ``context`` and update any code that
+        checks for the ``unrelated`` label to check for ``irrelevant``
+        instead. This class will be removed in a future major version.
 
     Args:
         llm (LLM): The LLM instance to use for the evaluation.
@@ -66,6 +76,15 @@ class DocumentRelevanceEvaluator(ClassificationEvaluator):
         llm: LLM,
         **kwargs: Any,
     ):
+        # TODO(v4): remove this class in favor of RetrievalRelevanceEvaluator.
+        warnings.warn(
+            "DocumentRelevanceEvaluator is deprecated and will be removed in a future "
+            "major version; use RetrievalRelevanceEvaluator instead. Rename the "
+            "'document_text' input field to 'context', and update any code that checks "
+            "for the 'unrelated' label to check for 'irrelevant' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             name=self.NAME,
             llm=llm,


### PR DESCRIPTION
## What
`DocumentRelevanceEvaluator` (Python) and `createDocumentRelevanceEvaluator`
(TypeScript) overlap with `RetrievalRelevanceEvaluator`, which covers
single-document evaluation as well as holistic, source-agnostic retrieval
evaluation — but the older document-focused evaluators remained publicly
exported without formal deprecation status.

## Changes
- **Python**: instantiating `DocumentRelevanceEvaluator` now emits a
  `DeprecationWarning` naming the replacement and the exact migration
  (`document_text` → `context`, `unrelated` → `irrelevant`). Importing the
  module/package is unaffected — only instantiation warns, so this doesn't
  spam anyone who merely has the package installed.
- **TypeScript**: `createDocumentRelevanceEvaluator` and
  `DocumentRelevanceEvaluationRecord` are marked `@deprecated` via JSDoc,
  matching this codebase's existing deprecation convention (no runtime
  warning — see `asEvaluator` in `runExperiment.ts`). Added a changeset for
  the release notes.
- **Docs**: added a migration callout with an old → new field/label mapping
  table to the Retrieval Relevance page.

Both are marked for removal in a future major version (v4 for
`arize-phoenix-evals`, v3 for `@arizeai/phoenix-evals`).

fixes #15873

## Testing
- Ran the full Python metrics test suite (81 tests) — all pass; manually
  confirmed the warning fires on instantiation but not on `import
  phoenix.evals`
- Ran the full TypeScript test suite for `phoenix-evals` (210 tests) — all
  pass, plus `tsc --noEmit` and `oxlint` clean
- `ruff check` / `ruff format --check` clean on the Python side