### PR TITLE
fix(pxi): pass LLM evaluator ID in project context

### DIFF
--- a/js/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
+++ b/js/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
@@ -470,7 +470,7 @@ function EditCodeDatasetEvaluatorSlideoverContent({
           initialSourceCode={evaluatorSourceCode}
           sandboxConfigs={sandboxConfigs}
           initialSandboxConfigId={initialSandboxConfigId}
-          evaluatorNodeId={evaluator.id}
+          codeEvaluatorNodeId={evaluator.id}
         />
       )}
     </EvaluatorStoreProvider>

--- a/js/app/src/components/dataset/EditLLMDatasetEvaluatorSlideover.tsx
+++ b/js/app/src/components/dataset/EditLLMDatasetEvaluatorSlideover.tsx
@@ -388,7 +388,7 @@ const EditEvaluatorDialog = ({
           isSubmitting={isUpdating}
           mode="update"
           error={error}
-          evaluatorNodeId={datasetEvaluator.evaluator.id}
+          llmEvaluatorNodeId={datasetEvaluator.evaluator.id}
         />
       )}
     </EvaluatorStoreProvider>

--- a/js/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -126,7 +126,7 @@ export const EditCodeEvaluatorDialogContent = ({
   initialSourceCode,
   sandboxConfigs,
   initialSandboxConfigId,
-  evaluatorNodeId,
+  codeEvaluatorNodeId,
 }: {
   onSubmit: (payload: {
     language: CodeEvaluatorLanguage;
@@ -149,7 +149,8 @@ export const EditCodeEvaluatorDialogContent = ({
   initialSourceCode: string;
   sandboxConfigs: SandboxConfigOption[];
   initialSandboxConfigId?: string | null;
-  evaluatorNodeId?: string | null;
+  /** Relay node ID of the underlying code evaluator, not an association wrapper. */
+  codeEvaluatorNodeId?: string | null;
 }) => {
   const store = useEvaluatorStoreInstance();
   const grain = useEvaluatorStore(
@@ -254,9 +255,9 @@ export const EditCodeEvaluatorDialogContent = ({
   const advertisedCodeEvaluatorContext = useMemo(
     () => ({
       type: "code_evaluator" as const,
-      evaluatorNodeId: evaluatorNodeId ?? null,
+      evaluatorNodeId: codeEvaluatorNodeId ?? null,
     }),
-    [evaluatorNodeId]
+    [codeEvaluatorNodeId]
   );
   useAdvertiseAgentContext(advertisedCodeEvaluatorContext);
 
@@ -295,7 +296,7 @@ export const EditCodeEvaluatorDialogContent = ({
         firstOutputConfigName;
       return {
         mode: mode === "create" ? "create" : "edit",
-        evaluatorNodeId: evaluatorNodeId ?? null,
+        evaluatorNodeId: codeEvaluatorNodeId ?? null,
         name: draftName,
         description: state.evaluator.description,
         language: local.language,
@@ -437,7 +438,7 @@ export const EditCodeEvaluatorDialogContent = ({
         }
       }
     };
-  }, [agentStore, store, mode, evaluatorNodeId]);
+  }, [agentStore, store, mode, codeEvaluatorNodeId]);
 
   const handleCancel = () => {
     onCancel?.();

--- a/js/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/js/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -30,7 +30,6 @@ export const EditLLMEvaluatorDialogContent = ({
   submitHint?: ReactNode;
   mode: "create" | "update";
   error?: string;
-  /** Relay node ID of the underlying LLM evaluator, not an association wrapper. */
   llmEvaluatorNodeId?: string | null;
   title?: string;
   formLeftPanel?: ReactNode;

--- a/js/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/js/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -18,7 +18,7 @@ export const EditLLMEvaluatorDialogContent = ({
   submitHint,
   mode,
   error,
-  evaluatorNodeId,
+  llmEvaluatorNodeId,
   title,
   formLeftPanel,
   formRightPanel,
@@ -30,7 +30,8 @@ export const EditLLMEvaluatorDialogContent = ({
   submitHint?: ReactNode;
   mode: "create" | "update";
   error?: string;
-  evaluatorNodeId?: string | null;
+  /** Relay node ID of the underlying LLM evaluator, not an association wrapper. */
+  llmEvaluatorNodeId?: string | null;
   title?: string;
   formLeftPanel?: ReactNode;
   /**
@@ -44,9 +45,9 @@ export const EditLLMEvaluatorDialogContent = ({
     useMemo(
       () => ({
         type: "llm_evaluator" as const,
-        evaluatorNodeId: evaluatorNodeId ?? null,
+        evaluatorNodeId: llmEvaluatorNodeId ?? null,
       }),
-      [evaluatorNodeId]
+      [llmEvaluatorNodeId]
     )
   );
 
@@ -70,7 +71,7 @@ export const EditLLMEvaluatorDialogContent = ({
 
   useLlmEvaluatorDraftRegistration({
     mode,
-    evaluatorNodeId,
+    llmEvaluatorNodeId,
     handleSubmitRef,
   });
   return (

--- a/js/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
+++ b/js/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
@@ -40,11 +40,12 @@ import { getInstancePromptParamsFromStore } from "@phoenix/pages/playground/play
  */
 export const useLlmEvaluatorDraftRegistration = ({
   mode,
-  evaluatorNodeId,
+  llmEvaluatorNodeId,
   handleSubmitRef,
 }: {
   mode: "create" | "update";
-  evaluatorNodeId?: string | null;
+  /** Relay node ID of the underlying LLM evaluator, not an association wrapper. */
+  llmEvaluatorNodeId?: string | null;
   handleSubmitRef: RefObject<() => Promise<EvaluatorSubmitResult>>;
 }) => {
   const store = useEvaluatorStoreInstance();
@@ -73,7 +74,7 @@ export const useLlmEvaluatorDraftRegistration = ({
       );
       return {
         mode: mode === "create" ? "create" : "edit",
-        evaluatorNodeId: evaluatorNodeId ?? null,
+        evaluatorNodeId: llmEvaluatorNodeId ?? null,
         name: state.evaluator.name || state.evaluator.globalName,
         description: state.evaluator.description,
         inputMapping: state.evaluator.inputMapping,
@@ -207,7 +208,7 @@ export const useLlmEvaluatorDraftRegistration = ({
     playgroundStore,
     instanceId,
     mode,
-    evaluatorNodeId,
+    llmEvaluatorNodeId,
     handleSubmitRef,
   ]);
 };

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -444,7 +444,7 @@ function EditLlmProjectEvaluatorContent({
             isSubmitDisabled={!isFilterValid}
             mode="update"
             error={error}
-            evaluatorNodeId={evaluator.evaluator.id}
+            llmEvaluatorNodeId={evaluator.evaluator.id}
             formLeftPanel={
               <ProjectLlmEvaluatorFormSections
                 projectId={evaluator.project.id}

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -444,7 +444,7 @@ function EditLlmProjectEvaluatorContent({
             isSubmitDisabled={!isFilterValid}
             mode="update"
             error={error}
-            evaluatorNodeId={evaluator.id}
+            evaluatorNodeId={evaluator.evaluator.id}
             formLeftPanel={
               <ProjectLlmEvaluatorFormSections
                 projectId={evaluator.project.id}


### PR DESCRIPTION
## Summary

Fix PXI context generation when editing a project LLM evaluator.

The edit slideover previously passed the outer `ProjectEvaluator` Relay ID as the LLM evaluator context. PXI expects the underlying `LLMEvaluator` ID, causing the chat request to fail validation with HTTP 422.

This change passes the nested evaluator ID so PXI can access the evaluator being edited.

## Testing

- `make build-frontend`
- `make typecheck-frontend`
- Focused Oxlint and Oxfmt checks
- Verified in the browser that:
  - The PXI request contains an `llm_evaluator` context with an `LLMEvaluator` Relay ID.
  - The chat endpoint returns HTTP 200.
  - PXI can read the open evaluator draft.

`make lint-frontend` continues to report pre-existing errors in unrelated files.

## Screenshots

Not applicable; this change has no visual impact.
