### PR TITLE
fix(annotation): make explanation control clickable

### DIFF
--- a/js/app/src/components/annotation/CategoricalAnnotationInput.tsx
+++ b/js/app/src/components/annotation/CategoricalAnnotationInput.tsx
@@ -35,10 +35,6 @@ export function CategoricalAnnotationInput({
 }: CategoricalAnnotationInputProps & { ref?: Ref<HTMLButtonElement> }) {
   return (
     <Flex gap="size-50" alignItems="center" position="relative">
-      <AnnotationInputExplanation
-        annotation={annotation}
-        onSubmit={onSubmitExplanation}
-      />
       <Select
         id={annotationConfig.id}
         name={annotationConfig.name}
@@ -65,6 +61,10 @@ export function CategoricalAnnotationInput({
           </ListBox>
         </Popover>
       </Select>
+      <AnnotationInputExplanation
+        annotation={annotation}
+        onSubmit={onSubmitExplanation}
+      />
     </Flex>
   );
 }

--- a/js/app/src/components/annotation/ContinuousAnnotationInput.tsx
+++ b/js/app/src/components/annotation/ContinuousAnnotationInput.tsx
@@ -20,10 +20,6 @@ export function ContinuousAnnotationInput({
 }: ContinuousAnnotationInputProps & { ref?: Ref<HTMLDivElement> }) {
   return (
     <Flex gap="size-50" alignItems="center" position="relative">
-      <AnnotationInputExplanation
-        annotation={annotation}
-        onSubmit={onSubmitExplanation}
-      />
       <NumberField
         defaultValue={annotation?.score ?? undefined}
         {...props}
@@ -47,6 +43,10 @@ export function ContinuousAnnotationInput({
           from {annotationConfig.lowerBound} to {annotationConfig.upperBound}
         </Text>
       </NumberField>
+      <AnnotationInputExplanation
+        annotation={annotation}
+        onSubmit={onSubmitExplanation}
+      />
     </Flex>
   );
 }

--- a/js/app/src/components/annotation/__tests__/AnnotationInputs.test.tsx
+++ b/js/app/src/components/annotation/__tests__/AnnotationInputs.test.tsx
@@ -1,0 +1,106 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { Root } from "react-dom/client";
+import { userEvent } from "storybook/test";
+
+import { CategoricalAnnotationInput } from "../CategoricalAnnotationInput";
+import { ContinuousAnnotationInput } from "../ContinuousAnnotationInput";
+import type {
+  Annotation,
+  AnnotationConfigCategorical,
+  AnnotationConfigContinuous,
+} from "../types";
+
+const annotation: Annotation = {
+  id: "annotation-1",
+  name: "helpfulness",
+  label: "helpful",
+  score: 0.8,
+  explanation: null,
+};
+
+const categoricalConfig: AnnotationConfigCategorical = {
+  id: "categorical-config",
+  name: "helpfulness",
+  annotationType: "CATEGORICAL",
+  description: "How helpful was the response?",
+  optimizationDirection: "MAXIMIZE",
+  values: [
+    { label: "helpful", score: 1 },
+    { label: "unhelpful", score: 0 },
+  ],
+};
+
+const continuousConfig: AnnotationConfigContinuous = {
+  id: "continuous-config",
+  name: "helpfulness",
+  annotationType: "CONTINUOUS",
+  description: "How helpful was the response?",
+  optimizationDirection: "MAXIMIZE",
+  lowerBound: 0,
+  upperBound: 1,
+};
+
+describe("annotation input focus order", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("focuses a categorical value before its explanation button", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      root.render(
+        <CategoricalAnnotationInput
+          annotation={annotation}
+          annotationConfig={categoricalConfig}
+        />
+      );
+    });
+    const valueButton = container.querySelector<HTMLButtonElement>(
+      "button:not(.annotation-input-explanation)"
+    );
+    const explanationButton = container.querySelector<HTMLButtonElement>(
+      "button.annotation-input-explanation"
+    );
+
+    await act(async () => user.tab());
+    expect(document.activeElement).toBe(valueButton);
+
+    await act(async () => user.tab());
+    expect(document.activeElement).toBe(explanationButton);
+  });
+
+  it("focuses a continuous score before its explanation button", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      root.render(
+        <ContinuousAnnotationInput
+          annotation={annotation}
+          annotationConfig={continuousConfig}
+        />
+      );
+    });
+    const scoreInput = container.querySelector<HTMLInputElement>(
+      "input.react-aria-Input"
+    );
+    const explanationButton = container.querySelector<HTMLButtonElement>(
+      "button.annotation-input-explanation"
+    );
+
+    await act(async () => user.tab());
+    expect(document.activeElement).toBe(scoreInput);
+
+    await act(async () => user.tab());
+    expect(document.activeElement).toBe(explanationButton);
+  });
+});


### PR DESCRIPTION
## Summary

- render the explanation trigger after categorical and continuous annotation inputs so it wins normal paint-order hit testing
- preserve the score/label-first keyboard order while keeping Explain reachable by Tab
- add focused component coverage for both annotation input types

## Validation

- annotation input focus tests: 2 passed
- annotation component suite: 45 passed
- targeted oxfmt and oxlint passed
- manually verified at 1280px and 900px: pointer click opens the popover, `e` focuses the score, Tab reaches Explain, and Enter focuses the explanation input
- `tsc --noEmit` remains blocked by 33 pre-existing errors under `evals/aiQuery/**`; no errors are in touched files

Follow-up to #15960.

Fixes #15952
