### PR TITLE
docs: link the AI Agent Handbook agent evaluation guide

### DIFF
--- a/docs/phoenix.mdx
+++ b/docs/phoenix.mdx
@@ -41,7 +41,7 @@ In addition to Phoenix, Arize offers Arize AX, a managed enterprise platform bui
       <video src="https://storage.googleapis.com/arize-phoenix-assets/assets/gifs/evals.mp4" width="100%" height="100%" style={{ display: 'block', objectFit: 'fill', backgroundColor: 'transparent' }} controls autoPlay muted loop />
     </Frame>
 
-    [Evaluations](/docs/phoenix/evaluation/llm-evals) help you measure the output quality of your application. You can score traces & spans with LLM-based evaluators, code-based checks, or human labels so you can track performance and identify failures consistently.
+    [Evaluations](/docs/phoenix/evaluation/llm-evals) help you measure the output quality of your application. You can score traces & spans with LLM-based evaluators, code-based checks, or human labels so you can track performance and identify failures consistently. New to evaluations? Our AI agent handbook covers [agent evaluation](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) end to end.
 
     * [LLM-based evaluations](/docs/phoenix/evaluation/pre-built-metrics) — Run pre-built or custom evaluators on your data
     * [Dataset evaluators](/docs/phoenix/datasets-and-experiments/how-to-experiments/how-to-dataset-evaluators) — Attach evaluators to datasets so they run automatically during experiments

--- a/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems.mdx
+++ b/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems.mdx
@@ -71,7 +71,7 @@ Multi-agent systems introduce added complexity:
 
 ### **Leverage Single-Agent Evaluations**
 
-Adapt single-agent evaluation methods like tool-calling evaluations and planning assessments.
+Adapt single-agent evaluation methods like tool-calling evaluations and planning assessments. Check out our [AI agent evaluation handbook](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) to learn more about the concepts behind evals.
 
 Use our [pre-built evals](/docs/phoenix/evaluation/pre-built-metrics) that you can leverage in Phoenix.
 

--- a/docs/phoenix/evaluation/llm-evals.mdx
+++ b/docs/phoenix/evaluation/llm-evals.mdx
@@ -3,7 +3,7 @@ title: "Evaluation"
 sidebarTitle: "Overview"
 ---
 
-Evaluations measure the quality of your AI application's outputs — whether responses are accurate, grounded, safe, or relevant to the user's intent. Unlike traditional software, LLM outputs can't be tested with simple assertions. Evaluations give you a systematic way to catch regressions, compare model or prompt changes, and build confidence before shipping.
+Evaluations measure the quality of your AI application's outputs — whether responses are accurate, grounded, safe, or relevant to the user's intent. Unlike traditional software, LLM outputs can't be tested with simple assertions. Evaluations give you a systematic way to catch regressions, compare model or prompt changes, and build confidence before shipping. Still new to the concepts behind evaluation? Check out our [AI agent evaluation handbook](https://arize.com/guides/ai-agent-handbook/agent-evaluation/).
 
 Phoenix supports both deterministic code-based evaluators (exact match, regex, custom heuristics) and LLM-as-a-judge evaluators, where a second model scores the output against a rubric. You can run evaluations on traces from production, on experiment results, or on any dataset. Phoenix provides two approaches:
 

--- a/docs/phoenix/user-guide.mdx
+++ b/docs/phoenix/user-guide.mdx
@@ -118,6 +118,8 @@ In the testing and staging environment, Phoenix supports comprehensive evaluatio
 
     Phoenix's flexible evaluation framework supports thorough testing of LLM outputs. Teams can define custom metrics, collect user feedback, and leverage separate LLMs for automated assessment. Phoenix offers tools for analyzing evaluation results, identifying trends, and tracking improvements over time.
 
+    * [Agent evaluation handbook](https://arize.com/guides/ai-agent-handbook/agent-evaluation/): learn how to choose metrics and design a judge.
+
   </Tab>
 
   <Tab title="Curate Data">


### PR DESCRIPTION
Adds a pointer to the [AI Agent Handbook's agent evaluation chapter](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) from four evaluation-adjacent docs pages. Each link sits at a point where the existing copy raises a concept it doesn't explain, so it reads as further reading rather than a bolted-on plug.

| Page | Placement |
|:--|:--|
| `docs/phoenix.mdx` | Evaluation feature tab — after the one-sentence definition, before the internal feature links |
| `evaluation/llm-evals.mdx` | Overview intro, right after "LLM outputs can't be tested with simple assertions" |
| `evaluation/concepts-evals/evaluating-multi-agent-systems.mdx` | "Leverage Single-Agent Evaluations" — the section tells readers to adapt single-agent methods but never explains them |
| `user-guide.mdx` | "Evals Testing" tab, which was the only tab in Testing/Staging with no link bullet |

Anchor text is "agent evaluation" / "AI agent evaluation handbook" / "Agent evaluation handbook" depending on the surrounding sentence.

`tracing/llm-traces.mdx` was also considered but is not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)