### PR TITLE
fix(cost): add support for gpt-6-astra

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1951,6 +1951,7 @@ class OpenAIChatCompletionsClient(OpenAICompatibleClient):
 
 
 OPENAI_REASONING_MODELS = [
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -4516,6 +4516,57 @@
       ]
     },
     {
+      "name": "gpt-6-astra",
+      "name_pattern": "gpt-6-astra",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 0.00001,
+          "is_prompt": true,
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00002
+          }
+        },
+        {
+          "base_rate": 0.00005,
+          "is_prompt": false,
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000075
+          }
+        },
+        {
+          "base_rate": 1e-6,
+          "is_prompt": true,
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-6
+          }
+        },
+        {
+          "base_rate": 0.0000125,
+          "is_prompt": true,
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000025
+          }
+        }
+      ]
+    },
+    {
       "name": "gpt-audio",
       "name_pattern": "gpt-audio",
       "source": "litellm",


### PR DESCRIPTION
resolves #15905

Adds support for OpenAI's `gpt-6-astra` across the three surfaces requested in the issue: cost, enum, and playground.

## Changes

- **Enum + playground** (`playground_clients.py`): register `gpt-6-astra` in `OPENAI_REASONING_MODELS`.
- **Cost** (`model_cost_manifest.json`): add the `gpt-6-astra` cost entry. Pulled from LiteLLM via `.github/.scripts/sync_models.py` (source: `litellm`), including the 272k-token threshold tier on input / output / cache_read / cache_write. Only this one entry is added — unrelated catalog drift from the sync was reverted to keep the diff scoped.

## Testing

- Confirmed `gpt-6-astra` appears and is selectable in the playground model picker.
- Invoking the model live in the playground currently returns OpenAI's `The model 'gpt-6-astra' does not exist or you do not have access to it`. This is an upstream OpenAI availability/access response. Might be because of mi API KEY (?).

<img width="1608" height="633" alt="astra not available" src="https://github.com/user-attachments/assets/17d1c2d5-ceb0-4a77-bafe-71ba9475e8a9" />

