### PR TITLE
feat(ui): show trace annotations by default on the traces table

### DIFF
--- a/js/app/src/pages/project/TracesTable.tsx
+++ b/js/app/src/pages/project/TracesTable.tsx
@@ -554,14 +554,14 @@ export function TracesTable(props: TracesTableProps) {
       {
         header: () => (
           <Flex direction="row" gap="size-50" alignItems="center">
-            <span>root span annotations</span>
+            <span>span annotations</span>
             <ContextualHelp>
               <Heading level={3} weight="heavy">
-                Root span annotations
+                Span annotations
               </Heading>
               <Text>
-                Evaluations and human annotations attached to the root span of
-                the trace.
+                Evaluations and human annotations attached to each span. Expand
+                a trace to see the annotations on its child spans.
               </Text>
             </ContextualHelp>
           </Flex>

--- a/js/app/src/pages/project/TracesTable.tsx
+++ b/js/app/src/pages/project/TracesTable.tsx
@@ -554,14 +554,14 @@ export function TracesTable(props: TracesTableProps) {
       {
         header: () => (
           <Flex direction="row" gap="size-50" alignItems="center">
-            <span>Annotations</span>
+            <span>root span annotations</span>
             <ContextualHelp>
               <Heading level={3} weight="heavy">
-                Annotations
+                Root span annotations
               </Heading>
               <Text>
-                Evaluations and human annotations logged via the API or set via
-                the UI.
+                Evaluations and human annotations attached to the root span of
+                the trace.
               </Text>
             </ContextualHelp>
           </Flex>
@@ -617,13 +617,13 @@ export function TracesTable(props: TracesTableProps) {
       {
         header: () => (
           <Flex direction="row" gap="size-50" alignItems="center">
-            <span>Trace annotations</span>
+            <span>trace annotations</span>
             <ContextualHelp>
               <Heading level={3} weight="heavy">
                 Trace annotations
               </Heading>
               <Text>
-                Annotations attached to the parent trace of this span.
+                Evaluations and annotations applied directly to the trace.
               </Text>
             </ContextualHelp>
           </Flex>

--- a/js/app/src/store/tracingStore.tsx
+++ b/js/app/src/store/tracingStore.tsx
@@ -69,6 +69,15 @@ const makeTracingStoreKey = ({
   tableId: ProjectTab;
 }) => `arize-phoenix-tracing-${projectId}-${tableId}`;
 
+const defaultColumnVisibility = (tableId: ProjectTab): VisibilityState => ({
+  metadata: false,
+  spanNotes: false,
+  traceNotes: false,
+  spanId: false,
+  traceId: false,
+  ...(tableId === "traces" ? {} : { [TRACE_ANNOTATIONS_COLUMN_ID]: false }),
+});
+
 export type CreateTracingStoreProps = {
   projectId: string;
   tableId: ProjectTab;
@@ -80,14 +89,7 @@ export const createTracingStore = (initialProps: CreateTracingStoreProps) => {
     [["zustand/devtools", unknown]]
   > = (set) => ({
     projectId: initialProps.projectId,
-    columnVisibility: {
-      metadata: false,
-      spanNotes: false,
-      traceNotes: false,
-      spanId: false,
-      traceId: false,
-      [TRACE_ANNOTATIONS_COLUMN_ID]: false,
-    },
+    columnVisibility: defaultColumnVisibility(initialProps.tableId),
     columnSizing: {
       metadata: 200,
     },


### PR DESCRIPTION
resolves #16084

![Traces table with an expanded trace showing the Span annotations column populated for the root span and its child spans, alongside the Trace annotations column](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/16086-traces-span-annotations-expanded.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)