### PR TITLE
refactor(evals): rename EvaluatorMappingSourceGrain to EvaluatorRecordKind

### DIFF
--- a/js/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
+++ b/js/app/src/components/dataset/CreateCodeDatasetEvaluatorSlideover.tsx
@@ -211,7 +211,7 @@ const CreateCodeEvaluatorDialog = ({
         selectedSplitIds: [],
       },
       evaluatorMappingSource: {
-        grain: "dataset",
+        recordKind: "dataset",
         source: EVALUATOR_MAPPING_SOURCE_DEFAULT,
       },
       showPromptPreview: false,

--- a/js/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
+++ b/js/app/src/components/dataset/EditCodeDatasetEvaluatorSlideover.tsx
@@ -364,7 +364,7 @@ function EditCodeDatasetEvaluatorSlideoverContent({
       selectedSplitIds: [],
     },
     evaluatorMappingSource: {
-      grain: "dataset",
+      recordKind: "dataset",
       source: EVALUATOR_MAPPING_SOURCE_DEFAULT,
     },
     showPromptPreview: false,

--- a/js/app/src/components/evaluators/CodeEvaluatorSourceEditor.tsx
+++ b/js/app/src/components/evaluators/CodeEvaluatorSourceEditor.tsx
@@ -53,8 +53,8 @@ export const CodeEvaluatorSourceEditor = ({
   const evaluatorMappingSource = useEvaluatorStore(
     (state) => state.evaluatorMappingSource.source
   );
-  const mappingSourceGrain = useEvaluatorStore(
-    (state) => state.evaluatorMappingSource.grain
+  const recordKind = useEvaluatorStore(
+    (state) => state.evaluatorMappingSource.recordKind
   );
 
   // Generate the type footer based on language and available data
@@ -135,9 +135,7 @@ export const CodeEvaluatorSourceEditor = ({
             variant="quiet"
             leadingVisual={<Icon svg={<Icons.Refresh />} />}
             onPress={() =>
-              onChange(
-                getDefaultCodeEvaluatorSource(language, mappingSourceGrain)
-              )
+              onChange(getDefaultCodeEvaluatorSource(language, recordKind))
             }
           >
             Reset

--- a/js/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -153,8 +153,8 @@ export const EditCodeEvaluatorDialogContent = ({
   codeEvaluatorNodeId?: string | null;
 }) => {
   const store = useEvaluatorStoreInstance();
-  const grain = useEvaluatorStore(
-    (state) => state.evaluatorMappingSource.grain
+  const recordKind = useEvaluatorStore(
+    (state) => state.evaluatorMappingSource.recordKind
   );
   const [showValidationError, setShowValidationError] = useState(false);
   const [sourceCode, setSourceCode] = useState(initialSourceCode);
@@ -379,7 +379,7 @@ export const EditCodeEvaluatorDialogContent = ({
         JSON.stringify(next.testPayload) !== JSON.stringify(current.testPayload)
       ) {
         state.setEvaluatorMappingSource({
-          grain: state.evaluatorMappingSource.grain,
+          recordKind: state.evaluatorMappingSource.recordKind,
           source: next.testPayload,
         });
       }
@@ -586,10 +586,16 @@ export const EditCodeEvaluatorDialogContent = ({
                       // placeholder — never overwrite user-authored code.
                       if (
                         sourceCode ===
-                        getDefaultCodeEvaluatorSource(currentLanguage, grain)
+                        getDefaultCodeEvaluatorSource(
+                          currentLanguage,
+                          recordKind
+                        )
                       ) {
                         setSourceCode(
-                          getDefaultCodeEvaluatorSource(nextLanguage, grain)
+                          getDefaultCodeEvaluatorSource(
+                            nextLanguage,
+                            recordKind
+                          )
                         );
                       }
                       return nextLanguage;
@@ -860,17 +866,17 @@ export const CodeEvaluatorSourceEditor = ({
   );
   const evaluatorMappingSource = evaluatorMappingSourceState.source;
   const evaluationContext = useMemo(() => {
-    const grain = evaluatorMappingSourceState.grain;
-    return grain === "dataset"
+    const recordKind = evaluatorMappingSourceState.recordKind;
+    return recordKind === "dataset"
       ? null
       : materializeEvaluatorContext({
-          grain,
+          recordKind,
           evaluatorMappingSource: evaluatorMappingSourceState,
           inputMapping,
         });
   }, [evaluatorMappingSourceState, inputMapping]);
 
-  // The footer names what `evaluate` receives, so for a project grain it reads
+  // The footer names what `evaluate` receives, so for a project record kind it reads
   // the mapping applied rather than the record as it arrived — the same
   // context the autocomplete offers from. A dataset example is bound by name
   // and has no such gap.
@@ -980,7 +986,7 @@ export const CodeEvaluatorSourceEditor = ({
               onChange(
                 getDefaultCodeEvaluatorSource(
                   language,
-                  evaluatorMappingSourceState.grain
+                  evaluatorMappingSourceState.recordKind
                 )
               )
             }

--- a/js/app/src/components/evaluators/EvaluatorChatTemplate/EvaluatorChatTemplate.tsx
+++ b/js/app/src/components/evaluators/EvaluatorChatTemplate/EvaluatorChatTemplate.tsx
@@ -33,11 +33,11 @@ export const EvaluatorChatTemplate = () => {
   // A dataset evaluator's template has no record behind it, so it keeps the
   // flat path list; a project evaluator's completes what it actually receives.
   const evaluationContext = useMemo(() => {
-    const grain = evaluatorMappingSource.grain;
-    return grain === "dataset"
+    const recordKind = evaluatorMappingSource.recordKind;
+    return recordKind === "dataset"
       ? null
       : materializeEvaluatorContext({
-          grain,
+          recordKind,
           evaluatorMappingSource,
           inputMapping,
         });

--- a/js/app/src/components/evaluators/EvaluatorInputPreview.tsx
+++ b/js/app/src/components/evaluators/EvaluatorInputPreview.tsx
@@ -120,19 +120,19 @@ const EvaluatorInputPreviewContent = () => {
   // this value is the one that will actually be used when testing an evaluator
   const setEvaluatorInputObject = useEffectEvent(setEvaluatorMappingSource);
   useEffect(() => {
-    setEvaluatorInputObject({ grain: "dataset", source: defaultValue });
+    setEvaluatorInputObject({ recordKind: "dataset", source: defaultValue });
   }, [defaultValue]);
 
-  if (evaluatorMappingSource.grain !== "dataset") {
+  if (evaluatorMappingSource.recordKind !== "dataset") {
     return null;
   }
 
   return (
     <EvaluatorMappingSourceEditor
-      grain="dataset"
+      recordKind="dataset"
       value={evaluatorMappingSource.source}
       onFieldChange={(field, value) =>
-        setEvaluatorMappingSourceField({ grain: "dataset", field, value })
+        setEvaluatorMappingSourceField({ recordKind: "dataset", field, value })
       }
       editorKeyPrefix={`${datasetId}-${exampleId}`}
     />

--- a/js/app/src/components/evaluators/EvaluatorMappingSourceEditor.tsx
+++ b/js/app/src/components/evaluators/EvaluatorMappingSourceEditor.tsx
@@ -12,13 +12,13 @@ import {
 import { useDebouncedJSONSync } from "@phoenix/hooks";
 import type {
   EvaluatorMappingSource,
-  EvaluatorMappingSourceGrain,
+  EvaluatorRecordKind,
 } from "@phoenix/types";
 
 type EvaluatorMappingSourceFieldConfig<
-  TGrain extends EvaluatorMappingSourceGrain,
+  TRecordKind extends EvaluatorRecordKind,
 > = {
-  field: Extract<keyof EvaluatorMappingSource<TGrain>, string>;
+  field: Extract<keyof EvaluatorMappingSource<TRecordKind>, string>;
   label: string;
   description: string;
   tooltip: string;
@@ -70,7 +70,7 @@ const editorContainerCSS = css`
  * arrives from the server and is chosen, never typed.
  */
 type EvaluatorMappingSourceEditorProps = {
-  grain: "dataset";
+  recordKind: "dataset";
   value: EvaluatorMappingSource<"dataset">;
   onFieldChange: (
     field: Extract<keyof EvaluatorMappingSource<"dataset">, string>,
@@ -90,21 +90,19 @@ export function EvaluatorMappingSourceEditor(
   );
 }
 
-function EvaluatorMappingSourceFields<
-  TGrain extends EvaluatorMappingSourceGrain,
->({
+function EvaluatorMappingSourceFields<TRecordKind extends EvaluatorRecordKind>({
   value,
   onFieldChange,
   editorKeyPrefix = "",
   fieldConfig,
 }: {
-  value: EvaluatorMappingSource<TGrain>;
+  value: EvaluatorMappingSource<TRecordKind>;
   onFieldChange: (
-    field: Extract<keyof EvaluatorMappingSource<TGrain>, string>,
+    field: Extract<keyof EvaluatorMappingSource<TRecordKind>, string>,
     value: Record<string, unknown>
   ) => void;
   editorKeyPrefix?: string;
-  fieldConfig: EvaluatorMappingSourceFieldConfig<TGrain>[];
+  fieldConfig: EvaluatorMappingSourceFieldConfig<TRecordKind>[];
 }) {
   const defaultExpandedKeys = fieldConfig.map(({ field }) => field as string);
   return (

--- a/js/app/src/components/evaluators/EvaluatorPathField.tsx
+++ b/js/app/src/components/evaluators/EvaluatorPathField.tsx
@@ -10,7 +10,7 @@ import { useCallback, useMemo } from "react";
 
 import type { DSLFilterConditionValidationResult } from "@phoenix/components/filter/DSLFilterConditionField";
 import { DSLFilterConditionField } from "@phoenix/components/filter/DSLFilterConditionField";
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import type { EvaluatorMappingSourceState } from "@phoenix/store/evaluatorStore";
 import type { EvaluatorInputMapping } from "@phoenix/types";
 
@@ -71,7 +71,7 @@ export function EvaluatorPathField({
   errorMessage,
   ariaLabel,
   evaluatorMappingSource,
-  grain,
+  recordKind,
   slotName,
 }: {
   value: string;
@@ -81,10 +81,10 @@ export function EvaluatorPathField({
   errorMessage?: string;
   ariaLabel: string;
   evaluatorMappingSource: EvaluatorMappingSourceState;
-  grain: ProjectEvaluatorMappingSourceGrain;
+  recordKind: ProjectEvaluatorRecordKind;
   slotName: EvaluatorSlotName;
 }) {
-  const suggestedPaths = getEvaluatorSlotSuggestedPaths(grain, slotName);
+  const suggestedPaths = getEvaluatorSlotSuggestedPaths(recordKind, slotName);
 
   // CodeMirror is reconfigured whenever these change identity, which discards
   // the open dropdown, so they are memoized rather than left to the compiler.
@@ -93,11 +93,11 @@ export function EvaluatorPathField({
   const evaluationContext = useMemo(
     () =>
       materializeEvaluatorContext({
-        grain,
+        recordKind,
         evaluatorMappingSource,
         inputMapping: UNMAPPED,
       }),
-    [grain, evaluatorMappingSource]
+    [recordKind, evaluatorMappingSource]
   );
   const mappingSource =
     evaluationContext === null

--- a/js/app/src/components/evaluators/SwitchableEvaluatorInput.tsx
+++ b/js/app/src/components/evaluators/SwitchableEvaluatorInput.tsx
@@ -108,7 +108,7 @@ export interface SwitchableEvaluatorInputProps<
   /**
    * Renders the path control in place of the flat list of options.
    *
-   * A record's fields nest, so the project grains choose a path from a tree of
+   * A record's fields nest, so the project record kinds choose a path from a tree of
    * the record rather than from a list of every leaf it has.
    */
   renderPathInput?: (props: {

--- a/js/app/src/components/evaluators/__tests__/codeEvaluatorAutocomplete.test.ts
+++ b/js/app/src/components/evaluators/__tests__/codeEvaluatorAutocomplete.test.ts
@@ -93,9 +93,9 @@ describe("createCompletionOptions", () => {
 
 describe("code evaluator completions", () => {
   const evaluationContext = materializeEvaluatorContext({
-    grain: "span",
+    recordKind: "span",
     evaluatorMappingSource: {
-      grain: "span",
+      recordKind: "span",
       source: {
         input: "Why?",
         output: "Because.",
@@ -189,9 +189,9 @@ describe("code evaluator completions", () => {
 
 describe("code evaluator signature completions", () => {
   const evaluationContext = materializeEvaluatorContext({
-    grain: "span",
+    recordKind: "span",
     evaluatorMappingSource: {
-      grain: "span",
+      recordKind: "span",
       source: {
         input: "Why?",
         output: "Because.",

--- a/js/app/src/components/evaluators/__tests__/codeEvaluatorUtils.test.ts
+++ b/js/app/src/components/evaluators/__tests__/codeEvaluatorUtils.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../codeEvaluatorUtils";
 
 describe("the default source a new code evaluator opens on", () => {
-  it("names only what its grain hands the evaluator", () => {
+  it("names only what its recordKind hands the evaluator", () => {
     expect(getDefaultCodeEvaluatorSource("TYPESCRIPT", "dataset")).toContain(
       "function evaluate({ output, reference, input, metadata }: EvaluatorParams)"
     );
@@ -22,9 +22,9 @@ describe("the default source a new code evaluator opens on", () => {
     expect(getDefaultCodeEvaluatorSource("PYTHON", "session")).toContain(
       "def evaluate(input=None, output=None, metadata=None):"
     );
-    for (const grain of ["span", "session"] as const) {
+    for (const recordKind of ["span", "session"] as const) {
       for (const language of ["PYTHON", "TYPESCRIPT"] as const) {
-        const source = getDefaultCodeEvaluatorSource(language, grain);
+        const source = getDefaultCodeEvaluatorSource(language, recordKind);
         expect(source).not.toContain("reference");
         expect(source).not.toContain("EvaluatorParams");
       }

--- a/js/app/src/components/evaluators/__tests__/evaluatorContext.test.ts
+++ b/js/app/src/components/evaluators/__tests__/evaluatorContext.test.ts
@@ -5,7 +5,7 @@ import {
   SPAN_ANNOTATION_FIELDS,
   getEvaluatorMetadataEntries,
 } from "@phoenix/pages/project/evaluators/evaluatorBoundVariables";
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { getSampleSessionEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSessionEvaluationContext";
 import { getSampleSpanEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSpanEvaluationContext";
 import { SPAN_EVALUATOR_MAPPING_SOURCE_DEFAULT } from "@phoenix/store/evaluatorStore";
@@ -22,9 +22,9 @@ const UNMAPPED: EvaluatorInputMapping = { pathMapping: {}, literalMapping: {} };
 describe("materializeEvaluatorContext", () => {
   it("materializes each slot with the path it reads", () => {
     const spanContext = materializeEvaluatorContext({
-      grain: "span",
+      recordKind: "span",
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: {
           input: "Why?",
           output: "Because.",
@@ -69,9 +69,9 @@ describe("materializeEvaluatorContext", () => {
     ]);
 
     const sessionContext = materializeEvaluatorContext({
-      grain: "session",
+      recordKind: "session",
       evaluatorMappingSource: {
-        grain: "session",
+        recordKind: "session",
         source: {
           input: "Hello",
           output: "Goodbye",
@@ -103,9 +103,9 @@ describe("materializeEvaluatorContext", () => {
 
   it("holds back every preview until a record has been sampled", () => {
     const unsampledContext = materializeEvaluatorContext({
-      grain: "span",
+      recordKind: "span",
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: SPAN_EVALUATOR_MAPPING_SOURCE_DEFAULT,
       },
       inputMapping: UNMAPPED,
@@ -131,9 +131,9 @@ describe("materializeEvaluatorContext", () => {
   // to read as a failure here rather than as the literal that never runs.
   it("fails a slot whose set path matches nothing, literal or not", () => {
     const context = materializeEvaluatorContext({
-      grain: "span",
+      recordKind: "span",
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: {
           input: "Why?",
           output: "Because.",
@@ -156,9 +156,9 @@ describe("materializeEvaluatorContext", () => {
 
   it("lets a literal overwrite the path it sits beside once that path resolves", () => {
     const context = materializeEvaluatorContext({
-      grain: "span",
+      recordKind: "span",
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: {
           input: "Why?",
           output: "Because.",
@@ -179,12 +179,12 @@ describe("materializeEvaluatorContext", () => {
     });
   });
 
-  it("materializes nothing for a source built for the other grain", () => {
+  it("materializes nothing for a source built for the other recordKind", () => {
     expect(
       materializeEvaluatorContext({
-        grain: "span",
+        recordKind: "span",
         evaluatorMappingSource: {
-          grain: "session",
+          recordKind: "session",
           source: { input: null, output: null, metadata: {} },
         },
         inputMapping: UNMAPPED,
@@ -202,42 +202,45 @@ describe("materializeEvaluatorContext", () => {
 describe("the preview binds what a live run binds", () => {
   const clientContexts: {
     label: string;
-    grain: ProjectEvaluatorMappingSourceGrain;
-    source: EvaluatorMappingSource<ProjectEvaluatorMappingSourceGrain>;
+    recordKind: ProjectEvaluatorRecordKind;
+    source: EvaluatorMappingSource<ProjectEvaluatorRecordKind>;
   }[] = [
     {
       label: "sample span",
-      grain: "span",
+      recordKind: "span",
       source: getSampleSpanEvaluationContext().context,
     },
     {
       label: "sample session",
-      grain: "session",
+      recordKind: "session",
       source: getSampleSessionEvaluationContext().context,
     },
   ];
 
   it.each(clientContexts)(
     "$label carries the whole binding surface",
-    ({ grain, source }) => {
+    ({ recordKind, source }) => {
       const materialized = materializeEvaluatorContext({
-        grain,
+        recordKind,
         evaluatorMappingSource:
-          grain === "span"
-            ? { grain, source: source as EvaluatorMappingSource<"span"> }
-            : { grain, source: source as EvaluatorMappingSource<"session"> },
+          recordKind === "span"
+            ? { recordKind, source: source as EvaluatorMappingSource<"span"> }
+            : {
+                recordKind,
+                source: source as EvaluatorMappingSource<"session">,
+              },
         inputMapping: UNMAPPED,
       });
 
-      const metadataNames = getEvaluatorMetadataEntries(grain).map(
+      const metadataNames = getEvaluatorMetadataEntries(recordKind).map(
         ({ name }) => name
       );
       // The server binds by the three top-level names and nothing else.
       expect(Object.keys(materialized?.values ?? {})).toEqual([
         ...EVALUATOR_SLOT_NAMES,
       ]);
-      // Under `metadata`: the grain's vocabulary and its record fields, flat —
-      // no grain-named level. A sampled span may also spread its own metadata
+      // Under `metadata`: the record kind's vocabulary and its record fields, flat —
+      // no record-kind-named level. A sampled span may also spread its own metadata
       // attribute's keys beside them.
       expect(Object.keys(source.metadata)).toEqual(
         expect.arrayContaining(metadataNames)
@@ -249,7 +252,7 @@ describe("the preview binds what a live run binds", () => {
       expect(materialized?.hasSampledRecord).toBe(true);
       // Declared types drive the container badge, so a sampled value has to
       // actually be that type.
-      for (const { name, type } of getEvaluatorMetadataEntries(grain)) {
+      for (const { name, type } of getEvaluatorMetadataEntries(recordKind)) {
         const value = source.metadata[name];
         if (value === null) {
           continue; // a scalar the sampled record legitimately lacks

--- a/js/app/src/components/evaluators/__tests__/evaluatorSlotDefaults.test.ts
+++ b/js/app/src/components/evaluators/__tests__/evaluatorSlotDefaults.test.ts
@@ -1,4 +1,4 @@
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { getSampleSessionEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSessionEvaluationContext";
 import { getSampleSpanEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSpanEvaluationContext";
 
@@ -11,24 +11,27 @@ import {
 } from "../evaluatorSlotDefaults";
 
 /**
- * Where each grain's sample record comes from. A grain added to the union
+ * Where each record kind's sample record comes from. A record kind added to the union
  * fails to compile here until it supplies its own, rather than silently being
- * checked against another grain's.
+ * checked against another record kind's.
  */
-const SAMPLE_CONTEXT_BY_GRAIN: Record<
-  ProjectEvaluatorMappingSourceGrain,
+const SAMPLE_CONTEXT_BY_RECORD_KIND: Record<
+  ProjectEvaluatorRecordKind,
   () => { context: unknown }
 > = {
   span: getSampleSpanEvaluationContext,
   session: getSampleSessionEvaluationContext,
 };
 
-const GRAINS = Object.keys(
-  SAMPLE_CONTEXT_BY_GRAIN
-) as ProjectEvaluatorMappingSourceGrain[];
+const RECORD_KINDS = Object.keys(
+  SAMPLE_CONTEXT_BY_RECORD_KIND
+) as ProjectEvaluatorRecordKind[];
 
-const sampleContextFor = (grain: ProjectEvaluatorMappingSourceGrain) =>
-  SAMPLE_CONTEXT_BY_GRAIN[grain]().context as Record<string, unknown>;
+const sampleContextFor = (recordKind: ProjectEvaluatorRecordKind) =>
+  SAMPLE_CONTEXT_BY_RECORD_KIND[recordKind]().context as Record<
+    string,
+    unknown
+  >;
 
 /**
  * The record path that publishes the same value a slot's identity default
@@ -38,7 +41,7 @@ const sampleContextFor = (grain: ProjectEvaluatorMappingSourceGrain) =>
  * for an LLM span), a derivation rather than a copy of one record field.
  */
 const RECORD_PATHS: Record<
-  ProjectEvaluatorMappingSourceGrain,
+  ProjectEvaluatorRecordKind,
   Partial<Record<EvaluatorSlotName, string>>
 > = {
   span: {
@@ -52,15 +55,15 @@ const RECORD_PATHS: Record<
 };
 
 const boundValue = (
-  grain: ProjectEvaluatorMappingSourceGrain,
+  recordKind: ProjectEvaluatorRecordKind,
   slotName: EvaluatorSlotName,
   path?: string
 ) =>
   materializeEvaluatorContext({
-    grain,
+    recordKind,
     evaluatorMappingSource: {
-      grain,
-      source: sampleContextFor(grain) as never,
+      recordKind,
+      source: sampleContextFor(recordKind) as never,
     },
     inputMapping: {
       pathMapping: path ? { [slotName]: path } : {},
@@ -73,14 +76,14 @@ describe("evaluator slot defaults", () => {
   // publishes under a name of its own. Saying so in the ghost is only safe
   // while the two agree, so the agreement is checked rather than assumed.
   it("binds what the record path it replaced bound", () => {
-    for (const grain of GRAINS) {
+    for (const recordKind of RECORD_KINDS) {
       for (const slotName of EVALUATOR_SLOT_NAMES) {
-        const recordPath = RECORD_PATHS[grain][slotName];
+        const recordPath = RECORD_PATHS[recordKind][slotName];
         if (recordPath === undefined) {
           continue;
         }
-        expect(boundValue(grain, slotName)).toEqual(
-          boundValue(grain, slotName, recordPath)
+        expect(boundValue(recordKind, slotName)).toEqual(
+          boundValue(recordKind, slotName, recordPath)
         );
       }
     }
@@ -89,10 +92,10 @@ describe("evaluator slot defaults", () => {
   // An unmapped slot binds the context key of its own name; the ghost shows
   // that name as a path, so it has to be one the context actually holds.
   it("keeps every slot name a path the context actually holds", () => {
-    for (const grain of GRAINS) {
+    for (const recordKind of RECORD_KINDS) {
       for (const path of EVALUATOR_SLOT_NAMES) {
         expect(
-          resolveEvaluatorPath({ source: sampleContextFor(grain), path })
+          resolveEvaluatorPath({ source: sampleContextFor(recordKind), path })
         ).toMatchObject({ status: "resolved" });
       }
     }
@@ -100,10 +103,12 @@ describe("evaluator slot defaults", () => {
 
   it("pins worked examples of what each slot's mapping can reach", () => {
     const paths = (
-      grain: ProjectEvaluatorMappingSourceGrain,
+      recordKind: ProjectEvaluatorRecordKind,
       slotName: EvaluatorSlotName
     ) =>
-      getEvaluatorSlotSuggestedPaths(grain, slotName).map(({ path }) => path);
+      getEvaluatorSlotSuggestedPaths(recordKind, slotName).map(
+        ({ path }) => path
+      );
 
     expect(paths("span", "input")).toEqual([
       "metadata.attributes.llm.input_messages",
@@ -126,15 +131,15 @@ describe("evaluator slot defaults", () => {
   });
 
   it("suggests only paths a real record resolves", () => {
-    for (const grain of GRAINS) {
+    for (const recordKind of RECORD_KINDS) {
       for (const slotName of EVALUATOR_SLOT_NAMES) {
         for (const { path, description } of getEvaluatorSlotSuggestedPaths(
-          grain,
+          recordKind,
           slotName
         )) {
           expect(description).not.toBe("");
           expect(
-            resolveEvaluatorPath({ source: sampleContextFor(grain), path })
+            resolveEvaluatorPath({ source: sampleContextFor(recordKind), path })
           ).toMatchObject({ status: "resolved" });
         }
       }

--- a/js/app/src/components/evaluators/codeEvaluatorUtils.ts
+++ b/js/app/src/components/evaluators/codeEvaluatorUtils.ts
@@ -5,7 +5,7 @@ import { EditorState } from "@codemirror/state";
 
 import type {
   CodeEvaluatorLanguage,
-  EvaluatorMappingSourceGrain,
+  EvaluatorRecordKind,
 } from "@phoenix/types";
 
 const PYTHON_INDENT = "    ";
@@ -18,14 +18,14 @@ const TYPESCRIPT_INDENT = "  ";
  *
  * A dataset example carries a `reference` beside the three every evaluator
  * receives; a span or a session does not, and its footer declares no
- * `EvaluatorParams` to annotate against — so the project grains open on the
+ * `EvaluatorParams` to annotate against — so the project record kinds open on the
  * three names they are actually handed, unannotated.
  */
 export function getDefaultCodeEvaluatorSource(
   language: CodeEvaluatorLanguage,
-  grain: EvaluatorMappingSourceGrain
+  recordKind: EvaluatorRecordKind
 ): string {
-  const isDataset = grain === "dataset";
+  const isDataset = recordKind === "dataset";
   if (language === "PYTHON") {
     const parameters = isDataset
       ? "output, reference=None, input=None, metadata=None"

--- a/js/app/src/components/evaluators/evaluatorContext.ts
+++ b/js/app/src/components/evaluators/evaluatorContext.ts
@@ -6,7 +6,7 @@ import {
   getEvaluatorMetadataEntries,
   type EvaluatorBoundVariable,
 } from "@phoenix/pages/project/evaluators/evaluatorBoundVariables";
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import type { EvaluatorMappingSourceState } from "@phoenix/store/evaluatorStore";
 import type { EvaluatorInputMapping } from "@phoenix/types";
 import { isStringKeyedObject } from "@phoenix/typeUtils";
@@ -35,8 +35,8 @@ export type MaterializedEvaluatorContextEntry = {
 };
 
 export type MaterializedEvaluatorContext = {
-  grain: ProjectEvaluatorMappingSourceGrain;
-  /** False while the store holds only the grain's default source. */
+  recordKind: ProjectEvaluatorRecordKind;
+  /** False while the store holds only the recordKind's default source. */
   hasSampledRecord: boolean;
   /**
    * The three values the evaluator receives, by name. Paths an authoring tool
@@ -59,20 +59,20 @@ export type MaterializedEvaluatorContext = {
  * preview it.
  */
 export function materializeEvaluatorContext({
-  grain,
+  recordKind,
   evaluatorMappingSource,
   inputMapping,
 }: {
-  grain: ProjectEvaluatorMappingSourceGrain;
+  recordKind: ProjectEvaluatorRecordKind;
   evaluatorMappingSource: EvaluatorMappingSourceState;
   inputMapping: EvaluatorInputMapping;
 }): MaterializedEvaluatorContext | null {
-  if (evaluatorMappingSource.grain !== grain) {
+  if (evaluatorMappingSource.recordKind !== recordKind) {
     return null;
   }
 
   const source = evaluatorMappingSource.source as Record<string, unknown>;
-  const boundVariables = getEvaluatorBoundVariables(grain);
+  const boundVariables = getEvaluatorBoundVariables(recordKind);
   const recordMetadata = isStringKeyedObject(source[EVALUATOR_METADATA_SLOT])
     ? source[EVALUATOR_METADATA_SLOT]
     : {};
@@ -101,12 +101,12 @@ export function materializeEvaluatorContext({
   const boundMetadata = isStringKeyedObject(values[EVALUATOR_METADATA_SLOT])
     ? values[EVALUATOR_METADATA_SLOT]
     : {};
-  const vocabulary = getEvaluatorMetadataEntries(grain).map((variable) =>
+  const vocabulary = getEvaluatorMetadataEntries(recordKind).map((variable) =>
     materializeVocabularyEntry({ variable, boundMetadata, hasSampledRecord })
   );
 
   return {
-    grain,
+    recordKind,
     hasSampledRecord,
     values,
     evaluatorInputs,

--- a/js/app/src/components/evaluators/evaluatorContextCompletions.ts
+++ b/js/app/src/components/evaluators/evaluatorContextCompletions.ts
@@ -23,8 +23,8 @@ export const EVALUATOR_INPUT_SECTION: CompletionSection = {
   rank: 1,
 };
 
-export const RECORD_SECTION_BY_GRAIN: Record<
-  MaterializedEvaluatorContext["grain"],
+export const RECORD_SECTION_BY_RECORD_KIND: Record<
+  MaterializedEvaluatorContext["recordKind"],
   CompletionSection
 > = {
   span: { name: "From the span", rank: 2 },
@@ -76,7 +76,8 @@ export type EvaluatorContextCandidate = {
 export function buildEvaluatorContextCandidates(
   evaluationContext: MaterializedEvaluatorContext
 ): EvaluatorContextCandidate[] {
-  const recordSection = RECORD_SECTION_BY_GRAIN[evaluationContext.grain];
+  const recordSection =
+    RECORD_SECTION_BY_RECORD_KIND[evaluationContext.recordKind];
   const inputs = evaluationContext.evaluatorInputs.map((entry, index) => ({
     label: entry.name,
     rootName: entry.name,
@@ -86,7 +87,7 @@ export function buildEvaluatorContextCandidates(
     detail: getEvaluatorInputDetail({ entry, evaluationContext }),
     info:
       entry.name === EVALUATOR_METADATA_SLOT
-        ? `${capitalize(evaluationContext.grain)} properties.`
+        ? `${capitalize(evaluationContext.recordKind)} properties.`
         : "",
     section: EVALUATOR_INPUT_SECTION,
     boost: 100 - index,

--- a/js/app/src/components/evaluators/evaluatorSlotDefaults.ts
+++ b/js/app/src/components/evaluators/evaluatorSlotDefaults.ts
@@ -1,11 +1,11 @@
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 export const EVALUATOR_SLOT_NAMES = ["input", "output", "metadata"] as const;
 
 export type EvaluatorSlotName = (typeof EVALUATOR_SLOT_NAMES)[number];
 
 type BySlot<T> = Record<
-  ProjectEvaluatorMappingSourceGrain,
+  ProjectEvaluatorRecordKind,
   Record<EvaluatorSlotName, T>
 >;
 
@@ -76,8 +76,8 @@ const SLOT_SUGGESTED_PATHS: BySlot<readonly EvaluatorSlotSuggestedPath[]> = {
 };
 
 export function getEvaluatorSlotSuggestedPaths(
-  grain: ProjectEvaluatorMappingSourceGrain,
+  recordKind: ProjectEvaluatorRecordKind,
   slotName: EvaluatorSlotName
 ): readonly EvaluatorSlotSuggestedPath[] {
-  return SLOT_SUGGESTED_PATHS[grain][slotName];
+  return SLOT_SUGGESTED_PATHS[recordKind][slotName];
 }

--- a/js/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
+++ b/js/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
@@ -139,7 +139,7 @@ export const useLlmEvaluatorDraftRegistration = ({
         JSON.stringify(next.testPayload) !== JSON.stringify(current.testPayload)
       ) {
         state.setEvaluatorMappingSource({
-          grain: state.evaluatorMappingSource.grain,
+          recordKind: state.evaluatorMappingSource.recordKind,
           source: next.testPayload,
         });
       }

--- a/js/app/src/components/templateEditor/__tests__/evaluatorTemplateCompletions.test.ts
+++ b/js/app/src/components/templateEditor/__tests__/evaluatorTemplateCompletions.test.ts
@@ -3,7 +3,7 @@ import type { EditorView } from "@uiw/react-codemirror";
 import { describe, expect, it } from "vitest";
 
 import { materializeEvaluatorContext } from "@phoenix/components/evaluators/evaluatorContext";
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 import {
   findOpenTemplateVariable,
@@ -21,9 +21,9 @@ const SPAN_ATTRIBUTES = {
   },
 };
 
-function buildContext(grain: ProjectEvaluatorMappingSourceGrain) {
+function buildContext(recordKind: ProjectEvaluatorRecordKind) {
   const metadata =
-    grain === "span"
+    recordKind === "span"
       ? {
           span_id: "7f3b1c9a",
           name: "ChatCompletion",
@@ -37,11 +37,17 @@ function buildContext(grain: ProjectEvaluatorMappingSourceGrain) {
           turns: [{ input: "Hello", output: "Because." }],
         };
   return materializeEvaluatorContext({
-    grain,
+    recordKind,
     evaluatorMappingSource:
-      grain === "span"
-        ? { grain, source: { input: "Why?", output: "Because.", metadata } }
-        : { grain, source: { input: "Hello", output: "Because.", metadata } },
+      recordKind === "span"
+        ? {
+            recordKind,
+            source: { input: "Why?", output: "Because.", metadata },
+          }
+        : {
+            recordKind,
+            source: { input: "Hello", output: "Because.", metadata },
+          },
     inputMapping: { pathMapping: {}, literalMapping: {} },
   });
 }
@@ -49,16 +55,16 @@ function buildContext(grain: ProjectEvaluatorMappingSourceGrain) {
 /** Completions for a template whose whole text sits before the cursor. */
 function complete({
   doc,
-  grain = "span",
+  recordKind = "span",
   templateFormat = TemplateFormats.Mustache,
   sectionStack = [],
 }: {
   doc: string;
-  grain?: ProjectEvaluatorMappingSourceGrain;
+  recordKind?: ProjectEvaluatorRecordKind;
   templateFormat?: TemplateFormat;
   sectionStack?: string[];
 }) {
-  const evaluationContext = buildContext(grain);
+  const evaluationContext = buildContext(recordKind);
   if (evaluationContext === null) {
     throw new Error("expected a materialized evaluator context");
   }
@@ -83,7 +89,7 @@ function applyCompletion({
   after = "",
   label,
   templateFormat,
-  grain,
+  recordKind,
 }: {
   /** Template text to the left of the cursor. */
   before: string;
@@ -91,9 +97,9 @@ function applyCompletion({
   after?: string;
   label: string;
   templateFormat?: TemplateFormat;
-  grain?: ProjectEvaluatorMappingSourceGrain;
+  recordKind?: ProjectEvaluatorRecordKind;
 }): { doc: string; head: number } {
-  const result = complete({ doc: before, templateFormat, grain });
+  const result = complete({ doc: before, templateFormat, recordKind });
   const completion = result?.options.find((option) => option.label === label);
   if (typeof completion?.apply !== "function") {
     throw new Error(`"${label}" is not offered for ${before}`);
@@ -204,7 +210,7 @@ describe("getEvaluatorTemplateCompletions", () => {
     });
 
     expect(
-      complete({ doc: "{{", grain: "session" })?.options.find(
+      complete({ doc: "{{", recordKind: "session" })?.options.find(
         (option) => option.label === "metadata.first_input"
       )
     ).toMatchObject({ section: { name: "From the session" } });
@@ -342,7 +348,7 @@ describe("getEvaluatorTemplateCompletions", () => {
     // whole path the variable menu uses.
     for (const doc of ["{{#", "{{#metadata."]) {
       expect(
-        complete({ doc, grain: "session" })?.options.map(
+        complete({ doc, recordKind: "session" })?.options.map(
           (option) => option.label
         )
       ).toContain("#metadata.turns");
@@ -350,7 +356,7 @@ describe("getEvaluatorTemplateCompletions", () => {
     // A dot after a list offers the block in place of members it cannot name,
     // whether the list was written from its home or without it.
     for (const doc of ["{{metadata.turns.", "{{turns."]) {
-      const atList = complete({ doc, grain: "session" });
+      const atList = complete({ doc, recordKind: "session" });
       expect(atList?.from).toBe(2);
       expect(atList?.options.map((option) => option.label)).toEqual([
         "#metadata.turns",
@@ -361,7 +367,7 @@ describe("getEvaluatorTemplateCompletions", () => {
       applyCompletion({
         before: "{{metadata.turns.",
         label: "#metadata.turns",
-        grain: "session",
+        recordKind: "session",
       })
     ).toEqual({ doc: "{{#metadata.turns}}{{/metadata.turns}}", head: 19 });
   });

--- a/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectCodeEvaluatorDialogContent.tsx
@@ -36,7 +36,7 @@ import { ProjectCodeEvaluatorFormSections } from "@phoenix/pages/project/evaluat
 import { ProjectEvaluatorScopePanel } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopePanel";
 import {
   toEvaluationDelayInput,
-  toEvaluatorMappingSourceGrain,
+  toEvaluatorRecordKind,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { refetchProjectEvaluators } from "@phoenix/pages/project/evaluators/refetchProjectEvaluators";
@@ -107,14 +107,14 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
     data.sandboxBackends
   );
 
-  const grain = toEvaluatorMappingSourceGrain(scope.targetType);
+  const recordKind = toEvaluatorRecordKind(scope.targetType);
   const [language, setLanguage] = useState<CodeEvaluatorLanguage>(
     initialValues?.language ?? "PYTHON"
   );
   const [sourceCode, setSourceCode] = useState(
     () =>
       initialValues?.sourceCode ??
-      getDefaultCodeEvaluatorSource("PYTHON", grain)
+      getDefaultCodeEvaluatorSource("PYTHON", recordKind)
   );
   const [sandboxConfigId, setSandboxConfigId] = useState<string | null>(
     initialValues?.sandboxConfigId ?? null
@@ -170,8 +170,8 @@ export const CreateProjectCodeEvaluatorDialogContent = ({
   const handleLanguageChange = (nextLanguage: CodeEvaluatorLanguage) => {
     // Auto-swap only if sourceCode is still the generated placeholder — never
     // overwrite user-authored code.
-    if (sourceCode === getDefaultCodeEvaluatorSource(language, grain)) {
-      setSourceCode(getDefaultCodeEvaluatorSource(nextLanguage, grain));
+    if (sourceCode === getDefaultCodeEvaluatorSource(language, recordKind)) {
+      setSourceCode(getDefaultCodeEvaluatorSource(nextLanguage, recordKind));
     }
     setLanguage(nextLanguage);
   };

--- a/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/CreateProjectEvaluatorSlideover.tsx
@@ -40,7 +40,7 @@ import { useProjectEvaluatorSubmitHint } from "@phoenix/pages/project/evaluators
 import {
   DEFAULT_EVALUATION_DELAY_SECONDS,
   toEvaluationDelayInput,
-  toEvaluatorMappingSourceGrain,
+  toEvaluatorRecordKind,
   type ProjectEvaluatorScope,
   type ProjectEvaluatorTarget,
   withProjectEvaluatorTarget,
@@ -234,7 +234,7 @@ const CreateProjectEvaluatorDialog = ({
           createDefaultFreeformOutputConfig(""),
         ],
         evaluatorMappingSource: defaultEvaluatorMappingSourceState(
-          toEvaluatorMappingSourceGrain(scope.targetType)
+          toEvaluatorRecordKind(scope.targetType)
         ),
       } satisfies EvaluatorStoreProps;
     }
@@ -279,7 +279,7 @@ const CreateProjectEvaluatorDialog = ({
             ? [{ ...outputConfigs[0], name: defaultEvaluatorName }]
             : [],
       evaluatorMappingSource: defaultEvaluatorMappingSourceState(
-        toEvaluatorMappingSourceGrain(scope.targetType)
+        toEvaluatorRecordKind(scope.targetType)
       ),
     } satisfies EvaluatorStoreProps;
   })();

--- a/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/js/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -37,7 +37,7 @@ import { ProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/Pro
 import {
   isSameInputMapping,
   toEvaluationDelayInput,
-  toEvaluatorMappingSourceGrain,
+  toEvaluatorRecordKind,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import {
@@ -370,7 +370,7 @@ function EditLlmProjectEvaluatorContent({
     // The persisted target decides the mapping vocabulary before any recorded
     // record loads; a session evaluator must never open speaking span.
     evaluatorMappingSource: defaultEvaluatorMappingSourceState(
-      toEvaluatorMappingSourceGrain(scope.targetType)
+      toEvaluatorRecordKind(scope.targetType)
     ),
   } satisfies EvaluatorStoreProps;
 
@@ -540,7 +540,7 @@ function EditCodeProjectEvaluator({
     outputConfigs: loadedOutputConfigs,
     showPromptPreview: false,
     evaluatorMappingSource: defaultEvaluatorMappingSourceState(
-      toEvaluatorMappingSourceGrain(scope.targetType)
+      toEvaluatorRecordKind(scope.targetType)
     ),
   };
   return (

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorFormSections.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorFormSections.tsx
@@ -6,10 +6,10 @@ import { LLMEvaluatorForm } from "@phoenix/components/evaluators/LLMEvaluatorFor
 import { ProjectEvaluatorInputMapping } from "@phoenix/pages/project/evaluators/ProjectEvaluatorInputMapping";
 import { ProjectEvaluatorScopeFieldGroup } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeFields";
 import type {
-  ProjectEvaluatorMappingSourceGrain,
+  ProjectEvaluatorRecordKind,
   ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
-import { toEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import { toEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 /**
  * The left definition panel for an LLM project evaluator; the matching-span
@@ -55,7 +55,7 @@ export const ProjectLlmEvaluatorFormSections = ({
       <LLMEvaluatorForm
         inputMappingSection={
           <ProjectEvaluatorInputMappingSection
-            grain={toEvaluatorMappingSourceGrain(scope.targetType)}
+            recordKind={toEvaluatorRecordKind(scope.targetType)}
           />
         }
       />
@@ -64,11 +64,11 @@ export const ProjectLlmEvaluatorFormSections = ({
 };
 
 const ProjectEvaluatorInputMappingSection = ({
-  grain,
+  recordKind,
 }: {
-  grain: ProjectEvaluatorMappingSourceGrain;
+  recordKind: ProjectEvaluatorRecordKind;
 }) => {
-  const recordNoun = grain;
+  const recordNoun = recordKind;
   return (
     <Flex direction="column" gap="size-200" marginTop="size-200">
       <Flex direction="column" gap="size-100">
@@ -89,7 +89,10 @@ const ProjectEvaluatorInputMappingSection = ({
         >
           {/* Keyed so the rows rebuild against the new record kind rather than
               carrying the previous one's paths forward. */}
-          <ProjectEvaluatorInputMapping key={grain} grain={grain} />
+          <ProjectEvaluatorInputMapping
+            key={recordKind}
+            recordKind={recordKind}
+          />
         </View>
       </Flex>
     </Flex>

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorInputMapping.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorInputMapping.tsx
@@ -5,8 +5,8 @@ import { EVALUATOR_SLOT_NAMES } from "@phoenix/components/evaluators/evaluatorSl
 import { SwitchableEvaluatorInput } from "@phoenix/components/evaluators/SwitchableEvaluatorInput";
 import { useEvaluatorStore } from "@phoenix/contexts/EvaluatorContext";
 import {
-  dropOtherGrainEntityPathMappings,
-  type ProjectEvaluatorMappingSourceGrain,
+  dropOtherRecordKindPathMappings,
+  type ProjectEvaluatorRecordKind,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 /**
@@ -18,16 +18,16 @@ import {
  * reachable under `metadata`, so nothing about it is off limits.
  */
 export const ProjectEvaluatorInputMapping = ({
-  grain,
+  recordKind,
 }: {
-  grain: ProjectEvaluatorMappingSourceGrain;
+  recordKind: ProjectEvaluatorRecordKind;
 }) => {
   const { control, setValue } = useEvaluatorInputMappingControlsForm({
     pruneEmptyEntries: true,
-    // Mounted under a key of the grain, so switching what the evaluator runs on
+    // Mounted under a key of the record kind, so switching what the evaluator runs on
     // rebuilds these rows without the previous record kind's paths in them.
     filterInitialMapping: (inputMapping) =>
-      dropOtherGrainEntityPathMappings(inputMapping, grain),
+      dropOtherRecordKindPathMappings(inputMapping, recordKind),
   });
   const evaluatorMappingSource = useEvaluatorStore(
     (state) => state.evaluatorMappingSource
@@ -58,7 +58,7 @@ export const ProjectEvaluatorInputMapping = ({
               errorMessage={errorMessage}
               ariaLabel={ariaLabel}
               evaluatorMappingSource={evaluatorMappingSource}
-              grain={grain}
+              recordKind={recordKind}
               slotName={slotName}
             />
           )}

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopeFields.tsx
@@ -14,13 +14,13 @@ import {
 } from "@phoenix/components";
 import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 import {
-  dropOtherGrainEntityPathMappings,
+  dropOtherRecordKindPathMappings,
   formatEvaluationTarget,
   isProjectEvaluatorTarget,
   MIN_EVALUATION_DELAY_SECONDS,
-  toEvaluatorMappingSourceGrain,
+  toEvaluatorRecordKind,
   toProjectEvaluatorSamplingFraction,
-  type ProjectEvaluatorMappingSourceGrain,
+  type ProjectEvaluatorRecordKind,
   type ProjectEvaluatorScope,
   type ProjectEvaluatorTarget,
   withProjectEvaluatorTarget,
@@ -63,7 +63,7 @@ export const ProjectEvaluatorScopeFieldGroup = ({
   const evaluatorStore = useEvaluatorStoreInstance();
   // A target change is the one act that moves a form between kinds of record,
   // so everything written against the old kind changes here with it: the
-  // filter (a different language), the store's grain (span and session
+  // filter (a different language), the store's record kind (span and session
   // contexts are structurally identical, so the store cannot infer it), and
   // mapping paths rooted at a name the new record does not carry (a path that
   // matches nothing fails the evaluation).
@@ -71,13 +71,15 @@ export const ProjectEvaluatorScopeFieldGroup = ({
     if (targetType === scope.targetType) {
       return;
     }
-    const grain = toEvaluatorMappingSourceGrain(targetType);
-    if (grain !== toEvaluatorMappingSourceGrain(scope.targetType)) {
+    const recordKind = toEvaluatorRecordKind(targetType);
+    if (recordKind !== toEvaluatorRecordKind(scope.targetType)) {
       const state = evaluatorStore.getState();
-      state.setEvaluatorMappingSourceGrain(grain);
+      state.setEvaluatorRecordKind(recordKind);
       state.setPathMapping(
-        dropOtherGrainEntityPathMappings(state.evaluator.inputMapping, grain)
-          .pathMapping
+        dropOtherRecordKindPathMappings(
+          state.evaluator.inputMapping,
+          recordKind
+        ).pathMapping
       );
     }
     onScopeChange(withProjectEvaluatorTarget({ scope, targetType }));
@@ -350,7 +352,7 @@ const ProjectEvaluatorFilterField = ({
 
 type ProjectEvaluatorFilterField = {
   /** The filter language the field parses, which also picks its editor. */
-  language: ProjectEvaluatorMappingSourceGrain;
+  language: ProjectEvaluatorRecordKind;
   label: string;
   placeholder: string;
   /** What an empty condition evaluates, said in the records' own noun. */
@@ -366,7 +368,7 @@ const SPAN_FILTER_FIELD: ProjectEvaluatorFilterField = {
 
 /**
  * The filter each target authors, one row per target. TRACE collapses onto the
- * span grain — see `toEvaluatorMappingSourceGrain` — so it filters spans by
+ * span record kind — see `toEvaluatorRecordKind` — so it filters spans by
  * saying so here, rather than by falling through to the span row.
  */
 const FILTER_FIELDS_BY_TARGET: Record<

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -78,8 +78,8 @@ import { getEvaluatorMetadataEntries } from "@phoenix/pages/project/evaluators/e
 import { ProjectEvaluatorScopeFieldGroup } from "@phoenix/pages/project/evaluators/ProjectEvaluatorScopeFields";
 import {
   getProjectEvaluatorMappingDiagnostics,
-  toEvaluatorMappingSourceGrain,
-  type ProjectEvaluatorMappingSourceGrain,
+  toEvaluatorRecordKind,
+  type ProjectEvaluatorRecordKind,
   type ProjectEvaluatorScope,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import { getSampleSessionEvaluationContext } from "@phoenix/pages/project/evaluators/sampleSessionEvaluationContext";
@@ -191,12 +191,12 @@ type RecordRunListProps = {
 };
 
 /**
- * What the matching-records half of the panel varies by grain: how it counts
+ * What the matching-records half of the panel varies by record kind: how it counts
  * the records in scope, how it lists them, and any note it opens with. The
- * prose around them names the grain directly.
+ * prose around them names the record kind directly.
  */
-const MATCHING_RECORDS_BY_GRAIN: Record<
-  ProjectEvaluatorMappingSourceGrain,
+const MATCHING_RECORDS_BY_RECORD_KIND: Record<
+  ProjectEvaluatorRecordKind,
   {
     CountLine: ComponentType<MatchedCountLineProps>;
     RunList: ComponentType<RecordRunListProps>;
@@ -239,9 +239,7 @@ export const ProjectEvaluatorScopePanel = (
   // target and condition together keeps the current count and rows visible
   // without sending one target's filter language to the other's queries.
   const filterCondition = deferredPreviewScope.filterCondition;
-  const mappingSourceGrain = toEvaluatorMappingSourceGrain(
-    deferredPreviewScope.targetType
-  );
+  const recordKind = toEvaluatorRecordKind(deferredPreviewScope.targetType);
   const scopeFields = props.showScopeFields !== false ? props : null;
   // The run list below the Suspense boundary owns the records and the run
   // machinery; it hands the header's Test All button the latest run-all
@@ -259,12 +257,12 @@ export const ProjectEvaluatorScopePanel = (
       Test All
     </Button>
   );
-  // Every target maps onto a mapping-source grain, and the preview reads the
-  // grain's records: TRACE collapses onto span, so a trace evaluator previews
+  // Every target maps onto a mapping-source record kind, and the preview reads the
+  // record kind's records: TRACE collapses onto span, so a trace evaluator previews
   // spans by way of that mapping, not by default.
   const { CountLine, RunList, note } =
-    MATCHING_RECORDS_BY_GRAIN[mappingSourceGrain];
-  const records = `${mappingSourceGrain}s`;
+    MATCHING_RECORDS_BY_RECORD_KIND[recordKind];
+  const records = `${recordKind}s`;
   const runListProps: RecordRunListProps = {
     projectId,
     filterCondition,
@@ -313,7 +311,7 @@ export const ProjectEvaluatorScopePanel = (
                 gap="size-200"
               >
                 <Heading level={2} weight="heavy">
-                  Test with a {capitalize(mappingSourceGrain)}
+                  Test with a {capitalize(recordKind)}
                 </Heading>
                 <Flex direction="row" alignItems="center" gap="size-100">
                   <TimeWindowSegmentedControl
@@ -857,7 +855,7 @@ function RecordedRunList({
   onCanRunAllChange,
 }: {
   rows: RecordedRunListRow[];
-  recordNoun: ProjectEvaluatorMappingSourceGrain;
+  recordNoun: ProjectEvaluatorRecordKind;
   listLabel: string;
   hasMore: boolean;
   isLoadingMore: boolean;
@@ -886,7 +884,7 @@ function RecordedRunList({
     (state) => state.evaluator.inputMapping
   );
   useEvaluatorMappingSourceBoundToRow({
-    grain: recordNoun,
+    recordKind: recordNoun,
     rowKey: activeRow?.key ?? null,
     context: activeRow?.context,
   });
@@ -978,7 +976,7 @@ function RecordedRunRow({
   requiredVariables,
 }: {
   row: RecordedRunListRow;
-  recordNoun: ProjectEvaluatorMappingSourceGrain;
+  recordNoun: ProjectEvaluatorRecordKind;
   isExpanded: boolean;
   onToggleExpanded: () => void;
   run: RecordedRun | undefined;
@@ -1062,7 +1060,7 @@ function RecordedRunRow({
                     <Flex direction="column" gap="size-200">
                       <BindingPreview
                         context={row.context}
-                        grain={recordNoun}
+                        recordKind={recordNoun}
                         inputMapping={inputMapping}
                         requiredVariables={requiredVariables}
                         isSampleContext={row.isSample}
@@ -1196,14 +1194,14 @@ type BindingRow = {
  */
 export function BindingPreview({
   context,
-  grain,
+  recordKind,
   inputMapping,
   requiredVariables,
   isSampleContext,
 }: {
   context: unknown;
   /** The kind of record the row holds; the same word its prose uses. */
-  grain: ProjectEvaluatorMappingSourceGrain;
+  recordKind: ProjectEvaluatorRecordKind;
   inputMapping: EvaluatorInputMapping;
   requiredVariables?: string[];
   isSampleContext: boolean;
@@ -1224,8 +1222,8 @@ export function BindingPreview({
   // `metadata` key, and the path resolver all live there, not here.
   const evaluationContext = hasEvaluatorMappingSourceShape(context)
     ? materializeEvaluatorContext({
-        grain,
-        evaluatorMappingSource: { grain, source: context },
+        recordKind,
+        evaluatorMappingSource: { recordKind, source: context },
         inputMapping,
       })
     : null;
@@ -1261,8 +1259,8 @@ export function BindingPreview({
   return (
     <Flex direction="column" gap="size-50" marginTop="size-100">
       {isSampleContext ? (
-        <Alert variant="info" title={`Standard ${grain} fields`}>
-          No matching {grain} yet; values are empty.
+        <Alert variant="info" title={`Standard ${recordKind} fields`}>
+          No matching {recordKind} yet; values are empty.
         </Alert>
       ) : null}
       {[...slotRows, ...mappedRows].map((row) =>
@@ -1290,11 +1288,11 @@ export function BindingPreview({
           <Alert
             key={variable}
             variant="danger"
-            title={`${variable} would fail on this ${grain}`}
+            title={`${variable} would fail on this ${recordKind}`}
           >
             {source === "path"
               ? `Nothing matches ${path}. No annotation is written.`
-              : `This ${grain} has no ${variable}. No annotation is written.`}
+              : `This ${recordKind} has no ${variable}. No annotation is written.`}
           </Alert>
         ) : status === "unverified" ? (
           <Alert
@@ -1321,9 +1319,9 @@ function MetadataBindingTree({
 }: {
   evaluationContext: MaterializedEvaluatorContext;
 }) {
-  const { grain, hasSampledRecord } = evaluationContext;
+  const { recordKind, hasSampledRecord } = evaluationContext;
   const definitionByName = new Map(
-    getEvaluatorMetadataEntries(grain).map((variable) => [
+    getEvaluatorMetadataEntries(recordKind).map((variable) => [
       variable.name,
       variable,
     ])
@@ -1592,17 +1590,17 @@ function getLatestMessageText(value: unknown): string | null {
  * can all return a new transcript for the same row. Keying on what the context
  * says rather than on the row's identity follows the value, not the row.
  *
- * The grain comes from the list the row renders in and is bound with the
+ * The record kind comes from the list the row renders in and is bound with the
  * context, so a target switch that remounts a cached list binds a record the
- * store reads as what it is, whichever of this and the target's grain effect
+ * store reads as what it is, whichever of this and the target's record kind effect
  * runs first.
  */
 export function useEvaluatorMappingSourceBoundToRow({
-  grain,
+  recordKind,
   rowKey,
   context,
 }: {
-  grain: ProjectEvaluatorMappingSourceGrain;
+  recordKind: ProjectEvaluatorRecordKind;
   rowKey: string | null;
   context: unknown;
 }) {
@@ -1615,23 +1613,23 @@ export function useEvaluatorMappingSourceBoundToRow({
     if (hasEvaluatorMappingSourceShape(context)) {
       evaluatorStore
         .getState()
-        .setEvaluatorMappingSource({ grain, source: context });
+        .setEvaluatorMappingSource({ recordKind, source: context });
     }
   });
   useEffect(() => {
     syncMappingSource();
-  }, [grain, rowKey, contextIdentity]);
+  }, [recordKind, rowKey, contextIdentity]);
 }
 
 /**
  * Span and session contexts share this shape, so this cannot tell them apart —
- * the grain the row is bound under does, and the store decides from that what
+ * the record kind the row is bound under does, and the store decides from that what
  * of `metadata` to keep. Only `metadata` is guaranteed to be an object by the
  * server context shape; `input`/`output` are raw attribute values.
  */
 function hasEvaluatorMappingSourceShape(
   value: unknown
-): value is EvaluatorMappingSource<ProjectEvaluatorMappingSourceGrain> {
+): value is EvaluatorMappingSource<ProjectEvaluatorRecordKind> {
   return isStringKeyedObject(value) && isStringKeyedObject(value.metadata);
 }
 

--- a/js/app/src/pages/project/evaluators/ProjectEvaluatorSubmitHint.tsx
+++ b/js/app/src/pages/project/evaluators/ProjectEvaluatorSubmitHint.tsx
@@ -1,6 +1,6 @@
 import { useEvaluatorStore } from "@phoenix/contexts/EvaluatorContext";
 import {
-  toEvaluatorMappingSourceGrain,
+  toEvaluatorRecordKind,
   type ProjectEvaluatorTarget,
 } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
@@ -20,7 +20,7 @@ export const useProjectEvaluatorSubmitHint = ({
     return `Name your evaluator to ${submitLabel}`;
   }
   if (!isFilterValid) {
-    const filterNoun = toEvaluatorMappingSourceGrain(targetType);
+    const filterNoun = toEvaluatorRecordKind(targetType);
     return `Fix the ${filterNoun} filter to ${submitLabel}`;
   }
   return undefined;

--- a/js/app/src/pages/project/evaluators/__tests__/bindingPreview.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/bindingPreview.test.tsx
@@ -34,7 +34,7 @@ describe("the binding preview", () => {
         >
           <BindingPreview
             context={getSampleSpanEvaluationContext().context}
-            grain="span"
+            recordKind="span"
             inputMapping={{
               pathMapping: { input: "metadata.name" },
               literalMapping: {},

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorLiteralRoundTrip.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorLiteralRoundTrip.test.tsx
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { useEvaluatorInputMappingControlsForm } from "@phoenix/components/evaluators/EvaluatorInputMapping";
 import { EvaluatorStoreProvider } from "@phoenix/contexts/EvaluatorContext";
-import { dropOtherGrainEntityPathMappings } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import { dropOtherRecordKindPathMappings } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 import type { EvaluatorStoreInstance } from "@phoenix/store/evaluatorStore";
 
 /**
@@ -26,7 +26,7 @@ function PathOnlyMappingForm({
   const { control } = useEvaluatorInputMappingControlsForm({
     pruneEmptyEntries: true,
     filterInitialMapping: (inputMapping) =>
-      dropOtherGrainEntityPathMappings(inputMapping, "span"),
+      dropOtherRecordKindPathMappings(inputMapping, "span"),
   });
   return (
     <Controller

--- a/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
+++ b/js/app/src/pages/project/evaluators/__tests__/projectEvaluatorTypes.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_SPAN_FILTER_CONDITION } from "@phoenix/pages/project/spanFilterRootScopeConstants";
 
 import {
-  dropOtherGrainEntityPathMappings,
+  dropOtherRecordKindPathMappings,
   formatProjectEvaluatorRunCounts,
   getDefaultProjectEvaluatorFilterCondition,
   getProjectEvaluatorMappingDiagnostics,
@@ -242,10 +242,10 @@ describe("getProjectEvaluatorMappingDiagnostics", () => {
   });
 });
 
-describe("dropOtherGrainEntityPathMappings", () => {
+describe("dropOtherRecordKindPathMappings", () => {
   it("drops paths rooted at the record kind the evaluator no longer runs on", () => {
     expect(
-      dropOtherGrainEntityPathMappings(
+      dropOtherRecordKindPathMappings(
         {
           literalMapping: { rubric: "helpfulness" },
           pathMapping: {
@@ -274,7 +274,7 @@ describe("dropOtherGrainEntityPathMappings", () => {
 
   it("drops session-rooted paths when the evaluator moves to spans", () => {
     expect(
-      dropOtherGrainEntityPathMappings(
+      dropOtherRecordKindPathMappings(
         {
           literalMapping: {},
           pathMapping: {

--- a/js/app/src/pages/project/evaluators/__tests__/useEvaluatorMappingSourceBoundToRow.test.tsx
+++ b/js/app/src/pages/project/evaluators/__tests__/useEvaluatorMappingSourceBoundToRow.test.tsx
@@ -24,7 +24,10 @@ function RunListRow({
   onStore: (store: EvaluatorStoreInstance) => void;
 }) {
   onStore(useEvaluatorStoreInstance());
-  useEvaluatorMappingSourceBoundToRow({ grain: "session", ...SESSION_ROW });
+  useEvaluatorMappingSourceBoundToRow({
+    recordKind: "session",
+    ...SESSION_ROW,
+  });
   return null;
 }
 
@@ -43,7 +46,7 @@ describe("useEvaluatorMappingSourceBoundToRow", () => {
     container.remove();
   });
 
-  it("binds the open row's context to the store under the row's own grain", async () => {
+  it("binds the open row's context to the store under the row's own recordKind", async () => {
     let store: EvaluatorStoreInstance | null = null;
     await act(async () =>
       root.render(
@@ -69,7 +72,7 @@ describe("useEvaluatorMappingSourceBoundToRow", () => {
       )
     );
     expect(store!.getState().evaluatorMappingSource).toEqual({
-      grain: "session",
+      recordKind: "session",
       source: SESSION_ROW.context,
     });
   });

--- a/js/app/src/pages/project/evaluators/evaluatorBoundVariables.ts
+++ b/js/app/src/pages/project/evaluators/evaluatorBoundVariables.ts
@@ -1,4 +1,4 @@
-import type { ProjectEvaluatorMappingSourceGrain } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import type { ProjectEvaluatorRecordKind } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
 
 /**
  * The values a span or session supplies to an evaluator by name alone, with no
@@ -106,58 +106,60 @@ export const SPAN_ANNOTATION_FIELDS = [
   "email",
 ] as const;
 
-const BOUND_VARIABLES_BY_GRAIN: Record<
-  ProjectEvaluatorMappingSourceGrain,
+const BOUND_VARIABLES_BY_RECORD_KIND: Record<
+  ProjectEvaluatorRecordKind,
   EvaluatorBoundVariable[]
 > = {
   span: SPAN_BOUND_VARIABLES,
   session: SESSION_BOUND_VARIABLES,
 };
 
-const METADATA_FIELDS_BY_GRAIN: Record<
-  ProjectEvaluatorMappingSourceGrain,
+const METADATA_FIELDS_BY_RECORD_KIND: Record<
+  ProjectEvaluatorRecordKind,
   EvaluatorBoundVariable[]
 > = {
   span: SPAN_METADATA_FIELDS,
   session: SESSION_METADATA_FIELDS,
 };
 
-export const EVALUATOR_MAPPING_SOURCE_GRAINS = Object.keys(
-  BOUND_VARIABLES_BY_GRAIN
-) as ProjectEvaluatorMappingSourceGrain[];
+export const EVALUATOR_RECORD_KINDS = Object.keys(
+  BOUND_VARIABLES_BY_RECORD_KIND
+) as ProjectEvaluatorRecordKind[];
 
 /**
  * Ordered for reading: identity first, then status, then measures. The server
  * returns them unordered, so the order is this list's to decide.
  */
 export function getEvaluatorBoundVariables(
-  grain: ProjectEvaluatorMappingSourceGrain
+  recordKind: ProjectEvaluatorRecordKind
 ): EvaluatorBoundVariable[] {
-  return BOUND_VARIABLES_BY_GRAIN[grain];
+  return BOUND_VARIABLES_BY_RECORD_KIND[recordKind];
 }
 
 /** The record fields beside the vocabulary, after it in reading order. */
 export function getEvaluatorMetadataFields(
-  grain: ProjectEvaluatorMappingSourceGrain
+  recordKind: ProjectEvaluatorRecordKind
 ): EvaluatorBoundVariable[] {
-  return METADATA_FIELDS_BY_GRAIN[grain];
+  return METADATA_FIELDS_BY_RECORD_KIND[recordKind];
 }
 
 export function getEvaluatorMetadataEntries(
-  grain: ProjectEvaluatorMappingSourceGrain
+  recordKind: ProjectEvaluatorRecordKind
 ): EvaluatorBoundVariable[] {
-  const fields = getEvaluatorMetadataFields(grain);
+  const fields = getEvaluatorMetadataFields(recordKind);
   const isContainer = ({ type }: EvaluatorBoundVariable) =>
     type === "object" || type === "list";
   return [
     ...fields.filter(isContainer),
-    ...getEvaluatorBoundVariables(grain),
+    ...getEvaluatorBoundVariables(recordKind),
     ...fields.filter((field) => !isContainer(field)),
   ];
 }
 
 export function getEvaluatorMetadataEntryNames(
-  grain: ProjectEvaluatorMappingSourceGrain
+  recordKind: ProjectEvaluatorRecordKind
 ): Set<string> {
-  return new Set(getEvaluatorMetadataEntries(grain).map(({ name }) => name));
+  return new Set(
+    getEvaluatorMetadataEntries(recordKind).map(({ name }) => name)
+  );
 }

--- a/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/js/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -5,13 +5,13 @@ import { resolveEvaluatorPath } from "@phoenix/components/evaluators/evaluatorPa
 import type { MetricChartTableView } from "@phoenix/pages/project/constants";
 import type { EvaluationTarget } from "@phoenix/pages/project/evaluators/__generated__/createProjectLlmEvaluatorMutation.graphql";
 import {
-  EVALUATOR_MAPPING_SOURCE_GRAINS,
+  EVALUATOR_RECORD_KINDS,
   getEvaluatorMetadataEntryNames,
 } from "@phoenix/pages/project/evaluators/evaluatorBoundVariables";
 import { DEFAULT_SPAN_FILTER_CONDITION } from "@phoenix/pages/project/spanFilterRootScopeConstants";
 import type {
   EvaluatorInputMapping,
-  EvaluatorMappingSourceGrain,
+  EvaluatorRecordKind,
 } from "@phoenix/types";
 import { assertUnreachable, isStringKeyedObject } from "@phoenix/typeUtils";
 
@@ -19,15 +19,17 @@ import { assertUnreachable, isStringKeyedObject } from "@phoenix/typeUtils";
  * Drops paths rooted at a `metadata` name the new record kind does not carry —
  * a path that matches nothing fails the evaluation server-side.
  */
-export function dropOtherGrainEntityPathMappings(
+export function dropOtherRecordKindPathMappings(
   inputMapping: EvaluatorInputMapping,
-  grain: ProjectEvaluatorMappingSourceGrain
+  recordKind: ProjectEvaluatorRecordKind
 ): EvaluatorInputMapping {
-  const ownNames = getEvaluatorMetadataEntryNames(grain);
-  const staleNames = EVALUATOR_MAPPING_SOURCE_GRAINS.filter(
-    (otherGrain) => otherGrain !== grain
+  const ownNames = getEvaluatorMetadataEntryNames(recordKind);
+  const staleNames = EVALUATOR_RECORD_KINDS.filter(
+    (otherRecordKind) => otherRecordKind !== recordKind
   )
-    .flatMap((otherGrain) => [...getEvaluatorMetadataEntryNames(otherGrain)])
+    .flatMap((otherRecordKind) => [
+      ...getEvaluatorMetadataEntryNames(otherRecordKind),
+    ])
     .filter((name) => !ownNames.has(name));
   const pathMapping = Object.fromEntries(
     Object.entries(inputMapping.pathMapping).filter(
@@ -181,8 +183,8 @@ export const isProjectEvaluatorTarget = (
   PROJECT_EVALUATOR_TARGETS.includes(value as ProjectEvaluatorTarget);
 
 /** A project evaluator runs on a record, never on a dataset example. */
-export type ProjectEvaluatorMappingSourceGrain = Exclude<
-  EvaluatorMappingSourceGrain,
+export type ProjectEvaluatorRecordKind = Exclude<
+  EvaluatorRecordKind,
   "dataset"
 >;
 
@@ -193,9 +195,9 @@ export type ProjectEvaluatorMappingSourceGrain = Exclude<
  * that can tell them apart; every place that builds or resets a project
  * evaluator's mapping source goes through here.
  */
-export function toEvaluatorMappingSourceGrain(
+export function toEvaluatorRecordKind(
   target: ProjectEvaluatorTarget
-): ProjectEvaluatorMappingSourceGrain {
+): ProjectEvaluatorRecordKind {
   switch (target) {
     case "SESSION":
       return "session";

--- a/js/app/src/pages/project/evaluators/sampleSessionEvaluationContext.ts
+++ b/js/app/src/pages/project/evaluators/sampleSessionEvaluationContext.ts
@@ -3,7 +3,7 @@ import type { EvaluatorMappingSource } from "@phoenix/types";
 /**
  * Mirrors the server's `session_eval_context()`. A project with no recorded
  * sessions yet still needs something to author a mapping against, the same way
- * the span grain has a sample span.
+ * the span record kind has a sample span.
  */
 export type SampleSessionEvaluationContext = {
   context: EvaluatorMappingSource<"session">;

--- a/js/app/src/store/__tests__/evaluatorStore.test.ts
+++ b/js/app/src/store/__tests__/evaluatorStore.test.ts
@@ -33,11 +33,11 @@ const createFreeformStore = (
     ...evaluatorMappingSourceState,
   });
 
-describe("evaluatorStore mapping source grain", () => {
+describe("evaluatorStore mapping source recordKind", () => {
   it("keeps dataset mapping sources including reference data", () => {
     const store = createFreeformStore({
       evaluatorMappingSource: {
-        grain: "dataset",
+        recordKind: "dataset",
         source: {
           input: { question: "What is Phoenix?" },
           output: { answer: "An AI observability platform" },
@@ -48,7 +48,7 @@ describe("evaluatorStore mapping source grain", () => {
     });
 
     expect(store.getState().evaluatorMappingSource).toEqual({
-      grain: "dataset",
+      recordKind: "dataset",
       source: {
         input: { question: "What is Phoenix?" },
         output: { answer: "An AI observability platform" },
@@ -61,7 +61,7 @@ describe("evaluatorStore mapping source grain", () => {
   it("keeps span mapping sources limited to runtime context fields", () => {
     const store = createFreeformStore({
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: {
           input: { question: "What is Phoenix?" },
           output: { answer: "An AI observability platform" },
@@ -81,18 +81,18 @@ describe("evaluatorStore mapping source grain", () => {
     });
   });
 
-  it("keeps a recorded session context under the grain it was bound as", () => {
+  it("keeps a recorded session context under the recordKind it was bound as", () => {
     // The store is left on span: a session context is structurally identical to
-    // a span one, so only the grain the caller binds it under says what it is.
+    // a span one, so only the record kind the caller binds it under says what it is.
     const store = createFreeformStore({
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: SPAN_EVALUATOR_MAPPING_SOURCE_DEFAULT,
       },
     });
 
     store.getState().setEvaluatorMappingSource({
-      grain: "session",
+      recordKind: "session",
       source: {
         input: "hi",
         output: "hello",
@@ -103,7 +103,7 @@ describe("evaluatorStore mapping source grain", () => {
     // Read as a span, `turns` is metadata no span vocabulary names, and the
     // context would be dropped for an empty one.
     expect(store.getState().evaluatorMappingSource).toEqual({
-      grain: "session",
+      recordKind: "session",
       source: {
         input: "hi",
         output: "hello",
@@ -112,10 +112,10 @@ describe("evaluatorStore mapping source grain", () => {
     });
   });
 
-  it("resets the source to the new grain's default when the grain changes", () => {
+  it("resets the source to the new recordKind's default when the recordKind changes", () => {
     const store = createFreeformStore({
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: {
           input: "What is Phoenix?",
           output: "An AI observability platform",
@@ -124,10 +124,10 @@ describe("evaluatorStore mapping source grain", () => {
       },
     });
 
-    store.getState().setEvaluatorMappingSourceGrain("session");
+    store.getState().setEvaluatorRecordKind("session");
 
     expect(store.getState().evaluatorMappingSource).toEqual({
-      grain: "session",
+      recordKind: "session",
       source: SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT,
     });
   });
@@ -135,7 +135,7 @@ describe("evaluatorStore mapping source grain", () => {
   it("preserves raw string and null span input/output verbatim", () => {
     const store = createFreeformStore({
       evaluatorMappingSource: {
-        grain: "span",
+        recordKind: "span",
         source: {
           input: "What is Phoenix?",
           output: null,

--- a/js/app/src/store/evaluatorStore.tsx
+++ b/js/app/src/store/evaluatorStore.tsx
@@ -12,7 +12,7 @@ import type {
   EvaluatorKind,
   EvaluatorMappingSource,
   EvaluatorMappingSourceField,
-  EvaluatorMappingSourceGrain,
+  EvaluatorRecordKind,
   EvaluatorOptimizationDirection,
   FreeformEvaluatorAnnotationConfig,
 } from "@phoenix/types";
@@ -28,13 +28,13 @@ export type AnnotationConfig =
   | ContinuousEvaluatorAnnotationConfig
   | FreeformEvaluatorAnnotationConfig;
 
-/** A mapping source and the kind of record it describes, one member per grain. */
+/** A mapping source and the kind of record it describes, one member per record kind. */
 export type EvaluatorMappingSourceState = {
-  [TGrain in EvaluatorMappingSourceGrain]: {
-    grain: TGrain;
-    source: EvaluatorMappingSource<TGrain>;
+  [TRecordKind in EvaluatorRecordKind]: {
+    recordKind: TRecordKind;
+    source: EvaluatorMappingSource<TRecordKind>;
   };
-}[EvaluatorMappingSourceGrain];
+}[EvaluatorRecordKind];
 
 export type EvaluatorStoreProps = {
   datasetEvaluator?: {
@@ -92,38 +92,38 @@ export type EvaluatorStoreActions = {
   setDatasetId: (datasetId: string | null) => void;
   /**
    * Sets the evaluator mapping source data (input, output, reference) as a
-   * record of the grain the caller declares it to be.
+   * record of the record kind the caller declares it to be.
    *
    * Span and session sources are structurally identical, so a payload alone
    * cannot say which record it came from. The caller binding one knows — a run
    * list binds the kind of record it renders, a draft tool binds the kind it
-   * was authored against — so the grain travels with the payload rather than
+   * was authored against — so the record kind travels with the payload rather than
    * being read back off whatever the store happens to hold.
    */
   setEvaluatorMappingSource: <
-    TGrain extends EvaluatorMappingSourceGrain,
+    TRecordKind extends EvaluatorRecordKind,
   >(evaluatorMappingSource: {
-    grain: TGrain;
-    source: EvaluatorMappingSource<TGrain>;
+    recordKind: TRecordKind;
+    source: EvaluatorMappingSource<TRecordKind>;
   }) => void;
   /**
    * Switches which kind of record the mapping source describes, resetting it to
-   * that grain's default.
+   * that record kind's default.
    *
    * Span and session sources are structurally identical, so no setter can infer
-   * the grain from a source. Callers that change the evaluated target must say
+   * the record kind from a source. Callers that change the evaluated target must say
    * so explicitly, or mapping vocabulary silently keeps naming the old record.
    */
-  setEvaluatorMappingSourceGrain: (grain: EvaluatorMappingSourceGrain) => void;
+  setEvaluatorRecordKind: (recordKind: EvaluatorRecordKind) => void;
   /** Sets a single field of the evaluator mapping source. */
   setEvaluatorMappingSourceField: (
     params: {
-      [TGrain in EvaluatorMappingSourceGrain]: {
-        grain: TGrain;
-        field: EvaluatorMappingSourceField<TGrain>;
+      [TRecordKind in EvaluatorRecordKind]: {
+        recordKind: TRecordKind;
+        field: EvaluatorMappingSourceField<TRecordKind>;
         value: Record<string, unknown>;
       };
-    }[EvaluatorMappingSourceGrain]
+    }[EvaluatorRecordKind]
   ) => void;
   /** Sets the currently selected example ID within the dataset. */
   setSelectedExampleId: (selectedExampleId?: string | null) => void;
@@ -243,17 +243,17 @@ export const SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT: EvaluatorMappingSource<"s
   };
 
 /**
- * How each grain reads a payload declared to be one of its records: its own
+ * How each record kind reads a payload declared to be one of its records: its own
  * fields, validated against its own vocabulary and nothing else.
  *
- * Metadata a grain cannot vouch for — an agent-authored payload, a context
- * built for another record kind — is dropped for that grain's empty metadata
+ * Metadata a record kind cannot vouch for — an agent-authored payload, a context
+ * built for another record kind — is dropped for that record kind's empty metadata
  * rather than read under a vocabulary it does not speak.
  */
-const READ_MAPPING_SOURCE_BY_GRAIN: {
-  [TGrain in EvaluatorMappingSourceGrain]: (
-    source: EvaluatorMappingSource<TGrain>
-  ) => EvaluatorMappingSource<TGrain>;
+const READ_MAPPING_SOURCE_BY_RECORD_KIND: {
+  [TRecordKind in EvaluatorRecordKind]: (
+    source: EvaluatorMappingSource<TRecordKind>
+  ) => EvaluatorMappingSource<TRecordKind>;
 } = {
   dataset: ({ input, output, reference, metadata }) => ({
     input: isStringKeyedObject(input) ? input : {},
@@ -280,39 +280,39 @@ const READ_MAPPING_SOURCE_BY_GRAIN: {
   }),
 };
 
-/** Reads a payload as the grain whoever bound it declared it to be. */
+/** Reads a payload as the recordKind whoever bound it declared it to be. */
 export function readEvaluatorMappingSource<
-  TGrain extends EvaluatorMappingSourceGrain,
+  TRecordKind extends EvaluatorRecordKind,
 >({
-  grain,
+  recordKind,
   source,
 }: {
-  grain: TGrain;
-  source: EvaluatorMappingSource<TGrain>;
+  recordKind: TRecordKind;
+  source: EvaluatorMappingSource<TRecordKind>;
 }): EvaluatorMappingSourceState {
-  // The cast pairs a grain with its own source; the compiler tracks that only
-  // once `TGrain` is one grain, which it is at every call site.
+  // The cast pairs a record kind with its own source; the compiler tracks that only
+  // once `TRecordKind` is one record kind, which it is at every call site.
   return {
-    grain,
-    source: READ_MAPPING_SOURCE_BY_GRAIN[grain](source),
+    recordKind,
+    source: READ_MAPPING_SOURCE_BY_RECORD_KIND[recordKind](source),
   } as EvaluatorMappingSourceState;
 }
 
-const MAPPING_SOURCE_DEFAULT_BY_GRAIN: {
-  [TGrain in EvaluatorMappingSourceGrain]: EvaluatorMappingSource<TGrain>;
+const MAPPING_SOURCE_DEFAULT_BY_RECORD_KIND: {
+  [TRecordKind in EvaluatorRecordKind]: EvaluatorMappingSource<TRecordKind>;
 } = {
   dataset: EVALUATOR_MAPPING_SOURCE_DEFAULT,
   span: SPAN_EVALUATOR_MAPPING_SOURCE_DEFAULT,
   session: SESSION_EVALUATOR_MAPPING_SOURCE_DEFAULT,
 };
 
-/** The mapping source a grain starts from before any record is selected. */
+/** The mapping source a recordKind starts from before any record is selected. */
 export function defaultEvaluatorMappingSourceState(
-  grain: EvaluatorMappingSourceGrain
+  recordKind: EvaluatorRecordKind
 ): EvaluatorMappingSourceState {
   return {
-    grain,
-    source: MAPPING_SOURCE_DEFAULT_BY_GRAIN[grain],
+    recordKind,
+    source: MAPPING_SOURCE_DEFAULT_BY_RECORD_KIND[recordKind],
   } as EvaluatorMappingSourceState;
 }
 
@@ -340,7 +340,7 @@ export const DEFAULT_STORE_VALUES = {
     includeExplanation: true,
   },
   evaluatorMappingSource: {
-    grain: "dataset",
+    recordKind: "dataset",
     source: EVALUATOR_MAPPING_SOURCE_DEFAULT,
   },
   showPromptPreview: false,
@@ -565,29 +565,29 @@ export const createEvaluatorStore = (
               "setEvaluatorMappingSource"
             );
           },
-          setEvaluatorMappingSourceGrain(grain) {
-            if (get().evaluatorMappingSource.grain === grain) {
+          setEvaluatorRecordKind(recordKind) {
+            if (get().evaluatorMappingSource.recordKind === recordKind) {
               return;
             }
             set(
               {
                 evaluatorMappingSource:
-                  defaultEvaluatorMappingSourceState(grain),
+                  defaultEvaluatorMappingSourceState(recordKind),
               },
               undefined,
-              "setEvaluatorMappingSourceGrain"
+              "setEvaluatorRecordKind"
             );
           },
           setEvaluatorMappingSourceField(params) {
             const evaluatorMappingSource = get().evaluatorMappingSource;
             invariant(
-              evaluatorMappingSource.grain === params.grain,
-              "Evaluator mapping source grain must match the field grain"
+              evaluatorMappingSource.recordKind === params.recordKind,
+              "Evaluator mapping source recordKind must match the field recordKind"
             );
             set(
               {
                 evaluatorMappingSource: {
-                  grain: evaluatorMappingSource.grain,
+                  recordKind: evaluatorMappingSource.recordKind,
                   source: {
                     ...evaluatorMappingSource.source,
                     [params.field]: params.value,

--- a/js/app/src/types/evaluators.ts
+++ b/js/app/src/types/evaluators.ts
@@ -187,8 +187,8 @@ export type SpanEvaluatorMappingSource = {
  * and `turns`.
  *
  * Structurally identical to a span source, but semantically distinct: the two
- * grains name different records and offer different mapping vocabulary, so the
- * grain a source belongs to can never be inferred from its shape.
+ * record kinds name different records and offer different mapping vocabulary, so the
+ * record kind a source belongs to can never be inferred from its shape.
  */
 export type SessionEvaluatorMappingSource = {
   input: unknown;
@@ -196,18 +196,18 @@ export type SessionEvaluatorMappingSource = {
   metadata: Record<string, unknown>;
 };
 
-export type EvaluatorMappingSourceGrain = "dataset" | "span" | "session";
+export type EvaluatorRecordKind = "dataset" | "span" | "session";
 
-export type EvaluatorMappingSourceByGrain = {
+export type EvaluatorMappingSourceByRecordKind = {
   dataset: DatasetEvaluatorMappingSource;
   span: SpanEvaluatorMappingSource;
   session: SessionEvaluatorMappingSource;
 };
 
 export type EvaluatorMappingSource<
-  TGrain extends EvaluatorMappingSourceGrain = EvaluatorMappingSourceGrain,
-> = EvaluatorMappingSourceByGrain[TGrain];
+  TRecordKind extends EvaluatorRecordKind = EvaluatorRecordKind,
+> = EvaluatorMappingSourceByRecordKind[TRecordKind];
 
 export type EvaluatorMappingSourceField<
-  TGrain extends EvaluatorMappingSourceGrain,
-> = keyof EvaluatorMappingSourceByGrain[TGrain];
+  TRecordKind extends EvaluatorRecordKind,
+> = keyof EvaluatorMappingSourceByRecordKind[TRecordKind];


### PR DESCRIPTION
## Summary

Pure mechanical rename per the table in #15899 — no behavior change. The "grain" naming convention used for the evaluator mapping-source record kind is renamed to "record kind":

| Current | Renamed to |
|---|---|
| `EvaluatorMappingSourceGrain` | `EvaluatorRecordKind` |
| `EvaluatorMappingSourceByGrain` | `EvaluatorMappingSourceByRecordKind` |
| `ProjectEvaluatorMappingSourceGrain` | `ProjectEvaluatorRecordKind` |
| `EVALUATOR_MAPPING_SOURCE_GRAINS` | `EVALUATOR_RECORD_KINDS` |
| `toEvaluatorMappingSourceGrain` | `toEvaluatorRecordKind` |
| `setEvaluatorMappingSourceGrain` | `setEvaluatorRecordKind` |
| `dropOtherGrainEntityPathMappings` | `dropOtherRecordKindPathMappings` |
| locals `mappingSourceGrain`, `grain`, `TGrain` | `recordKind`, `TRecordKind` |

Runtime string values (`"dataset" | "span" | "session"`) are unchanged. Doc comments that used "grain" in prose to describe this concept were also reworded to "record kind" for consistency. Occurrences of "grain"/"fine-grained" elsewhere in `js/app/src` that refer to an unrelated concept (DSL filter granularity, GitHub fine-grained tokens, trace-annotation grain) were left untouched — confirmed by manual review of every grep hit.

37 files changed across `js/app/src` (store, components, pages, tests).

## Test plan

- [x] `pnpm run typecheck` in `js/app` — no errors introduced by this change (pre-existing unrelated failures in `evals/aiQuery/*` confirmed present on the base branch before this change too)
- [x] `npx oxfmt --config ../.oxfmtrc.jsonc` applied to all changed files
- [x] `evaluatorStore.test.ts` — passes
- [x] `evaluatorContext.test.ts` — passes
- [x] `evaluatorSlotDefaults.test.ts` — passes
- [x] `projectEvaluatorTypes.test.ts` — passes
- [x] All 41 tests across the four files above pass unchanged apart from identifier names in the test code itself

Fixes #15899

🤖 Generated with [Claude Code](https://claude.com/claude-code)