### PR TITLE
feat(ui): set version metadata when saving a prompt version

### DIFF
--- a/js/app/src/pages/playground/SavePromptForm.tsx
+++ b/js/app/src/pages/playground/SavePromptForm.tsx
@@ -197,40 +197,42 @@ export function SavePromptForm({
                 </TextField>
               )}
             />
-            {mode === "create" && (
-              <Controller
-                name="metadata"
-                control={control}
-                rules={{
-                  validate: (value) => {
-                    // Allow empty values (will be treated as null)
-                    if (!value || value.trim() === "") {
-                      return true;
-                    }
-                    if (!isJSONObjectString(value)) {
-                      return "metadata must be a valid JSON object";
-                    }
+            <Controller
+              name="metadata"
+              control={control}
+              rules={{
+                validate: (value) => {
+                  // Allow empty values (will be treated as null)
+                  if (!value || value.trim() === "") {
                     return true;
-                  },
-                }}
-                render={({
-                  field: { onChange, onBlur, value },
-                  fieldState: { error },
-                }) => (
-                  <CodeEditorFieldWrapper
-                    label={"Metadata"}
-                    errorMessage={error?.message}
-                    description="A JSON object containing metadata for the prompt (optional)"
-                  >
-                    <JSONEditor
-                      value={value}
-                      onChange={onChange}
-                      onBlur={onBlur}
-                    />
-                  </CodeEditorFieldWrapper>
-                )}
-              />
-            )}
+                  }
+                  if (!isJSONObjectString(value)) {
+                    return "metadata must be a valid JSON object";
+                  }
+                  return true;
+                },
+              }}
+              render={({
+                field: { onChange, onBlur, value },
+                fieldState: { error },
+              }) => (
+                <CodeEditorFieldWrapper
+                  label={"Metadata"}
+                  errorMessage={error?.message}
+                  description={
+                    mode === "create"
+                      ? "A JSON object containing metadata for the prompt (optional)"
+                      : "A JSON object containing metadata for this version (optional)"
+                  }
+                >
+                  <JSONEditor
+                    value={value}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                  />
+                </CodeEditorFieldWrapper>
+              )}
+            />
           </Flex>
         </View>
 

--- a/js/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
+++ b/js/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
@@ -27,6 +27,16 @@ type UpsertPromptFromTemplateProps = {
   selectedPromptId?: string;
 };
 
+/**
+ * Parses the form's metadata JSON, treating an empty editor as no metadata.
+ */
+function parseMetadata(metadata: string | undefined): unknown {
+  if (!metadata || metadata.trim() === "") {
+    return null;
+  }
+  return JSON.parse(metadata);
+}
+
 export const UpsertPromptFromTemplateDialog = ({
   instanceId,
   selectedPromptId,
@@ -99,15 +109,12 @@ export const UpsertPromptFromTemplateDialog = ({
         instanceId,
         store
       );
-      // Parse metadata, or set to null to clear if empty
-      let metadata: unknown = null;
-      if (params.metadata && params.metadata.trim() !== "") {
-        try {
-          metadata = JSON.parse(params.metadata);
-        } catch (_error) {
-          setError("Failed to parse metadata as JSON");
-          return;
-        }
+      let metadata: unknown;
+      try {
+        metadata = parseMetadata(params.metadata);
+      } catch (_error) {
+        setError("Failed to parse metadata as JSON");
+        return;
       }
 
       const tags = params.tags ?? [];
@@ -159,6 +166,14 @@ export const UpsertPromptFromTemplateDialog = ({
         instanceId,
         store
       );
+      let metadata: unknown;
+      try {
+        metadata = parseMetadata(params.metadata);
+      } catch (_error) {
+        setError("Failed to parse metadata as JSON");
+        return;
+      }
+
       const tags = params.tags ?? [];
       updatePrompt({
         variables: {
@@ -167,6 +182,7 @@ export const UpsertPromptFromTemplateDialog = ({
             promptVersion: {
               ...promptInput,
               description: params.description,
+              metadata,
             },
             tags: toPromptVersionTagInputs(tags),
           },


### PR DESCRIPTION
![Save-prompt dialog in update mode showing the metadata validation message rendered under the editor](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/16031-update-dialog-invalid-metadata.png)

resolves #16029