### PR TITLE
fix(ci): repair version-online-evals CI after the main merge

### DIFF
--- a/js/app/src/components/chart/AnnotationMetricsChart.tsx
+++ b/js/app/src/components/chart/AnnotationMetricsChart.tsx
@@ -229,7 +229,7 @@ function AnnotationMetricsChartContent({
   const semanticColors = useSemanticChartColors();
   const { hiddenDataKeys, isDataKeyHidden, toggleDataKey } =
     useInteractiveLegend();
-  const { data, reference, labels } = series;
+  const { data, labels } = series;
   // Null means "no good-versus-bad reading": stay on the categorical palette.
   const {
     chartData,

--- a/js/app/src/components/evaluators/codeEvaluatorMemberPath.ts
+++ b/js/app/src/components/evaluators/codeEvaluatorMemberPath.ts
@@ -45,6 +45,7 @@ export type CodeEvaluatorMemberCursor = {
  * Returns null when the text is not a member access — a bare name is the body's
  * root completion, not a drill into something.
  */
+// oxlint-disable-next-line complexity
 export function getCodeEvaluatorMemberCursor(
   textBeforeCursor: string
 ): CodeEvaluatorMemberCursor | null {

--- a/js/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/js/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -399,6 +399,7 @@ function createCodeEvaluatorEditorState({
   });
 }
 
+// oxlint-disable-next-line complexity
 function getCodeEvaluatorDefinition({
   language,
   state,

--- a/js/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/js/app/src/components/filter/DSLFilterConditionField.tsx
@@ -600,6 +600,7 @@ export function DSLFilterConditionField<
     loadedCompletionsRef.current = null;
   }, [loadCompletions]);
 
+  /* eslint-disable react/preserve-manual-memoization */
   const contentAttributes = useMemo(
     () =>
       EditorView.contentAttributes.of({
@@ -713,6 +714,7 @@ export function DSLFilterConditionField<
     contentAttributes,
     selectOnOpen,
   ]);
+  /* eslint-enable react/preserve-manual-memoization */
 
   // Completion data can arrive after the user has already focused the empty
   // field — the sampled record behind a mapping path field, a fetched name

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -213,6 +213,7 @@ const CreateProjectEvaluatorDialog = ({
     })
   );
 
+  // oxlint-disable-next-line complexity
   const initialState = (() => {
     if (creationMode.kind === "newCode" || creationMode.kind === "copyCode") {
       const copiedState =

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorGalleryPage.tsx
@@ -170,6 +170,7 @@ export function ProjectEvaluatorGalleryPage() {
   );
 }
 
+// oxlint-disable-next-line complexity
 function EvaluatorGallery() {
   const navigate = useNavigate();
   const paths = useProjectEvaluatorPaths();

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorMeanScoreCell.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorMeanScoreCell.tsx
@@ -158,6 +158,7 @@ export function ProjectEvaluatorMeanScoreCell({
   );
 }
 
+// oxlint-disable-next-line complexity
 function AnnotationMeanScoreView({
   annotation,
   scoreWindow,

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_pii_detection_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_pii_detection_classification_evaluator_config.py
@@ -1,7 +1,10 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    PromptMessage,
+)
 
 PII_DETECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="pii_detection",

--- a/src/phoenix/__generated__/classification_evaluator_configs/_pii_detection_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_pii_detection_classification_evaluator_config.py
@@ -1,7 +1,10 @@
 # This file is generated. Do not edit by hand.
 # ruff: noqa: E501
 
-from ._models import ClassificationEvaluatorConfig, PromptMessage
+from ._models import (
+    ClassificationEvaluatorConfig,
+    PromptMessage,
+)
 
 PII_DETECTION_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
     name="pii_detection",

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -291,16 +291,23 @@ async def test_builtin_implementation_version_changes_fingerprint(
 ) -> None:
     async with db() as session:
         project = await _add_project(session)
-        evaluator = models.BuiltinEvaluator(
-            name=Identifier(root="contains"),
-            kind="BUILTIN",
-            key="contains",
-            input_schema={},
-            output_configs=[],
-            synced_at=_now(),
+        # The test database is seeded with the app's startup rows, which include
+        # the synced builtin evaluators; reuse that row rather than insert a
+        # second `contains` (evaluators.name is unique).
+        evaluator = await session.scalar(
+            select(models.BuiltinEvaluator).where(models.BuiltinEvaluator.key == "contains")
         )
-        session.add(evaluator)
-        await session.flush()
+        if evaluator is None:
+            evaluator = models.BuiltinEvaluator(
+                name=Identifier(root="contains"),
+                kind="BUILTIN",
+                key="contains",
+                input_schema={},
+                output_configs=[],
+                synced_at=_now(),
+            )
+            session.add(evaluator)
+            await session.flush()
         project_evaluator = models.ProjectEvaluator(
             trace_project=models.Project(name=f"project-evaluator-{token_hex(12)}"),
             project_id=project.id,


### PR DESCRIPTION
## Why

`version-online-evals` has been red since fb0b3643f0 (Merge main, Sep 4): every PR into it — #15879, #15936, #15851, #15827, #15776, #15530 — inherits three failures that have nothing to do with the PR.

## What

| Job | Cause | Fix |
|---|---|---|
| Unit Tests (sqlite, postgresql) | Main's conftest seeds each test DB from a template that has already run the startup `Facilitator`, which syncs the builtin evaluators. `test_producer.py::test_builtin_implementation_version_changes_fingerprint` inserted a second `contains` builtin → `uq_evaluators_name`, deterministically on both dialects. | Look the seeded row up by key first (same pattern as `test_consumer._seed_builtin_criteria`), insert only if absent. |
| Compile Prompts | `make codegen-prompts` output drifted from the committed `_pii_detection_classification_evaluator_config.py` (both copies) — import formatting. | Regenerated. |
| CI Typescript › Lint | Main's oxlint rules (React Compiler + `complexity` 20) now cover branch-only code: 5 functions over the complexity limit, 7 `preserve-manual-memoization` errors in `DSLFilterConditionField`, 1 unused binding. | `// oxlint-disable-next-line complexity` on the five functions (main disables this rule the same way in `Chat.tsx`, `DatasetFromFileForm.tsx`, `ExperimentCompareMetricsPage.tsx`), a scoped `preserve-manual-memoization` disable around the two CodeMirror memos, and the unused `reference` removed. |

No behavior changes.

## Verification

- `pnpm run lint`, `pnpm run typecheck`, Prettier: clean
- `tests/unit/server/online_eval`: 170 passed (SQLite)
- ruff / mypy on the test change: clean
- `make codegen-prompts` is idempotent after the regen

https://claude.ai/code/session_01TbnFJbLHMXumQqz1wZ52mP

