### PR TITLE
fix(ui): keep invalid code-editor input from crashing prompt dialogs

### DIFF
--- a/js/app/src/components/code/CodeEditorFieldWrapper.tsx
+++ b/js/app/src/components/code/CodeEditorFieldWrapper.tsx
@@ -86,7 +86,11 @@ export function CodeEditorFieldWrapper({
         {children}
       </div>
       {errorMessage ? (
-        <Text id={errorId} slot="errorMessage" color="danger" role="alert">
+        // slot={null} opts out of a parent's slotted TextContext: this wrapper
+        // is not a RAC Field, so no ancestor offers an "errorMessage" slot and
+        // a Dialog ancestor (save/clone/edit prompt) rejects it at render
+        // (#16027). The error stays associated via aria-describedby + role.
+        <Text id={errorId} slot={null} color="danger" role="alert">
           {errorMessage}
         </Text>
       ) : null}

--- a/js/app/src/components/code/__tests__/CodeEditorFieldWrapper.test.tsx
+++ b/js/app/src/components/code/__tests__/CodeEditorFieldWrapper.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Dialog } from "@phoenix/components";
+
+import { CodeEditorFieldWrapper } from "../CodeEditorFieldWrapper";
+
+const ERROR_MESSAGE = "metadata must be a valid JSON object";
+
+describe("CodeEditorFieldWrapper", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders the validation message inside a dialog (#16027)", () => {
+    act(() => {
+      root.render(
+        <Dialog>
+          <CodeEditorFieldWrapper label="Metadata" errorMessage={ERROR_MESSAGE}>
+            <div>editor</div>
+          </CodeEditorFieldWrapper>
+        </Dialog>
+      );
+    });
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toBe(ERROR_MESSAGE);
+    expect(
+      container.querySelector(".json-editor-wrap.is-invalid")
+    ).not.toBeNull();
+  });
+
+  it("renders the validation message outside a dialog", () => {
+    act(() => {
+      root.render(
+        <CodeEditorFieldWrapper label="Metadata" errorMessage={ERROR_MESSAGE}>
+          <div>editor</div>
+        </CodeEditorFieldWrapper>
+      );
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      ERROR_MESSAGE
+    );
+  });
+
+  it("shows the description when there is no error", () => {
+    act(() => {
+      root.render(
+        <Dialog>
+          <CodeEditorFieldWrapper label="Metadata" description="Optional JSON">
+            <div>editor</div>
+          </CodeEditorFieldWrapper>
+        </Dialog>
+      );
+    });
+
+    expect(container.textContent).toContain("Optional JSON");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
resolves #16027

## Root Cause
`SavePromptForm` validates metadata with `mode: onChange`, so typing a momentarily-invalid value (e.g. the opening quote of a key) sets a field error. `CodeEditorFieldWrapper` renders that error as `<Text slot="errorMessage">`, but the form lives inside a RAC `Dialog` whose `TextContext` only offers the `description` slot, so React Aria throws `Invalid slot "errorMessage"` and the whole page crashes. The wrapper is not a RAC Field, so no ancestor ever offers `errorMessage` — the same path backs the save, clone, and edit prompt dialogs.

## Fix
Render the error `Text` with `slot={null}` (the opt-out contract documented on our own `Text` component and already used in `SettingsAgentsPermissionsTab`). The accessible association is preserved by the wrapper's own `aria-describedby` + `role="alert"`; the `description` slot path is untouched. Other `slot="errorMessage"` uses sit inside real RAC Fields that offer the slot and are out of scope.

## Test
- [x] Regression test `js/app/src/components/code/__tests__/CodeEditorFieldWrapper.test.tsx` (dialog crash / outside-dialog / description-only)
- [x] pre-fix FAIL实证: `Invalid slot "errorMessage". Valid slot names are "description."` on the dialog case, 2/3 pass; post-fix 3/3 pass
- [x] Related suites: `vitest run src/components` → 676 passed
- [x] Pinned checks: `oxfmt --check` clean, `oxlint` 0 warnings/errors, `tsc --noEmit` has 33 errors all in untouched `evals/aiQuery/*` (missing built `@arizeai/phoenix-client/vitest` dist) — identical count on pristine `upstream/main`, so pre-existing and unrelated

## Diff scope
2 files, +77/-1 (1-line fix + comment, 1 new test file)