### PR TITLE
feat(mcp-bench): prepare deterministic private TRAIL fixtures

### DIFF
--- a/evals/mcp/Makefile
+++ b/evals/mcp/Makefile
@@ -15,8 +15,8 @@ mcp-typecheck:
 	.venv/bin/mypy --config-file $(MCP_DIR)/pyproject.toml --python-executable $(MCP_PYTHON)
 
 mcp-lint:
-	$(MCP_DIR)/.venv/bin/ruff check $(MCP_DIR)
-	$(MCP_DIR)/.venv/bin/ruff format --check $(MCP_DIR)
+	$(MCP_DIR)/.venv/bin/ruff check $(MCP_DIR) scripts/prepare_patronus_trail.py
+	$(MCP_DIR)/.venv/bin/ruff format --check $(MCP_DIR) scripts/prepare_patronus_trail.py
 
 mcp-preflight:
 	$(MCP_PYTHON) $(MCP_DIR)/preflight.py $(ARGS)
@@ -29,5 +29,9 @@ mcp-plugin-test:
 
 .PHONY: mcp-format
 mcp-format:
-	$(MCP_DIR)/.venv/bin/ruff format $(MCP_DIR)
-	$(MCP_DIR)/.venv/bin/ruff check --fix $(MCP_DIR)
+	$(MCP_DIR)/.venv/bin/ruff format $(MCP_DIR) scripts/prepare_patronus_trail.py
+	$(MCP_DIR)/.venv/bin/ruff check --fix $(MCP_DIR) scripts/prepare_patronus_trail.py
+
+.PHONY: mcp-fixture
+mcp-fixture:
+	$(MCP_PYTHON) -m scripts.prepare_patronus_trail --output $(MCP_DIR)/.private/trail $(ARGS)

--- a/evals/mcp/README.md
+++ b/evals/mcp/README.md
@@ -33,3 +33,18 @@ records. The shared Phoenix database is never disposable benchmark state.
 
 Private wheels, downloaded TRAIL data, logs, and trajectories belong under ignored
 `.runtime/` or `.private/`. Do not publish TRAIL payloads or populated images.
+
+Fixture preparation is separate from seeding:
+
+```sh
+# Trusted setup process only; requires authorized HF_TOKEN in its environment.
+make mcp-fixture
+# Or use private local rows without any network request:
+make mcp-fixture ARGS='--input /absolute/private/rows.json'
+```
+
+The default revision is immutable. Outputs under `.private/trail` include source
+payload and protected truth. Repeated preparation accepts identical contents;
+changed contents require a new output directory. Fixture preparation creates no
+Phoenix server or database. The programmatic `fixture.seed` helper requires a
+caller-managed, authorized fresh target and refuses an existing fixture project.

--- a/evals/mcp/fixture.py
+++ b/evals/mcp/fixture.py
@@ -1,0 +1,36 @@
+"""Trusted, additive seed API. The caller must first authorize and create a fresh target.
+
+This module owns no target lifecycle and has no database/file cleanup operations.
+It must never be passed the shared results server as a disposable target.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+
+def seed(client: Any, payload: dict[str, Any]) -> None:
+    project = payload["project"]
+    # Refuse accidental reuse. Never delete existing resources to make a seed pass.
+    if any(item["name"] == project for item in client.projects.list()):
+        raise ValueError("Fixture project already exists; select an authorized fresh target")
+    client.projects.create(name=project)
+    client.spans.log_spans(project_identifier=project, spans=payload["spans"])
+    if payload["span_annotations"]:
+        client.spans.log_span_annotations(span_annotations=payload["span_annotations"])
+    if payload["trace_annotations"]:
+        client.traces.log_trace_annotations(trace_annotations=payload["trace_annotations"])
+
+
+def await_ready(
+    read_state: Callable[[], dict[str, Any]], expected: dict[str, Any], *, timeout: float = 60
+) -> None:
+    """A trusted API reader must supply complete paginated semantic state, not healthz."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if read_state() == expected:
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Target semantic state does not match the immutable fixture")
+        time.sleep(0.1)

--- a/evals/mcp/tests/test_fixture.py
+++ b/evals/mcp/tests/test_fixture.py
@@ -1,0 +1,66 @@
+import copy
+import json
+from unittest.mock import Mock
+
+import pytest
+from scripts.prepare_patronus_trail import prepare
+
+from fixture import await_ready, seed
+
+
+def row(trace_id="trace-a", span_id="span-a"):
+    return {
+        "trace": json.dumps(
+            {
+                "trace_id": trace_id,
+                "spans": [
+                    {
+                        "trace_id": trace_id,
+                        "span_id": span_id,
+                        "span_name": "original synthetic test",
+                        "timestamp": "2025-01-01T00:00:00Z",
+                        "duration": "PT0.125S",
+                        "span_attributes": {"llm.token_count.prompt": "3"},
+                        "child_spans": [],
+                    }
+                ],
+            }
+        ),
+        "labels": json.dumps({"errors": [], "scores": []}),
+    }
+
+
+def test_semantics_are_stable_across_row_order_and_repeated_preparation():
+    rows = [row(), row("trace-b", "span-b")]
+    first = prepare(rows, revision="a" * 40, source="gaia")
+    assert first == prepare(list(reversed(rows)), revision="a" * 40, source="gaia")
+    assert first["truth"]["trace_count"] == 2
+    assert first["payload"]["spans"][0]["attributes"]["llm.token_count.prompt"] == 3
+    assert first["payload"]["spans"][0]["end_time"].endswith("00.125000+00:00")
+    assert (
+        first["manifest"]["fixture_hash"]
+        != prepare(rows, revision="b" * 40, source="gaia")["manifest"]["fixture_hash"]
+    )
+
+
+def test_duplicate_ids_empty_traces_and_dangling_annotations_fail():
+    with pytest.raises(ValueError, match="Duplicate"):
+        prepare([row(), row()], revision="a" * 40, source="gaia")
+    bad = copy.deepcopy(row())
+    bad["labels"] = json.dumps({"errors": [{"location": "missing"}]})
+    with pytest.raises(ValueError, match="missing span"):
+        prepare([bad], revision="a" * 40, source="gaia")
+    with pytest.raises(ValueError, match="empty"):
+        prepare([], revision="a" * 40, source="gaia")
+
+
+def test_seed_refuses_existing_project_and_readiness_requires_state():
+    client = Mock()
+    client.projects.list.return_value = [{"name": "mcp-trail-gaia"}]
+    fixture = prepare([row()], revision="a" * 40, source="gaia")
+    with pytest.raises(ValueError, match="already exists"):
+        seed(client, fixture["payload"])
+    client.projects.create.assert_not_called()
+    with pytest.raises(TimeoutError):
+        await_ready(lambda: {"healthy": True}, fixture["truth"], timeout=0)
+    await_ready(lambda: fixture["truth"], fixture["truth"], timeout=0)

--- a/scripts/prepare_patronus_trail.py
+++ b/scripts/prepare_patronus_trail.py
@@ -1,0 +1,175 @@
+"""Prepare a private, deterministic TRAIL fixture without touching any Phoenix database.
+
+Run through `make mcp-fixture`. Download requires an explicit HF_TOKEN in this
+trusted process. Outputs contain restricted data and must never enter images or git.
+The general-purpose converter remains load_patronus_trail.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from scripts import load_patronus_trail as loader
+
+REVISION = "b424ce63d5973d5dcd7169b1bc3c07ccdee276d1"
+CONVERTER_VERSION = "trail-deterministic-1"
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+class StableIds(loader.IdMapper):
+    def __init__(self, namespace: str):
+        super().__init__(regenerate=False)
+        self.namespace = namespace
+
+    def _map(self, kind: str, original: str, length: int) -> str:
+        if not original:
+            raise ValueError("Missing source ID")
+        return hashlib.sha256(f"{self.namespace}:{kind}:{original}".encode()).hexdigest()[:length]
+
+    def map_trace(self, original: str) -> str:
+        return self._map("trace", original, 32)
+
+    def map_span(self, original: str) -> str:
+        return self._map("span", original, 16)
+
+
+def prepare(rows: list[dict[str, str]], *, revision: str, source: str) -> dict[str, Any]:
+    """Derive truth from source identities, independently of converted Phoenix spans."""
+    mapper = StableIds(f"{revision}:{source}")
+    decoded = [
+        (loader._loads_tolerant(row["trace"]), loader._loads_tolerant(row["labels"]))
+        for row in rows
+    ]
+    decoded.sort(key=lambda pair: str(pair[0]["trace_id"]))
+    identities: set[str] = set()
+    raw_span_ids: set[str] = set()
+    spans, annotations, trace_annotations = [], [], []
+    for trace, labels in decoded:
+        trace_id = str(trace["trace_id"])
+        if trace_id in identities:
+            raise ValueError("Duplicate source trace")
+        identities.add(trace_id)
+        raw_spans = list(loader._walk_spans(trace.get("spans") or []))
+        if not raw_spans:
+            raise ValueError("Empty trace cannot support independent count truth")
+        local_ids = {str(span["span_id"]) for span in raw_spans}
+        if len(local_ids) != len(raw_spans) or local_ids.intersection(raw_span_ids):
+            raise ValueError("Duplicate source span")
+        raw_span_ids.update(local_ids)
+        for span in raw_spans:
+            if str(span["trace_id"]) != trace_id:
+                raise ValueError("Span belongs to another trace")
+            if span.get("parent_span_id") and str(span["parent_span_id"]) not in local_ids:
+                raise ValueError("Parent span is absent from selected trace")
+        converted = [loader._to_phoenix_span(span, mapper) for span in raw_spans]
+        spans.extend(converted)
+        for error in labels.get("errors") or []:
+            if error.get("location") and str(error["location"]) not in local_ids:
+                raise ValueError("Annotation targets a missing span")
+        annotations.extend(loader._to_span_annotations(labels.get("errors") or [], mapper))
+        trace_annotations.extend(
+            loader._scores_to_annotations(
+                loader._extract_scores(labels.get("scores") or []),
+                on_trace=True,
+                target_id=mapper.map_trace(trace_id),
+            )
+        )
+    if not spans:
+        raise ValueError("Fixture is empty")
+    spans.sort(key=lambda span: (span["context"]["trace_id"], span["context"]["span_id"]))
+    annotations.sort(key=lambda annotation: annotation["identifier"])
+    trace_annotations.sort(key=lambda annotation: annotation["identifier"])
+    project = f"mcp-trail-{source}"
+    payload = {
+        "project": project,
+        "spans": spans,
+        "span_annotations": annotations,
+        "trace_annotations": trace_annotations,
+    }
+    source_hash = hashlib.sha256(canonical(decoded)).hexdigest()
+    fixture_hash = hashlib.sha256(
+        canonical(
+            {
+                "version": CONVERTER_VERSION,
+                "revision": revision,
+                "source_hash": source_hash,
+                "payload": payload,
+            }
+        )
+    ).hexdigest()
+    return {
+        "manifest": {
+            "corpus": "PatronusAI/TRAIL",
+            "revision": revision,
+            "source": source,
+            "converter_version": CONVERTER_VERSION,
+            "source_hash": source_hash,
+            "fixture_hash": fixture_hash,
+            "project": project,
+            "trace_count": len(identities),
+            "span_count": len(raw_span_ids),
+            "span_annotation_count": len(annotations),
+            "trace_annotation_count": len(trace_annotations),
+        },
+        "truth": {
+            "project": project,
+            "trace_count": len(identities),
+            "trace_ids": sorted(mapper.map_trace(t) for t in identities),
+            "span_ids": sorted(mapper.map_span(s) for s in raw_span_ids),
+        },
+        "payload": payload,
+    }
+
+
+def download(source: str, revision: str, cache: Path) -> list[dict[str, str]]:
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        raise ValueError("Missing HF_TOKEN in trusted downloader environment")
+    from datasets import load_dataset
+
+    dataset = load_dataset(
+        loader.DATASET_REPO, split=source, revision=revision, token=token, cache_dir=str(cache)
+    )
+    return [{"trace": row["trace"], "labels": row["labels"]} for row in dataset]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, help="Private local JSON rows; skips download")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source", choices=["gaia", "swe_bench"], default="gaia")
+    parser.add_argument("--revision", default=REVISION)
+    args = parser.parse_args()
+    if len(args.revision) != 40 or any(c not in "0123456789abcdef" for c in args.revision):
+        parser.error("revision must be an immutable 40-character commit")
+    os.umask(0o077)
+    args.output.mkdir(parents=True, exist_ok=True, mode=0o700)
+    rows = (
+        json.loads(args.input.read_text())
+        if args.input
+        else download(args.source, args.revision, args.output / "hf-cache")
+    )
+    fixture = prepare(rows, revision=args.revision, source=args.source)
+    for name, value in fixture.items():
+        path = args.output / f"{name}.json"
+        # Never overwrite a prior fixture, which could be attached to a historical run.
+        data = canonical(value) + b"\n"
+        if path.exists():
+            if path.read_bytes() != data:
+                raise ValueError("Output contains a different fixture; use a new output directory")
+        else:
+            with path.open("xb") as stream:
+                stream.write(data)
+    print(json.dumps({"fixture_hash": fixture["manifest"]["fixture_hash"], "prepared": True}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Superseded by #16088, which consolidates this work with the reviewed fresh-target redesign. The original branches remain available for recovery.

Prepare a deterministic private TRAIL fixture and typed benchmark metadata without creating or resetting a Phoenix database. The trusted downloader pins `PatronusAI/TRAIL` revision `b424ce63d5973d5dcd7169b1bc3c07ccdee276d1`, reuses the existing converter, preserves timestamps, maps stable IDs, hashes the fixture, and derives trace-count truth independently from source identities.

Preparation rejects duplicate/missing identities and dangling parent or annotation references. Existing outputs must be byte-identical. The additive seed helper refuses an existing project; it never deletes resources to make setup succeed. Task metadata provides controlled facets and validates task/family identity.

Validation: fixture and metadata tests pass. Live seeding into the shared development database produced 117 traces and 3,579 spans. The converter's identifier upserts turn 585 span-annotation input records into 581 stored annotations; all 581 span annotations and 585 trace annotations were checked against their expected targets, labels, scores, explanations, names, and annotator kinds. Private payloads are excluded from git and images.
