### PR TITLE
fix(traces): normalize legacy GenAI media fields before validation

### DIFF
--- a/src/phoenix/trace/gen_ai/README.md
+++ b/src/phoenix/trace/gen_ai/README.md
@@ -1,0 +1,74 @@
+# OTel GenAI conversion compatibility
+
+`conversion.py` synthesizes OpenInference attributes from `gen_ai.*` attributes.
+The models in `__generated__/models.py` target semantic conventions v1.41.1;
+regenerate them with `make gen-otel-models`. Keep producer compatibility in the
+conversion layer so regeneration does not erase it.
+
+## Message processing path
+
+1. Decode the JSON attribute once in `_normalize_and_validate_message_list`.
+2. Normalize known legacy part fields in the decoded dictionaries.
+3. Validate against the generated canonical model with `model_validate`.
+4. Flatten typed parts into OpenInference message attributes.
+
+Input and output messages have nested `parts` lists. System instructions are a
+flat part list, projected into a synthetic system message before the input turns.
+Normalization applies only to these three attributes. Retrieval documents retain
+the direct JSON validation path; tool definitions have their own compatibility
+step for a missing `type`.
+
+## Patterns addressed
+
+Older producer shapes (including the google-genai-style payload covered by the
+regression tests) use blob `data` instead of `content` and omit `modality`.
+Without normalization, these parts can fall through the model union to
+`GenericPart`, which the flattener omits, causing attachments to disappear.
+Compatibility is selected by field shape, without guessing a producer version.
+
+For example, this legacy part:
+
+```json
+{"type": "blob", "mime_type": "image/png", "data": "SGVsbG8="}
+```
+
+is normalized to:
+
+```json
+{"type": "blob", "mime_type": "image/png", "content": "SGVsbG8=", "modality": "image"}
+```
+
+The resulting OpenInference image URL is `data:image/png;base64,SGVsbG8=`.
+The base64 payload is preserved, not decoded and re-encoded.
+
+| Pattern | Compatibility rule |
+| --- | --- |
+| Blob has `data` but no `content` | Move `data` to `content`. |
+| Blob has both fields | Existing `content` wins, even if invalid. |
+| Blob, URI, or file lacks `modality` | If `mime_type` is a string containing `/`, use the portion before `/`. |
+| Explicit `modality` | Preserve it, even if invalid or inconsistent with MIME type. |
+| Missing/unusable MIME type | Do not invent a modality; let validation decide. |
+| Other part types | Leave unchanged. |
+
+The generated modality type accepts arbitrary strings, so `application/pdf`
+produces `application`, just as `image/png` produces `image`. This is field
+compatibility, not MIME validation or a claim of renderer support.
+
+## Failure behavior and limits
+
+Invalid JSON, non-list roots, non-serialized attributes, or a model validation
+error yield no messages for that attribute. A structurally invalid message can
+reject the entire list. A part accepted as `GenericPart` is instead omitted by
+the flattener while supported sibling parts survive. Normalization only changes
+freshly decoded data; it does not mutate the source attributes.
+
+URI and blob parts use OpenInference's image content surface, including non-image
+MIME types; successful conversion does not guarantee that the UI can display that
+media. File parts can be normalized and validated, but remain omitted because the
+flattener has no mapping from provider file IDs to OpenInference content. Unknown
+parts remain omitted. This does not add support for arbitrary future schema drift.
+
+When extending compatibility, add a narrow shape rule before validation and
+regression coverage in `tests/unit/trace/gen_ai/test_conversion.py`. Cover input,
+output, and system shapes, canonical-field precedence, and malformed payloads;
+keep `_flatten_message` concerned with validated models.

--- a/src/phoenix/trace/gen_ai/conversion.py
+++ b/src/phoenix/trace/gen_ai/conversion.py
@@ -607,6 +607,52 @@ def _definition_to_oi_schema(
 
 _R = TypeVar("_R")
 
+# Early-draft message parts (notably from opentelemetry-instrumentation-google-genai)
+# predate the v1.41.1 field set: blob parts carry ``data`` instead of ``content``
+# and omit ``modality``, which did not exist in that draft. ``modality`` defaults
+# from the MIME main type ("image/png" -> "image"); anything the draft did not
+# cover is left untouched for validation to judge as before.
+_MIME_PREFIX_TO_MODALITY = {"image": "image", "audio": "audio", "video": "video"}
+
+
+def _normalize_v130_message_parts(value: Any) -> Any:
+    """Fold early-draft part shapes into the v1.41.1 schema before validation.
+
+    Drifted parts fail BlobPart/UriPart/FilePart validation (``modality`` became
+    required and the blob payload was renamed), fall through the pydantic union
+    to GenericPart, and are silently dropped by ``_flatten_message`` — images
+    vanish from ``llm.input_messages``. Mirrors the forgiveness step in
+    ``_validate_tool_definitions``. Never raises: on any surprise the original
+    value flows to validation unchanged, preserving the current failure mode.
+    """
+    if not isinstance(value, (str, bytes, bytearray)):
+        return value
+    try:
+        payload = json.loads(value)
+    except (TypeError, ValueError):
+        return value
+    if not isinstance(payload, list):
+        return value
+
+    changed = False
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        parts = item.get("parts") if isinstance(item.get("parts"), list) else [item]
+        for part in parts:
+            if not isinstance(part, dict) or part.get("type") not in ("blob", "uri", "file"):
+                continue
+            if part.get("type") == "blob" and "content" not in part and "data" in part:
+                part["content"] = part.pop("data")
+                changed = True
+            if "modality" not in part:
+                mime_type = part.get("mime_type")
+                if isinstance(mime_type, str) and "/" in mime_type:
+                    main_type = mime_type.partition("/")[0]
+                    part["modality"] = _MIME_PREFIX_TO_MODALITY.get(main_type, main_type)
+                    changed = True
+    return json.dumps(payload) if changed else value
+
 
 def _validate_root_list(
     value: Any,
@@ -617,6 +663,7 @@ def _validate_root_list(
     A single malformed item drops the whole payload (MVP tradeoff for using the
     fast ``model_validate_json`` path). The OTel-emitted attribute is always a JSON
     string; non-string values yield an empty list."""
+    value = _normalize_v130_message_parts(value)
     if not isinstance(value, (str, bytes, bytearray)):
         return []
     try:

--- a/src/phoenix/trace/gen_ai/conversion.py
+++ b/src/phoenix/trace/gen_ai/conversion.py
@@ -1,4 +1,4 @@
-"""Convert OTel GenAI semantic-convention attributes back to OpenInference attributes."""
+"""Convert OTel GenAI attributes to OpenInference. See README.md for compatibility rules."""
 
 import json
 from collections.abc import Mapping, Sequence
@@ -158,8 +158,8 @@ def get_openinference_message_attributes(
     # synthetic system-role message at input_messages.0, shifting the actual
     # user/assistant turns down by one.
     next_input_index = 0
-    sys_parts = _validate_root_list(
-        attributes.get(gen_ai.GEN_AI_SYSTEM_INSTRUCTIONS), SystemInstructions
+    sys_parts = _normalize_and_validate_message_list(
+        attributes.get(gen_ai.GEN_AI_SYSTEM_INSTRUCTIONS), model_cls=SystemInstructions
     )
     if sys_parts:
         sys_msg = ChatMessage.model_construct(role=Role.system, parts=list(sys_parts))
@@ -168,14 +168,18 @@ def get_openinference_message_attributes(
         )
         next_input_index += 1
 
-    for in_msg in _validate_root_list(attributes.get(gen_ai.GEN_AI_INPUT_MESSAGES), InputMessages):
+    for in_msg in _normalize_and_validate_message_list(
+        attributes.get(gen_ai.GEN_AI_INPUT_MESSAGES), model_cls=InputMessages
+    ):
         oi_attributes.update(
             _flatten_message(in_msg, SpanAttributes.LLM_INPUT_MESSAGES, next_input_index)
         )
         next_input_index += 1
 
     for index, out_msg in enumerate(
-        _validate_root_list(attributes.get(gen_ai.GEN_AI_OUTPUT_MESSAGES), OutputMessages)
+        _normalize_and_validate_message_list(
+            attributes.get(gen_ai.GEN_AI_OUTPUT_MESSAGES), model_cls=OutputMessages
+        )
     ):
         oi_attributes.update(_flatten_message(out_msg, SpanAttributes.LLM_OUTPUT_MESSAGES, index))
 
@@ -443,21 +447,6 @@ def _build_invocation_parameters(
     return parameters
 
 
-# TODO: handle OTel GenAI semconv drift between producers.
-# Our generated models target semconv v1.41.1 (BlobPart has ``content: bytes`` and a
-# required ``modality`` field; UriPart/FilePart similarly renamed). Some producers
-# emit older drafts — notably opentelemetry-instrumentation-google-genai uses the
-# v1.30-era shape: ``data`` instead of ``content``, no ``modality``. Pydantic union
-# validation falls through to GenericPart for those parts, and ``_flatten_message``
-# below drops them silently (e.g. images vanish from llm.input_messages).
-# Three options when we get to this:
-#   1. Loosen the generated models (accept ``data``/``content`` aliases, optional
-#      ``modality``). Most permissive but modifies generated code.
-#   2. Pre-normalize part dicts in ``_validate_root_list`` (rename ``data`` ->
-#      ``content``, default ``modality`` from ``mime_type``). Contained.
-#   3. Sniff GenericPart for known ``type`` values (``blob``/``uri``/``file``) in
-#      ``_flatten_message`` and pull image fields from ``model_extra``. Most
-#      defensive — covers future drift too.
 def _flatten_message(
     message: ChatMessage | OutputMessage,
     prefix: str,
@@ -607,52 +596,54 @@ def _definition_to_oi_schema(
 
 _R = TypeVar("_R")
 
-# Early-draft message parts (notably from opentelemetry-instrumentation-google-genai)
-# predate the v1.41.1 field set: blob parts carry ``data`` instead of ``content``
-# and omit ``modality``, which did not exist in that draft. ``modality`` defaults
-# from the MIME main type ("image/png" -> "image"); anything the draft did not
-# cover is left untouched for validation to judge as before.
-_MIME_PREFIX_TO_MODALITY = {"image": "image", "audio": "audio", "video": "video"}
 
+def _normalize_and_validate_message_list(
+    value: Any,
+    model_cls: type[RootModel[list[_R]]],
+) -> list[_R]:
+    """Decode, normalize known legacy parts, then validate the canonical schema.
 
-def _normalize_v130_message_parts(value: Any) -> Any:
-    """Fold early-draft part shapes into the v1.41.1 schema before validation.
-
-    Drifted parts fail BlobPart/UriPart/FilePart validation (``modality`` became
-    required and the blob payload was renamed), fall through the pydantic union
-    to GenericPart, and are silently dropped by ``_flatten_message`` — images
-    vanish from ``llm.input_messages``. Mirrors the forgiveness step in
-    ``_validate_tool_definitions``. Never raises: on any surprise the original
-    value flows to validation unchanged, preserving the current failure mode.
+    Input/output messages contain nested ``parts``; system instructions are a
+    flat part list. Only these message attributes use this compatibility path.
+    See README.md for examples, precedence, and unsupported shapes.
     """
     if not isinstance(value, (str, bytes, bytearray)):
-        return value
+        return []
     try:
         payload = json.loads(value)
     except (TypeError, ValueError):
-        return value
+        return []
     if not isinstance(payload, list):
-        return value
+        return []
 
-    changed = False
-    for item in payload:
-        if not isinstance(item, dict):
+    if model_cls is SystemInstructions:
+        _normalize_legacy_media_part_fields(payload)
+    else:
+        for message in payload:
+            if isinstance(message, dict) and isinstance(parts := message.get("parts"), list):
+                _normalize_legacy_media_part_fields(parts)
+    try:
+        return model_cls.model_validate(payload).root
+    except ValidationError:
+        return []
+
+
+def _normalize_legacy_media_part_fields(parts: list[Any]) -> None:
+    """Normalize freshly decoded part dicts in place; never overwrite canonical fields.
+
+    Older producers use blob ``data`` and omit media ``modality``. Without this
+    step, those parts can validate as GenericPart and disappear during flattening.
+    Match the shape, not a producer/version identifier; leave unknown parts alone.
+    """
+    for part in parts:
+        if not isinstance(part, dict) or part.get("type") not in ("blob", "uri", "file"):
             continue
-        raw_parts = item.get("parts")
-        parts = raw_parts if isinstance(raw_parts, list) else [item]
-        for part in parts:
-            if not isinstance(part, dict) or part.get("type") not in ("blob", "uri", "file"):
-                continue
-            if part.get("type") == "blob" and "content" not in part and "data" in part:
-                part["content"] = part.pop("data")
-                changed = True
-            if "modality" not in part:
-                mime_type = part.get("mime_type")
-                if isinstance(mime_type, str) and "/" in mime_type:
-                    main_type = mime_type.partition("/")[0]
-                    part["modality"] = _MIME_PREFIX_TO_MODALITY.get(main_type, main_type)
-                    changed = True
-    return json.dumps(payload) if changed else value
+        if part.get("type") == "blob" and "content" not in part and "data" in part:
+            part["content"] = part.pop("data")
+        if "modality" not in part:
+            mime_type = part.get("mime_type")
+            if isinstance(mime_type, str) and "/" in mime_type:
+                part["modality"] = mime_type.partition("/")[0]
 
 
 def _validate_root_list(
@@ -664,7 +655,6 @@ def _validate_root_list(
     A single malformed item drops the whole payload (MVP tradeoff for using the
     fast ``model_validate_json`` path). The OTel-emitted attribute is always a JSON
     string; non-string values yield an empty list."""
-    value = _normalize_v130_message_parts(value)
     if not isinstance(value, (str, bytes, bytearray)):
         return []
     try:

--- a/src/phoenix/trace/gen_ai/conversion.py
+++ b/src/phoenix/trace/gen_ai/conversion.py
@@ -638,7 +638,8 @@ def _normalize_v130_message_parts(value: Any) -> Any:
     for item in payload:
         if not isinstance(item, dict):
             continue
-        parts = item.get("parts") if isinstance(item.get("parts"), list) else [item]
+        raw_parts = item.get("parts")
+        parts = raw_parts if isinstance(raw_parts, list) else [item]
         for part in parts:
             if not isinstance(part, dict) or part.get("type") not in ("blob", "uri", "file"):
                 continue

--- a/tests/unit/trace/gen_ai/test_conversion.py
+++ b/tests/unit/trace/gen_ai/test_conversion.py
@@ -1072,3 +1072,92 @@ def test_embedding_attributes_empty_for_non_embedding_span() -> None:
         )
         == {}
     )
+
+
+# ---------------------------------------------------------------------------
+# early-draft (pre-v1.41) part shapes from drifted producers
+# ---------------------------------------------------------------------------
+
+
+def test_v130_blob_part_with_data_field_becomes_data_url() -> None:
+    """google-genai-style producers emit ``data`` and no ``modality``; the fold
+    must land them on the v1.41.1 schema instead of dropping them silently."""
+    out = get_openinference_message_attributes(
+        _input_messages(
+            [
+                {
+                    "role": "user",
+                    "parts": [{"type": "blob", "mime_type": "image/png", "data": "SGVsbG8="}],
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_INPUT_MESSAGES}.0"
+    image = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
+    assert (
+        out[f"{base}.{MessageAttributes.MESSAGE_CONTENTS}.0.{image}.{ImageAttributes.IMAGE_URL}"]
+        == "data:image/png;base64,SGVsbG8="
+    )
+
+
+def test_blob_part_modality_defaults_from_mime_main_type() -> None:
+    """A non-AV blob (application/pdf) still renders: modality defaults to the
+    MIME main type, which the ``Modality | str`` schema accepts."""
+    out = get_openinference_message_attributes(
+        _input_messages(
+            [
+                {
+                    "role": "user",
+                    "parts": [{"type": "blob", "mime_type": "application/pdf", "data": "AAAA"}],
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_INPUT_MESSAGES}.0"
+    image = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
+    assert (
+        out[f"{base}.{MessageAttributes.MESSAGE_CONTENTS}.0.{image}.{ImageAttributes.IMAGE_URL}"]
+        == "data:application/pdf;base64,AAAA"
+    )
+
+
+def test_uri_part_without_modality_renders() -> None:
+    out = get_openinference_message_attributes(
+        _input_messages(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "uri",
+                            "mime_type": "image/jpeg",
+                            "uri": "https://example.com/cat.jpg",
+                        }
+                    ],
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_INPUT_MESSAGES}.0"
+    image = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
+    assert (
+        out[f"{base}.{MessageAttributes.MESSAGE_CONTENTS}.0.{image}.{ImageAttributes.IMAGE_URL}"]
+        == "https://example.com/cat.jpg"
+    )
+
+
+def test_v130_blob_part_in_system_instructions_survives() -> None:
+    """system_instructions is a flat part list; the fold must cover that shape too."""
+    attributes = {
+        gen_ai.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
+            [{"type": "blob", "mime_type": "image/png", "data": "SGVsbG8="}]
+        ),
+    }
+    out = get_openinference_message_attributes(attributes)
+    image = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
+    assert (
+        out[
+            f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENTS}.0.{image}.{ImageAttributes.IMAGE_URL}"
+        ]
+        == "data:image/png;base64,SGVsbG8="
+    )

--- a/tests/unit/trace/gen_ai/test_conversion.py
+++ b/tests/unit/trace/gen_ai/test_conversion.py
@@ -1075,11 +1075,11 @@ def test_embedding_attributes_empty_for_non_embedding_span() -> None:
 
 
 # ---------------------------------------------------------------------------
-# early-draft (pre-v1.41) part shapes from drifted producers
+# Legacy media fields: blob data aliases and missing modality
 # ---------------------------------------------------------------------------
 
 
-def test_v130_blob_part_with_data_field_becomes_data_url() -> None:
+def test_blob_data_without_modality_becomes_data_url() -> None:
     """google-genai-style producers emit ``data`` and no ``modality``; the fold
     must land them on the v1.41.1 schema instead of dropping them silently."""
     out = get_openinference_message_attributes(
@@ -1101,7 +1101,7 @@ def test_v130_blob_part_with_data_field_becomes_data_url() -> None:
 
 
 def test_blob_part_modality_defaults_from_mime_main_type() -> None:
-    """A non-AV blob (application/pdf) still renders: modality defaults to the
+    """A non-AV blob (application/pdf) still converts: modality defaults to the
     MIME main type, which the ``Modality | str`` schema accepts."""
     out = get_openinference_message_attributes(
         _input_messages(
@@ -1146,7 +1146,7 @@ def test_uri_part_without_modality_renders() -> None:
     )
 
 
-def test_v130_blob_part_in_system_instructions_survives() -> None:
+def test_system_instruction_blob_data_without_modality_becomes_data_url() -> None:
     """system_instructions is a flat part list; the fold must cover that shape too."""
     attributes = {
         gen_ai.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
@@ -1161,3 +1161,67 @@ def test_v130_blob_part_in_system_instructions_survives() -> None:
         ]
         == "data:image/png;base64,SGVsbG8="
     )
+
+
+@pytest.mark.parametrize(
+    "attribute",
+    [
+        gen_ai.GEN_AI_INPUT_MESSAGES,
+        gen_ai.GEN_AI_OUTPUT_MESSAGES,
+        gen_ai.GEN_AI_SYSTEM_INSTRUCTIONS,
+    ],
+)
+@pytest.mark.parametrize("part_type", ["blob", "uri", "file"])
+def test_legacy_media_matches_canonical_messages(attribute: str, part_type: str) -> None:
+    legacy: dict[str, Any] = {"type": part_type, "mime_type": "image/png"}
+    canonical = {**legacy, "modality": "image"}
+    if part_type == "blob":
+        legacy["data"] = "SGVsbG8="
+        canonical["content"] = "SGVsbG8="
+    elif part_type == "uri":
+        legacy["uri"] = canonical["uri"] = "https://example.com/image.png"
+    else:
+        legacy["file_id"] = canonical["file_id"] = "file-123"
+
+    def attributes(part: dict[str, Any]) -> dict[str, AttributeValue]:
+        parts = [{"type": "text", "content": "Keep this sibling"}, part]
+        payload = (
+            parts
+            if attribute == gen_ai.GEN_AI_SYSTEM_INSTRUCTIONS
+            else [{"role": "assistant", "finish_reason": "stop", "parts": parts}]
+        )
+        return {attribute: json.dumps(payload)}
+
+    source = attributes(legacy)
+    original = dict(source)
+    assert get_openinference_message_attributes(source) == get_openinference_message_attributes(
+        attributes(canonical)
+    )
+    assert source == original
+
+
+def test_legacy_blob_does_not_override_canonical_content() -> None:
+    canonical = {"type": "blob", "content": "AAAA", "modality": "image"}
+    assert get_openinference_message_attributes(
+        _input_messages([{"role": "user", "parts": [{**canonical, "data": "BBBB"}]}])
+    ) == get_openinference_message_attributes(
+        _input_messages([{"role": "user", "parts": [canonical]}])
+    )
+
+
+@pytest.mark.parametrize("modality", [None, 42])
+def test_invalid_explicit_modality_is_not_repaired(modality: Any) -> None:
+    parts = [
+        {"type": "text", "content": "survives"},
+        {"type": "blob", "data": "AAAA", "mime_type": "image/png", "modality": modality},
+    ]
+    assert get_openinference_message_attributes(
+        _input_messages([{"role": "user", "parts": parts}])
+    ) == get_openinference_message_attributes(
+        _input_messages([{"role": "user", "parts": parts[:1]}])
+    )
+
+
+@pytest.mark.parametrize("payload", ["{", "null", "{}", "[null]", '[{"parts": []}]'])
+def test_invalid_message_payload_yields_no_attributes(payload: str) -> None:
+    assert get_openinference_message_attributes({gen_ai.GEN_AI_INPUT_MESSAGES: payload}) == {}


### PR DESCRIPTION
Older GenAI producers can emit blob `data` instead of `content` and omit media `modality`. These parts can validate as `GenericPart` against Phoenix's generated v1.41.1 models and disappear during OpenInference conversion. This change normalizes those known field shapes before validation so blob and URI attachments survive.

## Processing path

Input messages, output messages, and system instructions use `_normalize_and_validate_message_list`: decode JSON once, normalize legacy media fields, validate the canonical model, then flatten typed parts into OpenInference attributes. `_normalize_legacy_media_part_fields` moves blob `data` to `content` when absent and infers missing `modality` from the MIME main type. Existing canonical fields take precedence, including invalid explicit values; compatibility is selected by shape, not a producer version.

Retrieval documents retain their direct JSON validation path. Generated models remain the schema authority. The conversion README documents examples, field precedence, malformed-payload behavior, and extension guidance; the obsolete TODO is removed.

## Limits

File parts can be normalized and validated but remain omitted because provider file IDs have no mapping in the flattener. Blob and URI media use the existing OpenInference image surface; conversion of non-image MIME types does not guarantee UI rendering. Unknown parts remain omitted, and structural validation errors can reject the whole message list.

## Validation

- Conversion unit suite: 113 passed, including input/output/system coverage, canonical-field precedence, malformed payloads, and source-attribute preservation.
- Ruff lint and formatting checks passed for the changed Python files.
- Mypy passed for `src/phoenix/trace/gen_ai/conversion.py`.
