### PR TITLE
feat: add managed worktree development sessions

### DIFF
--- a/.agents/skills/phoenix-pr-screenshot/SKILL.md
+++ b/.agents/skills/phoenix-pr-screenshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phoenix-pr-screenshot
-description: Screenshot a running Phoenix feature and attach images to a GitHub PR. Builds the frontend, starts Phoenix with env vars, uses agent-browser to capture screenshots, uploads to GCS, and updates the PR body.
+description: Screenshot a running Phoenix feature and attach images to a GitHub PR. Builds the frontend, uses agent-browser to capture screenshots, uploads to GCS, and updates the PR body.
 user-invocable: true
 metadata:
   internal: true
@@ -24,7 +24,7 @@ Capture screenshots of the Phoenix UI to visually document a feature in a pull r
 The Phoenix backend serves the built frontend from `src/phoenix/server/static/`. Build it from the `js/app/` directory:
 
 ```bash
-cd <repo-root>/app
+cd <repo-root>/js/app
 pnpm install   # only if node_modules is missing
 pnpm run build
 ```
@@ -33,25 +33,22 @@ This compiles the React app and copies static assets into the Python server's st
 
 ### Step 2: Start Phoenix
 
-Start the Phoenix backend with any env vars the feature requires. Always use a fresh working directory to avoid DB migration conflicts in worktrees:
+Use a Phoenix development instance that matches the current checkout. If none is
+running, start one with the repository's development commands and any
+feature-specific environment variables. In a git worktree, follow the
+`phoenix-worktree-dev` skill for optional isolated session management.
 
-```bash
-PHOENIX_PORT=6007 PHOENIX_WORKING_DIR=/tmp/phoenix-screenshot-demo <OTHER_ENV_VARS> uv run phoenix serve &
-```
-
-Key points:
-- Use `PHOENIX_PORT` (not `--port`) to set the port — the CLI doesn't accept a port flag
-- Use a temp `PHOENIX_WORKING_DIR` so you don't collide with an existing DB that may have newer migrations
-- Wait for the server to be ready: `sleep 10 && curl -s -o /dev/null -w "%{http_code}" http://localhost:6007/playground` should return 200
-- Check `/tmp/phoenix-*.log` if it fails — common issues are migration errors (use a fresh working dir) or port conflicts
+Prefer fresh data for screenshots unless the feature needs an existing dataset.
+Record the instance base URL as `PHOENIX_URL`, wait until it is ready, and do not
+start a second server when a suitable one already exists.
 
 ### Step 3: Screenshot with agent-browser
 
 Navigate to the relevant page, interact with UI elements to show the feature, and capture screenshots:
 
 ```bash
-# Open the page
-agent-browser open http://localhost:6007/playground
+# Use the base URL of the selected development instance
+agent-browser open "${PHOENIX_URL}/playground"
 
 # Wait for React to fully render
 agent-browser wait --load networkidle
@@ -110,13 +107,9 @@ Always preserve the existing PR body content — read it first with `gh pr view 
 
 ### Step 6: Cleanup
 
-```bash
-# Kill the Phoenix server
-kill <PID>
-
-# Close the browser
-agent-browser close
-```
+Stop only the development instance started for this screenshot workflow, using
+the matching development command. Then close the browser with `agent-browser
+close`.
 
 ## Removing screenshots
 

--- a/.agents/skills/phoenix-worktree-dev/SKILL.md
+++ b/.agents/skills/phoenix-worktree-dev/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: phoenix-worktree-dev
+description: Use whenever Codex operates in a Phoenix git worktree. Explains the optional managed development-session tooling for running, inspecting, restarting, sharing, screenshotting, and cleaning up isolated Phoenix instances. Do not use for a primary checkout unless the user asks for worktree session tooling.
+metadata:
+  internal: true
+---
+
+# Phoenix Worktree Development
+
+This skill owns worktree-specific development workflow decisions. General
+Phoenix skills should stay independent of how the server is launched.
+
+Do not start a server only because the checkout is a worktree. Use a managed
+session when the task benefits from a live full-stack instance, concurrent
+servers, browser verification, screenshots, or a URL the user can open. Honor
+an explicit user choice or a suitable server that is already running.
+
+## Managed Sessions
+
+Start an isolated full-stack session in a long-running terminal:
+
+```bash
+make dev-session
+```
+
+Portless allocates the HTTP and Vite ports and exposes stable HTTPS names.
+The session allocates its remaining service ports. On first start, it snapshots
+the primary checkout's `js/app/.env` and makes a private online copy of its
+SQLite database. The worktree `.env` is an overlay, while session-owned ports,
+URLs, and writable paths remain isolated.
+
+Use `PHOENIX_DEV_SEED_DATABASE=false make dev-session` when existing data is not
+needed, especially for screenshots that must not expose developer data. Use
+`PHOENIX_DEV_DATABASE_SOURCE=/path/to/phoenix.db make dev-session` to select a
+different SQLite source. Never point a managed session directly at the primary
+database.
+
+## Follow-up Changes
+
+Vite handles ordinary frontend hot reload. Restart the API after Python or
+runtime schema changes; restart both processes when environment or shared build
+state changed:
+
+```bash
+make dev-sessions ARGS="restart api"
+make dev-sessions ARGS="restart frontend"
+make dev-sessions ARGS="restart all"
+```
+
+These commands retain the session URL and private data.
+
+## Browser Verification and Screenshots
+
+Resolve the current worktree URL instead of assuming port 6006:
+
+```bash
+PHOENIX_URL="$(make --silent dev-sessions ARGS=url)"
+```
+
+Use this URL with `agent-browser`. For PR screenshots, also follow the
+`phoenix-pr-screenshot` skill. Use an empty session database unless the requested
+image depends on representative primary data.
+
+## Hand Off a Running Instance
+
+If leaving the instance active helps the user review the work, run:
+
+```bash
+make dev-sessions ARGS="status"
+```
+
+Only describe the instance as available when both API and frontend report
+`ready`. Give the user the clickable app URL and
+`make dev-sessions ARGS="stop"`. Stop the session instead when it was used only
+for internal verification and no follow-up access is useful.
+
+## Manage Several Worktrees
+
+The control plane works from any Phoenix worktree. A selector can be a session
+ID, branch, or worktree path; omission selects the current worktree.
+
+```bash
+make dev-sessions
+make dev-sessions ARGS="status <session>"
+make dev-sessions ARGS="open <session>"
+make dev-sessions ARGS="stop <session>"
+make dev-sessions ARGS="stop --all"
+make dev-sessions ARGS="prune"
+make dev-sessions ARGS="clean <stopped-session>"
+make dev-sessions ARGS="doctor"
+```
+
+`stop` preserves the session environment and data. `clean` removes them, so the
+next start takes a fresh snapshot.

--- a/.agents/skills/phoenix-worktree-dev/SKILL.md
+++ b/.agents/skills/phoenix-worktree-dev/SKILL.md
@@ -91,4 +91,7 @@ make dev-sessions ARGS="doctor"
 ```
 
 `stop` preserves the session environment and data. `clean` removes them, so the
-next start takes a fresh snapshot.
+next start takes a fresh snapshot. Session listings and status output show the
+age of each private database clone. Treat clones older than seven days as a
+cleanup prompt, not permission to delete data: tell the user about the retained
+clone and clean it only when they confirm it is no longer needed.

--- a/.agents/skills/phoenix-worktree-dev/SKILL.md
+++ b/.agents/skills/phoenix-worktree-dev/SKILL.md
@@ -1,97 +1,50 @@
 ---
 name: phoenix-worktree-dev
-description: Use whenever Codex operates in a Phoenix git worktree. Explains the optional managed development-session tooling for running, inspecting, restarting, sharing, screenshotting, and cleaning up isolated Phoenix instances. Do not use for a primary checkout unless the user asks for worktree session tooling.
+description: Start and manage isolated Phoenix development instances in git worktrees when a task needs a live server, browser verification, or instance lifecycle management.
 metadata:
   internal: true
 ---
 
 # Phoenix Worktree Development
 
-This skill owns worktree-specific development workflow decisions. General
-Phoenix skills should stay independent of how the server is launched.
-
-Do not start a server only because the checkout is a worktree. Use a managed
-session when the task benefits from a live full-stack instance, concurrent
-servers, browser verification, screenshots, or a URL the user can open. Honor
-an explicit user choice or a suitable server that is already running.
-
-## Managed Sessions
-
-Start an isolated full-stack session in a long-running terminal:
+Honor the user's chosen workflow or a suitable instance that is already running.
+Start an isolated development instance in an attached, long-running terminal:
 
 ```bash
 make dev-session
 ```
 
-Portless allocates the HTTP and Vite ports and exposes stable HTTPS names.
-The session allocates its remaining service ports. On first start, it snapshots
-the primary checkout's `js/app/.env` and makes a private online copy of its
-SQLite database. The worktree `.env` is an overlay, while session-owned ports,
-URLs, and writable paths remain isolated.
+First startup copies primary configuration and SQLite data into private state.
+For screenshots, use an empty database unless representative data is needed:
+`PHOENIX_DEV_SEED_DATABASE=false make dev-session` skips cloning on first start;
+it does not clear data retained by an existing development instance.
 
-Use `PHOENIX_DEV_SEED_DATABASE=false make dev-session` when existing data is not
-needed, especially for screenshots that must not expose developer data. Use
-`PHOENIX_DEV_DATABASE_SOURCE=/path/to/phoenix.db make dev-session` to select a
-different SQLite source. Never point a managed session directly at the primary
-database.
-
-## Follow-up Changes
-
-Vite handles ordinary frontend hot reload. Restart the API after Python or
-runtime schema changes; restart both processes when environment or shared build
-state changed:
-
-```bash
-make dev-sessions ARGS="restart api"
-make dev-sessions ARGS="restart frontend"
-make dev-sessions ARGS="restart all"
-```
-
-These commands retain the session URL and private data.
-
-## Browser Verification and Screenshots
-
-Resolve the current worktree URL instead of assuming port 6006:
+Resolve the current development instance URL for browser verification:
 
 ```bash
 PHOENIX_URL="$(make --silent dev-sessions ARGS=url)"
 ```
 
-Use this URL with `agent-browser`. For PR screenshots, also follow the
-`phoenix-pr-screenshot` skill. Use an empty session database unless the requested
-image depends on representative primary data.
+Use this URL with `agent-browser`; for PR screenshots, follow
+`phoenix-pr-screenshot`. Vite handles frontend hot reload. After Python or runtime
+schema changes, run `make dev-sessions ARGS="restart api"`. Restart `all` when
+environment or shared build state changes. Restarting retains the URL and data.
 
-## Hand Off a Running Instance
-
-If leaving the instance active helps the user review the work, run:
+Before handing off a running development instance, check readiness:
 
 ```bash
 make dev-sessions ARGS="status"
 ```
 
-Only describe the instance as available when both API and frontend report
-`ready`. Give the user the clickable app URL and
-`make dev-sessions ARGS="stop"`. Stop the session instead when it was used only
-for internal verification and no follow-up access is useful.
+Only report it as available when API and frontend both show `ready`. Give the
+user the clickable URL and `make dev-sessions ARGS="stop"`. Stop instances used
+only for internal verification when follow-up access would not be useful.
 
-## Manage Several Worktrees
+Stopping retains configuration and data; cleaning deletes them. Surface the
+seven-day clone-age suggestion when reporting status or discussing cleanup.
+Clean within the user's authorized scope; clone age alone does not authorize
+deletion or require a new confirmation when cleanup is already authorized.
 
-The control plane works from any Phoenix worktree. A selector can be a session
-ID, branch, or worktree path; omission selects the current worktree.
-
-```bash
-make dev-sessions
-make dev-sessions ARGS="status <session>"
-make dev-sessions ARGS="open <session>"
-make dev-sessions ARGS="stop <session>"
-make dev-sessions ARGS="stop --all"
-make dev-sessions ARGS="prune"
-make dev-sessions ARGS="clean <stopped-session>"
-make dev-sessions ARGS="doctor"
-```
-
-`stop` preserves the session environment and data. `clean` removes them, so the
-next start takes a fresh snapshot. Session listings and status output show the
-age of each private database clone. Treat clones older than seven days as a
-cleanup prompt, not permission to delete data: tell the user about the retained
-clone and clean it only when they confirm it is no longer needed.
+See [the command reference](../../../DEVELOPMENT.md#optional-worktree-development-sessions)
+for managing multiple development instances, selectors, alternate database
+sources, `open`, `prune`, `clean`, and `doctor`.

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -5,15 +5,6 @@ name = "phoenix"
 [setup]
 script = '''
 uv sync --python 3.10
-WORKTREE_PATH="$(pwd)"
-WORKTREE_ID="$(basename "$(dirname "${WORKTREE_PATH}")")"
-PORT_OFFSET="$(printf '%s' "${WORKTREE_PATH}" | cksum | awk '{print $1 % 1000}')"
-PHOENIX_PORT="$((6006 + PORT_OFFSET))"
-PHOENIX_WORKING_DIR="/tmp/${WORKTREE_ID}"
-VITE_PORT="$((5173 + PORT_OFFSET))"
-DEBUGPY_PORT="$((5678 + PORT_OFFSET))"
-
-mkdir -p "${PHOENIX_WORKING_DIR}"
 
 cd js
 pnpm install
@@ -22,13 +13,6 @@ pnpm run build:deps
 
 touch .env
 
-cat >> .env <<EOF
-export PHOENIX_PORT=${PHOENIX_PORT}
-export PHOENIX_WORKING_DIR=${PHOENIX_WORKING_DIR}
-export VITE_PORT=${VITE_PORT}
-export DEBUGPY_PORT=${DEBUGPY_PORT}
-EOF
-
 cd ../..
 '''
 
@@ -36,6 +20,5 @@ cd ../..
 name = "run"
 icon = "tool"
 command = '''
-cd js/app
-pnpm dev
+make dev-session
 '''

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -111,7 +111,7 @@ Check out the `README.md` file in the `js/app` directory for more information on
 
 Phoenix also provides `make dev-session` for developers who run concurrent
 worktrees. Each worktree receives its own Phoenix database and service ports,
-plus stable HTTPS names through
+plus stable HTTPS names derived from the worktree ID through
 [Portless](https://portless.sh/). The command stays attached so `Ctrl+C`
 performs a graceful shutdown. The fixed-port `make dev` and `pnpm --dir js/app
 dev` commands remain available.
@@ -141,6 +141,11 @@ SQLite database with SQLite's online backup API. The current worktree's `.env`
 is then applied as an optional overlay. Session-owned ports, URLs, and writable
 paths always replace inherited values, so the session cannot write to the
 primary database or another worktree's database.
+
+Service names are saved with each development instance. URLs remain stable
+when a detached worktree gains a branch or a branch is renamed. From another
+checkout, you can still inspect, stop, and clean an instance after its worktree
+directory has been deleted.
 
 `stop` preserves the environment snapshot and database for the next start.
 `clean` removes them, so the next start takes a fresh snapshot. Set

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,6 +3,7 @@
 - [Developer's Guide](#developers-guide)
   - [Quickstart](#quickstart)
   - [Setting Up Your macOS Development Environment](#setting-up-your-macos-development-environment)
+  - [Optional Worktree Development Sessions](#optional-worktree-development-sessions)
   - [Testing and Linting](#testing-and-linting)
   - [Installing Pre-Commit Hooks](#installing-pre-commit-hooks)
   - [Contributing Notebooks](#contributing-notebooks)
@@ -105,6 +106,49 @@ cp app/.env.example app/.env
 ```
 
 Check out the `README.md` file in the `js/app` directory for more information on developing the web application.
+
+## Optional Worktree Development Sessions
+
+Phoenix also provides `make dev-session` for developers who run concurrent
+worktrees. Each worktree receives its own Phoenix database and service ports,
+plus stable HTTPS names through
+[Portless](https://portless.sh/). The command stays attached so `Ctrl+C`
+performs a graceful shutdown. The fixed-port `make dev` and `pnpm --dir js/app
+dev` commands remain available.
+
+Use the control-plane command from any Phoenix worktree to inspect or manage all
+sessions on the machine:
+
+```bash
+make dev-sessions                                      # list running sessions
+make dev-sessions ARGS="status <session>"              # readiness and URL
+make dev-sessions ARGS="open <session>"                # open one in a browser
+make dev-sessions ARGS="restart api <session>"         # restart Python after backend changes
+make dev-sessions ARGS="restart frontend <session>"    # restart Vite without changing its URL
+make dev-sessions ARGS="restart all <session>"         # restart both processes in place
+make dev-sessions ARGS="stop <session>"                # graceful shutdown
+make dev-sessions ARGS="stop --all"                    # stop all sessions
+make dev-sessions ARGS="prune"                         # remove stale Portless routes
+make dev-sessions ARGS="clean <stopped-session>"       # remove its data and logs
+make dev-sessions ARGS="doctor"                        # diagnose Portless setup
+```
+
+Session selectors accept the ID shown by `list`, a branch name, a route name,
+or a worktree path. Omitting the selector targets the current worktree. Runtime
+state lives under `~/.cache/phoenix/dev-sessions`. On first start, the session
+takes a private snapshot of the primary checkout's `js/app/.env` and copies its
+SQLite database with SQLite's online backup API. The current worktree's `.env`
+is then applied as an optional overlay. Session-owned ports, URLs, and writable
+paths always replace inherited values, so the session cannot write to the
+primary database or another worktree's database.
+
+`stop` preserves the environment snapshot and database for the next start.
+`clean` removes them, so the next start takes a fresh snapshot. Set
+`PHOENIX_DEV_SEED_DATABASE=false` to start without primary data, or set
+`PHOENIX_DEV_DATABASE_SOURCE=/path/to/phoenix.db` to select another SQLite
+source. Database seeding can take time and disk space when the source is large.
+Primary PostgreSQL databases are not copied; these sessions start with empty
+SQLite data.
 
 ## Testing and Linting
 
@@ -386,7 +430,7 @@ The dev server runs with `debugpy` enabled, allowing you to attach a debugger fr
 2. **Start the dev environment** from the `js/app` directory:
 
 ```bash
- pnpm dev
+pnpm dev
 ```
 
 This launches both the Python server and the frontend UI simultaneously using `mprocs`. The server will start with debugpy listening on port 5678.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ NC := \033[0m # No Color
 	setup setup-remote-export install-python install-node \
 	graphql schema-graphql relay-build \
 	openapi schema-openapi schema-generative-ui ui-message-stream-fixtures codegen-python-client codegen-ts-client codegen-ts-app \
-	dev dev-backend dev-frontend dev-docker dev-mock-llm \
+	dev dev-session dev-sessions dev-backend dev-frontend dev-docker dev-mock-llm \
 	test test-python test-frontend test-ts test-helm test-jcs doctest typecheck typecheck-python typecheck-python-ty typecheck-frontend typecheck-ts \
 	format format-python format-frontend format-ts lint lint-python lint-frontend lint-ts clean-notebooks \
 	build build-python build-frontend build-ts \
@@ -67,6 +67,8 @@ help: ## Show this help message
 	@echo -e ""
 	@echo -e "$(GREEN)Development:$(NC)"
 	@echo -e "  $(YELLOW)dev$(NC)                   - Full dev environment (backend + frontend)"
+	@echo -e "  dev-session           - Managed worktree dev environment with a stable URL"
+	@echo -e "  dev-sessions          - Inspect, restart, or stop managed sessions"
 	@echo -e "  dev-backend            - Backend only (FastAPI server)"
 	@echo -e "  dev-frontend           - Frontend only (React dev server)"
 	@echo -e "  dev-docker             - Docker devops environment (use ARGS= for arguments)"
@@ -251,6 +253,12 @@ openapi: schema-openapi codegen-python-client codegen-ts-client codegen-ts-testi
 dev: ## Full dev environment (backend + frontend with hot reload)
 	@echo -e "$(CYAN)Starting full development environment...$(NC)"
 	cd $(APP_DIR) && $(PNPM) dev
+
+dev-session: ## Managed worktree dev environment with a stable Portless URL
+	@$(NODE) --disable-warning=ExperimentalWarning scripts/dev-sessions.ts start $(ARGS)
+
+dev-sessions: ## Manage worktree dev sessions (ARGS="list", "stop", "clean", ...)
+	@$(NODE) --disable-warning=ExperimentalWarning scripts/dev-sessions.ts $(or $(ARGS),list)
 
 dev-backend: ## Backend only (FastAPI server)
 	@echo -e "$(CYAN)Starting backend server...$(NC)"

--- a/js/app/mprocs.managed.yaml
+++ b/js/app/mprocs.managed.yaml
@@ -1,0 +1,8 @@
+procs:
+  api:
+    shell: "../../scripts/dev-process.sh api"
+    stop: { cmd: "pnpm exec portless run --name phoenix --force true" }
+
+  frontend:
+    shell: "../../scripts/dev-process.sh frontend"
+    stop: { cmd: "pnpm exec portless run --name phoenix-vite --force true" }

--- a/js/app/mprocs.managed.yaml
+++ b/js/app/mprocs.managed.yaml
@@ -1,8 +1,14 @@
 procs:
   api:
     shell: "../../scripts/dev-process.sh api"
-    stop: { cmd: "pnpm exec portless run --name phoenix --force true" }
+    stop:
+      {
+        cmd: 'pnpm exec portless --name "${PHOENIX_DEV_API_NAME:?}" --force true',
+      }
 
   frontend:
     shell: "../../scripts/dev-process.sh frontend"
-    stop: { cmd: "pnpm exec portless run --name phoenix-vite --force true" }
+    stop:
+      {
+        cmd: 'pnpm exec portless --name "${PHOENIX_DEV_FRONTEND_NAME:?}" --force true',
+      }

--- a/js/app/vite.config.mts
+++ b/js/app/vite.config.mts
@@ -39,7 +39,9 @@ export default defineConfig(() => {
     plugins,
     publicDir: resolve(__dirname, "static"),
     server: {
+      host: process.env.VITE_HOST || "localhost",
       port: parseInt(process.env.VITE_PORT || "5173"),
+      strictPort: true,
       warmup: {
         clientFiles: ["./index.tsx", "./App.tsx", "./Routes.tsx"],
       },

--- a/js/package.json
+++ b/js/package.json
@@ -41,6 +41,7 @@
     "oxlint": "~1.79.0",
     "oxlint-tsgolint": "~7.0.2001",
     "pkg-pr-new": "^0.0.75",
+    "portless": "0.15.6",
     "rimraf": "^6.1.3",
     "tsc-alias": "1.9.0",
     "typedoc": "^0.28.20",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       pkg-pr-new:
         specifier: ^0.0.75
         version: 0.0.75
+      portless:
+        specifier: 0.15.6
+        version: 0.15.6
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -8259,6 +8262,12 @@ packages:
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
     engines: {node: '>=10'}
+
+  portless@0.15.6:
+    resolution: {integrity: sha512-uOAwWLF32rmyEGFASzSO0VOaqb/AQxFCCzyZbPGd82UNNOfIEvc09zy92nroNibE5HNfzV4oVB0ObKbPXgkM9A==}
+    engines: {node: '>=24'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   postcss@8.5.28:
     resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
@@ -17429,6 +17438,8 @@ snapshots:
   polished@4.3.1:
     dependencies:
       '@babel/runtime': 7.29.7
+
+  portless@0.15.6: {}
 
   postcss@8.5.28:
     dependencies:

--- a/scripts/dev-process.sh
+++ b/scripts/dev-process.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "${PHOENIX_DEV_ENV_FILE:?}"
+
+case "${1:-}" in
+  api)
+    exec pnpm exec portless run --name phoenix bash -c '
+      export PHOENIX_PORT="$PORT"
+      export PHOENIX_ALLOWED_ORIGINS="${PHOENIX_ALLOWED_ORIGINS:+$PHOENIX_ALLOWED_ORIGINS,}$PORTLESS_URL"
+      exec uv run python -Xfrozen_modules=off -m phoenix.server.main serve --dev --debug
+    '
+    ;;
+  frontend)
+    exec pnpm exec portless run --name phoenix-vite bash -c '
+      export VITE_PORT="$PORT" VITE_HOST="$HOST"
+      pnpm run build:static
+      pnpm run build:relay
+      exec vite
+    '
+    ;;
+  *)
+    echo "Usage: dev-process.sh api|frontend" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/dev-process.sh
+++ b/scripts/dev-process.sh
@@ -6,14 +6,14 @@ source "${PHOENIX_DEV_ENV_FILE:?}"
 
 case "${1:-}" in
   api)
-    exec pnpm exec portless run --name phoenix bash -c '
+    exec pnpm exec portless --name "${PHOENIX_DEV_API_NAME:?}" bash -c '
       export PHOENIX_PORT="$PORT"
       export PHOENIX_ALLOWED_ORIGINS="${PHOENIX_ALLOWED_ORIGINS:+$PHOENIX_ALLOWED_ORIGINS,}$PORTLESS_URL"
       exec uv run python -Xfrozen_modules=off -m phoenix.server.main serve --dev --debug
     '
     ;;
   frontend)
-    exec pnpm exec portless run --name phoenix-vite bash -c '
+    exec pnpm exec portless --name "${PHOENIX_DEV_FRONTEND_NAME:?}" bash -c '
       export VITE_PORT="$PORT" VITE_HOST="$HOST"
       pnpm run build:static
       pnpm run build:relay

--- a/scripts/dev-sessions.ts
+++ b/scripts/dev-sessions.ts
@@ -1,0 +1,579 @@
+/* eslint-disable no-console -- Terminal output is this CLI's public interface. */
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createServer } from "node:net";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { backup, DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const APP_ROOT = join(REPOSITORY_ROOT, "js", "app");
+const STATE_ROOT = resolve(
+  process.env.PHOENIX_DEV_SESSIONS_DIR ??
+    join(homedir(), ".cache", "phoenix", "dev-sessions")
+);
+const PORTLESS = join(
+  REPOSITORY_ROOT,
+  "js",
+  "node_modules",
+  ".bin",
+  "portless"
+);
+const MPROCS = join(APP_ROOT, "node_modules", ".bin", "mprocs");
+
+type Session = {
+  id: string;
+  branch: string;
+  worktreePath: string;
+  pid: number | null;
+  controlPort: number;
+  grpcPort: number;
+  startedAt: string;
+};
+
+function run({
+  command,
+  arguments_,
+  cwd = REPOSITORY_ROOT,
+  inherit = false,
+}: {
+  command: string;
+  arguments_: string[];
+  cwd?: string;
+  inherit?: boolean;
+}): string {
+  try {
+    const output = execFileSync(command, arguments_, {
+      cwd,
+      encoding: "utf8",
+      stdio: inherit ? "inherit" : ["ignore", "pipe", "pipe"],
+    });
+    return output?.trim() ?? "";
+  } catch (error) {
+    const stderr = (error as { stderr?: string | Buffer }).stderr;
+    const message =
+      typeof stderr === "string" ? stderr.trim() : stderr?.toString().trim();
+    throw new Error(message || `${command} failed`, { cause: error });
+  }
+}
+
+function runGit({
+  arguments_,
+  cwd = process.cwd(),
+}: {
+  arguments_: string[];
+  cwd?: string;
+}): string {
+  return run({ command: "git", arguments_, cwd });
+}
+
+function getIdentity(): Pick<Session, "id" | "branch" | "worktreePath"> {
+  const worktreePath = resolve(
+    runGit({ arguments_: ["rev-parse", "--show-toplevel"] })
+  );
+  const commonGitDirectory = resolve(
+    worktreePath,
+    runGit({
+      arguments_: ["rev-parse", "--git-common-dir"],
+      cwd: worktreePath,
+    })
+  );
+  const branch =
+    runGit({ arguments_: ["branch", "--show-current"], cwd: worktreePath }) ||
+    `detached-${runGit({ arguments_: ["rev-parse", "--short", "HEAD"], cwd: worktreePath })}`;
+  const id = createHash("sha256")
+    .update(`${commonGitDirectory}\0${worktreePath}`)
+    .digest("hex")
+    .slice(0, 12);
+  return { id, branch, worktreePath };
+}
+
+const getSessionDirectory = (id: string) => join(STATE_ROOT, id);
+const getSessionPath = (id: string) =>
+  join(getSessionDirectory(id), "session.json");
+const getDataDirectory = (id: string) => join(getSessionDirectory(id), "data");
+const getLogDirectory = (id: string) => join(getSessionDirectory(id), "logs");
+const getEnvironmentPath = (id: string) =>
+  join(getSessionDirectory(id), "env.sh");
+
+async function readSession(id: string): Promise<Session | null> {
+  try {
+    return JSON.parse(await readFile(getSessionPath(id), "utf8")) as Session;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function readSessions(): Promise<Session[]> {
+  let ids: string[];
+  try {
+    ids = await readdir(STATE_ROOT);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return (await Promise.all(ids.map(readSession))).filter(
+    (session): session is Session => session !== null
+  );
+}
+
+async function writeSession(session: Session): Promise<void> {
+  const directory = getSessionDirectory(session.id);
+  await mkdir(directory, { recursive: true });
+  const temporaryPath = join(directory, `session.${process.pid}.tmp`);
+  await writeFile(temporaryPath, `${JSON.stringify(session, null, 2)}\n`);
+  await rename(temporaryPath, getSessionPath(session.id));
+}
+
+function isRunning(session: Session): boolean {
+  if (session.pid === null) return false;
+  try {
+    process.kill(session.pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function selectSession(selector?: string): Promise<Session> {
+  if (!selector) {
+    const session = await readSession(getIdentity().id);
+    if (session) return session;
+    throw new Error("This worktree does not have a dev session.");
+  }
+  const matches = (await readSessions()).filter(
+    (session) =>
+      session.id.startsWith(selector) ||
+      session.branch === selector ||
+      session.worktreePath === resolve(selector)
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      matches.length === 0
+        ? `No dev session matches "${selector}".`
+        : `More than one dev session matches "${selector}".`
+    );
+  }
+  return matches[0] as Session;
+}
+
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  const port = await new Promise<number>((resolvePort, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string")
+        return reject(new Error("Could not allocate a local port."));
+      resolvePort(address.port);
+    });
+  });
+  await new Promise<void>((resolveClose, reject) =>
+    server.close((error) => (error ? reject(error) : resolveClose()))
+  );
+  return port;
+}
+
+function getPortlessUrl({
+  name,
+  worktreePath,
+}: {
+  name: string;
+  worktreePath: string;
+}): string {
+  return run({
+    command: PORTLESS,
+    arguments_: ["get", name],
+    cwd: worktreePath,
+  });
+}
+
+function isReady(url: string): boolean {
+  const result = spawnSync(
+    "curl",
+    ["--fail", "--insecure", "--silent", "--max-time", "1", url],
+    {
+      stdio: "ignore",
+    }
+  );
+  return result.status === 0;
+}
+
+function quoteShell(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function readEnvironment(path: string): NodeJS.ProcessEnv {
+  if (!existsSync(path)) return {};
+  const output = run({
+    command: "/bin/sh",
+    arguments_: [
+      "-c",
+      'set -a; . "$1" >/dev/null; env -0',
+      "dev-session",
+      path,
+    ],
+    cwd: APP_ROOT,
+  });
+  return Object.fromEntries(
+    output
+      .split("\0")
+      .filter(Boolean)
+      .map((entry) => {
+        const separator = entry.indexOf("=");
+        return [entry.slice(0, separator), entry.slice(separator + 1)];
+      })
+  );
+}
+
+function findSqliteDatabase({
+  environment,
+  primaryRoot,
+}: {
+  environment: NodeJS.ProcessEnv;
+  primaryRoot: string;
+}): string | null {
+  if (process.env.PHOENIX_DEV_DATABASE_SOURCE)
+    return resolve(process.env.PHOENIX_DEV_DATABASE_SOURCE);
+  if (environment.PHOENIX_POSTGRES_HOST) return null;
+  if (environment.PHOENIX_SQL_DATABASE_URL) {
+    const match = environment.PHOENIX_SQL_DATABASE_URL.match(
+      /^sqlite(?:\+[^:]+)?:\/\/\/([^?#]*)/
+    );
+    if (!match?.[1]) return null;
+    return resolve(primaryRoot, "js", "app", decodeURIComponent(match[1]));
+  }
+  return join(
+    resolve(environment.PHOENIX_WORKING_DIR ?? join(homedir(), ".phoenix")),
+    "phoenix.db"
+  );
+}
+
+async function seedDatabase({
+  environmentPath,
+  primaryRoot,
+  targetPath,
+}: {
+  environmentPath: string;
+  primaryRoot: string;
+  targetPath: string;
+}): Promise<void> {
+  const isEnabled = !["0", "false", "no"].includes(
+    (process.env.PHOENIX_DEV_SEED_DATABASE ?? "true").toLowerCase()
+  );
+  if (!isEnabled || existsSync(targetPath)) return;
+  const sourcePath = findSqliteDatabase({
+    environment: readEnvironment(environmentPath),
+    primaryRoot,
+  });
+  if (!sourcePath || !existsSync(sourcePath)) {
+    console.log("No primary SQLite database found; using empty session data.");
+    return;
+  }
+  console.log(`Copying ${sourcePath} ...`);
+  const temporaryPath = `${targetPath}.tmp`;
+  const source = new DatabaseSync(sourcePath, { readOnly: true });
+  try {
+    await backup(source, temporaryPath, { rate: 4096 });
+    await rename(temporaryPath, targetPath);
+  } finally {
+    source.close();
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+async function prepareSession(session: Session): Promise<void> {
+  const primaryRoot = dirname(
+    resolve(
+      session.worktreePath,
+      runGit({
+        arguments_: ["rev-parse", "--git-common-dir"],
+        cwd: session.worktreePath,
+      })
+    )
+  );
+  const directory = getSessionDirectory(session.id);
+  const dataDirectory = getDataDirectory(session.id);
+  const primaryEnvironment = join(directory, "primary.env");
+  await Promise.all([
+    mkdir(dataDirectory, { recursive: true }),
+    mkdir(getLogDirectory(session.id), { recursive: true }),
+  ]);
+  if (!existsSync(primaryEnvironment)) {
+    const source = join(primaryRoot, "js", "app", ".env");
+    if (existsSync(source)) await copyFile(source, primaryEnvironment);
+    else await writeFile(primaryEnvironment, "");
+    await chmod(primaryEnvironment, 0o600);
+  }
+  await seedDatabase({
+    environmentPath: primaryEnvironment,
+    primaryRoot,
+    targetPath: join(dataDirectory, "phoenix.db"),
+  });
+  const appUrl = getPortlessUrl({
+    name: "phoenix",
+    worktreePath: session.worktreePath,
+  });
+  const viteUrl = getPortlessUrl({
+    name: "phoenix-vite",
+    worktreePath: session.worktreePath,
+  });
+  const environment = [
+    `test ! -f ${quoteShell(primaryEnvironment)} || source ${quoteShell(primaryEnvironment)}`,
+    `test ! -f ${quoteShell(join(APP_ROOT, ".env"))} || source ${quoteShell(join(APP_ROOT, ".env"))}`,
+    "unset PHOENIX_SQL_DATABASE_READ_REPLICA_URL PHOENIX_SQL_DATABASE_SCHEMA",
+    "unset PHOENIX_POSTGRES_HOST PHOENIX_POSTGRES_PORT PHOENIX_POSTGRES_USER PHOENIX_POSTGRES_PASSWORD PHOENIX_POSTGRES_DB",
+    "unset PHOENIX_HOST_ROOT_PATH PHOENIX_TLS_CERT_FILE PHOENIX_TLS_KEY_FILE PHOENIX_TLS_CA_FILE",
+    "export PHOENIX_HOST=127.0.0.1",
+    "export PHOENIX_TLS_ENABLED=false",
+    "export PHOENIX_TLS_ENABLED_FOR_HTTP=false",
+    "export PHOENIX_TLS_ENABLED_FOR_GRPC=false",
+    `export PHOENIX_GRPC_PORT=${session.grpcPort}`,
+    `export PHOENIX_WORKING_DIR=${quoteShell(dataDirectory)}`,
+    `export PHOENIX_SQL_DATABASE_URL=${quoteShell(`sqlite:///${join(dataDirectory, "phoenix.db")}`)}`,
+    `export PHOENIX_CHAT_LOG_DIR=${quoteShell(join(dataDirectory, "chat-logs"))}`,
+    `export PHOENIX_ROOT_URL=${quoteShell(appUrl)}`,
+    `export PHOENIX_COLLECTOR_ENDPOINT=${quoteShell(appUrl)}`,
+    `export PHOENIX_DEV_VITE_URL=${quoteShell(viteUrl)}`,
+    "",
+  ].join("\n");
+  await writeFile(getEnvironmentPath(session.id), environment, { mode: 0o600 });
+}
+
+async function startSession(): Promise<number> {
+  if (!existsSync(PORTLESS) || !existsSync(MPROCS))
+    throw new Error("Run `make install-node` before starting a dev session.");
+  const identity = getIdentity();
+  const existing = await readSession(identity.id);
+  if (existing && isRunning(existing))
+    throw new Error(
+      `This worktree is already running at ${getPortlessUrl({ name: "phoenix", worktreePath: identity.worktreePath })}`
+    );
+  const session: Session = {
+    ...identity,
+    pid: process.pid,
+    controlPort: await getFreePort(),
+    grpcPort: await getFreePort(),
+    startedAt: new Date().toISOString(),
+  };
+  await prepareSession(session);
+  await writeSession(session);
+  const url = getPortlessUrl({
+    name: "phoenix",
+    worktreePath: session.worktreePath,
+  });
+  console.log(`\nPhoenix dev session ${session.id}`);
+  console.log(`  app       ${url}`);
+  console.log(`  data      ${getDataDirectory(session.id)}`);
+  console.log(`  logs      ${getLogDirectory(session.id)}`);
+  console.log(`  stop      make dev-sessions ARGS="stop ${session.id}"\n`);
+  const child = spawn(
+    MPROCS,
+    [
+      "--config",
+      join(APP_ROOT, "mprocs.managed.yaml"),
+      "--server",
+      `127.0.0.1:${session.controlPort}`,
+      "--log-dir",
+      getLogDirectory(session.id),
+    ],
+    {
+      cwd: APP_ROOT,
+      detached: process.platform !== "win32",
+      env: {
+        ...process.env,
+        PHOENIX_DEV_ENV_FILE: getEnvironmentPath(session.id),
+      },
+      stdio: "inherit",
+    }
+  );
+  const stop = (signal: NodeJS.Signals) =>
+    child.pid &&
+    process.kill(process.platform === "win32" ? child.pid : -child.pid, signal);
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  const exitCode = await new Promise<number>((resolveExit, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolveExit(code ?? 0));
+  });
+  process.removeListener("SIGINT", stop);
+  process.removeListener("SIGTERM", stop);
+  await writeSession({ ...session, pid: null });
+  return exitCode;
+}
+
+function sendMprocs(session: Session, command: unknown): void {
+  if (!isRunning(session)) throw new Error(`${session.id} is not running.`);
+  run({
+    command: MPROCS,
+    arguments_: [
+      "--server",
+      `127.0.0.1:${session.controlPort}`,
+      "--ctl",
+      JSON.stringify(command),
+    ],
+    cwd: APP_ROOT,
+  });
+}
+
+async function listSessions(): Promise<void> {
+  const sessions = (await readSessions()).sort((left, right) =>
+    right.startedAt.localeCompare(left.startedAt)
+  );
+  if (sessions.length === 0) return console.log("No Phoenix dev sessions.");
+  for (const session of sessions) {
+    const status = isRunning(session) ? "running" : "stopped";
+    console.log(
+      `${session.id}  ${status.padEnd(7)}  ${session.branch}  ${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}`
+    );
+  }
+}
+
+async function printStatus(selector?: string): Promise<void> {
+  const session = await selectSession(selector);
+  const appUrl = getPortlessUrl({
+    name: "phoenix",
+    worktreePath: session.worktreePath,
+  });
+  const viteUrl = getPortlessUrl({
+    name: "phoenix-vite",
+    worktreePath: session.worktreePath,
+  });
+  console.log(`Phoenix dev session ${session.id}`);
+  console.log(`  status    ${isRunning(session) ? "running" : "stopped"}`);
+  console.log(`  branch    ${session.branch}`);
+  console.log(`  app       ${appUrl}`);
+  console.log(
+    `  api       ${isReady(`${appUrl}/healthz`) ? "ready" : "unavailable"}`
+  );
+  console.log(
+    `  frontend  ${isReady(`${viteUrl}/@vite/client`) ? "ready" : "unavailable"}`
+  );
+  console.log(`  logs      ${getLogDirectory(session.id)}`);
+}
+
+async function restartSession({
+  target,
+  selector,
+}: {
+  target: string;
+  selector?: string;
+}): Promise<void> {
+  const session = await selectSession(selector);
+  if (!["api", "backend", "frontend", "ui", "all"].includes(target))
+    throw new Error("Restart target must be api, frontend, or all.");
+  const index = target === "api" || target === "backend" ? 0 : 1;
+  sendMprocs(
+    session,
+    target === "all"
+      ? { c: "restart-all" }
+      : {
+          c: "batch",
+          cmds: [{ c: "select-proc", index }, { c: "restart-proc" }],
+        }
+  );
+  console.log(`Restarting ${target} for ${session.id}.`);
+}
+
+async function cleanSession(selector?: string): Promise<void> {
+  const session = await selectSession(selector);
+  if (isRunning(session))
+    throw new Error(`Stop ${session.id} before cleaning it.`);
+  const directory = getSessionDirectory(session.id);
+  if (relative(STATE_ROOT, directory).startsWith(".."))
+    throw new Error(`Refusing to remove unmanaged path ${directory}.`);
+  await rm(directory, { recursive: true });
+  console.log(`Removed data and logs for ${session.id} (${session.branch}).`);
+}
+
+async function stopSessions(selector?: string): Promise<void> {
+  const sessions =
+    selector === "--all"
+      ? (await readSessions()).filter(isRunning)
+      : [await selectSession(selector)];
+  for (const session of sessions) {
+    sendMprocs(session, { c: "quit" });
+    console.log(`Stopping ${session.id} (${session.branch})...`);
+  }
+}
+
+async function runCommand(): Promise<number> {
+  const [command = "list", ...arguments_] = process.argv.slice(2);
+  switch (command) {
+    case "start":
+      return startSession();
+    case "list":
+      await listSessions();
+      break;
+    case "status":
+      await printStatus(arguments_[0]);
+      break;
+    case "url": {
+      const session = await selectSession(arguments_[0]);
+      console.log(
+        getPortlessUrl({
+          name: "phoenix",
+          worktreePath: session.worktreePath,
+        })
+      );
+      break;
+    }
+    case "open": {
+      const session = await selectSession(arguments_[0]);
+      run({
+        command: "open",
+        arguments_: [
+          getPortlessUrl({
+            name: "phoenix",
+            worktreePath: session.worktreePath,
+          }),
+        ],
+      });
+      break;
+    }
+    case "restart":
+      await restartSession({
+        target: arguments_[0] ?? "",
+        selector: arguments_[1],
+      });
+      break;
+    case "stop": {
+      await stopSessions(arguments_[0]);
+      break;
+    }
+    case "clean":
+      await cleanSession(arguments_[0]);
+      break;
+    case "prune":
+    case "doctor":
+      run({ command: PORTLESS, arguments_: [command], inherit: true });
+      break;
+    default:
+      throw new Error(`Unknown command "${command}".`);
+  }
+  return 0;
+}
+
+runCommand().then(
+  (exitCode) => {
+    process.exitCode = exitCode;
+  },
+  (error: unknown) => {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  }
+);

--- a/scripts/dev-sessions.ts
+++ b/scripts/dev-sessions.ts
@@ -33,6 +33,7 @@ const PORTLESS = join(
   "portless"
 );
 const MPROCS = join(APP_ROOT, "node_modules", ".bin", "mprocs");
+const STALE_DATABASE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 type Session = {
   id: string;
@@ -42,6 +43,7 @@ type Session = {
   controlPort: number;
   grpcPort: number;
   startedAt: string;
+  databaseClonedAt: string | null;
 };
 
 function run({
@@ -108,6 +110,8 @@ const getDataDirectory = (id: string) => join(getSessionDirectory(id), "data");
 const getLogDirectory = (id: string) => join(getSessionDirectory(id), "logs");
 const getEnvironmentPath = (id: string) =>
   join(getSessionDirectory(id), "env.sh");
+const getDatabasePath = (id: string) =>
+  join(getDataDirectory(id), "phoenix.db");
 
 async function readSession(id: string): Promise<Session | null> {
   try {
@@ -129,6 +133,30 @@ async function readSessions(): Promise<Session[]> {
   return (await Promise.all(ids.map(readSession))).filter(
     (session): session is Session => session !== null
   );
+}
+
+/**
+ * @param params - Age formatting parameters.
+ * @param params.clonedAt - Time when the database clone was created.
+ * @param params.now - Reference time. Defaults to the current time.
+ */
+function getDatabaseAge({
+  clonedAt,
+  now = new Date(),
+}: {
+  clonedAt: string | null;
+  now?: Date;
+}): { ageMs: number; label: string } | null {
+  if (!clonedAt) return null;
+  const ageMs = Math.max(0, now.getTime() - Date.parse(clonedAt));
+  const ageHours = Math.floor(ageMs / (60 * 60 * 1000));
+  const label =
+    ageHours < 1
+      ? "<1h"
+      : ageHours < 48
+        ? `${ageHours}h`
+        : `${Math.floor(ageHours / 24)}d`;
+  return { ageMs, label };
 }
 
 async function writeSession(session: Session): Promise<void> {
@@ -292,18 +320,18 @@ async function seedDatabase({
   environmentPath: string;
   primaryRoot: string;
   targetPath: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const isEnabled = !["0", "false", "no"].includes(
     (process.env.PHOENIX_DEV_SEED_DATABASE ?? "true").toLowerCase()
   );
-  if (!isEnabled || existsSync(targetPath)) return;
+  if (!isEnabled || existsSync(targetPath)) return false;
   const sourcePath = findSqliteDatabase({
     environment: readEnvironment(environmentPath),
     primaryRoot,
   });
   if (!sourcePath || !existsSync(sourcePath)) {
     console.log("No primary SQLite database found; using empty session data.");
-    return;
+    return false;
   }
   console.log(`Copying ${sourcePath} ...`);
   const temporaryPath = `${targetPath}.tmp`;
@@ -311,13 +339,14 @@ async function seedDatabase({
   try {
     await backup(source, temporaryPath, { rate: 4096 });
     await rename(temporaryPath, targetPath);
+    return true;
   } finally {
     source.close();
     await rm(temporaryPath, { force: true });
   }
 }
 
-async function prepareSession(session: Session): Promise<void> {
+async function prepareSession(session: Session): Promise<boolean> {
   const primaryRoot = dirname(
     resolve(
       session.worktreePath,
@@ -340,10 +369,10 @@ async function prepareSession(session: Session): Promise<void> {
     else await writeFile(primaryEnvironment, "");
     await chmod(primaryEnvironment, 0o600);
   }
-  await seedDatabase({
+  const didCloneDatabase = await seedDatabase({
     environmentPath: primaryEnvironment,
     primaryRoot,
-    targetPath: join(dataDirectory, "phoenix.db"),
+    targetPath: getDatabasePath(session.id),
   });
   const appUrl = getPortlessUrl({
     name: "phoenix",
@@ -373,6 +402,7 @@ async function prepareSession(session: Session): Promise<void> {
     "",
   ].join("\n");
   await writeFile(getEnvironmentPath(session.id), environment, { mode: 0o600 });
+  return didCloneDatabase;
 }
 
 async function startSession(): Promise<number> {
@@ -390,9 +420,16 @@ async function startSession(): Promise<number> {
     controlPort: await getFreePort(),
     grpcPort: await getFreePort(),
     startedAt: new Date().toISOString(),
+    databaseClonedAt: existing?.databaseClonedAt ?? null,
   };
-  await prepareSession(session);
-  await writeSession(session);
+  const didCloneDatabase = await prepareSession(session);
+  const activeSession: Session = {
+    ...session,
+    databaseClonedAt: didCloneDatabase
+      ? session.startedAt
+      : session.databaseClonedAt,
+  };
+  await writeSession(activeSession);
   const url = getPortlessUrl({
     name: "phoenix",
     worktreePath: session.worktreePath,
@@ -427,7 +464,7 @@ async function startSession(): Promise<number> {
     if (isStopping) return;
     isStopping = true;
     try {
-      sendMprocs(session, { c: "quit" });
+      sendMprocs(activeSession, { c: "quit" });
     } catch {
       if (child.pid)
         process.kill(
@@ -446,9 +483,9 @@ async function startSession(): Promise<number> {
   } finally {
     for (const signal of signals) process.removeListener(signal, stop);
     try {
-      stopPortlessServices(session);
+      stopPortlessServices(activeSession);
     } finally {
-      await writeSession({ ...session, pid: null });
+      await writeSession({ ...activeSession, pid: null });
     }
   }
 }
@@ -478,8 +515,12 @@ async function listSessions(): Promise<void> {
       : hasReachableService(session)
         ? "orphaned"
         : "stopped";
+    const databaseAge = getDatabaseAge({
+      clonedAt: session.databaseClonedAt,
+    });
+    const database = databaseAge ? `db ${databaseAge.label}` : "no db clone";
     console.log(
-      `${session.id}  ${status.padEnd(7)}  ${session.branch}  ${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}`
+      `${session.id}  ${status.padEnd(8)}  ${database.padEnd(11)}  ${session.branch}  ${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}`
     );
   }
 }
@@ -496,6 +537,9 @@ async function printStatus(selector?: string): Promise<void> {
   });
   const isApiReady = isReady(`${appUrl}/healthz`);
   const isFrontendReady = isReady(`${viteUrl}/@vite/client`);
+  const databaseAge = getDatabaseAge({
+    clonedAt: session.databaseClonedAt,
+  });
   const status = isRunning(session)
     ? "running"
     : isApiReady || isFrontendReady
@@ -507,7 +551,16 @@ async function printStatus(selector?: string): Promise<void> {
   console.log(`  app       ${appUrl}`);
   console.log(`  api       ${isApiReady ? "ready" : "unavailable"}`);
   console.log(`  frontend  ${isFrontendReady ? "ready" : "unavailable"}`);
+  console.log(
+    `  database  ${databaseAge ? `cloned ${databaseAge.label} ago` : "no primary database clone"}`
+  );
   console.log(`  logs      ${getLogDirectory(session.id)}`);
+  if (databaseAge && databaseAge.ageMs > STALE_DATABASE_AGE_MS) {
+    const cleanupStep = status === "stopped" ? "run" : "stop it, then run";
+    console.log(
+      `  cleanup   clone is over 7d old; ${cleanupStep} make dev-sessions ARGS="clean ${session.id}" if it is no longer needed`
+    );
+  }
 }
 
 async function restartSession({

--- a/scripts/dev-sessions.ts
+++ b/scripts/dev-sessions.ts
@@ -44,6 +44,7 @@ type Session = {
   grpcPort: number;
   startedAt: string;
   databaseClonedAt: string | null;
+  routes: { api: string; frontend: string };
 };
 
 function run({
@@ -115,7 +116,11 @@ const getDatabasePath = (id: string) =>
 
 async function readSession(id: string): Promise<Session | null> {
   try {
-    return JSON.parse(await readFile(getSessionPath(id), "utf8")) as Session;
+    const session = JSON.parse(
+      await readFile(getSessionPath(id), "utf8")
+    ) as Session;
+    session.routes ??= getRoutes(session.id);
+    return session;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
@@ -187,6 +192,7 @@ async function selectSession(selector?: string): Promise<Session> {
     (session) =>
       session.id.startsWith(selector) ||
       session.branch === selector ||
+      Object.values(session.routes).includes(selector) ||
       session.worktreePath === resolve(selector)
   );
   if (matches.length !== 1) {
@@ -216,17 +222,14 @@ async function getFreePort(): Promise<number> {
   return port;
 }
 
-function getPortlessUrl({
-  name,
-  worktreePath,
-}: {
-  name: string;
-  worktreePath: string;
-}): string {
+function getRoutes(id: string): Session["routes"] {
+  return { api: `phoenix-${id}`, frontend: `phoenix-vite-${id}` };
+}
+
+function getPortlessUrl(name: string): string {
   return run({
     command: PORTLESS,
-    arguments_: ["get", name],
-    cwd: worktreePath,
+    arguments_: ["get", name, "--no-worktree"],
   });
 }
 
@@ -243,21 +246,16 @@ function isReady(url: string): boolean {
 
 function hasReachableService(session: Session): boolean {
   return (
-    isReady(
-      `${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}/healthz`
-    ) ||
-    isReady(
-      `${getPortlessUrl({ name: "phoenix-vite", worktreePath: session.worktreePath })}/@vite/client`
-    )
+    isReady(`${getPortlessUrl(session.routes.api)}/healthz`) ||
+    isReady(`${getPortlessUrl(session.routes.frontend)}/@vite/client`)
   );
 }
 
 function stopPortlessServices(session: Session): void {
-  for (const name of ["phoenix", "phoenix-vite"]) {
+  for (const name of Object.values(session.routes)) {
     run({
       command: PORTLESS,
-      arguments_: ["run", "--name", name, "--force", "true"],
-      cwd: session.worktreePath,
+      arguments_: ["--name", name, "--force", "true"],
     });
   }
 }
@@ -374,14 +372,8 @@ async function prepareSession(session: Session): Promise<boolean> {
     primaryRoot,
     targetPath: getDatabasePath(session.id),
   });
-  const appUrl = getPortlessUrl({
-    name: "phoenix",
-    worktreePath: session.worktreePath,
-  });
-  const viteUrl = getPortlessUrl({
-    name: "phoenix-vite",
-    worktreePath: session.worktreePath,
-  });
+  const appUrl = getPortlessUrl(session.routes.api);
+  const viteUrl = getPortlessUrl(session.routes.frontend);
   const environment = [
     `test ! -f ${quoteShell(primaryEnvironment)} || source ${quoteShell(primaryEnvironment)}`,
     `test ! -f ${quoteShell(join(APP_ROOT, ".env"))} || source ${quoteShell(join(APP_ROOT, ".env"))}`,
@@ -412,10 +404,11 @@ async function startSession(): Promise<number> {
   const existing = await readSession(identity.id);
   if (existing && (isRunning(existing) || hasReachableService(existing)))
     throw new Error(
-      `This worktree is already running at ${getPortlessUrl({ name: "phoenix", worktreePath: identity.worktreePath })}`
+      `This worktree is already running at ${getPortlessUrl(existing.routes.api)}`
     );
   const session: Session = {
     ...identity,
+    routes: getRoutes(identity.id),
     pid: process.pid,
     controlPort: await getFreePort(),
     grpcPort: await getFreePort(),
@@ -430,10 +423,7 @@ async function startSession(): Promise<number> {
       : session.databaseClonedAt,
   };
   await writeSession(activeSession);
-  const url = getPortlessUrl({
-    name: "phoenix",
-    worktreePath: session.worktreePath,
-  });
+  const url = getPortlessUrl(session.routes.api);
   console.log(`\nPhoenix dev session ${session.id}`);
   console.log(`  app       ${url}`);
   console.log(`  data      ${getDataDirectory(session.id)}`);
@@ -455,6 +445,8 @@ async function startSession(): Promise<number> {
       env: {
         ...process.env,
         PHOENIX_DEV_ENV_FILE: getEnvironmentPath(session.id),
+        PHOENIX_DEV_API_NAME: session.routes.api,
+        PHOENIX_DEV_FRONTEND_NAME: session.routes.frontend,
       },
       stdio: "inherit",
     }
@@ -520,21 +512,15 @@ async function listSessions(): Promise<void> {
     });
     const database = databaseAge ? `db ${databaseAge.label}` : "no db clone";
     console.log(
-      `${session.id}  ${status.padEnd(8)}  ${database.padEnd(11)}  ${session.branch}  ${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}`
+      `${session.id}  ${status.padEnd(8)}  ${database.padEnd(11)}  ${session.branch}  ${getPortlessUrl(session.routes.api)}`
     );
   }
 }
 
 async function printStatus(selector?: string): Promise<void> {
   const session = await selectSession(selector);
-  const appUrl = getPortlessUrl({
-    name: "phoenix",
-    worktreePath: session.worktreePath,
-  });
-  const viteUrl = getPortlessUrl({
-    name: "phoenix-vite",
-    worktreePath: session.worktreePath,
-  });
+  const appUrl = getPortlessUrl(session.routes.api);
+  const viteUrl = getPortlessUrl(session.routes.frontend);
   const isApiReady = isReady(`${appUrl}/healthz`);
   const isFrontendReady = isReady(`${viteUrl}/@vite/client`);
   const databaseAge = getDatabaseAge({
@@ -627,24 +613,14 @@ async function runCommand(): Promise<number> {
       break;
     case "url": {
       const session = await selectSession(arguments_[0]);
-      console.log(
-        getPortlessUrl({
-          name: "phoenix",
-          worktreePath: session.worktreePath,
-        })
-      );
+      console.log(getPortlessUrl(session.routes.api));
       break;
     }
     case "open": {
       const session = await selectSession(arguments_[0]);
       run({
         command: "open",
-        arguments_: [
-          getPortlessUrl({
-            name: "phoenix",
-            worktreePath: session.worktreePath,
-          }),
-        ],
+        arguments_: [getPortlessUrl(session.routes.api)],
       });
       break;
     }

--- a/scripts/dev-sessions.ts
+++ b/scripts/dev-sessions.ts
@@ -213,6 +213,27 @@ function isReady(url: string): boolean {
   return result.status === 0;
 }
 
+function hasReachableService(session: Session): boolean {
+  return (
+    isReady(
+      `${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}/healthz`
+    ) ||
+    isReady(
+      `${getPortlessUrl({ name: "phoenix-vite", worktreePath: session.worktreePath })}/@vite/client`
+    )
+  );
+}
+
+function stopPortlessServices(session: Session): void {
+  for (const name of ["phoenix", "phoenix-vite"]) {
+    run({
+      command: PORTLESS,
+      arguments_: ["run", "--name", name, "--force", "true"],
+      cwd: session.worktreePath,
+    });
+  }
+}
+
 function quoteShell(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
@@ -359,7 +380,7 @@ async function startSession(): Promise<number> {
     throw new Error("Run `make install-node` before starting a dev session.");
   const identity = getIdentity();
   const existing = await readSession(identity.id);
-  if (existing && isRunning(existing))
+  if (existing && (isRunning(existing) || hasReachableService(existing)))
     throw new Error(
       `This worktree is already running at ${getPortlessUrl({ name: "phoenix", worktreePath: identity.worktreePath })}`
     );
@@ -401,19 +422,35 @@ async function startSession(): Promise<number> {
       stdio: "inherit",
     }
   );
-  const stop = (signal: NodeJS.Signals) =>
-    child.pid &&
-    process.kill(process.platform === "win32" ? child.pid : -child.pid, signal);
-  process.once("SIGINT", stop);
-  process.once("SIGTERM", stop);
-  const exitCode = await new Promise<number>((resolveExit, reject) => {
-    child.once("error", reject);
-    child.once("close", (code) => resolveExit(code ?? 0));
-  });
-  process.removeListener("SIGINT", stop);
-  process.removeListener("SIGTERM", stop);
-  await writeSession({ ...session, pid: null });
-  return exitCode;
+  let isStopping = false;
+  const stop = (signal: NodeJS.Signals) => {
+    if (isStopping) return;
+    isStopping = true;
+    try {
+      sendMprocs(session, { c: "quit" });
+    } catch {
+      if (child.pid)
+        process.kill(
+          process.platform === "win32" ? child.pid : -child.pid,
+          signal
+        );
+    }
+  };
+  const signals: NodeJS.Signals[] = ["SIGHUP", "SIGINT", "SIGTERM"];
+  for (const signal of signals) process.once(signal, stop);
+  try {
+    return await new Promise<number>((resolveExit, reject) => {
+      child.once("error", reject);
+      child.once("close", (code) => resolveExit(code ?? 0));
+    });
+  } finally {
+    for (const signal of signals) process.removeListener(signal, stop);
+    try {
+      stopPortlessServices(session);
+    } finally {
+      await writeSession({ ...session, pid: null });
+    }
+  }
 }
 
 function sendMprocs(session: Session, command: unknown): void {
@@ -436,7 +473,11 @@ async function listSessions(): Promise<void> {
   );
   if (sessions.length === 0) return console.log("No Phoenix dev sessions.");
   for (const session of sessions) {
-    const status = isRunning(session) ? "running" : "stopped";
+    const status = isRunning(session)
+      ? "running"
+      : hasReachableService(session)
+        ? "orphaned"
+        : "stopped";
     console.log(
       `${session.id}  ${status.padEnd(7)}  ${session.branch}  ${getPortlessUrl({ name: "phoenix", worktreePath: session.worktreePath })}`
     );
@@ -453,16 +494,19 @@ async function printStatus(selector?: string): Promise<void> {
     name: "phoenix-vite",
     worktreePath: session.worktreePath,
   });
+  const isApiReady = isReady(`${appUrl}/healthz`);
+  const isFrontendReady = isReady(`${viteUrl}/@vite/client`);
+  const status = isRunning(session)
+    ? "running"
+    : isApiReady || isFrontendReady
+      ? "orphaned"
+      : "stopped";
   console.log(`Phoenix dev session ${session.id}`);
-  console.log(`  status    ${isRunning(session) ? "running" : "stopped"}`);
+  console.log(`  status    ${status}`);
   console.log(`  branch    ${session.branch}`);
   console.log(`  app       ${appUrl}`);
-  console.log(
-    `  api       ${isReady(`${appUrl}/healthz`) ? "ready" : "unavailable"}`
-  );
-  console.log(
-    `  frontend  ${isReady(`${viteUrl}/@vite/client`) ? "ready" : "unavailable"}`
-  );
+  console.log(`  api       ${isApiReady ? "ready" : "unavailable"}`);
+  console.log(`  frontend  ${isFrontendReady ? "ready" : "unavailable"}`);
   console.log(`  logs      ${getLogDirectory(session.id)}`);
 }
 
@@ -496,6 +540,7 @@ async function cleanSession(selector?: string): Promise<void> {
   const directory = getSessionDirectory(session.id);
   if (relative(STATE_ROOT, directory).startsWith(".."))
     throw new Error(`Refusing to remove unmanaged path ${directory}.`);
+  stopPortlessServices(session);
   await rm(directory, { recursive: true });
   console.log(`Removed data and logs for ${session.id} (${session.branch}).`);
 }
@@ -503,10 +548,15 @@ async function cleanSession(selector?: string): Promise<void> {
 async function stopSessions(selector?: string): Promise<void> {
   const sessions =
     selector === "--all"
-      ? (await readSessions()).filter(isRunning)
+      ? await readSessions()
       : [await selectSession(selector)];
   for (const session of sessions) {
-    sendMprocs(session, { c: "quit" });
+    if (isRunning(session)) {
+      sendMprocs(session, { c: "quit" });
+    } else {
+      await writeSession({ ...session, pid: null });
+    }
+    stopPortlessServices(session);
     console.log(`Stopping ${session.id} (${session.branch})...`);
   }
 }

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -277,8 +277,8 @@ class AppConfig(NamedTuple):
     """ Whether the in-process MCP server is mounted at /mcp """
     mcp_code_mode_enabled: bool = False
     """ Whether the MCP server presents the code-mode tool surface """
-    dev_vite_port: int = 5173
-    """ Port the Vite dev server runs on. Only used in development mode. """
+    dev_vite_url: str = "http://localhost:5173"
+    """ URL of the Vite dev server. Only used in development mode. """
 
 
 class Static(StaticFiles):
@@ -333,7 +333,7 @@ class Static(StaticFiles):
                     "basename": get_root_path(scope),
                     "platform_version": phoenix_version,
                     "is_development": self._app_config.is_development,
-                    "vite_port": self._app_config.dev_vite_port,
+                    "vite_url": self._app_config.dev_vite_url,
                     "manifest": self._web_manifest,
                     "authentication_enabled": self._app_config.authentication_enabled,
                     "oauth2_idps": self._app_config.oauth2_idps,
@@ -925,6 +925,7 @@ def create_app(
     debug: bool = False,
     dev: bool = False,
     dev_vite_port: int = 5173,
+    dev_vite_url: Optional[str] = None,
     read_only: bool = False,
     grpc_port: Optional[int] = None,
     enable_prometheus: bool = False,
@@ -1305,7 +1306,7 @@ def create_app(
                     mcp_server_enabled=mcp_mount_path is not None,
                     mcp_code_mode_enabled=mcp_mount_path is not None and get_env_mcp_code_mode(),
                     auth_error_messages=dict(AUTH_ERROR_MESSAGES) if authentication_enabled else {},
-                    dev_vite_port=dev_vite_port,
+                    dev_vite_url=dev_vite_url or f"http://localhost:{dev_vite_port}",
                 ),
             ),
             name="static",

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -295,6 +295,9 @@ def run(args: Namespace) -> None:
     agents_env = AgentsEnvConfig.from_env()
     # Dev tooling ports set by the frontend dev scripts (e.g. `pnpm dev:server`)
     vite_port = os.getenv("VITE_PORT") or (str(args.dev_vite_port) if args.dev else None)
+    dev_vite_url = os.getenv("PHOENIX_DEV_VITE_URL") or (
+        f"http://localhost:{vite_port}" if vite_port else None
+    )
     debugpy_port = os.getenv("DEBUGPY_PORT")
     boot_message = BootMessage(
         version=phoenix_version,
@@ -338,7 +341,7 @@ def run(args: Namespace) -> None:
         telemetry_enabled=get_env_telemetry_enabled(),
         dev_mode=args.dev,
         debug_logging=args.debug,
-        dev_vite_url=f"http://localhost:{vite_port}" if vite_port else None,
+        dev_vite_url=dev_vite_url,
         debugpy_url=f"localhost:{debugpy_port}" if debugpy_port else None,
     )
 
@@ -381,6 +384,7 @@ def run(args: Namespace) -> None:
         debug=args.debug,
         dev=args.dev,
         dev_vite_port=args.dev_vite_port,
+        dev_vite_url=dev_vite_url,
         serve_ui=not args.no_ui,
         read_only=read_only,
         grpc_port=grpc_port,

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -157,14 +157,14 @@
     {%- endif %}
     {% if is_development -%}
       <script type="module">
-        import RefreshRuntime from 'http://localhost:{{ vite_port }}/@react-refresh'
+        import RefreshRuntime from '{{ vite_url }}/@react-refresh'
         RefreshRuntime.injectIntoGlobalHook(window)
         window.$RefreshReg$ = () => {}
         window.$RefreshSig$ = () => (type) => type
         window.__vite_plugin_react_preamble_installed__ = true
       </script>
-      <script type="module" src="http://localhost:{{ vite_port }}/@vite/client"></script>
-      <script type="module" src="http://localhost:{{ vite_port }}/index.tsx"></script>
+      <script type="module" src="{{ vite_url }}/@vite/client"></script>
+      <script type="module" src="{{ vite_url }}/index.tsx"></script>
     {%- else -%}
       {{- render_js() -}}
     {%- endif -%}

--- a/tests/unit/server/test_static_well_known.py
+++ b/tests/unit/server/test_static_well_known.py
@@ -16,7 +16,7 @@ from starlette.exceptions import HTTPException
 from phoenix.server.app import AppConfig, Static
 
 
-def _static(directory: Path) -> Static:
+def _static(directory: Path, *, dev_vite_url: str = "http://localhost:5173") -> Static:
     return Static(
         directory=directory,
         app_config=AppConfig(
@@ -25,6 +25,7 @@ def _static(directory: Path) -> Static:
             authentication_enabled=False,
             auth_error_messages={},
             oauth2_idps=[],
+            dev_vite_url=dev_vite_url,
         ),
     )
 
@@ -55,3 +56,12 @@ async def test_files_that_exist_are_still_served(tmp_path: Path) -> None:
     static = _static(tmp_path)
     response = await static.get_response("real.txt", _scope("/real.txt"))
     assert response.status_code == 200
+
+
+async def test_development_index_uses_configured_vite_url(tmp_path: Path) -> None:
+    vite_url = "https://vite.feature.phoenix.localhost"
+    static = _static(tmp_path, dev_vite_url=vite_url)
+    response = await static.get_response("", _scope("/"))
+    body = bytes(response.body).decode()
+    assert f"{vite_url}/@vite/client" in body
+    assert f"{vite_url}/index.tsx" in body


### PR DESCRIPTION
## Summary

- Add an optional `make dev-session` workflow for concurrent worktrees.
- Give each session isolated ports, logs, writable data, and stable Portless URLs.
- Seed new sessions with the primary checkout configuration and a private SQLite copy.
- Add commands to inspect, restart, open, stop, and clean sessions.
- Add a worktree-specific Codex skill for operating and handing off development instances.

The existing fixed-port development workflow remains the default in general guidance.