### PR TITLE
fix(server): emit a default Content-Security-Policy with configurable img-src

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -374,6 +374,7 @@ Whether to mask internal server errors from the GraphQL and REST APIs. Defaults 
 
 # Authentication settings
 ENV_PHOENIX_ENABLE_AUTH = "PHOENIX_ENABLE_AUTH"
+ENV_PHOENIX_CSP_IMG_SRC_ALLOWLIST = "PHOENIX_CSP_IMG_SRC_ALLOWLIST"
 ENV_PHOENIX_DISABLE_BASIC_AUTH = "PHOENIX_DISABLE_BASIC_AUTH"
 """
 Forbid login via password and disable the creation of local users, which log in via passwords.
@@ -1226,6 +1227,13 @@ def get_env_enable_auth() -> bool:
     Gets the value of the PHOENIX_ENABLE_AUTH environment variable.
     """
     return _bool_val(ENV_PHOENIX_ENABLE_AUTH, False)
+
+
+def get_env_csp_img_src_allowlist() -> str:
+    """
+    Gets the img-src allowlist for the UI Content-Security-Policy.
+    """
+    return os.environ.get(ENV_PHOENIX_CSP_IMG_SRC_ALLOWLIST, "'self' data:")
 
 
 def get_env_disable_basic_auth() -> bool:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -65,6 +65,7 @@ from phoenix.config import (
     get_env_allow_external_resources,
     get_env_allowed_providers,
     get_env_allowed_sandbox_providers,
+    get_env_csp_img_src_allowlist,
     get_env_csrf_trusted_origins,
     get_env_database_allocated_storage_capacity_gibibytes,
     get_env_database_usage_insertion_blocking_threshold_percentage,
@@ -392,6 +393,21 @@ class HeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         response.headers["x-colab-notebook-cache-control"] = "no-cache"
         response.headers[PHOENIX_SERVER_VERSION_HEADER] = phoenix_version
+        img_src = get_env_csp_img_src_allowlist()
+        response.headers["Content-Security-Policy"] = "; ".join(
+            (
+                "default-src 'self'",
+                "script-src 'self' 'wasm-unsafe-eval' blob:",
+                "style-src 'self' 'unsafe-inline'",
+                f"img-src {img_src}",
+                "font-src 'self' data:",
+                "connect-src 'self'",
+                "worker-src 'self' blob:",
+                "object-src 'none'",
+                "base-uri 'self'",
+                "frame-ancestors 'self'",
+            )
+        )
         return response
 
 


### PR DESCRIPTION
## Why

Phoenix starts with authentication disabled by default: `get_env_enable_auth()` in `src/phoenix/config.py` returns `False` unless `PHOENIX_ENABLE_AUTH` is set, and `AuthenticationMiddleware` is only mounted inside the enabled+secret branch. On a zero-config `phoenix serve` (the documented quickstart; the repo's own `docker-compose.yml` sets no auth env vars), anything that can reach the port can write to `/v1/traces` with no credentials — the ingest route's only dependencies are `is_not_locked` / `is_not_at_capacity`.

Separately, a span can carry an image message whose URL the trace viewer renders as `<img src={url}>` (`MessageContentsList.tsx` → `SpanImage.tsx`, gated only by `isRedactedUrl`). Combine the two and you get an unauthenticated, render-side beacon chain:

1. An anonymous OTLP POST plants one span whose image URL points at an attacker-controlled origin (verified: HTTP 200 with zero credentials).
2. An analyst opens the poisoned trace in the Phoenix UI.
3. The analyst's browser silently GETs the attacker's URL — leaking the analyst's IP and User-Agent, confirming a live human viewer per trace, and usable to blind-probe internal hosts from the analyst's machine (`http://10.0.x.y/...` image URLs).

No Phoenix session cookies are attached to a cross-origin `img` fetch, so this is not credential theft; it is a tracking pixel and a browser-driven internal-recon primitive. Today the server sends no `Content-Security-Policy` at all — `HeadersMiddleware` sets only the Colab cache-control and version headers — so nothing in the browser stops the fetch.

I verified the full chain end-to-end with a cold-run PoC (fresh venv, editable install at the base commit, scrubbed environment, virgin sqlite home): anonymous `/v1/traces` POST returned 200, the beacon URL surfaced verbatim through the unauthenticated UI GraphQL API, and a local listener standing in for the attacker captured `GET /d3-beacon.png?c=analyst-view`.

## What

This PR adds a CSP as **defense-in-depth on the render side**. It does not change the auth default.

- `src/phoenix/config.py` — new env var `PHOENIX_CSP_IMG_SRC_ALLOWLIST` (`get_env_csp_img_src_allowlist()`, default `'self' data:`).
- `src/phoenix/server/app.py` — `HeadersMiddleware` now sets on every response:

  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src <allowlist>; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'`

With the default `img-src 'self' data:`, an ingested `http://attacker/...` image URL is refused by the analyst's browser. Operators who legitimately render remote images (e.g. hosted model output) widen `img-src` explicitly via the env var — the trade-off is deliberate and visible rather than silent.

Honest scope of what this CSP does **not** fix:

- Anonymous ingest itself remains open; this is the render-side half only.
- Plain `http(s)` links rendered as text/markdown still navigate on click — `img-src` does not constrain anchor navigation.
- `data:` URIs stay allowed by default (no outbound request, but content can still be carried into the view).
- Widening the allowlist to `http:` / `https:` / `*` reopens the beacon exactly.
- The unauthenticated UI GraphQL API still returns ingested URLs to any reader; non-browser consumers are outside CSP's reach.
- `form-action` is not pinned (it does not fall back to `default-src`).
- The non-`img-src` directives follow common SPA baselines (`'unsafe-inline'` styles, `blob:` workers/scripts); I could not drive the full UI under the new policy in this environment, so a quick local pass over the trace viewer by a maintainer would be worthwhile — and the env knob means `img-src` can be widened in an emergency without a code change.

## Verification

- PoC flip (same cold-run harness, fresh venv + fresh `PHOENIX_HOME`): pre-fix — anonymous ingest 200, beacon captured by the listener, exit 0; post-fix — the server emits the CSP header above and the PoC aborts at the header check before any beacon fires (`[FIXED] CSP present, img-src blocks beacon origin`, exit 1).
- `pytest src/phoenix/tests/test_config.py` — 4/4 passed with the fix applied.
- `ruff==0.15.3 check` and `ruff format --check` clean on both changed files (also clean under ruff 0.16.6; CI's lockfile pins 0.16.1).
- Scope note: the wider unit-test matrix (tox `unit_tests`, sqlite + postgresql legs) was not run locally — it needs the repo's full dev dependency group — so those legs are deferred to CI here.
