### PR TITLE
docs(skills): weekly audit — 2026-09-09

### DIFF
--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -14,6 +14,7 @@ TypeScript. For `minimize` evaluators a high score is the bad outcome.
 
 | Evaluator | Inputs (Python names) | Labels (1.0 / 0.0) | Direction |
 | --------- | --------------------- | ------------------ | --------- |
+| Completeness | `conversation` | `complete` / `incomplete` | maximize |
 | Conciseness | `input`, `output` | `concise` / `verbose` | maximize |
 | Correctness | `input`, `output` | `correct` / `incorrect` | maximize |
 | Faithfulness | `input`, `output`, `context` | `faithful` / `unfaithful` | maximize |
@@ -60,6 +61,15 @@ const faithfulnessEval = createFaithfulnessEvaluator({ model: openai("gpt-4o") }
   itself: `input` holds the full history the assistant saw, including tool
   calls and results, and there is no `context` field — use it for multi-turn
   agents and chat.
+- **Completeness scores finished work, not acknowledgement.** A delivered
+  answer, a delivered artifact including its required parts, or an action whose
+  success is visible in the record counts as complete; a refusal, a clarifying
+  question, or a blocker report does not, and a request the user withdrew is
+  excluded from the judgement. For agent traces put tool calls and tool results
+  into the single `conversation` field so the judge can verify that an action
+  actually succeeded — with tools omitted it falls back to the visible dialogue
+  and will credit a claimed action. The `explanation` lists each request it
+  found and what happened to it.
 - **PII detection screens the whole record.** The single `conversation` field
   should include everything — system instructions, tool calls and results,
   retrieved documents — not just what the user saw. The judge's `explanation`

--- a/.agents/skills/phoenix-evals/references/observe-sampling-python.md
+++ b/.agents/skills/phoenix-evals/references/observe-sampling-python.md
@@ -98,4 +98,26 @@ traces = client.traces.get_traces(
     order="desc",
     limit=50,
 )
+
+# Server-side error and latency filters (requires Phoenix server >= 20.8.0)
+slow_failures = client.traces.get_traces(
+    project_identifier="my-app",
+    error=True,             # only traces containing at least one errored span
+    min_latency_ms=1000,    # inclusive lower bound, milliseconds
+    limit=50,
+)
+
+# The clean, slow traces — the ones that are wrong without crashing
+quiet_and_slow = client.traces.get_traces(
+    project_identifier="my-app",
+    error=False,            # only traces with no errored spans
+    min_latency_ms=5000,
+    max_latency_ms=30000,   # inclusive upper bound
+    limit=50,
+)
 ```
+
+`error=False` is a filter in its own right, not "unfiltered" — leave `error`
+unset to get every trace. Negative bounds, and a `min_latency_ms` above
+`max_latency_ms`, raise `ValueError` client-side instead of returning an empty
+page.

--- a/.agents/skills/phoenix-evals/references/observe-sampling-typescript.md
+++ b/.agents/skills/phoenix-evals/references/observe-sampling-typescript.md
@@ -113,7 +113,28 @@ const { traces: recentTraces } = await getTraces({
   limit: 50,
   includeSpans: true,
 });
+
+// Server-side error and latency filters (requires Phoenix server >= 20.8.0)
+const { traces: slowFailures } = await getTraces({
+  project: { projectName: "my-project" },
+  error: true, // only traces containing at least one errored span
+  minLatencyMs: 1000, // inclusive lower bound, milliseconds
+  limit: 50,
+});
+
+// The clean, slow traces — the ones that are wrong without crashing
+const { traces: quietAndSlow } = await getTraces({
+  project: { projectName: "my-project" },
+  error: false, // only traces with no errored spans
+  minLatencyMs: 5000,
+  maxLatencyMs: 30000, // inclusive upper bound
+  limit: 50,
+});
 ```
+
+`error: false` is a filter in its own right, not "unfiltered" — omit `error` to
+get every trace. Negative bounds, and a `minLatencyMs` above `maxLatencyMs`,
+throw client-side instead of returning an empty page.
 
 ## Building a Review Queue
 

--- a/.agents/skills/phoenix-evals/references/production-continuous.md
+++ b/.agents/skills/phoenix-evals/references/production-continuous.md
@@ -107,8 +107,7 @@ For trace-level monitoring (e.g., agent workflows), use `get_traces`/`getTraces`
 traces = client.traces.get_traces(
     project_identifier="my-app",
     start_time=datetime.now() - timedelta(hours=1),
-    sort="latency_ms",
-    order="desc",
+    min_latency_ms=1000,
     limit=50,
 )
 ```
@@ -120,9 +119,14 @@ import { getTraces } from "@arizeai/phoenix-client/traces";
 const { traces } = await getTraces({
   project: { projectName: "my-app" },
   startTime: new Date(Date.now() - 60 * 60 * 1000),
+  minLatencyMs: 1000,
   limit: 50,
 });
 ```
+
+The `error`, `min_latency_ms`/`minLatencyMs`, and `max_latency_ms`/`maxLatencyMs`
+filters require Phoenix server >= 20.8.0; against an older server the client
+raises rather than silently returning unfiltered traces.
 
 ## Alerting
 

--- a/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-atif-python.md
@@ -6,7 +6,7 @@
 
 ATIF (Agent Trajectory Interchange Format) is an open schema for recording agent execution. Frameworks like **Claude Code**, **OpenHands**, **Gemini CLI**, and **Codex** export ATIF via [Harbor](https://www.harborframework.com/docs). The `phoenix-client` package converts ATIF JSON into OpenTelemetry span trees and uploads them to Phoenix.
 
-Supports ATIF schema versions v1.0 through v1.7.
+Supports ATIF schema versions v1.0 through v1.7. Callers load the documents themselves — the helper does not read referenced files, fetch URLs, or upload media bytes.
 
 ## Installation
 
@@ -44,35 +44,74 @@ def upload_atif_trajectories_as_spans(
 ```
 
 - `client` — a `phoenix.client.Client` instance
-- `trajectories` — one or more ATIF trajectory dicts (v1.0–v1.7)
+- `trajectories` — one or more ATIF trajectory dicts (v1.0–v1.7); put parents before external children
 - `project_name` — the Phoenix project to upload spans into
 - `timeout` — request timeout in seconds (default: 30)
 
+Raises `ValueError` when a trajectory or the resulting span graph fails validation.
+
 ## Trace Hierarchy
 
-The converter builds a span tree matching what real-time instrumentors produce:
+Each trajectory gets an AGENT root. Spans are named by their target, since the
+span kind already names the operation: the agent name for the root, the model
+name for LLM calls, the tool name for tool calls. Each fresh agent step becomes
+a CHAIN span named `iteration N`; context-management steps become
+`compaction N` and operational system steps `system event N`. User messages are
+prompt context, not spans.
 
-**Single-turn:**
+**Single-turn** — every step hangs off the root:
 ```
-AGENT (root — input=user message, output=final agent reply)
-  LLM
-  TOOL
-  LLM
+AGENT assistant
+  CHAIN iteration 1
+    LLM gpt-4
+    TOOL search
+  CHAIN iteration 2
+    LLM gpt-4
 ```
 
-**Multi-turn:**
+**Multi-turn** — one AGENT span per turn. A turn opens at each user message
+that follows agent activity, so leading system steps and consecutive context
+messages stay in the turn they introduce:
 ```
-AGENT (root — input=first user message, output=final agent reply)
-  AGENT turn_1 (input=user msg 1, output=agent reply 1)
-    LLM
-    TOOL
-  AGENT turn_2 (input=user msg 2, output=agent reply 2)
-    LLM
+AGENT assistant
+  AGENT turn 1
+    CHAIN iteration 1
+      LLM gpt-4
+      TOOL search
+  AGENT turn 2
+    CHAIN iteration 2
+      LLM gpt-4
 ```
+
+Steps marked `is_copied_context: true` reconstruct prompt history without
+creating execution spans; an LLM span whose context includes copied history
+carries `metadata.has_copied_context = True`.
+
+An agent step with `llm_call_count: 0` is non-LLM orchestration that issued
+tool calls. It still gets its iteration CHAIN and its TOOL spans, but no LLM
+span.
+
+## Timing
+
+ATIF records one event timestamp per step, not an interval, so the converter
+reports honest event timing rather than fabricating durations:
+
+- A step's CHAIN span runs from the preceding fresh event to its own
+  timestamp (`metadata.atif.timing = "event_interval"`).
+- TOOL spans are zero-duration events at the step timestamp
+  (`metadata.atif.timing = "event"`). ATIF does not say whether tool calls in
+  one step ran serially or concurrently.
+- An LLM span is a zero-duration event too, unless an adapter supplies a
+  measured latency; a measured interval is clamped to the step interval and
+  recorded as `metadata.atif.measured_latency_ms`.
+- Missing or non-monotonic timestamps collapse onto the preceding event.
+
+Document order and tool-call array order are preserved.
 
 ## Multi-Agent / Subagent Linking
 
-Upload parent and child trajectories together for cross-references to resolve:
+Upload parent and child trajectories together, parents first, for
+cross-references to resolve:
 
 ```python
 with open("parent.json") as f:
@@ -87,48 +126,60 @@ upload_atif_trajectories_as_spans(
 
 Resulting trace:
 ```
-AGENT (parent)
-  LLM
-  TOOL (delegate_task)
-    AGENT (child agent)
-      LLM
-      TOOL
+AGENT parent
+  CHAIN iteration 1
+    LLM gpt-4
+    TOOL delegate_task
+      AGENT child agent
+        CHAIN iteration 1
+          LLM gpt-4
+          TOOL search
 ```
 
 ### Which span parents the child
 
 A step in the parent trajectory declares that it spawned a subagent via a
-`subagent_trajectory_ref` in its result. The child's spans always land in the
-parent's trace; the ref decides which span they nest under. There are two cases:
+`subagent_trajectory_ref` in its observation result. The child's spans always
+land in the parent's trace; the ref decides which span they nest under, and the
+child attaches to the closest span the document actually proves:
 
-**The subagent was spawned by a tool call** (e.g. a `delegate_task` tool). The
-child nests under that TOOL span, as in the trace above. For this to happen,
-the referencing step must actually own the call: it is an agent step
-(`source: "agent"`), its result names the spawning call in `source_call_id`,
-and one of the step's `tool_calls` has that `tool_call_id`.
+**The subagent was spawned by a named tool call** (e.g. a `delegate_task`
+tool). The result's `source_call_id` matches one of the step's `tool_calls`, so
+the child nests under that TOOL span, as in the trace above.
 
-**Anything else** — the subagent was started by the system or an orchestration
-layer, there is no `source_call_id`, or the `source_call_id` doesn't match any
-of the step's tool calls. No TOOL span exists for such a spawn, so the child
-nests directly under the parent trajectory's root AGENT span:
+**The spawn is attributable to a step but not to a call** — the system or an
+orchestration layer started it, there is no `source_call_id`, or the
+`source_call_id` matches none of the step's tool calls. There is no TOOL span
+to hang it on, so the child nests under that step's CHAIN span:
 
 ```
-AGENT (parent)
-  LLM
-  AGENT (child agent — system-initiated)
-    LLM
-    TOOL
+AGENT parent
+  CHAIN iteration 1
+    LLM gpt-4
+    AGENT child agent
+      CHAIN iteration 1
+        LLM gpt-4
 ```
 
-**ATIF v1.7**: embedded `subagent_trajectories` inside a single trajectory file are automatically flattened and linked. References resolve by `trajectory_id` — no separate upload needed.
+**The referencing step is not operational** (copied context, a bare message).
+There is no CHAIN span either, so the child nests directly under the parent
+trajectory's root AGENT span.
 
-## Deterministic Dispatch (v1.7+)
+Duplicate span IDs, unresolved parents, cross-trace parent links, and cycles
+are rejected before upload.
 
-Agent steps with `llm_call_count: 0` represent non-LLM orchestration that issued tool calls. These steps do not produce a synthetic LLM span; their TOOL spans are still emitted under the AGENT/turn parent.
+**ATIF v1.7**: embedded `subagent_trajectories` inside a single trajectory file
+are included automatically and resolve by `trajectory_id` — no separate upload
+needed. Earlier versions resolve refs by `session_id`.
 
 ## Continuation Merging
 
-When an agent's context window fills up, Harbor splits the session across multiple files. The converter detects continuation files (session IDs ending in `-cont-N`) and merges them into one trace. Continuation root spans are annotated with `metadata.is_continuation = True`.
+When an agent's context window fills up, Harbor splits the session across
+multiple files. Load them into the same batch: a `session_id` ending in
+`-cont-N` joins the original session's trace. The continuation root is named
+`<agent> (continuation N)` and carries `metadata.is_continuation = True` plus
+`metadata.continuation_index`. A continuation of a subagent stays beneath the
+same caller as the first document.
 
 ## Attribute Mapping
 
@@ -141,19 +192,56 @@ When an agent's context window fills up, Harbor splits the session across multip
 | `agent.model_name` / step `model_name` | `llm.model_name` |
 | `agent.tool_definitions` | `llm.tools.{i}.tool.json_schema` |
 | `reasoning_content` | `metadata.reasoning_content` |
-| `session_id` | `session.id` |
+| `final_metrics` | Root span `metadata.final_metrics` |
 | `trajectory_id` | Root span `metadata.trajectory_id` |
+| `session_id` | `session.id` on every span |
 | Step messages | `llm.input_messages` / `llm.output_messages` |
+| Text and image message parts | `message.contents` |
 | Tool calls | `llm.output_messages.{i}.message.tool_calls` |
 | Observations | Tool span `output.value` |
 
-## Deterministic IDs
+Only LLM spans carry `llm.*` attributes. Every span carries
+`metadata.agent_name` and, below the root, `metadata.atif.step_id` holding the
+producer's own step identifier.
 
-Trace IDs are derived from the run-scoped `session_id` when present. Span IDs use document-scoped `trajectory_id` when available. ATIF v1.7 embedded subagents use the same `trajectory_id`-based seeding so they do not collide even when inheriting the same `session_id`. Re-uploading the same trajectory produces the same trace (idempotent).
+ATIF has no fields for cache-write or reasoning tokens, so producers record
+them under `metrics.extra` with their own names — Claude Code writes
+`cache_creation_input_tokens` and `output_tokens_details.thinking_tokens`,
+Codex writes `cache_write_input_tokens` and `reasoning_output_tokens`. The
+converter maps whichever it finds to
+`llm.token_count.prompt_details.cache_write` and
+`llm.token_count.completion_details.reasoning`.
+
+## Reconstructed Messages
+
+LLM inputs are reconstructed from ATIF context, not captured provider requests,
+and every LLM span says so with `metadata.atif.input_source = "reconstructed"`.
+ATIF sources `user`, `system`, and `agent` map to roles `user`, `system`, and
+`assistant`. The converter does not parse provider-native messages or interpret
+tool argument keys. A result with a matching call ID becomes a tool message;
+feedback without one stays an `observation` entry with `after_step_id` in
+`input.value` and no inferred role. Multimodal results keep their content
+parts. ATIF v1.8 audio fields are not supported.
+
+## Deterministic IDs and Re-uploads
+
+IDs are deterministic for the same documents and parent relationships: the
+converter seeds them from session and document identities, falling back to
+content hashes for v1.7 documents with no document ID. Give separate documents
+distinct `trajectory_id` values where the format allows it.
+
+Determinism is not deduplication. This helper does not skip spans Phoenix has
+already stored, and Phoenix rejects a batch containing an existing span ID — so
+re-running an upload over an already-imported trajectory fails rather than
+merging. The Harbor plugin handles replay itself by querying stored IDs and
+uploading only the missing spans.
 
 ## Known Limitation
 
-Each LLM span includes the full conversation history as `llm.input_messages`. For very long sessions (~16+ turns with dense tool calls), this can exceed OTel attribute size limits and cause truncation.
+Each LLM span repeats its whole reconstructed context in `input.value` and its
+known-role messages in `llm.input_messages`. Very long sessions can exceed OTel
+attribute size limits and be truncated or rejected, as with live
+instrumentation.
 
 ## API Reference
 

--- a/.agents/skills/phoenix-tracing/references/span-llm.md
+++ b/.agents/skills/phoenix-tracing/references/span-llm.md
@@ -55,6 +55,22 @@ parts of the same message. Code that reads message text should filter on
 `message_content.type` rather than concatenating every part, or reasoning text
 will be mixed into the visible answer.
 
+A `reasoning` part carries the provider's replay payload alongside the summary,
+under the same `message_content` prefix:
+
+- `.id` — the provider's own identifier for the part (an OpenAI Responses
+  reasoning item id, for example), which has to be echoed back on replay
+- `.signature` — an opaque vendor signature captured verbatim (an Anthropic
+  thinking signature, a Gemini `thoughtSignature`)
+- `.data` — opaque vendor data captured verbatim (Anthropic
+  `redacted_thinking.data`)
+- `.encrypted_content` — OpenAI encrypted reasoning captured verbatim
+
+Only `.text` is human-readable, and it is optional: OpenAI returns reasoning
+encrypted unless a summary was requested, so a `reasoning` part can arrive with
+nothing but `.id` and `.encrypted_content`. Treat a missing `.text` as "the
+provider withheld the summary", not as an empty thought.
+
 ## Example: Basic LLM Call
 
 ```json


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-09-02 → 2026-09-09

**Audited against:** `origin/main` at `7d1c463141b4ac5958c007c52f4060f062bb5306`
**Commits analyzed:** 95 (6 user-facing candidates expanded into edits, 89 skipped)

## Edits applied

### phoenix-tracing

- `references/instrumentation-atif-python.md` — rewritten against the reworked
  ATIF converter shipped in `30dccec0` ("feat(client): add ATIF tracing to Harbor
  plugin", #15715). Grounded in
  `packages/phoenix-client/src/phoenix/client/helpers/atif/__init__.py:54-198`
  (the `upload_atif_trajectories_as_spans` docstring) and
  `helpers/atif/_convert.py`. What changed in the reference:
  - **Trace hierarchy** — each fresh agent step now owns a CHAIN span named
    `iteration N` (`_convert.py:443-468` `_step_names`, `:1084-1110`
    `_step_span`); context-management steps become `compaction N` and
    operational system steps `system event N`. Spans are named by their target
    (agent name / model name / tool name), and multi-turn adds an `AGENT turn N`
    layer (`_convert.py:1034-1050` `_turn_span`). Tree diagrams replaced to match
    `_convert.py:1194-1201`.
  - **Subagent parenting** — three cases rather than two: matching
    `source_call_id` → the TOOL span, otherwise an operational step → that step's
    CHAIN, otherwise → the trajectory root
    (`_convert.py:219-241` `_subagent_parent_span_id`).
  - **Timing** — new section for the event-timing model: CHAIN spans are
    event intervals, TOOL spans zero-duration events, LLM spans zero-duration
    unless an adapter supplies a clamped measured latency
    (`_convert.py:397-416` `_llm_timing`, `:1150-1166` `_tool_span`).
  - **Re-uploads** — corrected. The old text claimed re-uploading is idempotent;
    IDs are deterministic but the helper does not skip stored spans and Phoenix
    rejects a batch containing an existing span ID (`__init__.py:149-153`).
  - **Attribute mapping** — added `final_metrics` → root `metadata.final_metrics`
    (`_convert.py:999-1000`), text/image parts → `message.contents`, and the
    producer-specific cache-write / reasoning token mapping from `metrics.extra`
    to `llm.token_count.prompt_details.cache_write` and
    `llm.token_count.completion_details.reasoning` (`_convert.py:728-777`).
  - **Reconstructed messages** — new section covering
    `metadata.atif.input_source = "reconstructed"`, role mapping, and the
    unmatched-observation case (`__init__.py:154-163`).
  - Continuation roots documented as `<agent> (continuation N)` with
    `metadata.is_continuation` / `metadata.continuation_index`
    (`_convert.py:1004-1014`).
  The public signature is unchanged, so the Quick Start and Signature sections
  were kept as-is.

- `references/span-llm.md` — documented the replay fields a `reasoning` content
  part carries alongside its summary: `message_content.id`, `.signature`,
  `.data`, and `.encrypted_content`, plus the fact that `.text` is absent for an
  encrypted-only part. From `6de22347` ("feat(ui): render reasoning content
  blocks in LLM span messages"); keys and semantics verified against
  `js/app/src/openInference/tracing/types.ts:60-89` (the
  `MessageContentsAttributePostfixes` members) and the behavior cases in
  `js/app/src/pages/trace/span/__tests__/utils.test.ts:195-245`.

### phoenix-evals

- `references/evaluators-pre-built.md` — added the `Completeness` row
  (inputs `conversation`, labels `complete` / `incomplete`, direction maximize)
  and a "Notes on Specific Evaluators" bullet. From `63805d0f` ("feat(evals):
  completeness evaluator", #15767). Verified against
  `packages/phoenix-evals/src/phoenix/evals/metrics/completeness.py:13-84`
  (`CompletenessEvaluator`, exported from `phoenix.evals.metrics`) and
  `packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_completeness_classification_evaluator_config.py`
  (`name="completeness"`, `choices={"complete": 1.0, "incomplete": 0.0}`,
  `optimization_direction="maximize"`). The TypeScript mirror
  `createCompletenessEvaluator` shipped in the same commit
  (`js/packages/phoenix-evals/src/llm/createCompletenessEvaluator.ts`, exported
  from `src/llm/index.ts`) and follows the file's stated
  `create<Name>Evaluator` convention, so no separate snippet was added.

- `references/observe-sampling-python.md` — added the `error`,
  `min_latency_ms`, and `max_latency_ms` filters to the trace-level sampling
  examples, including the `error=False` gotcha and the client-side `ValueError`
  on bad bounds. From `c8392547` ("feat(client): add error and latency filters
  to get_traces in python and typescript clients") on top of `aea59d7a`
  ("feat(server): add error-status and latency filters to trace list endpoint",
  #14037). Signature quoted from
  `packages/phoenix-client/src/phoenix/client/resources/traces/__init__.py:402-473`;
  the `>= 20.8.0` requirement from `GET_TRACES_FILTERS` in
  `packages/phoenix-client/src/phoenix/client/constants/server_requirements.py:73-82`.

- `references/observe-sampling-typescript.md` — the TypeScript mirror
  (`error`, `minLatencyMs`, `maxLatencyMs`), verified against
  `js/packages/phoenix-client/src/traces/getTraces.ts:15-53` and
  `js/packages/phoenix-client/src/constants/serverRequirements.ts`.

- `references/production-continuous.md` — the "identify slow traces" snippets
  used `sort` + `limit`, which orders but does not filter; both now pass the
  server-side latency bound, with a note that these filters require a Phoenix
  server >= 20.8.0 and that the client raises against an older one rather than
  silently returning unfiltered traces (`ServerVersionGuard.require` →
  `_check_version` raises `PhoenixException`,
  `packages/phoenix-client/src/phoenix/client/utils/server_requirements.py:86-126`;
  `ensureServerCapability` throws on the TypeScript side).

## Audit candidates that produced no edit

- `397088a2` ("docs(phoenix-client): create_dataset docstring documented
  dataset_name, param is name") — tagged `evals`. Checked every
  `create_dataset` / `createDataset` call in the skill
  (`experiments-datasets-python.md`, `experiments-datasets-typescript.md`,
  `observe-tracing-setup.md`); all already pass `name=`, matching
  `packages/phoenix-client/.../resources/datasets/__init__.py:785-804`. The
  commit only corrected the docstring.
- `bf659ca5` ("feat(server): add DELETE /projects/{project_identifier}/traces",
  #15409) — tagged `cli`. The endpoint has no CLI or client wrapper: `px project`
  exposes only `list` / `get` / `delete`, `px api` exposes only `graphql`, and
  neither `packages/phoenix-client` nor `js/packages/phoenix-client` has a
  hand-written wrapper (only the generated `v1.ts` types picked it up).
  Documenting it in `phoenix-cli/SKILL.md` would describe a call the CLI cannot
  make. See "Out-of-scope findings" below.
- `c8392547` / `aea59d7a` trace filters — also tagged `cli`. `px trace list`
  gained no corresponding flags (`js/packages/phoenix-cli/src/commands/trace.ts:798-840`
  still offers only time-window, limit, and include flags), so the CLI skill was
  left alone. Noted below as a gap.
- `38db726b` ("fix(traces): count only leaf LLM spans in project token totals",
  #15913) — tagged `cli` because `phoenix-cli/SKILL.md` uses `tokenCountTotal`
  in a GraphQL example. The fix corrects a double-count in
  `src/phoenix/server/api/dataloaders/token_counts.py`; the skill states no
  semantics for the field, so there is nothing to correct.

## Skipped commits

- **Release / version bookkeeping:** `ab00d801`, `0a3b3328`, `a71218c7`,
  `01a38df9`, `8423d2fd`, `1db2a914`, `fadd6ae0`, `052b5dbb`, `25360732`,
  `84002e75`, `02b1e51f`, `1f7cec27`, `00dec3a0`, `1c75d62e`, `ab9e7a6b`,
  `8efdb56f`, `04294d7f`.
- **Dependency upgrades:** `59059618` (weekly upgrade — only `package.json`
  version ranges in `phoenix-evals` / `phoenix-otel`), `7b8b8f75`, `631b1fa7`,
  `89569724` (Vitest 5), `24eca05b`, `1e3dfd6b`, `bb77c31f`, `7624cc7c`,
  `9d757402` (Node 24).
- **Tests / CI only:** `7fcc2978`, `10915f5a`, `e6afbb39`, `42353ee7`,
  `7d100680`, and the unit-test startup series `64f6c60b`, `c73b0d2a`,
  `515dd6b7`, `e7faa374`, `9c0aa95e`, `7376f3fd`, `cfe1f883`, `1432884d`,
  `5df03f27`, `05583395`, `d231b1d7`, `02d606ad`, `89b9e098`.
- **Frontend-only:** `7d1c4631`, `2e8b4f61`, `8042bc83`, `1b97dc19`, `9a2074a0`,
  `e82e6662`, `ec350ca3`, `c41b8b82`, `4900aa9b`, `2086de43`.
- **Playground / model-provider catalog** (no effect on the three skills):
  `7e01ce70` (MiniMax), `58b70172` (Z.ai), `20c8be3e` (Gemini 3.8 Flash),
  `01f4fbf3` (gpt-6-astra), `bf047af2` (Meta muse — touches
  `js/packages/phoenix-cli/src/pxi/options.ts`, which is PXI model config, not a
  documented CLI command), `83855f74` / `466863d1` / `e346f8ab` (token prices).
- **Server / MCP internals:** `f11c885c` (FastMCP 4 — server-side transport, no
  change to `px setup mcp`), `ff94fc53`, `59c79341`, `9c531a5c`, `93e55d88`
  (the `IsoDatetime` serializer replaces a deprecated pydantic hook; the emitted
  ISO-8601 payloads are unchanged), `3b733145`, `0d1d92e7`.
- **Client internals:** `96e88059` (env-file ownership check narrowed to
  `sys.platform`; `.env.phoenix` discovery behavior on POSIX is unchanged),
  `76541854` (annotation-helper validation loop fix — corrects which rows raise,
  documents nothing new).
- **Agents / PXI / docs / skills:** `af7d8192`, `18fdcd2d`, `3f01ebbd`,
  `efe9955f`, `be57b068`, `b58a87d6`, `b849d7af`, `d5eeadbd`, `c1288c9c`,
  `b89a81e1`, `84866072`, `3e33ecff`, `31c5ffc5`, `41cf1835`, `1bfd8e81`.

## Out-of-scope findings

- **`DELETE /v1/projects/{project_identifier}/traces` has no client or CLI
  wrapper** (`bf659ca5`, #15409). The endpoint is real and documented in
  `docs/phoenix/`, but neither Python nor TypeScript `phoenix-client` exposes it
  and the CLI has no `px project clear` / `px trace delete --all` equivalent. If
  a wrapper lands, `phoenix-cli/SKILL.md` should gain it under Projects or
  Traces. Owner action, not a skill edit.
- **`px trace list` cannot use the new error/latency filters.** The REST
  endpoint and both clients support `error` / `min_latency_ms` /
  `max_latency_ms`, but the CLI does not pass them, so the fastest CLI path to
  "slow traces that errored" is still `px api graphql` with a
  `traceFilterCondition` — which `phoenix-cli/SKILL.md` already documents. Worth
  a CLI follow-up.
- **`_phoenix.span_order` sibling ordering** (introduced mid-PR in `30dccec0`
  for the frontend trace tree) is not emitted by the shipped ATIF converter — no
  reference to it survives in `helpers/atif/`. Left undocumented deliberately;
  if the frontend still reads it, that belongs to `phoenix-frontend`.
