### PR TITLE
fix(playwright): decouple password reset test from user pagination

### DIFF
--- a/js/app/tests/user-management.spec.ts
+++ b/js/app/tests/user-management.spec.ts
@@ -74,7 +74,7 @@ test("a new user only needs to reset their password once", async ({
     .getByRole("dialog")
     .getByRole("button", { name: "Add User" })
     .click();
-  await expect(page.getByRole("cell", { name: email })).toBeVisible();
+  await expect(page.getByRole("dialog")).not.toBeVisible();
 
   const userContext = await browser.newContext();
   const userPage = await userContext.newPage();


### PR DESCRIPTION
## Summary

- wait for the add-user dialog to close after the create-user mutation succeeds
- verify persistence through the existing login and password-reset flow
- avoid assuming the new account appears among the first 50 alphabetically paginated users

Fixes the regression observed in https://github.com/Arize-ai/phoenix/actions/runs/34500173624/job/102948676109.

## Tests

- `pnpm run build`
- `CI=1 pnpm exec playwright test tests/user-management.spec.ts --project=chromium --project=firefox --grep "a new user only needs to reset their password once" --reporter=list`