### PR TITLE
feat(mcp-bench): render four pinned interface conditions

### DIFF
--- a/evals/mcp/Makefile
+++ b/evals/mcp/Makefile
@@ -43,3 +43,7 @@ mcp-isolation-probe:
 .PHONY: mcp-stage-task
 mcp-stage-task:
 	$(MCP_PYTHON) $(MCP_DIR)/stage_task.py $(ARGS)
+
+.PHONY: mcp-matrix
+mcp-matrix:
+	$(MCP_PYTHON) $(MCP_DIR)/matrix.py $(ARGS)

--- a/evals/mcp/README.md
+++ b/evals/mcp/README.md
@@ -66,3 +66,10 @@ MCP registration, so CLI conditions cannot inherit an MCP server. Network defaul
 are closed. This staging command does not configure a runnable trial: trusted
 truth/audit transfer and condition access must be attached by the pending runner.
 The verifier emits no authoritative reward without trusted evidence.
+
+`make mcp-matrix ARGS='--tasks /private/tasks --output /private/jobs --target http://target:6006'`
+serializes four Harbor jobs plus separate plugin kwargs. Use the native plugin
+flag `--plugin arize-phoenix` when the runner is completed; Harbor ignores the old
+YAML `plugins` field. The JSON artifacts contain no credentials and do not launch
+anything. This layer still needs condition-specific images and trusted lifecycle
+integration before these configurations can become valid benchmark trials.

--- a/evals/mcp/configs/matrix.json
+++ b/evals/mcp/configs/matrix.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "verified_on": "2026-09-09",
+  "agent_versions": {"claude-code": "2.1.267", "codex": "0.154.0"},
+  "px_version": "1.18.1",
+  "requested_models": {"claude-code": "opus-5", "codex": "gpt-5.6"},
+  "documented_model_ids": {"opus-5": "claude-opus-5", "gpt-5.6": "gpt-5.6"},
+  "documented_alias_targets": {"gpt-5.6": "gpt-5.6-sol"},
+  "authenticated_models": false,
+  "reasoning_effort": "high",
+  "conditions": ["claude-mcp", "claude-cli", "codex-mcp", "codex-cli"]
+}

--- a/evals/mcp/matrix.py
+++ b/evals/mcp/matrix.py
@@ -1,0 +1,150 @@
+"""Render ordinary Harbor jobs without starting them or resolving any credentials."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlsplit
+
+from harbor.models.job.config import DatasetConfig, JobConfig
+from harbor.models.trial.config import AgentConfig
+
+from preflight import PROVIDER_KEYS
+from runtime import HERE
+
+MATRIX = json.loads((HERE / "configs/matrix.json").read_text())
+
+
+def runner_environment(
+    source: Mapping[str, str], *, agent: str, runner_home: Path
+) -> dict[str, str]:
+    """Explicit allowlist. No HF credentials, inherited auth files or endpoint overrides."""
+    key = PROVIDER_KEYS[agent]
+    if not source.get(key):
+        raise ValueError(f"Missing {key}")
+    return {"PATH": source["PATH"], "HOME": str(runner_home), "LANG": "C.UTF-8", key: source[key]}
+
+
+def render_job(
+    condition: str,
+    *,
+    tasks: Path,
+    target_endpoint: str,
+    results_endpoint: str,
+    job_name: str,
+    requested_model: str | None = None,
+) -> tuple[JobConfig, dict[str, str]]:
+    if condition not in MATRIX["conditions"]:
+        raise ValueError("Unknown condition")
+    target = urlsplit(target_endpoint)
+    results = urlsplit(results_endpoint)
+    if (
+        target.scheme not in {"http", "https"}
+        or not target.hostname
+        or target.username
+        or target.password
+        or target.query
+        or target.fragment
+        or target.path not in {"", "/"}
+    ):
+        raise ValueError("Target must be a credential-free Phoenix origin URL")
+    if (
+        results.scheme not in {"http", "https"}
+        or not results.hostname
+        or results.username
+        or results.password
+        or results.query
+        or results.fragment
+    ):
+        raise ValueError("Results endpoint must be a credential-free URL")
+    if target.hostname == results.hostname and target.port == results.port:
+        raise ValueError("Target and results roles require separate endpoints")
+    agent = "claude-code" if condition.startswith("claude-") else "codex"
+    interface = condition.rsplit("-", 1)[1]
+    requested = requested_model or MATRIX["requested_models"][agent]
+    # Only the documented request-to-ID mapping is applied. New values stay literal.
+    model = MATRIX["documented_model_ids"].get(requested, requested)
+    access = "the configured Phoenix MCP" if interface == "mcp" else "px CLI"
+    instruction = f"Your assigned Phoenix interface is {access}."
+    kwargs = {
+        "version": MATRIX["agent_versions"][agent],
+        "reasoning_effort": MATRIX["reasoning_effort"],
+    }
+    if agent == "claude-code":
+        kwargs |= {"disallowed_tools": "WebSearch,WebFetch", "append_system_prompt": instruction}
+        provider_host = "api.anthropic.com"
+    else:
+        kwargs |= {
+            "web_search": "disabled",
+            "config": {
+                "forced_login_method": "api",
+                "developer_instructions": instruction,
+                "web_search": "disabled",
+            },
+        }
+        provider_host = "api.openai.com"
+    mcp_servers = (
+        [
+            {
+                "name": "phoenix",
+                "transport": "streamable-http",
+                "url": target_endpoint.rstrip("/") + "/mcp",
+            }
+        ]
+        if interface == "mcp"
+        else []
+    )
+    agent_config = AgentConfig(
+        name=agent,
+        model_name=model,
+        kwargs=kwargs,
+        mcp_servers=mcp_servers,
+        extra_allowed_hosts=[target.hostname, provider_host],
+    )
+    # Target CLI configuration is separate from the results plugin endpoint. The
+    # future runner must inject this only into the CLI agent, without results auth.
+    if interface == "cli":
+        agent_config.env = {"PHOENIX_COLLECTOR_ENDPOINT": target_endpoint}
+    job = JobConfig(
+        job_name=job_name,
+        datasets=[DatasetConfig(path=tasks)],
+        agents=[agent_config],
+        n_concurrent_trials=1,
+        n_attempts=1,
+        retry={"max_retries": 0},
+        environment={"type": "docker", "delete": False},
+    )
+    plugin = {
+        "dataset": "phoenix-mcp-smoke",
+        "trace_mode": "atif",
+        "endpoint": results_endpoint,
+        "experiment_name": job_name,
+    }
+    return job, plugin
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tasks", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--results", default="http://localhost:6006")
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    for condition in MATRIX["conditions"]:
+        job, plugin = render_job(
+            condition,
+            tasks=args.tasks,
+            target_endpoint=args.target,
+            results_endpoint=args.results,
+            job_name=condition,
+        )
+        (args.output / f"{condition}.json").write_text(job.model_dump_json(indent=2))
+        (args.output / f"{condition}.plugin.json").write_text(json.dumps(plugin, indent=2))
+    (args.output / "matrix.json").write_text(json.dumps(MATRIX, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/mcp/matrix.py
+++ b/evals/mcp/matrix.py
@@ -59,8 +59,10 @@ def render_job(
         or results.fragment
     ):
         raise ValueError("Results endpoint must be a credential-free URL")
-    if target.hostname == results.hostname and target.port == results.port:
-        raise ValueError("Target and results roles require separate endpoints")
+    if target.hostname == results.hostname:
+        raise ValueError(
+            "Target and results require different hosts; host allowlists do not isolate ports"
+        )
     agent = "claude-code" if condition.startswith("claude-") else "codex"
     interface = condition.rsplit("-", 1)[1]
     requested = requested_model or MATRIX["requested_models"][agent]

--- a/evals/mcp/matrix.py
+++ b/evals/mcp/matrix.py
@@ -17,6 +17,13 @@ from runtime import HERE
 MATRIX = json.loads((HERE / "configs/matrix.json").read_text())
 
 
+def experiment_name(agent: str, model: str, interface: str) -> str:
+    """Display the configuration; Harbor metadata retains unique job identity."""
+    agent_label = {"claude-code": "Claude Code", "codex": "Codex"}[agent]
+    model_label = {"claude-opus-5": "Opus 5", "gpt-5.6": "GPT-5.6"}.get(model, model)
+    return f"{agent_label} · {model_label} · {interface.upper()}"
+
+
 def runner_environment(
     source: Mapping[str, str], *, agent: str, runner_home: Path
 ) -> dict[str, str]:
@@ -122,7 +129,7 @@ def render_job(
         "dataset": "phoenix-mcp-smoke",
         "trace_mode": "atif",
         "endpoint": results_endpoint,
-        "experiment_name": job_name,
+        "experiment_name": experiment_name(agent, model, interface),
     }
     return job, plugin
 

--- a/evals/mcp/tests/test_matrix.py
+++ b/evals/mcp/tests/test_matrix.py
@@ -77,3 +77,14 @@ def test_no_silent_model_substitution_or_endpoint_credentials(tmp_path):
     for bad in ("http://secret@target", "http://target?key=secret", "file:///tmp/db"):
         with pytest.raises(ValueError):
             render_job("codex-mcp", **(args | {"target_endpoint": bad}))
+
+
+def test_target_cannot_share_results_host_on_another_port(tmp_path):
+    with pytest.raises(ValueError, match="different hosts"):
+        render_job(
+            "codex-mcp",
+            tasks=tmp_path,
+            target_endpoint="http://target:6007",
+            results_endpoint="http://target:6006",
+            job_name="test",
+        )

--- a/evals/mcp/tests/test_matrix.py
+++ b/evals/mcp/tests/test_matrix.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+from harbor.agents.installed.claude_code import ClaudeCode
+from harbor.agents.installed.codex import Codex
+
+from matrix import MATRIX, render_job, runner_environment
+
+
+def test_four_conditions_use_same_tasks_and_isolated_interfaces(tmp_path):
+    jobs = []
+    for condition in MATRIX["conditions"]:
+        job, plugin = render_job(
+            condition,
+            tasks=tmp_path,
+            target_endpoint="http://target:6006",
+            results_endpoint="http://results:6006",
+            job_name=condition,
+        )
+        jobs.append(job)
+        agent = job.agents[0]
+        assert bool(agent.mcp_servers) == condition.endswith("mcp")
+        assert plugin["trace_mode"] == "atif"
+        assert agent.extra_allowed_hosts[0] == "target"
+        assert "results" not in agent.extra_allowed_hosts
+        assert job.n_concurrent_trials == 1
+        assert job.retry.max_retries == 0
+        implementation = ClaudeCode if agent.name == "claude-code" else Codex
+        # Exercise the pinned adapter's argument/flag validation, not only our JSON.
+        instance = implementation(
+            logs_dir=tmp_path / condition, model_name=agent.model_name, **agent.kwargs
+        )
+        assert instance._version == MATRIX["agent_versions"][agent.name]
+    assert all(job.datasets == jobs[0].datasets for job in jobs)
+    assert jobs[0].agents[0].model_name == jobs[1].agents[0].model_name == "claude-opus-5"
+    assert jobs[2].agents[0].model_name == jobs[3].agents[0].model_name == "gpt-5.6"
+    assert jobs[2].agents[0].kwargs["web_search"] == "disabled"
+
+
+def test_runner_credentials_are_selected_not_inherited(tmp_path):
+    source = {
+        "PATH": "/usr/bin",
+        "OPENAI_API_KEY": "OPENAI_CANARY",
+        "HF_TOKEN": "HF_CANARY",
+        "ANTHROPIC_API_KEY": "ANTHROPIC_CANARY",
+        "CODEX_AUTH_JSON_PATH": "/private/auth",
+        "OPENAI_BASE_URL": "https://unrelated.invalid",
+    }
+    selected = runner_environment(source, agent="codex", runner_home=tmp_path)
+    assert selected == {
+        "PATH": "/usr/bin",
+        "HOME": str(tmp_path),
+        "LANG": "C.UTF-8",
+        "OPENAI_API_KEY": "OPENAI_CANARY",
+    }
+    job, plugin = render_job(
+        "codex-cli",
+        tasks=tmp_path,
+        target_endpoint="http://target:6006",
+        results_endpoint="http://results:6006",
+        job_name="test",
+    )
+    assert "CANARY" not in job.model_dump_json() + json.dumps(plugin)
+    with pytest.raises(ValueError, match="Missing"):
+        runner_environment({}, agent="codex", runner_home=tmp_path)
+
+
+def test_no_silent_model_substitution_or_endpoint_credentials(tmp_path):
+    args = dict(
+        tasks=tmp_path,
+        target_endpoint="http://target:6006",
+        results_endpoint="http://results:6006",
+        job_name="test",
+    )
+    job, _ = render_job("codex-mcp", requested_model="unknown-request", **args)
+    assert job.agents[0].model_name == "unknown-request"
+    for bad in ("http://secret@target", "http://target?key=secret", "file:///tmp/db"):
+        with pytest.raises(ValueError):
+            render_job("codex-mcp", **(args | {"target_endpoint": bad}))


### PR DESCRIPTION
Superseded by #16088, which consolidates this work with the reviewed fresh-target redesign. The original branches remain available for recovery.

Render four matched Harbor configurations: Claude Code and Codex, each using either Phoenix MCP or the px CLI. All conditions share a task collection, serial execution, one attempt, no retries, and high reasoning effort. Agent versions are pinned to Claude Code 2.1.267 and Codex 0.154.0; px is 1.18.1.

MCP conditions receive one explicit Phoenix registration; CLI conditions receive only the target collector endpoint. Public web tools are disabled. Target and result origins must have different hosts because a hostname allowlist cannot distinguish ports. The live integration supplies a scoped target gateway over the shared DB and an inference-only provider gateway.

The requested `opus-5` maps explicitly to `claude-opus-5`; `gpt-5.6` stays literal and authenticated OpenAI inference resolves it to `gpt-5.6-sol`. Unknown requested models are never substituted. Credential selection excludes HF credentials and personal login/config fallbacks.

Experiment display names identify agent, model and interface, for example `Claude Code · Opus 5 · MCP` and `Codex · GPT-5.6 · CLI`. Harbor job IDs and timestamps remain in metadata, independent of the display name.

Validation: matrix tests instantiate the pinned Harbor adapters and pass. All four configurations subsequently completed one successful live trace-count sample.
