### PR TITLE
feat(agents): teach users about PXI slash commands

### DIFF
--- a/js/app/src/components/agent/AgentChatInput.tsx
+++ b/js/app/src/components/agent/AgentChatInput.tsx
@@ -93,8 +93,11 @@ function selectSuggestionContext(
   if (contextTypes.has("trace")) {
     return "trace";
   }
-  if (contextTypes.has("code_evaluator") || contextTypes.has("llm_evaluator")) {
-    return "evaluator";
+  if (contextTypes.has("code_evaluator")) {
+    return "code_evaluator";
+  }
+  if (contextTypes.has("llm_evaluator")) {
+    return "llm_evaluator";
   }
   if (contextTypes.has("playground")) {
     return "playground";

--- a/js/app/src/components/agent/AgentChatInput.tsx
+++ b/js/app/src/components/agent/AgentChatInput.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import type { ChatStatus } from "ai";
 import { useState } from "react";
 
+import { selectActiveContexts } from "@phoenix/agent/context/selectors";
 import { parseRequestedSkills } from "@phoenix/agent/skills/requestedSkills";
 import {
   parsePromptCommands,
@@ -16,7 +17,13 @@ import {
   PromptInputTools,
 } from "@phoenix/components/ai/prompt-input";
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import type { AgentState } from "@phoenix/store/agentStore";
 
+import {
+  type AgentChatSuggestionContext,
+  getAgentChatPlaceholder,
+} from "./agentChatPlaceholder";
 import { AgentContextPills } from "./AgentContextPills";
 import { AgentModelMenu } from "./AgentModelMenu";
 import { AgentWebSearchToggle } from "./AgentWebSearchToggle";
@@ -69,8 +76,31 @@ export type AgentChatInputProps = {
   onModelChange: (model: ModelMenuValue) => void;
   isInputDisabled?: boolean;
   isSubmitDisabled?: boolean;
+  hasMessages: boolean;
+  promptTokenCount: number | null;
   onStop: () => void;
 };
+
+function selectSuggestionContext(
+  state: AgentState
+): AgentChatSuggestionContext {
+  const contextTypes = new Set(
+    selectActiveContexts(state).map((context) => context.type)
+  );
+  if (contextTypes.has("span")) {
+    return "span";
+  }
+  if (contextTypes.has("trace")) {
+    return "trace";
+  }
+  if (contextTypes.has("code_evaluator") || contextTypes.has("llm_evaluator")) {
+    return "evaluator";
+  }
+  if (contextTypes.has("playground")) {
+    return "playground";
+  }
+  return contextTypes.has("project") ? "project" : null;
+}
 
 /** Names of the local prompt commands, for the submit-time command parse. */
 const availableCommandNames: ReadonlySet<string> = new Set(
@@ -96,6 +126,8 @@ export function AgentChatInput({
   onModelChange,
   isInputDisabled,
   isSubmitDisabled,
+  hasMessages,
+  promptTokenCount,
   onStop,
 }: AgentChatInputProps) {
   const [slashMenuLayer, setSlashMenuLayer] = useState<HTMLDivElement | null>(
@@ -104,6 +136,16 @@ export function AgentChatInput({
   const [availableSkills, setAvailableSkills] = useState<AvailableAgentSkill[]>(
     []
   );
+  const suggestionContext = useAgentContext(selectSuggestionContext);
+  const availableSkillNames = new Set(
+    availableSkills.map((skill) => skill.name)
+  );
+  const placeholder = getAgentChatPlaceholder({
+    hasMessages,
+    promptTokenCount,
+    suggestionContext,
+    availableSkillNames,
+  });
 
   const handleSubmit = (text: string) => {
     if (isInputDisabled) {
@@ -144,7 +186,7 @@ export function AgentChatInput({
           <AgentContextPills />
           <PromptInputBody>
             <SkillPromptInputBoundary
-              placeholder="Send a message..."
+              placeholder={placeholder}
               commands={PROMPT_COMMANDS}
               onSkillsChange={setAvailableSkills}
               textareaRef={textareaRef}

--- a/js/app/src/components/agent/Chat.tsx
+++ b/js/app/src/components/agent/Chat.tsx
@@ -61,6 +61,7 @@ import {
   UserMessage,
 } from "./ChatMessage";
 import { ChatScrollContext } from "./ChatScrollContext";
+import { getConversationUsage } from "./ChatSessionUsage";
 import {
   ElicitationDraftProvider,
   type PendingElicitationDraft,
@@ -591,6 +592,7 @@ export function ChatView({
   }, [sessionId, sendMessage, store]);
 
   const showsEmptyState = messages.length === 0 && !isBusyElsewhere;
+  const conversationUsage = getConversationUsage({ messages });
   const chatClassName = showsEmptyState ? "chat--empty" : "";
   const { missingCredentialsProvider, refreshCredentialStatus } =
     useAgentModelCredentialStatus(modelMenuValue);
@@ -1016,6 +1018,8 @@ export function ChatView({
               onModelChange={onModelChange}
               isInputDisabled={isCompacting || isBusyElsewhere}
               isSubmitDisabled={isSubmitDisabled}
+              hasMessages={messages.length > 0}
+              promptTokenCount={conversationUsage?.tokenCount.prompt ?? null}
               onStop={() => {
                 void stop();
               }}

--- a/js/app/src/components/agent/__tests__/agentChatPlaceholder.test.ts
+++ b/js/app/src/components/agent/__tests__/agentChatPlaceholder.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD,
+  getAgentChatPlaceholder,
+} from "../agentChatPlaceholder";
+
+const availableSkillNames = new Set([
+  "debug-trace",
+  "evaluators",
+  "playground",
+]);
+
+describe("getAgentChatPlaceholder", () => {
+  it("uses the default placeholder for an empty conversation", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: false,
+        promptTokenCount: COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD,
+        suggestionContext: "span",
+        availableSkillNames,
+      })
+    ).toBe("Send a message");
+  });
+
+  it("suggests compaction when the prompt reaches the token threshold", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD,
+        suggestionContext: "span",
+        availableSkillNames,
+      })
+    ).toBe("Try /compact to save tokens");
+  });
+
+  it("suggests debug-trace for an active span", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: 10_000,
+        suggestionContext: "span",
+        availableSkillNames,
+      })
+    ).toBe("Try /debug-trace to understand this span");
+  });
+
+  it("suggests debug-trace for an active trace", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: null,
+        suggestionContext: "trace",
+        availableSkillNames,
+      })
+    ).toBe("Try /debug-trace to understand this trace");
+  });
+
+  it("suggests debug-trace for an active project", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: null,
+        suggestionContext: "project",
+        availableSkillNames,
+      })
+    ).toBe("Try /debug-trace to find failure patterns");
+  });
+
+  it("suggests playground for an active playground", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: null,
+        suggestionContext: "playground",
+        availableSkillNames,
+      })
+    ).toBe("Try /playground to improve this prompt");
+  });
+
+  it("suggests evaluators for an active evaluator editor", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: null,
+        suggestionContext: "evaluator",
+        availableSkillNames,
+      })
+    ).toBe("Try /evaluators to refine this evaluator");
+  });
+
+  it("does not suggest an unavailable skill", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: true,
+        promptTokenCount: null,
+        suggestionContext: "span",
+        availableSkillNames: new Set(),
+      })
+    ).toBe("Send a message");
+  });
+});

--- a/js/app/src/components/agent/__tests__/agentChatPlaceholder.test.ts
+++ b/js/app/src/components/agent/__tests__/agentChatPlaceholder.test.ts
@@ -12,12 +12,34 @@ const availableSkillNames = new Set([
 ]);
 
 describe("getAgentChatPlaceholder", () => {
-  it("uses the default placeholder for an empty conversation", () => {
+  it("uses the default placeholder for an empty contextless conversation", () => {
     expect(
       getAgentChatPlaceholder({
         hasMessages: false,
-        promptTokenCount: COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD,
+        promptTokenCount: null,
+        suggestionContext: null,
+        availableSkillNames,
+      })
+    ).toBe("Send a message");
+  });
+
+  it("allows a specific context to teach a skill in an empty conversation", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: false,
+        promptTokenCount: null,
         suggestionContext: "span",
+        availableSkillNames,
+      })
+    ).toBe("Try /debug-trace to understand this span");
+  });
+
+  it("keeps broad project guidance neutral in an empty conversation", () => {
+    expect(
+      getAgentChatPlaceholder({
+        hasMessages: false,
+        promptTokenCount: null,
+        suggestionContext: "project",
         availableSkillNames,
       })
     ).toBe("Send a message");

--- a/js/app/src/components/agent/__tests__/agentChatPlaceholder.test.ts
+++ b/js/app/src/components/agent/__tests__/agentChatPlaceholder.test.ts
@@ -78,16 +78,19 @@ describe("getAgentChatPlaceholder", () => {
     ).toBe("Try /playground to improve this prompt");
   });
 
-  it("suggests evaluators for an active evaluator editor", () => {
-    expect(
-      getAgentChatPlaceholder({
-        hasMessages: true,
-        promptTokenCount: null,
-        suggestionContext: "evaluator",
-        availableSkillNames,
-      })
-    ).toBe("Try /evaluators to refine this evaluator");
-  });
+  it.each(["code_evaluator", "llm_evaluator"] as const)(
+    "suggests evaluators for an active %s editor",
+    (suggestionContext) => {
+      expect(
+        getAgentChatPlaceholder({
+          hasMessages: true,
+          promptTokenCount: null,
+          suggestionContext,
+          availableSkillNames,
+        })
+      ).toBe("Try /evaluators to refine this evaluator");
+    }
+  );
 
   it("does not suggest an unavailable skill", () => {
     expect(

--- a/js/app/src/components/agent/agentChatPlaceholder.ts
+++ b/js/app/src/components/agent/agentChatPlaceholder.ts
@@ -1,3 +1,5 @@
+import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
+
 export const COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD = 100_000;
 
 const DEFAULT_PLACEHOLDER = "Send a message";
@@ -8,13 +10,7 @@ const DEBUG_PROJECT_PLACEHOLDER = "Try /debug-trace to find failure patterns";
 const PLAYGROUND_PLACEHOLDER = "Try /playground to improve this prompt";
 const EVALUATOR_PLACEHOLDER = "Try /evaluators to refine this evaluator";
 
-export type AgentChatSuggestionContext =
-  | "span"
-  | "trace"
-  | "evaluator"
-  | "playground"
-  | "project"
-  | null;
+export type AgentChatSuggestionContext = AgentContext["type"] | null;
 
 /**
  * Select the most relevant teaching placeholder for the PXI composer.
@@ -61,7 +57,8 @@ export function getAgentChatPlaceholder({
       return availableSkillNames.has("playground")
         ? PLAYGROUND_PLACEHOLDER
         : DEFAULT_PLACEHOLDER;
-    case "evaluator":
+    case "code_evaluator":
+    case "llm_evaluator":
       return availableSkillNames.has("evaluators")
         ? EVALUATOR_PLACEHOLDER
         : DEFAULT_PLACEHOLDER;

--- a/js/app/src/components/agent/agentChatPlaceholder.ts
+++ b/js/app/src/components/agent/agentChatPlaceholder.ts
@@ -15,10 +15,11 @@ export type AgentChatSuggestionContext = AgentContext["type"] | null;
 /**
  * Select the most relevant teaching placeholder for the PXI composer.
  *
- * Empty conversations retain the neutral prompt. Once a conversation has
- * started, compaction takes priority over contextual skill suggestions because
- * it addresses an immediate context-window concern. Skill suggestions are only
- * shown when the advertised skill catalog confirms that the skill is available.
+ * Compaction takes priority because it addresses an immediate context-window
+ * concern. Specific page contexts can teach relevant skills even before the
+ * conversation starts, while broad project guidance waits until the user has
+ * begun chatting. Skill suggestions are only shown when the advertised catalog
+ * confirms that the skill is available.
  */
 export function getAgentChatPlaceholder({
   hasMessages,
@@ -31,9 +32,6 @@ export function getAgentChatPlaceholder({
   suggestionContext: AgentChatSuggestionContext;
   availableSkillNames: ReadonlySet<string>;
 }): string {
-  if (!hasMessages) {
-    return DEFAULT_PLACEHOLDER;
-  }
   if (
     promptTokenCount != null &&
     promptTokenCount >= COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD
@@ -50,7 +48,7 @@ export function getAgentChatPlaceholder({
         ? DEBUG_TRACE_PLACEHOLDER
         : DEFAULT_PLACEHOLDER;
     case "project":
-      return availableSkillNames.has("debug-trace")
+      return hasMessages && availableSkillNames.has("debug-trace")
         ? DEBUG_PROJECT_PLACEHOLDER
         : DEFAULT_PLACEHOLDER;
     case "playground":

--- a/js/app/src/components/agent/agentChatPlaceholder.ts
+++ b/js/app/src/components/agent/agentChatPlaceholder.ts
@@ -1,0 +1,71 @@
+export const COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD = 100_000;
+
+const DEFAULT_PLACEHOLDER = "Send a message";
+const COMPACTION_PLACEHOLDER = "Try /compact to save tokens";
+const DEBUG_SPAN_PLACEHOLDER = "Try /debug-trace to understand this span";
+const DEBUG_TRACE_PLACEHOLDER = "Try /debug-trace to understand this trace";
+const DEBUG_PROJECT_PLACEHOLDER = "Try /debug-trace to find failure patterns";
+const PLAYGROUND_PLACEHOLDER = "Try /playground to improve this prompt";
+const EVALUATOR_PLACEHOLDER = "Try /evaluators to refine this evaluator";
+
+export type AgentChatSuggestionContext =
+  | "span"
+  | "trace"
+  | "evaluator"
+  | "playground"
+  | "project"
+  | null;
+
+/**
+ * Select the most relevant teaching placeholder for the PXI composer.
+ *
+ * Empty conversations retain the neutral prompt. Once a conversation has
+ * started, compaction takes priority over contextual skill suggestions because
+ * it addresses an immediate context-window concern. Skill suggestions are only
+ * shown when the advertised skill catalog confirms that the skill is available.
+ */
+export function getAgentChatPlaceholder({
+  hasMessages,
+  promptTokenCount,
+  suggestionContext,
+  availableSkillNames,
+}: {
+  hasMessages: boolean;
+  promptTokenCount: number | null;
+  suggestionContext: AgentChatSuggestionContext;
+  availableSkillNames: ReadonlySet<string>;
+}): string {
+  if (!hasMessages) {
+    return DEFAULT_PLACEHOLDER;
+  }
+  if (
+    promptTokenCount != null &&
+    promptTokenCount >= COMPACTION_PLACEHOLDER_TOKEN_THRESHOLD
+  ) {
+    return COMPACTION_PLACEHOLDER;
+  }
+  switch (suggestionContext) {
+    case "span":
+      return availableSkillNames.has("debug-trace")
+        ? DEBUG_SPAN_PLACEHOLDER
+        : DEFAULT_PLACEHOLDER;
+    case "trace":
+      return availableSkillNames.has("debug-trace")
+        ? DEBUG_TRACE_PLACEHOLDER
+        : DEFAULT_PLACEHOLDER;
+    case "project":
+      return availableSkillNames.has("debug-trace")
+        ? DEBUG_PROJECT_PLACEHOLDER
+        : DEFAULT_PLACEHOLDER;
+    case "playground":
+      return availableSkillNames.has("playground")
+        ? PLAYGROUND_PLACEHOLDER
+        : DEFAULT_PLACEHOLDER;
+    case "evaluator":
+      return availableSkillNames.has("evaluators")
+        ? EVALUATOR_PLACEHOLDER
+        : DEFAULT_PLACEHOLDER;
+    default:
+      return DEFAULT_PLACEHOLDER;
+  }
+}

--- a/js/app/tests/app-frame-overlays.spec.ts
+++ b/js/app/tests/app-frame-overlays.spec.ts
@@ -7,7 +7,7 @@ async function openAssistant(page: Page) {
   const rail = page.getByRole("complementary", { name: "Assistant" });
   await expect(rail).toBeVisible();
   const acknowledgeButton = rail.getByRole("button", { name: "Acknowledge" });
-  const input = rail.getByPlaceholder("Send a message...");
+  const input = rail.getByLabel("Message input");
   await expect(acknowledgeButton.or(input)).toBeVisible();
   if (await acknowledgeButton.isVisible()) {
     await acknowledgeButton.click();
@@ -24,7 +24,7 @@ test.describe("application frame overlays", () => {
   }) => {
     await page.goto("/datasets");
     const rail = await openAssistant(page);
-    const railInput = rail.getByPlaceholder("Send a message...");
+    const railInput = rail.getByLabel("Message input");
     await rail.evaluate((element) => {
       element.setAttribute("data-e2e-identity", "persistent-rail");
     });
@@ -81,7 +81,7 @@ test.describe("application frame overlays", () => {
       .getByRole("button", { name: "Switch assistant to floating panel" })
       .click();
 
-    const assistantInput = page.getByPlaceholder("Send a message...");
+    const assistantInput = page.getByLabel("Message input");
     await expect(assistantInput).toBeVisible();
     // The detached panel may float over the top nav; activate the trigger
     // with the keyboard since this test audits assistant interactivity, not
@@ -222,7 +222,7 @@ test.describe("application frame overlays", () => {
           .map((animation) => animation.finished.catch(() => {}))
       );
     });
-    const railInput = rail.getByPlaceholder("Send a message...");
+    const railInput = rail.getByLabel("Message input");
     await rail.evaluate((element) => {
       element.setAttribute("data-e2e-identity", "persistent-rail");
     });

--- a/js/app/tests/overlay-audit.spec.ts
+++ b/js/app/tests/overlay-audit.spec.ts
@@ -25,7 +25,7 @@ async function openAssistant(page: Page) {
   const rail = page.getByRole("complementary", { name: "Assistant" });
   await expect(rail).toBeVisible();
   const acknowledgeButton = rail.getByRole("button", { name: "Acknowledge" });
-  const input = rail.getByPlaceholder("Send a message...");
+  const input = rail.getByLabel("Message input");
   await expect(acknowledgeButton.or(input)).toBeVisible();
   if (await acknowledgeButton.isVisible()) {
     await acknowledgeButton.click();
@@ -203,7 +203,7 @@ test.describe("overlay audit", () => {
     }) => {
       await page.goto("/settings/users");
       const rail = await openAssistant(page);
-      const railInput = rail.getByPlaceholder("Send a message...");
+      const railInput = rail.getByLabel("Message input");
       await railInput.fill("audit draft");
 
       await page.getByRole("button", { name: "Add User" }).click();


### PR DESCRIPTION
## Summary
- choose PXI composer placeholders from conversation usage and active page context
- surface slash commands only when relevant and available
- keep broad or contextless empty conversations neutral

## Placeholder triggers

Evaluated top-to-bottom; contextual skill placeholders require the skill to be available.

| Placeholder | Trigger |
|---|---|
| `Try /compact to save tokens` | Latest prompt usage is at least 100k tokens |
| `Try /debug-trace to understand this span` | A span is active |
| `Try /debug-trace to understand this trace` | A trace, but no span, is active |
| `Try /evaluators to refine this evaluator` | A code or LLM evaluator editor is active |
| `Try /playground to improve this prompt` | The playground is active |
| `Try /debug-trace to find failure patterns` | A project is active and the conversation has started |
| `Send a message` | No higher-priority condition matches |

## Testing
- `make typecheck-frontend`
- `make lint-frontend`
- `make test-frontend`
- browser-verified default, project, and span placeholders

Closes #15977
