### PR TITLE
fix(ci): read the Playwright version from the installed package

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -78,7 +78,9 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(pnpm list --json | jq -r '.[0].devDependencies["@playwright/test"].version')" >> $GITHUB_ENV
+        run: |
+          PLAYWRIGHT_VERSION=$(node -p "require('@playwright/test/package.json').version")
+          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> "$GITHUB_ENV"
       - name: Cache Playwright binaries
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: playwright-cache
@@ -98,6 +100,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: "pyproject.toml"
+          cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
         run: uv sync --extra container


### PR DESCRIPTION
Two one-line changes to the e2e job.

## 1. The cache key contained the string `null`

`PLAYWRIGHT_VERSION` feeds the browser cache key, and the lookup indexed the first entry of `pnpm list --json` — which stopped being the app and became the workspace root when the app moved into the `js` workspace (752e800ac; that commit updated every path in this workflow but left the `.[0]` index from the standalone-project era). The key became:

```
Linux-playwright-null-766bb245…
```

Blind to the Playwright version, so a version bump still matched the previous entry. Since `Install Playwright Browsers` is gated on that hit, the install was skipped and the job had no browser to launch — see [run 34179779759](https://github.com/Arize-ai/phoenix/actions/runs/34179779759/job/102136681381), where the two `setup` projects fail at launch and the remaining 216 tests never run.

It stayed hidden because the step could not fail: `echo "VAR=$(...)"` checks only `echo`'s exit status, so `jq` reporting a missing path as a successful `null` was written straight into the key while the step stayed green. Reading from the installed package and assigning on its own line fixes both — `node -p` throws when the package is unresolvable, and the assignment's status now reaches `bash -e`.

Verified: from `js/app` the new lookup returns `1.63.0`, and under `bash -e` a failed lookup exits 1 and writes nothing, where the old form exits 0 and writes `PLAYWRIGHT_VERSION=`.

## 2. setup-uv spends ~106s walking the repo

`setup-uv`'s default `cache-dependency-glob` matches `**/pyproject.toml`, `**/*requirements*.txt` and four more patterns across the whole tree. With `node_modules` for 20 workspace projects and `.venv` on disk, 106 of that step's 108s pass between two consecutive glob matches — 13% of the job — to key a cache that measures **1,666 bytes**. `uv.lock` is the only input that changes what uv installs here.

Unrelated to the bug above; separate commit.
