### PR TITLE
fix(app): prevent metric chart GraphQL request loops

### DIFF
--- a/js/app/src/components/datetime/TimeRangeContext.tsx
+++ b/js/app/src/components/datetime/TimeRangeContext.tsx
@@ -1,6 +1,7 @@
 import React, {
   createContext,
   startTransition,
+  useCallback,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -27,6 +28,11 @@ import {
 
 export type TimeRangeContextType = {
   timeRange: OpenTimeRangeWithKey;
+  /**
+   * The stable "now" anchor used to resolve open time ranges. It is owned by
+   * this provider so descendants can suspend and retry without changing it.
+   */
+  timeRangeNow: number;
   timeRangeISOStrings: TimeRangeISOStrings;
   /**
    * Set the time range with the state write wrapped in a transition so
@@ -43,6 +49,8 @@ export type TimeRangeContextType = {
    * Back restores the prior range.
    */
   setCustomTimeRange: (timeRange: TimeRange) => void;
+  /** Advance a live last-N range to the current time. */
+  refreshLiveTimeRange: () => void;
 };
 
 export type SetTimeRangeOptions = {
@@ -170,6 +178,9 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     options?: SetTimeRangeOptions
   ) => {
     startTransition(() => {
+      // Re-anchor partially open custom ranges as well as live presets at the
+      // time the user applies them.
+      setTimeRangeNow(Date.now());
       setSearchParams(
         (currentSearchParams) =>
           setTimeRangeSearchParams({
@@ -181,7 +192,6 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
       // Persist the preset and re-anchor "now" so the live window refreshes.
       if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
         setStoredLastNTimeRangeKey(timeRange.timeRangeKey);
-        setTimeRangeNow(Date.now());
       }
     });
   };
@@ -196,6 +206,12 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
       { history: "push" }
     );
   };
+
+  const refreshLiveTimeRange = useCallback(() => {
+    if (isLastNTimeRangeKey(timeRange.timeRangeKey)) {
+      setTimeRangeNow(Date.now());
+    }
+  }, [timeRange.timeRangeKey]);
 
   // Seed a fresh URL from the stored preference on first load. Once the URL
   // carries a range it is canonical, so this no-ops. A live window's refresh
@@ -224,12 +240,12 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     }
     const timeRangeKey = timeRange.timeRangeKey;
     const timeoutId = window.setTimeout(() => {
-      setTimeRangeNow(Date.now());
+      refreshLiveTimeRange();
     }, getMillisecondsUntilNextLastNTimeRangeRefresh(timeRangeKey));
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [timeRange.timeRangeKey, timeRangeStartMs]);
+  }, [timeRange.timeRangeKey, timeRangeStartMs, refreshLiveTimeRange]);
 
   useRegisterSetTimeRangeClientAction({ setTimeRange });
 
@@ -237,9 +253,11 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     <TimeRangeContext.Provider
       value={{
         timeRange,
+        timeRangeNow,
         timeRangeISOStrings,
         setTimeRange,
         setCustomTimeRange,
+        refreshLiveTimeRange,
       }}
     >
       {children}

--- a/js/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
+++ b/js/app/src/components/datetime/__tests__/TimeRangeContext.test.tsx
@@ -22,29 +22,43 @@ import type { LastNTimeRangeKey, OpenTimeRangeWithKey } from "../types";
 
 function TimeRangeReader({
   onRender,
+  onRenderNow,
   onRenderISOStrings,
   onSetTimeRange,
   onSetCustomTimeRange,
+  onRefreshLiveTimeRange,
   onLocation,
   onNavigate,
 }: {
   onRender: (timeRange: OpenTimeRangeWithKey) => void;
+  onRenderNow?: (timeRangeNow: number) => void;
   onRenderISOStrings?: (timeRangeISOStrings: TimeRangeISOStrings) => void;
   onSetTimeRange?: (setTimeRange: TimeRangeContextType["setTimeRange"]) => void;
   onSetCustomTimeRange?: (
     setCustomTimeRange: TimeRangeContextType["setCustomTimeRange"]
   ) => void;
+  onRefreshLiveTimeRange?: (
+    refreshLiveTimeRange: TimeRangeContextType["refreshLiveTimeRange"]
+  ) => void;
   onLocation?: (search: string) => void;
   onNavigate?: (navigate: NavigateFunction) => void;
 }) {
-  const { timeRange, timeRangeISOStrings, setTimeRange, setCustomTimeRange } =
-    useTimeRange();
+  const {
+    timeRange,
+    timeRangeNow,
+    timeRangeISOStrings,
+    setTimeRange,
+    setCustomTimeRange,
+    refreshLiveTimeRange,
+  } = useTimeRange();
   const location = useLocation();
   const navigate = useNavigate();
   onRender(timeRange);
+  onRenderNow?.(timeRangeNow);
   onRenderISOStrings?.(timeRangeISOStrings);
   onSetTimeRange?.(setTimeRange);
   onSetCustomTimeRange?.(setCustomTimeRange);
+  onRefreshLiveTimeRange?.(refreshLiveTimeRange);
   onLocation?.(location.search);
   onNavigate?.(navigate);
   return null;
@@ -55,9 +69,11 @@ function renderTimeRangeProvider({
   initialEntry = "/projects/project-1/traces",
   lastNTimeRangeKey = "15m",
   onRender,
+  onRenderNow,
   onRenderISOStrings,
   onSetTimeRange,
   onSetCustomTimeRange,
+  onRefreshLiveTimeRange,
   onLocation,
   onNavigate,
 }: {
@@ -65,10 +81,14 @@ function renderTimeRangeProvider({
   initialEntry?: string;
   lastNTimeRangeKey?: LastNTimeRangeKey;
   onRender: (timeRange: OpenTimeRangeWithKey) => void;
+  onRenderNow?: (timeRangeNow: number) => void;
   onRenderISOStrings?: (timeRangeISOStrings: TimeRangeISOStrings) => void;
   onSetTimeRange?: (setTimeRange: TimeRangeContextType["setTimeRange"]) => void;
   onSetCustomTimeRange?: (
     setCustomTimeRange: TimeRangeContextType["setCustomTimeRange"]
+  ) => void;
+  onRefreshLiveTimeRange?: (
+    refreshLiveTimeRange: TimeRangeContextType["refreshLiveTimeRange"]
   ) => void;
   onLocation?: (search: string) => void;
   onNavigate?: (navigate: NavigateFunction) => void;
@@ -81,9 +101,11 @@ function renderTimeRangeProvider({
             <TimeRangeProvider>
               <TimeRangeReader
                 onRender={onRender}
+                onRenderNow={onRenderNow}
                 onRenderISOStrings={onRenderISOStrings}
                 onSetTimeRange={onSetTimeRange}
                 onSetCustomTimeRange={onSetCustomTimeRange}
+                onRefreshLiveTimeRange={onRefreshLiveTimeRange}
                 onLocation={onLocation}
                 onNavigate={onNavigate}
               />
@@ -142,6 +164,60 @@ describe("TimeRangeProvider", () => {
       "2026-06-09T09:46:00.000Z"
     );
     expect(renderedTimeRanges.at(-1)?.end).toBeNull();
+  });
+
+  it("advances the provider-owned anchor only for live ranges", () => {
+    const renderedNow: number[] = [];
+    let setTimeRange: TimeRangeContextType["setTimeRange"] | null = null;
+    let refreshLiveTimeRange:
+      | TimeRangeContextType["refreshLiveTimeRange"]
+      | null = null;
+
+    renderTimeRangeProvider({
+      root,
+      initialEntry: "/projects/project-1/traces?timeRangeKey=12h",
+      onRender: () => null,
+      onRenderNow: (timeRangeNow) => {
+        renderedNow.push(timeRangeNow);
+      },
+      onSetTimeRange: (nextSetTimeRange) => {
+        setTimeRange = nextSetTimeRange;
+      },
+      onRefreshLiveTimeRange: (nextRefreshLiveTimeRange) => {
+        refreshLiveTimeRange = nextRefreshLiveTimeRange;
+      },
+    });
+
+    expect(renderedNow.at(-1)).toBe(
+      new Date("2026-06-09T10:00:30.000Z").getTime()
+    );
+
+    act(() => {
+      vi.setSystemTime(new Date("2026-06-09T10:01:00.000Z"));
+      refreshLiveTimeRange?.();
+    });
+    expect(renderedNow.at(-1)).toBe(
+      new Date("2026-06-09T10:01:00.000Z").getTime()
+    );
+
+    act(() => {
+      setTimeRange?.({
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T09:00:00.000Z"),
+        end: null,
+      });
+    });
+    expect(renderedNow.at(-1)).toBe(
+      new Date("2026-06-09T10:01:00.000Z").getTime()
+    );
+
+    act(() => {
+      vi.setSystemTime(new Date("2026-06-09T10:02:00.000Z"));
+      refreshLiveTimeRange?.();
+    });
+    expect(renderedNow.at(-1)).toBe(
+      new Date("2026-06-09T10:01:00.000Z").getTime()
+    );
   });
 
   it("exposes a referentially stable ISO string representation", () => {

--- a/js/app/src/pages/project/ProjectTimeRangeControls.tsx
+++ b/js/app/src/pages/project/ProjectTimeRangeControls.tsx
@@ -1,7 +1,10 @@
 import { startTransition, useEffect, useRef } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 
-import { ConnectedTimeRangeControls } from "@phoenix/components/datetime";
+import {
+  ConnectedTimeRangeControls,
+  useTimeRange,
+} from "@phoenix/components/datetime";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useInterval } from "@phoenix/hooks/useInterval";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
@@ -32,6 +35,7 @@ export function ProjectTimeRangeControls(props: {
     setIsStreaming,
     setFetchKey,
   } = useStreamState();
+  const { refreshLiveTimeRange } = useTimeRange();
   const { tab } = useProjectRootPath();
   const isStreamingTab = STREAMING_ENABLED_TABS.includes(tab);
   const isLiveStreaming = isStreamingTab && isStreamingState;
@@ -69,9 +73,12 @@ export function ProjectTimeRangeControls(props: {
     ) {
       // Update the loaded lastUpdatedAt so the effect doesn't fire again
       loadedLastUpdatedAtRef.current = currentLastUpdatedAt;
-      setFetchKey(`fetch-traces-${currentLastUpdatedAt}`);
+      startTransition(() => {
+        refreshLiveTimeRange();
+        setFetchKey(`fetch-traces-${currentLastUpdatedAt}`);
+      });
     }
-  }, [setFetchKey, currentLastUpdatedAt]);
+  }, [setFetchKey, currentLastUpdatedAt, refreshLiveTimeRange]);
 
   return (
     <ConnectedTimeRangeControls

--- a/js/app/src/pages/project/TableMetricsCharts.tsx
+++ b/js/app/src/pages/project/TableMetricsCharts.tsx
@@ -60,9 +60,7 @@ const TableMetricsCharts = memo(function TableMetricsCharts({
   );
   const { setCustomTimeRange } = useTimeRange();
   const { fetchKey } = useStreamState();
-  // Re-close the time range on each stream refresh so live, open-ended
-  // ranges extend to include newly streamed data
-  const timeRange = useClosedTimeRange({ refreshKey: fetchKey });
+  const timeRange = useClosedTimeRange();
   const charts = getProjectMetricCharts(selectedChartKeys);
   return (
     <ChartPanelStrip chartCount={charts.length}>

--- a/js/app/src/pages/project/metrics/__tests__/useClosedTimeRange.test.tsx
+++ b/js/app/src/pages/project/metrics/__tests__/useClosedTimeRange.test.tsx
@@ -1,0 +1,88 @@
+import { Suspense, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type TimeRangeContextType,
+  TimeRangeContext,
+} from "@phoenix/components/datetime";
+
+import { useClosedTimeRange } from "../useClosedTimeRange";
+
+describe("useClosedTimeRange", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T10:00:30.000Z"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("keeps the provider-owned end stable when a suspended render retries", async () => {
+    const timeRangeNow = new Date("2026-06-09T10:00:30.000Z").getTime();
+    const renderedEndTimes: number[] = [];
+    let shouldSuspend = true;
+    let resolveSuspension: (() => void) | undefined;
+    const suspension = new Promise<void>((resolve) => {
+      resolveSuspension = resolve;
+    });
+    const contextValue: TimeRangeContextType = {
+      timeRange: {
+        timeRangeKey: "12h",
+        start: new Date("2026-06-08T22:00:00.000Z"),
+        end: null,
+      },
+      timeRangeNow,
+      timeRangeISOStrings: {
+        start: "2026-06-08T22:00:00.000Z",
+        end: undefined,
+      },
+      setTimeRange: vi.fn(),
+      setCustomTimeRange: vi.fn(),
+      refreshLiveTimeRange: vi.fn(),
+    };
+
+    function SuspendedRangeReader() {
+      const timeRange = useClosedTimeRange();
+      renderedEndTimes.push(timeRange.end.getTime());
+      if (shouldSuspend) {
+        throw suspension;
+      }
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <TimeRangeContext.Provider value={contextValue}>
+          <Suspense fallback={null}>
+            <SuspendedRangeReader />
+          </Suspense>
+        </TimeRangeContext.Provider>
+      );
+    });
+
+    expect(renderedEndTimes.length).toBeGreaterThan(0);
+    expect(new Set(renderedEndTimes)).toEqual(new Set([timeRangeNow]));
+
+    await act(async () => {
+      vi.setSystemTime(new Date("2026-06-09T10:01:30.000Z"));
+      shouldSuspend = false;
+      resolveSuspension?.();
+      await suspension;
+    });
+
+    expect(renderedEndTimes.length).toBeGreaterThan(1);
+    expect(new Set(renderedEndTimes)).toEqual(new Set([timeRangeNow]));
+  });
+});

--- a/js/app/src/pages/project/metrics/useClosedTimeRange.ts
+++ b/js/app/src/pages/project/metrics/useClosedTimeRange.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import { useTimeRange } from "@phoenix/components";
 import { ONE_MONTH_MS } from "@phoenix/constants/timeConstants";
@@ -6,49 +6,14 @@ import { ONE_MONTH_MS } from "@phoenix/constants/timeConstants";
 /**
  * Hook that converts an open time range from context into a closed time range.
  * If the time range is already closed, it returns it as-is.
- * If it's open, it fills in missing start/end values based on a frozen "now" timestamp.
- *
- * The "now" timestamp is frozen and only updates when the context time range
- * actually changes (or when refreshKey changes), so the returned range is
- * referentially stable across unrelated re-renders.
+ * If it's open, it fills in missing start/end values based on the stable
+ * provider-owned "now" timestamp.
  */
-export function useClosedTimeRange({
-  refreshKey,
-}: {
-  /**
-   * Change this key to re-freeze "now", e.g. when new data is streamed in.
-   * Without it, an open-ended (live) range stays closed at a stale timestamp
-   * and refetches exclude data that arrived after the last freeze.
-   */
-  refreshKey?: string;
-} = {}): TimeRange {
-  const { timeRange: contextTimeRange } = useTimeRange();
+export function useClosedTimeRange(): TimeRange {
+  const { timeRange: contextTimeRange, timeRangeNow } = useTimeRange();
 
   const startMs = contextTimeRange.start?.getTime() ?? null;
   const endMs = contextTimeRange.end?.getTime() ?? null;
-
-  // Use a ref to freeze "now" until the context time range actually changes
-  const lastTimestampsRef = useRef({ startMs, endMs, refreshKey });
-  // eslint-disable-next-line react/purity
-  const frozenNowMsRef = useRef<number>(Date.now());
-
-  // Only update frozen "now" when the timestamps or refresh key actually change
-  if (
-    // eslint-disable-next-line react/refs
-    lastTimestampsRef.current.startMs !== startMs ||
-    // eslint-disable-next-line react/refs
-    lastTimestampsRef.current.endMs !== endMs ||
-    // eslint-disable-next-line react/refs
-    lastTimestampsRef.current.refreshKey !== refreshKey
-  ) {
-    // eslint-disable-next-line react/refs
-    lastTimestampsRef.current = { startMs, endMs, refreshKey };
-    // eslint-disable-next-line react/purity, react/refs
-    frozenNowMsRef.current = Date.now();
-  }
-
-  // eslint-disable-next-line react/refs
-  const frozenNowMs = frozenNowMsRef.current;
 
   return useMemo<TimeRange>(() => {
     if (startMs !== null && endMs !== null) {
@@ -59,15 +24,14 @@ export function useClosedTimeRange({
     } else if (startMs !== null) {
       // If start is in the past, close at "now"; else, one month after start
       const closedEndMs =
-        // eslint-disable-next-line react/refs
-        startMs < frozenNowMs ? frozenNowMs : startMs + ONE_MONTH_MS;
+        startMs < timeRangeNow ? timeRangeNow : startMs + ONE_MONTH_MS;
       return { start: new Date(startMs), end: new Date(closedEndMs) };
     } else {
       // both null → last month to now
       return {
-        start: new Date(frozenNowMs - ONE_MONTH_MS),
-        end: new Date(frozenNowMs),
+        start: new Date(timeRangeNow - ONE_MONTH_MS),
+        end: new Date(timeRangeNow),
       };
     }
-  }, [startMs, endMs, frozenNowMs]);
+  }, [startMs, endMs, timeRangeNow]);
 }


### PR DESCRIPTION
## Summary

- move the stable timestamp used to close live metric time ranges into `TimeRangeProvider`, above chart Suspense boundaries
- advance live ranges on intentional range, timer, and streaming updates while keeping Relay `fetchKey` responsible for refetching
- cover provider refresh behavior and suspended render retries with regression tests

## Testing

- `make test-frontend` — 235 files passed; 2,388 tests passed and 12 skipped
- `make format-frontend`
- `make lint-frontend`
- `make typecheck-frontend`
- browser comparison with mock data: changing Last 1 Hour to Last 12 Hours settled after 6 GraphQL requests with the fix; the same interaction on the baseline continued beyond 2,500 requests

Screenshots are not applicable because this changes request lifecycle behavior without changing the rendered UI.

Resolves #16012
