### PR TITLE
docs(phoenix-client): create_dataset docstring documented dataset_name, param is name

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -806,7 +806,7 @@ class Datasets:
         Create a new dataset by uploading examples to the Phoenix server.
 
         Args:
-            dataset_name: Name of the dataset.
+            name: Name of the dataset.
             examples: Either a single dictionary with required 'input' and 'output' keys
                 and an optional 'metadata' key, or an iterable of such dictionaries.
                 When provided, inputs/outputs/metadata are extracted automatically.
@@ -1732,7 +1732,7 @@ class AsyncDatasets:
         Create a new dataset by uploading examples to the Phoenix server.
 
         Args:
-            dataset_name: Name of the dataset.
+            name: Name of the dataset.
             examples: Either a single dictionary with required 'input' and 'output' keys
                 and an optional 'metadata' key, or an iterable of such dictionaries.
                 to add. When provided, inputs/outputs/metadata are extracted automatically.


### PR DESCRIPTION
## Docstring-only fix in `phoenix-client`

Both the sync `Datasets.create_dataset` and async `AsyncDatasets.create_dataset` take the keyword-only parameter `name` (forwarded to the payload key `dataset_name`), but both docstrings documented a `dataset_name:` parameter — a kwarg that actually raises `TypeError`. These docstrings feed the published Sphinx API reference (`docs/source/api/datasets.rst` uses autodoc).
