### PR TITLE
ci: verify release tags point at commits on main before publishing

### DIFF
--- a/.agents/skills/phoenix-sqlean/SKILL.md
+++ b/.agents/skills/phoenix-sqlean/SKILL.md
@@ -121,7 +121,7 @@ sqlean moves its own pin.
 - CI's `test` matrix compiles in place across every OS/arch pair the publish job ships;
   `windows-11-arm` skips 3.10 — CPython publishes no Windows ARM64 build for it. It never runs
   cibuildwheel, which is what the `wheel` job is for.
-- Publishing is gated on the tag `arize-phoenix-sqlean-v<manifest version>`. Until release-please
-  creates it, `sqlean-sources` skips and nothing builds.
+- Publishing is gated on the tag `arize-phoenix-sqlean-v<manifest version>`. If it is missing,
+  `sqlean-sources` fails.
 - PyPI uses trusted publishing with **no** GitHub environment; the publisher's Environment field
   must stay blank to match.

--- a/.github/actions/resolve-release-tag/action.yml
+++ b/.github/actions/resolve-release-tag/action.yml
@@ -1,0 +1,53 @@
+name: Resolve a release tag to a commit on the default branch
+description: >-
+  Resolve a release tag to its commit and fail unless that commit is reachable
+  from the default branch. Release jobs publish whatever they check out, and
+  any writer can point a tag at any commit; requiring the commit to be on the
+  default branch means it passed branch protection. Returns the commit SHA so
+  callers check out a pinned revision rather than a movable tag.
+
+inputs:
+  tag:
+    description: Tag name to resolve, without the refs/tags/ prefix.
+    required: true
+
+outputs:
+  revision:
+    description: >-
+      Full SHA of the commit the tag points at, verified to be on the default
+      branch.
+    value: ${{ steps.resolve.outputs.revision }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve tag and verify it is on the default branch
+      id: resolve
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        # ls-remote lists the peeled `^{}` line after an annotated tag's own
+        # line, so the last line is the commit for both tag types.
+        REVISION=$(git ls-remote origin "refs/tags/${TAG}" "refs/tags/${TAG}^{}" | tail -n1 | cut -f1)
+        if [ -z "$REVISION" ]; then
+          echo "::error::Tag ${TAG} does not exist"
+          exit 1
+        fi
+        # The compare API needs no local history (release jobs use shallow
+        # checkouts). identical/behind: every commit at the tag is on the
+        # default branch. ahead/diverged: at least one is not. per_page=1
+        # trims the commit and file lists; status covers the full range.
+        STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${DEFAULT_BRANCH}...${REVISION}?per_page=1" --jq .status)
+        case "$STATUS" in
+          identical|behind) ;;
+          *)
+            echo "::error::Tag ${TAG} (${REVISION}) is ${STATUS} relative to ${DEFAULT_BRANCH}. Release tags must point at a commit that is already on ${DEFAULT_BRANCH}."
+            exit 1
+            ;;
+        esac
+        echo "Tag ${TAG} -> ${REVISION} (on ${DEFAULT_BRANCH})"
+        echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -97,10 +97,15 @@ jobs:
           v=$(jq -r '.["."] // empty' .release-please-manifest.json)
           if [ -z "$v" ]; then echo "::error::No version for root (.) in manifest"; exit 1; fi
           echo "version=$v" >> $GITHUB_OUTPUT
+      - name: Resolve release tag
+        id: release
+        uses: ./.github/actions/resolve-release-tag
+        with:
+          tag: arize-phoenix-v${{ steps.version.outputs.version }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: refs/tags/arize-phoenix-v${{ steps.version.outputs.version }}
+          ref: ${{ steps.release.outputs.revision }}
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           package_json_file: js/package.json
@@ -197,9 +202,9 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         with:
           persist-credentials: false
-      - name: Resolve ref from manifest
+      - name: Read name and version from manifest
         if: steps.check.outputs.needed == 'true'
-        id: ref
+        id: manifest
         run: |
           VERSION=$(jq -r --arg p "${{ matrix.path }}" '.[$p] // empty' .release-please-manifest.json)
           NAME=$(jq -r --arg p "${{ matrix.path }}" '.packages[$p]["package-name"] // empty' release-please-config.json)
@@ -207,14 +212,19 @@ jobs:
             echo "::error::Missing version or package-name for path ${{ matrix.path }}"
             exit 1
           fi
-          echo "ref=refs/tags/${NAME}-v${VERSION}" >> $GITHUB_OUTPUT
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Resolve release tag
+        if: steps.check.outputs.needed == 'true'
+        id: release
+        uses: ./.github/actions/resolve-release-tag
+        with:
+          tag: ${{ steps.manifest.outputs.name }}-v${{ steps.manifest.outputs.version }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.check.outputs.needed == 'true'
         with:
           persist-credentials: false
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ steps.release.outputs.revision }}
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         if: steps.check.outputs.needed == 'true'
         with:
@@ -288,41 +298,32 @@ jobs:
     if: contains(fromJSON(needs.list-python-packages.outputs.package_paths), 'packages/phoenix-sqlean')
     permissions:
       contents: read
-    outputs:
-      needed: ${{ steps.ref.outputs.needed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Resolve ref from manifest
-        id: ref
+      - name: Read version from manifest
+        id: manifest
         run: |
           VERSION=$(jq -r '.["packages/phoenix-sqlean"] // empty' .release-please-manifest.json)
           if [ -z "$VERSION" ]; then
             echo "::error::Missing version for packages/phoenix-sqlean in manifest"
             exit 1
           fi
-          TAG="arize-phoenix-sqlean-v${VERSION}"
-          # Until release-please creates the first release of this package, the
-          # manifest version has no tag — skip instead of failing the run.
-          if git ls-remote --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
-            echo "needed=true" >> $GITHUB_OUTPUT
-            echo "ref=refs/tags/${TAG}" >> $GITHUB_OUTPUT
-          else
-            echo "Tag ${TAG} does not exist yet; skipping arize-phoenix-sqlean"
-            echo "needed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Resolve release tag
+        id: release
+        uses: ./.github/actions/resolve-release-tag
+        with:
+          tag: arize-phoenix-sqlean-v${{ steps.manifest.outputs.version }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: steps.ref.outputs.needed == 'true'
         with:
           persist-credentials: false
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ steps.release.outputs.revision }}
       - name: Download SQLite and sqlean extension sources
-        if: steps.ref.outputs.needed == 'true'
         working-directory: packages/phoenix-sqlean
         run: make prepare-src download-sqlite download-sqlean
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: steps.ref.outputs.needed == 'true'
         with:
           name: arize-phoenix-sqlean-sources
           path: packages/phoenix-sqlean
@@ -332,7 +333,7 @@ jobs:
   build-sqlean:
     name: Build arize-phoenix-sqlean
     needs: sqlean-sources
-    if: needs.sqlean-sources.result == 'success' && needs.sqlean-sources.outputs.needed == 'true'
+    if: needs.sqlean-sources.result == 'success'
     permissions:
       contents: read
     uses: ./.github/workflows/phoenix-sqlean-build.yml


### PR DESCRIPTION
## Summary

The release jobs in \`publish.yaml\` build and publish whatever commit a release tag points at, and any writer can point a tag at any commit. This adds a check that the tag's commit is reachable from the default branch, so only code that went through a reviewed PR under branch protection can be released.

- New composite action \`.github/actions/resolve-release-tag\`: resolves the tag with \`git ls-remote\`, checks its position relative to the default branch via the compare API (no local history needed, since the jobs use shallow checkouts), and outputs the commit SHA.
- \`build-phoenix\`, \`build-packages\`, and \`sqlean-sources\` call it and check out the returned SHA rather than the tag name, so a tag moved mid-run cannot change what is built.
- \`sqlean-sources\` no longer skips when the tag is missing; it fails like the other two jobs. The \`needed\` output and the conditional steps that supported the skip are removed, and \`build-sqlean\` only checks that \`sqlean-sources\` succeeded.
- One stale sentence in the sqlean skill doc updated to match.

Preview jobs are untouched: they check out feature branches by design.

## Notes

- Release tags are lightweight here; the \`^{}\` peeling handles annotated tags if that ever changes.
- All package versions come from static files, so checking out a bare SHA does not affect build output.
- A release cut from a non-default branch (e.g. a hotfix branch) would be refused until the base of the check is widened.

## Verification

Ran the action body locally against the live repo:

| Tag | Result |
|---|---|
| \`arize-phoenix-client-v3.5.0\` | resolved, on main |
| \`arize-phoenix-sqlean-v0.1.1\` | resolved, on main |
| nonexistent tag | fails |
| open PR head SHA vs main | \`diverged\`, would be refused |

zizmor reports no new findings beyond the existing \`self-repository\` style note that local \`./.github/actions\` uses already carry.