### PR TITLE
feat(mcp-bench): gate isolation and protect answer handoff

### DIFF
--- a/evals/mcp/Makefile
+++ b/evals/mcp/Makefile
@@ -35,3 +35,7 @@ mcp-format:
 .PHONY: mcp-fixture
 mcp-fixture:
 	$(MCP_PYTHON) -m scripts.prepare_patronus_trail --output $(MCP_DIR)/.private/trail $(ARGS)
+
+.PHONY: mcp-isolation-probe
+mcp-isolation-probe:
+	$(MCP_PYTHON) $(MCP_DIR)/isolation.py --docker-probe

--- a/evals/mcp/README.md
+++ b/evals/mcp/README.md
@@ -48,3 +48,9 @@ payload and protected truth. Repeated preparation accepts identical contents;
 changed contents require a new output directory. Fixture preparation creates no
 Phoenix server or database. The programmatic `fixture.seed` helper requires a
 caller-managed, authorized fresh target and refuses an existing fixture project.
+
+`make mcp-isolation-probe` runs Harbor's pinned ephemeral Alpine capability probe.
+It does not create Phoenix state or make model calls. A passing probe is only a
+prerequisite: actual egress, web-tool, repository, grader, reward, and shutdown
+probes must pass for each installed agent condition before execution is enabled.
+The current Docker Desktop kernel lacks `CONFIG_NFT_FIB_INET`, so this gate fails.

--- a/evals/mcp/isolation.py
+++ b/evals/mcp/isolation.py
@@ -1,0 +1,106 @@
+"""Fail-closed Docker capability probe and declared-artifact handoff primitives.
+
+These primitives are not a completed Harbor lifecycle integration. The runner must
+supply container IDs and protected audit evidence, never agent-authored claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+
+class InvalidEvidence(RuntimeError):
+    pass
+
+
+def read_regular(directory: Path, name: str, *, limit: int = 1_048_576) -> bytes:
+    if name not in {"answer.json", "trajectory.json"}:
+        raise InvalidEvidence("Undeclared artifact")
+    root = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        descriptor = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=root)
+        try:
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or info.st_size > limit:
+                raise InvalidEvidence("Artifact must be a bounded regular file")
+            with os.fdopen(os.dup(descriptor), "rb") as source:
+                data = source.read(limit + 1)
+            if len(data) > limit:
+                raise InvalidEvidence("Artifact exceeded size limit")
+            return data
+        finally:
+            os.close(descriptor)
+    finally:
+        os.close(root)
+
+
+def require_stopped(container_ids: list[str], inspect: Callable[[str], dict[str, Any]]) -> None:
+    if not container_ids:
+        raise InvalidEvidence("Missing agent container inventory")
+    for container_id in container_ids:
+        state = inspect(container_id)
+        # Missing containers are ambiguous: inspect before teardown, not after removal.
+        if state.get("Running") is not False or state.get("Pid") != 0:
+            raise InvalidEvidence("Agent shutdown was not independently confirmed")
+
+
+def snapshot_answer(source: Path, destination: Path, *, confirm_stopped: Callable[[], None]) -> str:
+    """Copy only the declared answer. Never transfer agent-written rewards or verifier code."""
+    confirm_stopped()
+    data = read_regular(source, "answer.json")
+    json.loads(data)  # Validate syntax without importing or executing agent code.
+    destination.mkdir(mode=0o700, parents=True, exist_ok=False)
+    with (destination / "answer.json").open("xb") as output:
+        output.write(data)
+    return hashlib.sha256(data).hexdigest()
+
+
+def docker_capability() -> dict[str, Any]:
+    from harbor.environments.docker.docker import DockerEnvironment
+
+    result = subprocess.run(
+        [
+            "docker",
+            "container",
+            "run",
+            "--rm",
+            DockerEnvironment._EGRESS_CONTROL_KERNEL_PROBE_IMAGE,
+            "sh",
+            "-c",
+            DockerEnvironment._EGRESS_CONTROL_KERNEL_PROBE_SCRIPT,
+        ],
+        capture_output=True,
+        timeout=45,
+    )
+    # Do not mistake an image pull/daemon failure for a missing kernel capability.
+    return {
+        "probe": "harbor-0.22.0-nft-fib-inet",
+        "exit_code": result.returncode,
+        "capability_probe_passed": result.returncode == 0,
+        "runtime_isolation_verified": False,
+        "next_step": (
+            "Run same-context egress and filesystem probes"
+            if result.returncode == 0
+            else "Fix Docker capability before any evaluated trial"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docker-probe", action="store_true", required=True)
+    parser.parse_args()
+    result = docker_capability()
+    print(json.dumps(result, indent=2))
+    return not result["capability_probe_passed"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/mcp/tests/test_isolation.py
+++ b/evals/mcp/tests/test_isolation.py
@@ -1,0 +1,56 @@
+import json
+import os
+
+import pytest
+
+from isolation import InvalidEvidence, read_regular, require_stopped, snapshot_answer
+
+
+def test_failed_or_missing_shutdown_invalidates_evidence():
+    for state in ({}, {"Running": True, "Pid": 12}, {"Running": False, "Pid": 12}):
+        with pytest.raises(InvalidEvidence, match="shutdown"):
+            require_stopped(["agent"], lambda _: state)
+    with pytest.raises(InvalidEvidence, match="inventory"):
+        require_stopped([], lambda _: {})
+    require_stopped(["agent"], lambda _: {"Running": False, "Pid": 0})
+
+
+def test_fake_reward_is_not_transferred(tmp_path):
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (agent / "answer.json").write_text('{"trace_count": 2}')
+    (agent / "reward.json").write_text('{"reward": 1}')
+    calls = []
+    verifier = tmp_path / "protected"
+    snapshot_answer(agent, verifier, confirm_stopped=lambda: calls.append("stopped"))
+    assert calls == ["stopped"]
+    assert list(verifier.iterdir()) == [verifier / "answer.json"]
+    assert json.loads((verifier / "answer.json").read_text()) == {"trace_count": 2}
+    with pytest.raises(InvalidEvidence, match="Undeclared"):
+        read_regular(agent, "reward.json")
+
+
+def test_symlinks_pipes_and_oversized_answers_rejected(tmp_path):
+    outside = tmp_path / "secret"
+    outside.write_text("private")
+    answer = tmp_path / "answer.json"
+    answer.symlink_to(outside)
+    with pytest.raises(OSError):
+        read_regular(tmp_path, "answer.json")
+    answer.unlink()
+    os.mkfifo(answer)
+    with pytest.raises(InvalidEvidence, match="regular"):
+        read_regular(tmp_path, "answer.json")
+    answer.unlink()
+    answer.write_bytes(b"a" * 11)
+    with pytest.raises(InvalidEvidence, match="bounded"):
+        read_regular(tmp_path, "answer.json", limit=10)
+
+
+def test_failed_shutdown_cannot_create_authoritative_snapshot(tmp_path):
+    def failed():
+        raise InvalidEvidence("still running")
+
+    with pytest.raises(InvalidEvidence):
+        snapshot_answer(tmp_path, tmp_path / "protected", confirm_stopped=failed)
+    assert not (tmp_path / "protected").exists()


### PR DESCRIPTION
Superseded by #16088, which consolidates this work with the reviewed fresh-target redesign. The original branches remain available for recovery.

Add protected artifact and shutdown primitives for benchmark verification. Artifact reads accept only declared, bounded regular files and reject symlinks; answer snapshotting requires an independent stopped-container check and never transfers an agent-written reward as authoritative evidence. Missing container identities or ambiguous shutdown state fail closed.

The Docker capability probe measures Harbor's pinned daemon-side nftables requirement. The current Docker Desktop kernel lacks `CONFIG_NFT_FIB_INET`, so the live integration uses a separately tested Docker internal-network gateway rather than bypassing the probe.

Validation: artifact, forged-reward, symlink, and shutdown tests pass. The completed live runner also proved blocked public/host access in each agent container and inspected stopped containers before launching a separate verifier.
