### PR TITLE
fix: Preserve ask-user question counts during streaming

### DIFF
--- a/js/app/src/components/agent/AskUserToolDetails.tsx
+++ b/js/app/src/components/agent/AskUserToolDetails.tsx
@@ -78,11 +78,32 @@ type AskUserListEntry = {
  */
 export function getAskUserToolPreview(part: ToolInvocationPart): string {
   const input = parseElicitToolInput(part.input);
-  if (!input) {
+  const questionCount =
+    input?.questions.length ??
+    (part.state === "input-streaming"
+      ? getStreamingQuestionCount(part.input)
+      : null);
+  if (questionCount === null) {
     return part.state === "output-error" ? "" : "Question pending";
   }
-  const count = input.questions.length;
-  return `${count} question${count === 1 ? "" : "s"}`;
+  return `${questionCount} question${questionCount === 1 ? "" : "s"}`;
+}
+
+/**
+ * Returns the number of questions visible in a partial tool input.
+ *
+ * A streaming question is temporarily invalid until all of its required
+ * fields arrive. Counting the array without parsing its entries keeps the
+ * collapsed preview stable while later questions stream in.
+ */
+function getStreamingQuestionCount(input: unknown): number | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+  const { questions } = input as { questions?: unknown };
+  return Array.isArray(questions) && questions.length > 0
+    ? questions.length
+    : null;
 }
 
 /**

--- a/js/app/src/components/agent/__tests__/AskUserToolDetails.test.tsx
+++ b/js/app/src/components/agent/__tests__/AskUserToolDetails.test.tsx
@@ -80,6 +80,32 @@ describe("AskUserToolDetails", () => {
     expect(formatAskUserState(part.state, part)).toBe("Preparing questions");
   });
 
+  it("keeps the question count visible while later questions stream", () => {
+    const firstQuestion = {
+      id: "question-1",
+      prompt: "Which option should we use?",
+      type: "freeform",
+    };
+    const firstSnapshot = createAskUserPart({
+      state: "input-streaming",
+      input: { questions: [firstQuestion] },
+    });
+    const secondSnapshot = createAskUserPart({
+      state: "input-streaming",
+      input: {
+        questions: [
+          firstQuestion,
+          {
+            id: "question-2",
+          },
+        ],
+      },
+    });
+
+    expect(getAskUserToolPreview(firstSnapshot)).toBe("1 question");
+    expect(getAskUserToolPreview(secondSnapshot)).toBe("2 questions");
+  });
+
   it("treats a completed ask_user call without output as awaiting a response", () => {
     const part = createAskUserPart({
       state: "output-available",


### PR DESCRIPTION
## Summary
- Preserve the visible question count while ask-user inputs stream.
- Add coverage for partially streamed questions.

## Testing
- Added unit tests for streaming question counts.