### PR TITLE
fix(ci): keep the integration server's log pipe drained on Windows

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -619,7 +619,7 @@ jobs:
           version-file: "pyproject.toml"
       - name: Run integration tests
         timeout-minutes: 30
-        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 16
+        run: uvx tox run -e integration_tests -- -ra --durations=20 --reruns 5 --timeout 360 -n 16
 
   test-migrations:
     name: DB Migration Continuity (${{ matrix.db }}${{ matrix.concurrently == true && ', concurrently' || '' }})

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -63,17 +63,11 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
         db: [sqlite, postgresql]
-        py: ["3.10", "3.13", "3.14"]
+        py: ["3.10", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
         exclude:
           - os: windows-latest
             db: postgresql
-          - os: windows-latest
-            py: "3.14"  # sqlean.py has no Windows wheels for 3.14
-          - os: macos-latest
-            py: "3.13"
-          - os: ubuntu-latest
-            py: "3.13"
           - os: macos-latest
             db: postgresql
           - os: ubuntu-latest
@@ -133,15 +127,11 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
         db: [sqlite, postgresql]
-        py: ["3.10", "3.13", "3.14"]
+        py: ["3.10", "3.14"]
         os: [windows-latest, ubuntu-latest]
         exclude:
           - os: windows-latest
             db: postgresql
-          - os: windows-latest
-            py: "3.14"  # sqlean.py has no Windows wheels for 3.14
-          - os: ubuntu-latest
-            py: "3.13"
           - os: ubuntu-latest
             py: "3.10"
             db: sqlite

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -187,7 +187,7 @@ jobs:
           version-file: "pyproject.toml"
       - name: Run integration tests
         timeout-minutes: 30
-        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
+        run: uvx tox run -e integration_tests -- -ra --durations=20 --reruns 5 --timeout 360 -n 4
 
   phoenix-client-non-linux:
     name: Phoenix Client (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.py }})

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -761,7 +761,22 @@ def _server(app: _AppInfo) -> Iterator[_AppInfo]:
         raise ValueError(f"{ENV_PHOENIX_SQL_DATABASE_SCHEMA} should start with {_SCHEMA_PREFIX}")
     command = f"{sys.executable} -m phoenix.server.main serve --debug"
     env = {**os.environ, **app.env} if sys.platform == "win32" else dict(app.env)
-    process = Popen(command.split(), stdout=PIPE, stderr=STDOUT, text=True, env=env)
+    # The server's stdio and this pipe's reader must agree on an encoding, and
+    # the reader must never die on a byte it cannot decode: it is the only
+    # thing draining the pipe, and a server whose pipe is full blocks on its
+    # next log write and stops answering requests. The locale encoding that
+    # Popen(text=True) would otherwise use is cp1252 on Windows, which cannot
+    # decode the box-drawing glyphs Rich puts around a logged traceback.
+    env["PYTHONIOENCODING"] = "utf-8"
+    process = Popen(
+        command.split(),
+        stdout=PIPE,
+        stderr=STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
     log: list[str] = []
     lock: Lock = Lock()
     Thread(target=_capture_stdout, args=(process, log, lock), daemon=True).start()

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -8,3 +8,8 @@ addopts =
   --color=yes
   --code-highlight=yes
   --import-mode=importlib
+# Once a test has run this long, dump every thread's stack and let it keep
+# running: the dump names a hung test and shows where it is blocked. Ending
+# the test is left to the larger --timeout that CI passes to pytest-timeout.
+faulthandler_timeout = 300.0
+faulthandler_exit_on_timeout = false


### PR DESCRIPTION
Every Windows integration job on the nightly platform matrix has died at the 30-minute step timeout since the July 20 run, with the pytest dot log stalling at about 90% of the suite and nothing failing. #15973 is the investigation; this is the fix it points to.

### What was happening
The test harness read the server's stdout pipe with `Popen(text=True)`, which decodes with the locale encoding: cp1252 on Windows. The server writes UTF-8, because tox sets `PYTHONIOENCODING=utf-8` in every environment it runs. FastMCP logs a failed tool call through Rich, which draws the traceback inside a box of Unicode glyphs, and the first admin-gated tool call by a member in `auth/test_mcp.py` put a byte on the pipe that cp1252 has no character for. The reader thread died on it, nothing drained the pipe from then on, the server blocked on a later log write, and every request to it hung. The integration suite had no per-test timeout, so xdist waited until the step was killed. Before #14175 nothing the server wrote on Windows fell outside cp1252, which is why the legs were green until that PR and red on every run after it. Linux never saw it because its locale is UTF-8.

### The change
- `tests/integration/_helpers.py`: the server's stdio encoding is pinned to UTF-8 explicitly, the pipe is decoded as UTF-8, and undecodable bytes are replaced instead of raising, so the reader cannot die this way. With this change the full Windows suite passed on 3.10 and 3.14 in #15973, the first green Windows integration run since July 17.
- Both CI invocations of the integration suite get `--timeout 360` and `--durations=20`, and `tests/integration/pytest.ini` gets a 300-second faulthandler dump, the same bounds #15794 gave the unit tests, so the next hang names itself instead of burning the job's budget anonymously. The slowest integration tests on Windows run 40 to 52 seconds.
- The nightly's Windows legs move from 3.10 and 3.13 to 3.10 and 3.14, oldest and newest supported like the other platforms. The 3.13 leg existed because sqlean.py had no Windows wheels for 3.14; the vendored arize-phoenix-sqlean publishes cp314 wheels for win_amd64 and win_arm64, and the integration suite installed and passed on 3.14 in #15973. With Windows on 3.14, no platform ran 3.13 in the unit or integration jobs, so 3.13 leaves those two version lists along with the per-OS exclusions that kept it out; the client and evals jobs still run it.

### Caveats
- The Windows unit-test leg on 3.14 has not run anywhere yet; the first nightly after this lands will show it. If it has an unrelated 3.14 problem, the matrix change can be reverted on its own.
- The nightly also runs the `version-online-evals` branch, whose Windows integration legs fail the same way. They stay red until this fix reaches that branch or it leaves the matrix.
- The upstream Windows deadlock in the MCP SDK's SSE teardown (PrefectHQ/fastmcp#4192) did not reproduce across 15 sessions per server; nothing here addresses it.
