### PR TITLE
fix(evals): find the text block in Anthropic responses instead of assuming index 0

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/anthropic/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/anthropic/adapter.py
@@ -90,12 +90,7 @@ class AnthropicAdapter(BaseLLMAdapter):
 
         try:
             response = self.client.messages.create(model=self.model, messages=messages, **kwargs)
-            if hasattr(response.content[0], "text"):
-                return cast(str, response.content[0].text)
-            else:
-                raise ValueError(
-                    f"Anthropic returned unexpected content format: {response.content}"
-                )
+            return self._extract_response_text(response.content)
         except Exception as e:
             logger.error(f"Anthropic completion failed: {e}")
             raise
@@ -117,10 +112,7 @@ class AnthropicAdapter(BaseLLMAdapter):
             response = await self.client.messages.create(
                 model=self.model, messages=messages, **kwargs
             )
-            if hasattr(response.content[0], "text"):
-                return cast(str, response.content[0].text)
-            else:
-                raise ValueError("Anthropic returned unexpected content format")
+            return self._extract_response_text(response.content)
         except Exception as e:
             logger.error(f"Anthropic async completion failed: {e}")
             raise
@@ -270,6 +262,29 @@ class AnthropicAdapter(BaseLLMAdapter):
 
         # Join all text parts with newlines
         return "\n".join(text_parts)
+
+    def _extract_response_text(self, content: Any) -> str:
+        """Extract the text from an Anthropic response's content blocks.
+
+        Scans every block rather than assuming the text is first: with
+        extended thinking enabled (``thinking={...}`` kwarg), the response
+        leads with one or more ``thinking``/``redacted_thinking`` blocks
+        before the ``text`` block.
+
+        Args:
+            content: ``response.content`` — a list of SDK content-block objects.
+
+        Returns:
+            The first text block's content.
+
+        Raises:
+            ValueError: If no block in ``content`` has a ``text`` attribute.
+        """
+        for block in content:
+            if hasattr(block, "text"):
+                return cast(str, block.text)
+
+        raise ValueError(f"Anthropic returned unexpected content format: {content}")
 
     def _transform_messages_to_anthropic(self, messages: List[Message]) -> list[dict[str, Any]]:
         """Transform List[Message] TypedDict to Anthropic message format.

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/test_generate_text.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/test_generate_text.py
@@ -1,0 +1,98 @@
+# type: ignore
+"""Tests for ``AnthropicAdapter.generate_text()`` / ``async_generate_text()`` response parsing."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from phoenix.evals.llm.adapters.anthropic.adapter import AnthropicAdapter
+
+
+def _make_sync_client() -> MagicMock:
+    client = MagicMock()
+    client.__module__ = "anthropic"
+    client.__class__.__name__ = "Anthropic"
+    client.messages.create = MagicMock()
+    # `_check_if_async_client` unwraps a `.client` attribute to support
+    # `AnthropicClientWrapper`; a plain MagicMock auto-vivifies one, which
+    # would shadow the `__module__`/`__class__` set above.
+    del client.client
+    return client
+
+
+def _make_async_client() -> MagicMock:
+    client = MagicMock()
+    client.__module__ = "anthropic"
+    client.__class__.__name__ = "AsyncAnthropic"
+    client.messages.create = AsyncMock()
+    del client.client
+    return client
+
+
+def _text_block(text: str) -> MagicMock:
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    return block
+
+
+def _thinking_block() -> MagicMock:
+    block = MagicMock()
+    block.type = "thinking"
+    del block.text  # real ThinkingBlock objects have no `.text` attribute
+    return block
+
+
+def test_generate_text_returns_the_text_block() -> None:
+    client = _make_sync_client()
+    client.messages.create.return_value = MagicMock(content=[_text_block("42")])
+    adapter = AnthropicAdapter(client=client, model="claude-3-sonnet")
+
+    assert adapter.generate_text("what is the answer?") == "42"
+
+
+def test_generate_text_finds_the_text_block_after_a_thinking_block() -> None:
+    """A `thinking` kwarg makes Anthropic prepend thinking block(s) before `text`."""
+    client = _make_sync_client()
+    client.messages.create.return_value = MagicMock(
+        content=[_thinking_block(), _text_block("The answer is 42.")]
+    )
+    adapter = AnthropicAdapter(client=client, model="claude-3-sonnet")
+
+    result = adapter.generate_text(
+        "what is the answer?", thinking={"type": "enabled", "budget_tokens": 1024}
+    )
+
+    assert result == "The answer is 42."
+
+
+def test_generate_text_raises_when_no_block_has_text() -> None:
+    client = _make_sync_client()
+    client.messages.create.return_value = MagicMock(content=[_thinking_block()])
+    adapter = AnthropicAdapter(client=client, model="claude-3-sonnet")
+
+    with pytest.raises(ValueError, match="unexpected content format"):
+        adapter.generate_text("what is the answer?")
+
+
+async def test_async_generate_text_finds_the_text_block_after_a_thinking_block() -> None:
+    client = _make_async_client()
+    client.messages.create.return_value = MagicMock(
+        content=[_thinking_block(), _text_block("The answer is 42.")]
+    )
+    adapter = AnthropicAdapter(client=client, model="claude-3-sonnet")
+
+    result = await adapter.async_generate_text(
+        "what is the answer?", thinking={"type": "enabled", "budget_tokens": 1024}
+    )
+
+    assert result == "The answer is 42."
+
+
+async def test_async_generate_text_raises_when_no_block_has_text() -> None:
+    client = _make_async_client()
+    client.messages.create.return_value = MagicMock(content=[_thinking_block()])
+    adapter = AnthropicAdapter(client=client, model="claude-3-sonnet")
+
+    with pytest.raises(ValueError, match="unexpected content format"):
+        await adapter.async_generate_text("what is the answer?")


### PR DESCRIPTION
## What

`AnthropicAdapter.generate_text()` / `async_generate_text()` raise a spurious `ValueError: Anthropic returned unexpected content format` whenever extended thinking is enabled:

```python
adapter.generate_text(
    "what is the answer?",
    thinking={"type": "enabled", "budget_tokens": 1024},
)
# ValueError: Anthropic returned unexpected content format: [...]
```

Both methods do `response.content[0]` and check `hasattr(..., "text")`. With `thinking` on, Anthropic's response leads with one or more `thinking`/`redacted_thinking` blocks before the `text` block — `content[0]` is never text, so the check fails even though the text is right there, one index later.

Any `**kwargs` the caller passes through to `generate_text`/`async_generate_text` reach `client.messages.create` unfiltered, so `thinking=...` is a legitimate, already-supported way to call these methods — it's just that the response can't be parsed back out.

## Change

Added `_extract_response_text`, which scans every block in `response.content` for the first one with a `text` attribute, instead of only checking index 0. Same `hasattr` check as before — just no longer position-dependent. This mirrors `_generate_with_tool_calling`, which already iterates `response.content` to find the `tool_use` block rather than assuming its position.

## Tests

New `test_generate_text.py`:
- `generate_text`/`async_generate_text` still return the text block in the plain case.
- Both find the text block when it's preceded by a `thinking` block — fails on `main` with the reported `ValueError`.
- Both still raise `ValueError` when no block has text at all.

Verified in red: reverting the fix fails exactly the two thinking-block tests with the reported error.

`uv run pytest packages/phoenix-evals/tests/phoenix/evals/llm/adapters/anthropic/` — 28 passed. Full `phoenix-evals` suite (excluding the pre-existing, unrelated `litellm` adapter tests, which fail to collect on Python 3.10 due to `typing.NotRequired`) — 655 passed, 1 skipped, 2 xpassed. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjzCQWswbH69CXJ2nCa9Zk
