### PR TITLE
fix(evals): JSON-serialize non-string variables in PromptTemplate render

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/prompts.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/prompts.py
@@ -10,6 +10,7 @@ The module supports template rendering with variable substitution using either
 mustache ({{variable}}) or f-string ({variable}) syntax.
 """
 
+import json
 import re
 import warnings
 from abc import ABC, abstractmethod
@@ -646,6 +647,21 @@ def create_content_part_template(
         raise ValueError(f"Unsupported content type: {content_type}")
 
 
+def _json_serialize_variable(value: Any) -> str:
+    """Serialize a non-string template variable to JSON for prompt rendering.
+
+    Falls back to ``str(value)`` when the value is not JSON-serializable.
+    Mirrors the ``SmartString`` coercion the evaluator input schemas apply, so
+    direct ``PromptTemplate``/``Template`` renders produce the same prompt text.
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
 class MessageTemplate:
     """Template for a single message with role and content.
 
@@ -755,14 +771,27 @@ class MessageTemplate:
             Content will be a string if the original input was a string,
             or a list of ContentPart if the original input was a list.
         """
+        # Honor the variable_types contract: variables classified as "string"
+        # are JSON-serialised when a non-string value is supplied, so the model
+        # sees valid JSON rather than a Python repr. "section" variables pass
+        # through unchanged so pystache can iterate or traverse them.
+        variable_types = self.variable_types()
+        coerced = {
+            key: (
+                _json_serialize_variable(value)
+                if variable_types.get(key) == "string"
+                else value
+            )
+            for key, value in variables.items()
+        }
         # For simple string content, return as string
         if self._is_string_content:
-            rendered_part = self._content_templates[0].render(variables)
+            rendered_part = self._content_templates[0].render(coerced)
             return Message(role=self.role, content=rendered_part["text"])
 
         # For multiple content parts, return as list
         rendered_parts: List[ContentPart] = [
-            template.render(variables) for template in self._content_templates
+            template.render(coerced) for template in self._content_templates
         ]
         return Message(role=self.role, content=rendered_parts)
 

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/test_prompts.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/test_prompts.py
@@ -874,3 +874,69 @@ class TestClassifyMessageListKind:
         # Non-Mapping entries can't carry a MessageRole — they should fall on
         # the dict side and be rejected later by validate_message_dict.
         assert classify_message_list_kind([42]) == "dict"
+
+
+class TestStringVariableJsonSerialization:
+    """Non-string values for string-typed variables render as JSON, not Python repr.
+
+    The variable_types contract (PromptTemplate.variable_types) promises that
+    variables classified as "string" are JSON-serialised when a non-string value
+    is supplied, while "section" variables pass through unchanged so pystache can
+    iterate or traverse them.
+    """
+
+    def test_mustache_dict_variable_renders_as_json(self) -> None:
+        template = PromptTemplate(template="Context: {{doc}}")
+        rendered = template.render({"doc": {"text": "hello", "n": 1}})
+        assert rendered[0]["content"] == 'Context: {"text": "hello", "n": 1}'
+
+    def test_mustache_list_variable_renders_as_json(self) -> None:
+        template = PromptTemplate(template="Items: {{items}}")
+        rendered = template.render({"items": ["x", "y"]})
+        assert rendered[0]["content"] == 'Items: ["x", "y"]'
+
+    def test_fstring_dict_variable_renders_as_json(self) -> None:
+        template = PromptTemplate(template="Data: {doc}")
+        rendered = template.render({"doc": {"a": 1}})
+        assert rendered[0]["content"] == 'Data: {"a": 1}'
+
+    def test_mustache_non_ascii_json_not_escaped(self) -> None:
+        template = PromptTemplate(template="Doc: {{doc}}")
+        rendered = template.render({"doc": {"text": "héllo"}})
+        assert rendered[0]["content"] == 'Doc: {"text": "héllo"}'
+
+    def test_section_variable_stays_structured(self) -> None:
+        template = PromptTemplate(template="{{#items}}{{name}} {{/items}}")
+        rendered = template.render({"items": [{"name": "a"}, {"name": "b"}]})
+        assert rendered[0]["content"] == "a b "
+
+    def test_dotted_lookup_root_stays_structured(self) -> None:
+        template = PromptTemplate(template="Hello {{user.name}}")
+        rendered = template.render({"user": {"name": "Bob"}})
+        assert rendered[0]["content"] == "Hello Bob"
+
+    def test_string_variable_unchanged(self) -> None:
+        template = PromptTemplate(template="Doc: {{doc}}")
+        rendered = template.render({"doc": "plain text"})
+        assert rendered[0]["content"] == "Doc: plain text"
+
+    def test_int_variable_renders_as_json_scalar(self) -> None:
+        template = PromptTemplate(template="N: {{n}}")
+        rendered = template.render({"n": 42})
+        assert rendered[0]["content"] == "N: 42"
+
+    def test_unserializable_falls_back_to_str(self) -> None:
+        class Weird:
+            def __str__(self) -> str:
+                return "weird!"
+
+        template = PromptTemplate(template="Obj: {{obj}}")
+        rendered = template.render({"obj": Weird()})
+        assert rendered[0]["content"] == "Obj: weird!"
+
+    def test_message_list_template_serializes_variables(self) -> None:
+        template = PromptTemplate(
+            template=[{"role": "user", "content": "Context: {{doc}}"}],
+        )
+        rendered = template.render({"doc": [1, 2]})
+        assert rendered[0]["content"] == 'Context: [1, 2]'


### PR DESCRIPTION
resolves #16047

## Summary

`PromptTemplate.variable_types` documents that `"string"`-classified variables "will be JSON-serialised when a non-string value is supplied", but the render path never did this: `MessageTemplate.render` passed values straight to the formatters, so dicts, lists, and numbers rendered as Python reprs (`{'text': 'hello'}`) instead of JSON (`{"text": "hello"}`). The evaluator path masks this because `LLMEvaluator`'s generated input schema coerces values through `SmartString` first; direct `PromptTemplate.render` callers got the repr.

## Changes

- `MessageTemplate.render` now coerces non-string values for `"string"`-typed variables with `json.dumps(value, ensure_ascii=False)`, falling back to `str(value)` for non-serializable objects. `"section"`-typed variables pass through unchanged so pystache sections (`{{#items}}`) and dotted lookups (`{{user.name}}`) keep working.
- New module-level `_json_serialize_variable` helper mirroring `evaluators._smart_string_coerce`.

## Tests

- 10 new tests in `tests/phoenix/evals/llm/test_prompts.py` (`TestStringVariableJsonSerialization`): dict/list/int/non-ASCII serialization for mustache and f-string, section iteration and dotted-lookup pass-through, string pass-through, `str()` fallback, message-list templates.
- Verified red before the fix (4 failures on the JSON cases), green after.
- Full `packages/phoenix-evals` suite: 660 passed, 1 skipped, 2 xpassed (litellm adapter tests excluded locally; installed litellm needs Python 3.11+, unrelated).