### PR TITLE
feat(mcp-bench): add count task and native plugin metadata contracts

### DIFF
--- a/evals/mcp/Makefile
+++ b/evals/mcp/Makefile
@@ -39,3 +39,7 @@ mcp-fixture:
 .PHONY: mcp-isolation-probe
 mcp-isolation-probe:
 	$(MCP_PYTHON) $(MCP_DIR)/isolation.py --docker-probe
+
+.PHONY: mcp-stage-task
+mcp-stage-task:
+	$(MCP_PYTHON) $(MCP_DIR)/stage_task.py $(ARGS)

--- a/evals/mcp/README.md
+++ b/evals/mcp/README.md
@@ -54,3 +54,15 @@ It does not create Phoenix state or make model calls. A passing probe is only a
 prerequisite: actual egress, web-tool, repository, grader, reward, and shutdown
 probes must pass for each installed agent condition before execution is enabled.
 The current Docker Desktop kernel lacks `CONFIG_NFT_FIB_INET`, so this gate fails.
+
+Task staging requires a prepared manifest and reviewed runtime image digests:
+
+```sh
+make mcp-stage-task ARGS='--manifest /private/manifest.json --output /private/tasks --agent-image registry/agent@sha256:DIGEST --verifier-image registry/python@sha256:DIGEST'
+```
+
+Replace `DIGEST` with actual 64-character image hashes. The canonical task has no
+MCP registration, so CLI conditions cannot inherit an MCP server. Network defaults
+are closed. This staging command does not configure a runnable trial: trusted
+truth/audit transfer and condition access must be attached by the pending runner.
+The verifier emits no authoritative reward without trusted evidence.

--- a/evals/mcp/stage_task.py
+++ b/evals/mcp/stage_task.py
@@ -1,0 +1,111 @@
+"""Stage one Harbor task from a canonical instruction and a private fixture manifest.
+
+Image digests are supplied only after the separate image/isolation acceptance work.
+This command does not run Harbor, provision a target, or attach trusted evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+import toml
+
+from metadata import TaskMetadata
+
+HERE = Path(__file__).resolve().parent
+
+
+def count_metadata(manifest: dict[str, Any]) -> TaskMetadata:
+    if manifest["project"] != "mcp-trail-gaia" or manifest["source"] != "gaia":
+        raise ValueError("Count task instruction requires the GAIA fixture project")
+    return TaskMetadata(
+        task_id="trace-count",
+        task_version="1",
+        task_family_id="trace-count",
+        task_type="aggregation",
+        primary_surface="tracing",
+        product_surfaces=["tracing"],
+        operation_types=["list", "aggregate"],
+        mutability="read_only",
+        split="development",
+        suites=["smoke", "core"],
+        difficulty="easy",
+        difficulty_rationale="One project count",
+        challenge_tags=[],
+        data_scale={
+            "category": "tiny",
+            "traces": manifest["trace_count"],
+            "spans": manifest["span_count"],
+        },
+        fixture_corpus=manifest["corpus"],
+        fixture_revision=manifest["revision"],
+        fixture_hash=manifest["fixture_hash"],
+        required_capabilities=["trace_count", "trace_list"],
+        eligible_interfaces=["mcp", "cli"],
+        verification_types=["deterministic", "state", "policy"],
+        evaluator_ids=["trace-count@1", "read-only-state@1", "access-policy@1"],
+        rubric_version="1",
+        sql_opportunity="aggregation",
+    )
+
+
+def stage(manifest: dict[str, Any], output: Path, *, agent_image: str, verifier_image: str) -> Path:
+    for image in (agent_image, verifier_image):
+        if not re.fullmatch(r"[a-z0-9./:_-]+@sha256:[a-f0-9]{64}", image):
+            raise ValueError("A pinned image digest is required")
+    metadata = count_metadata(manifest)
+    task = output / "trace-count"
+    task.mkdir(parents=True, exist_ok=False)
+    shutil.copy(HERE / "tasks/trace-count/instruction.md", task)
+    shutil.copytree(HERE / "tasks/trace-count/solution", task / "solution")
+    environment = task / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text(f"FROM {agent_image}\nWORKDIR /workspace\n")
+    tests = task / "tests"
+    tests.mkdir()
+    # Only the separate verifier context contains grading code. No fixture payload.
+    for name in ("verify.py", "isolation.py"):
+        shutil.copy(HERE / name, tests / name)
+    (tests / "test.sh").write_text("#!/bin/sh\nset -eu\npython /tests/verify.py\n")
+    (tests / "Dockerfile").write_text(
+        f"FROM {verifier_image}\nCOPY verify.py isolation.py test.sh /tests/\n"
+    )
+    config = {
+        "schema_version": "1.3",
+        "task": {"name": "arize/trace-count", "version": "1"},
+        "metadata": metadata.model_dump(mode="json"),
+        "environment": {"network_mode": "no-network", "cpus": 2, "memory_mb": 4096},
+        "agent": {"timeout_sec": 300},
+        "verifier": {
+            "environment_mode": "separate",
+            "timeout_sec": 60,
+            "environment": {"network_mode": "no-network"},
+        },
+        "artifacts": [{"source": "/workspace/answer.json", "destination": "answer.json"}],
+    }
+    (task / "task.toml").write_text(toml.dumps(config))
+    return task
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--agent-image", required=True)
+    parser.add_argument("--verifier-image", required=True)
+    args = parser.parse_args()
+    stage(
+        json.loads(args.manifest.read_text()),
+        args.output,
+        agent_image=args.agent_image,
+        verifier_image=args.verifier_image,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/mcp/stage_task.py
+++ b/evals/mcp/stage_task.py
@@ -80,7 +80,7 @@ def stage(manifest: dict[str, Any], output: Path, *, agent_image: str, verifier_
         "task": {"name": "arize/trace-count", "version": "1"},
         "metadata": metadata.model_dump(mode="json"),
         "environment": {"network_mode": "no-network", "cpus": 2, "memory_mb": 4096},
-        "agent": {"timeout_sec": 300},
+        "agent": {"timeout_sec": 300, "network_mode": "allowlist", "allowed_hosts": []},
         "verifier": {
             "environment_mode": "separate",
             "timeout_sec": 60,

--- a/evals/mcp/tasks/trace-count/instruction.md
+++ b/evals/mcp/tasks/trace-count/instruction.md
@@ -1,0 +1,11 @@
+How many traces are in the Phoenix project `mcp-trail-gaia`? Count all traces in
+that project, across its full recorded time range. Do not modify any Phoenix data.
+
+Write `/workspace/answer.json` with exactly these fields:
+- `project`: the project name.
+- `trace_count`: an integer count.
+- `evidence_trace_ids`: at least one trace ID from that project supporting your lookup.
+
+Also give a brief readable answer. Use only your assigned Phoenix interface for
+Phoenix data. Local shell/Python processing is allowed. Direct HTTP, SDK or database
+access, repository/web browsing, other interfaces, and writes are outside this task.

--- a/evals/mcp/tasks/trace-count/solution/solve.py
+++ b/evals/mcp/tasks/trace-count/solution/solve.py
@@ -1,0 +1,37 @@
+"""Oracle exercises the CLI against a seeded target. No fixture answer is embedded."""
+
+import json
+import subprocess
+from pathlib import Path
+
+cursor = None
+while True:
+    after = f", after: {json.dumps(cursor)}" if cursor else ""
+    query = (
+        "{ projects(first: 100" + after + ") { edges { node { name traceCount "
+        "traces(first: 1) { edges { node { traceId } } } } } "
+        "pageInfo { hasNextPage endCursor } } }"
+    )
+    result = json.loads(subprocess.check_output(["px", "api", "graphql", query], text=True))
+    if result.get("errors"):
+        raise RuntimeError("Oracle GraphQL returned errors")
+    projects = result["data"]["projects"]
+    for edge in projects["edges"]:
+        project = edge["node"]
+        if project["name"] == "mcp-trail-gaia":
+            Path("/workspace/answer.json").write_text(
+                json.dumps(
+                    {
+                        "project": project["name"],
+                        "trace_count": project["traceCount"],
+                        "evidence_trace_ids": [
+                            e["node"]["traceId"] for e in project["traces"]["edges"]
+                        ],
+                    }
+                )
+            )
+            raise SystemExit(0)
+    page = projects["pageInfo"]
+    if not page["hasNextPage"] or page["endCursor"] == cursor:
+        raise RuntimeError("Oracle target project not found")
+    cursor = page["endCursor"]

--- a/evals/mcp/tasks/trace-count/solution/solve.sh
+++ b/evals/mcp/tasks/trace-count/solution/solve.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python /solution/solve.py

--- a/evals/mcp/tests/test_count_task.py
+++ b/evals/mcp/tests/test_count_task.py
@@ -1,0 +1,84 @@
+import pytest
+from harbor.job import Job
+from harbor.models.job.config import DatasetConfig, JobConfig
+from harbor.models.trial.config import AgentConfig
+from phoenix.client.harbor._adapter import build_job_plan
+
+from isolation import InvalidEvidence
+from stage_task import stage
+from verify import grade_count
+
+
+def valid():
+    return (
+        {"project": "mcp-trail-gaia", "trace_count": 2, "evidence_trace_ids": ["a"]},
+        {"project": "mcp-trail-gaia", "trace_count": 2, "trace_ids": ["a", "b"]},
+        {
+            "shutdown_confirmed": True,
+            "audit_complete": True,
+            "target_state_complete": True,
+            "forbidden_attempts": [],
+            "state_unchanged": True,
+        },
+    )
+
+
+def test_oracle_pass_and_bad_answers_fail():
+    answer, truth, evidence = valid()
+    assert grade_count(answer, truth, evidence)["reward"] == 1
+    for bad in (
+        {},
+        None,
+        [],
+        answer | {"trace_count": True},
+        answer | {"trace_count": 3},
+        answer | {"project": "other"},
+        answer | {"evidence_trace_ids": ["fake"]},
+    ):
+        assert grade_count(bad, truth, evidence)["reward"] == 0
+    assert (
+        grade_count(answer, truth, evidence | {"forbidden_attempts": ["blocked db"]})["reward"] == 0
+    )
+    assert grade_count(answer, truth, evidence | {"state_unchanged": False})["reward"] == 0
+    with pytest.raises(InvalidEvidence):
+        grade_count(answer, truth, evidence | {"audit_complete": False})
+
+
+async def test_native_harbor_plugin_preserves_facets_and_fixture_identity(tmp_path):
+    manifest = {
+        "project": "mcp-trail-gaia",
+        "source": "gaia",
+        "trace_count": 2,
+        "span_count": 3,
+        "corpus": "original-test",
+        "revision": "1",
+        "fixture_hash": "a" * 64,
+    }
+    image = "example.invalid/runtime@sha256:" + "b" * 64
+    output = tmp_path / "collection"
+    task = stage(manifest, output, agent_image=image, verifier_image=image)
+
+    async def plan(name):
+        job = await Job.create(
+            JobConfig(
+                job_name=name,
+                jobs_dir=tmp_path / "jobs",
+                datasets=[DatasetConfig(path=output)],
+                agents=[AgentConfig(name="oracle")],
+            )
+        )
+        return build_job_plan(job)
+
+    first = await plan("first")
+    facets = first.tasks[0].to_example()["metadata"]["task_config"]["metadata"]
+    assert facets["task_id"] == "trace-count"
+    assert facets["product_surfaces"] == ["tracing"]
+    assert facets["fixture_hash"] == "a" * 64
+    assert (task / "environment/Dockerfile").read_text().count("COPY") == 0
+    assert first.tasks[0].config["verifier"]["environment_mode"] == "separate"
+    assert not first.tasks[0].config.get("mcp_servers")
+    config = task / "task.toml"
+    config.write_text(config.read_text().replace("a" * 64, "c" * 64))
+    second = await plan("second")
+    assert first.tasks[0].digest != second.tasks[0].digest
+    assert first.tasks[0].task_id == second.tasks[0].task_id

--- a/evals/mcp/tests/test_count_task.py
+++ b/evals/mcp/tests/test_count_task.py
@@ -82,3 +82,37 @@ async def test_native_harbor_plugin_preserves_facets_and_fixture_identity(tmp_pa
     second = await plan("second")
     assert first.tasks[0].digest != second.tasks[0].digest
     assert first.tasks[0].task_id == second.tasks[0].task_id
+
+
+@pytest.mark.parametrize(
+    "submission",
+    [None, b"not json", b"\xff", b"x" * 1_048_577],
+    ids=["missing", "malformed", "encoding", "oversized"],
+)
+def test_verifier_scores_invalid_submissions_without_an_infrastructure_error(tmp_path, submission):
+    import json
+
+    from verify import main
+
+    _, truth, evidence = valid()
+    trusted = tmp_path / "trusted"
+    workspace = tmp_path / "workspace"
+    trusted.mkdir()
+    workspace.mkdir()
+    (trusted / "truth.json").write_text(json.dumps(truth))
+    (trusted / "evidence.json").write_text(json.dumps(evidence))
+    if submission is not None:
+        (workspace / "answer.json").write_bytes(submission)
+    output = tmp_path / "reward.json"
+    main(trusted=trusted, workspace=workspace, output=output)
+    scores = json.loads(output.read_text())
+    assert scores["reward"] == scores["answer_correct"] == 0
+    assert scores["scope_preserved"] == scores["access_policy_ok"] == 1
+
+
+def test_verifier_still_requires_trusted_evidence(tmp_path):
+    from verify import main
+
+    with pytest.raises(FileNotFoundError):
+        main(trusted=tmp_path, workspace=tmp_path, output=tmp_path / "reward.json")
+    assert not (tmp_path / "reward.json").exists()

--- a/evals/mcp/verify.py
+++ b/evals/mcp/verify.py
@@ -1,0 +1,61 @@
+"""Deterministic count grading. Evidence arguments come only from the trusted runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from isolation import InvalidEvidence, read_regular
+
+
+def grade_count(answer: Any, truth: dict[str, Any], evidence: dict[str, Any]) -> dict[str, float]:
+    required = {"shutdown_confirmed", "audit_complete", "target_state_complete"}
+    if any(evidence.get(key) is not True for key in required):
+        raise InvalidEvidence("Required shutdown, audit or target state evidence is missing")
+    if not isinstance(evidence.get("forbidden_attempts"), list):
+        raise InvalidEvidence("Policy evidence is missing")
+    if not isinstance(evidence.get("state_unchanged"), bool):
+        raise InvalidEvidence("Read-only state comparison is missing")
+    shape = isinstance(answer, dict) and set(answer) == {
+        "project",
+        "trace_count",
+        "evidence_trace_ids",
+    }
+    count_valid = shape and type(answer["trace_count"]) is int and answer["trace_count"] >= 0
+    ids = answer.get("evidence_trace_ids") if isinstance(answer, dict) else None
+    evidence_valid = (
+        isinstance(ids, list)
+        and bool(ids)
+        and all(isinstance(item, str) for item in ids)
+        and set(ids).issubset(truth["trace_ids"])
+    )
+    scores = {
+        "answer_complete": float(bool(shape and count_valid and isinstance(ids, list) and ids)),
+        "answer_correct": float(
+            bool(
+                count_valid
+                and answer["project"] == truth["project"]
+                and answer["trace_count"] == truth["trace_count"]
+            )
+        ),
+        "evidence_valid": float(bool(evidence_valid)),
+        "scope_preserved": float(evidence["state_unchanged"]),
+        "access_policy_ok": float(not evidence["forbidden_attempts"]),
+    }
+    return scores | {"reward": float(all(value == 1 for value in scores.values()))}
+
+
+def main() -> None:
+    # This directory must be mounted by the trusted runner only into the verifier.
+    # Harbor does not provide it by default; missing evidence fails without a reward.
+    trusted = Path("/trusted")
+    truth = json.loads((trusted / "truth.json").read_text())
+    evidence = json.loads((trusted / "evidence.json").read_text())
+    answer = json.loads(read_regular(Path("/logs/artifacts"), "answer.json"))
+    scores = grade_count(answer, truth, evidence)
+    Path("/logs/verifier/reward.json").write_text(json.dumps(scores))
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/mcp/verify.py
+++ b/evals/mcp/verify.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from typing import Any
@@ -46,16 +47,32 @@ def grade_count(answer: Any, truth: dict[str, Any], evidence: dict[str, Any]) ->
     return scores | {"reward": float(all(value == 1 for value in scores.values()))}
 
 
-def main() -> None:
+def read_answer(workspace: Path) -> tuple[Any, str | None]:
+    """Invalid agent submissions fail the task; trusted evidence errors still raise."""
+    try:
+        return json.loads(read_regular(workspace, "answer.json")), None
+    except (FileNotFoundError, json.JSONDecodeError, UnicodeDecodeError, InvalidEvidence) as exc:
+        return None, type(exc).__name__
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            return None, "UnsafeArtifact"
+        raise
+
+
+def main(
+    *,
+    trusted: Path = Path("/trusted"),
+    workspace: Path = Path("/workspace"),
+    output: Path = Path("/logs/verifier/reward.json"),
+) -> None:
     # This directory must be mounted by the trusted runner only into the verifier.
     # Harbor does not provide it by default; missing evidence fails without a reward.
-    trusted = Path("/trusted")
     truth = json.loads((trusted / "truth.json").read_text())
     evidence = json.loads((trusted / "evidence.json").read_text())
     # Harbor restores declared artifacts to their original source paths.
-    answer = json.loads(read_regular(Path("/workspace"), "answer.json"))
+    answer, _ = read_answer(workspace)
     scores = grade_count(answer, truth, evidence)
-    Path("/logs/verifier/reward.json").write_text(json.dumps(scores))
+    output.write_text(json.dumps(scores))
 
 
 if __name__ == "__main__":

--- a/evals/mcp/verify.py
+++ b/evals/mcp/verify.py
@@ -52,7 +52,8 @@ def main() -> None:
     trusted = Path("/trusted")
     truth = json.loads((trusted / "truth.json").read_text())
     evidence = json.loads((trusted / "evidence.json").read_text())
-    answer = json.loads(read_regular(Path("/logs/artifacts"), "answer.json"))
+    # Harbor restores declared artifacts to their original source paths.
+    answer = json.loads(read_regular(Path("/workspace"), "answer.json"))
     scores = grade_count(answer, truth, evidence)
     Path("/logs/verifier/reward.json").write_text(json.dumps(scores))
 


### PR DESCRIPTION
Superseded by #16088, which consolidates this work with the reviewed fresh-target redesign. The original branches remain available for recovery.

Add one canonical Harbor aggregation task: count all traces in `mcp-trail-gaia` and provide supporting trace IDs. Exact count, answer completeness, evidence IDs, unchanged state, and access policy have separate deterministic scores.

Task staging attaches typed fixture metadata, requires pinned image references, defaults network access closed, and puts grading code in a separate verifier image. The verifier consumes runner-owned truth and audit evidence after confirmed shutdown. Harbor restores the declared answer to `/workspace/answer.json`.

Missing, malformed, oversized, or unsafe agent answer files become zero behavioral rewards. Missing trusted evidence still invalidates verification. This prevents bad agent submissions from being counted as infrastructure failures.

Validation: 20 tests pass, including verifier entrypoint checks for absent, malformed, invalid-encoding and oversized submissions, missing trusted evidence, and native Harbor task identity. Ruff passes. Earlier live trace-count samples passed in all four conditions; no paid runs were repeated for these fixes.
