### PR TITLE
fix(server): accept fetch-compatible OTLP protobuf media types

### DIFF
--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -442,20 +442,26 @@ async def post_traces(
     content_encoding: Optional[str] = Header(default=None),
     x_project_name: Optional[str] = Header(default=None),
 ) -> Response:
-    if content_type != "application/x-protobuf":
+    # HTTP media types are case-insensitive and may include parameters. Some
+    # fetch implementations append a charset parameter to binary requests.
+    normalized_content_type = (
+        content_type.split(";", 1)[0].strip().lower() if content_type else None
+    )
+    if normalized_content_type != "application/x-protobuf":
         raise HTTPException(
             detail=f"Unsupported content type: {content_type}",
             status_code=415,
         )
-    if content_encoding and content_encoding not in ("gzip", "deflate"):
+    normalized_content_encoding = content_encoding.strip().lower() if content_encoding else None
+    if normalized_content_encoding and normalized_content_encoding not in ("gzip", "deflate"):
         raise HTTPException(
             detail=f"Unsupported content encoding: {content_encoding}",
             status_code=415,
         )
     body = await request.body()
-    if content_encoding == "gzip":
+    if normalized_content_encoding == "gzip":
         body = await run_in_threadpool(gzip.decompress, body)
-    elif content_encoding == "deflate":
+    elif normalized_content_encoding == "deflate":
         body = await run_in_threadpool(zlib.decompress, body)
     req = ExportTraceServiceRequest()
     try:

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -302,6 +302,28 @@ async def test_traces_endpoint_otlp_compliance(
     response_message.ParseFromString(response.content)
 
 
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "APPLICATION/X-PROTOBUF",
+        "application/x-protobuf; charset=utf-8",
+    ],
+)
+async def test_traces_endpoint_accepts_content_type_parameters_and_casing(
+    httpx_client: httpx.AsyncClient,
+    content_type: str,
+) -> None:
+    request_data = ExportTraceServiceRequest().SerializeToString()
+
+    response = await httpx_client.post(
+        "v1/traces",
+        content=request_data,
+        headers={"Content-Type": content_type},
+    )
+
+    assert response.status_code == 200
+
+
 async def test_delete_trace_by_trace_id(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,


### PR DESCRIPTION
## Summary
- normalize OTLP protobuf Content-Type values before validation
- accept casing differences and charset parameters emitted by fetch implementations
- add regression coverage for both variants

## Validation
- `python -m compileall -q src/phoenix/server/api/routers/v1/traces.py tests/unit/server/api/routers/v1/test_traces.py`
- `git diff --check`
- targeted pytest could not run because the local uv is 0.12.9 while the repository requires exactly 0.12.7

Closes #15967