### PR TITLE
docs: document the Claude Code and Codex plugin marketplaces

### DIFF
--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -3,7 +3,7 @@ title: "Coding Agents"
 description: Integrate Phoenix with AI coding assistants using CLI, MCP, and skills in a single workflow guide.
 ---
 
-Use this guide to connect coding agents (Claude Code, Cursor, VS Code, Windsurf, and others) to Phoenix for debugging, observability, and evaluation workflows. If you haven't instrumented your app yet, start with [Agent-Assisted Setup](/docs/phoenix/agent-assisted-setup).
+Use this guide to connect coding agents (Claude Code, Codex, Cursor, VS Code, Windsurf, and others) to Phoenix for debugging, observability, and evaluation workflows. If you haven't instrumented your app yet, start with [Agent-Assisted Setup](/docs/phoenix/agent-assisted-setup).
 
 <Note>
 This page sets up your coding agent to **operate on Phoenix** — reading traces, experiments, and datasets via the CLI, MCP, and skills. To instead **trace your sessions with a coding agent** (turns, tool calls, and token costs), see [Coding Agents](/docs/phoenix/integrations/coding-agents/claude-code).
@@ -11,7 +11,7 @@ This page sets up your coding agent to **operate on Phoenix** — reading traces
 
 ## Recommended Setup
 
-Most users should set up all three:
+Phoenix connects to a coding agent through three pieces. Most setups use all three:
 
 <CardGroup cols={3}>
   <Card title="CLI" icon="terminal" href="#cli">
@@ -25,16 +25,13 @@ Most users should set up all three:
   </Card>
 </CardGroup>
 
-For agents with a plugin system, the Phoenix repository is also a plugin marketplace, so one install replaces the MCP setup below — and, for Claude Code, the skills setup too. The generic [CLI](#cli), [MCP](#mcp), and [Skills](#skills) sections cover every other agent and manual setup.
+How you install them depends on your agent. The Phoenix repository is also a plugin marketplace for agents that have one, and the plugin replaces the manual MCP setup:
 
-<CardGroup cols={2}>
-  <Card title="Claude Code" icon="terminal" href="#claude-code">
-    Plugin registers the Phoenix MCP server and the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills.
-  </Card>
-  <Card title="Codex" icon="terminal" href="#codex">
-    Plugin registers the Phoenix MCP server; add skills with `skills add`.
-  </Card>
-</CardGroup>
+- **Claude Code** — install the [Phoenix plugin](#claude-code). It registers the Phoenix MCP server and the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills, so the only piece left to add is the [CLI](#cli).
+- **Codex** — install the [Phoenix plugin](#codex). It registers the Phoenix MCP server; add the [CLI](#cli) and [skills](#skills) yourself.
+- **Every other agent** (Cursor, VS Code, Windsurf, and more) — follow the [CLI](#cli), [MCP](#mcp), and [Skills](#skills) sections below.
+
+Both plugins connect to the MCP endpoint built into the Phoenix server, which requires **Phoenix 19.0.0 or later**. Neither includes the [Phoenix Docs MCP](#phoenix-docs-mcp-documentation-access) for documentation lookup — add that separately if you want it.
 
 ### Find Your Phoenix Endpoint
 
@@ -51,10 +48,14 @@ Enter the endpoint column, never the `/mcp` column — the plugins and the `px` 
 
 The Phoenix repository is a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins). The `arize-phoenix` plugin registers the Phoenix MCP server and the Phoenix skills in one install, and because the marketplace is versioned in the repository, Claude Code updates both as new versions land.
 
+**Prerequisites:** Phoenix 19.0.0 or later, and a current Claude Code — if `/plugin` is not recognized, update Claude Code first. Steps 1, 2, and 4 are slash commands typed inside a Claude Code session; the shell equivalents follow the steps.
+
 ### Install the Plugin
 
 <Steps>
   <Step title="Add the marketplace">
+    Inside a Claude Code session, run:
+
     ```bash
     /plugin marketplace add Arize-ai/phoenix
     ```
@@ -79,11 +80,13 @@ The Phoenix repository is a [Claude Code plugin marketplace](https://code.claude
     A trailing slash or a pasted `/mcp` produces a wrong URL (`…//mcp` or `…/mcp/mcp`), so trim those off. This setting is stored in your user settings and applies to every project; see [Change the Endpoint](#change-the-endpoint) to update it later.
   </Step>
   <Step title="Verify">
-    Run `/mcp`, select **phoenix**, and complete the browser login. `claude plugin details arize-phoenix@arize-phoenix` lists everything the plugin registered and what it adds to your context window.
+    Run `/mcp` and select **phoenix**. If your Phoenix has auth enabled, a browser window opens to sign in with your Phoenix account; without auth, it connects straight away. The server is ready once `/mcp` shows it as connected.
+
+    To see everything the plugin added — the MCP server and the three skills — run `claude plugin details arize-phoenix@arize-phoenix` in your shell. It also reports what the plugin adds to your context window.
   </Step>
 </Steps>
 
-Outside a session, the same two commands are `claude plugin marketplace add Arize-ai/phoenix` and `claude plugin install arize-phoenix@arize-phoenix`, which install to user scope unless you pass `--scope project` or `--scope local`.
+To script the install instead, run the shell equivalents `claude plugin marketplace add Arize-ai/phoenix` and `claude plugin install arize-phoenix@arize-phoenix`. They install to user scope unless you pass `--scope project` or `--scope local`, and take effect the next time you start Claude Code (or after `/reload-plugins` in an open session).
 
 ### What the Plugin Registers
 
@@ -94,7 +97,7 @@ Outside a session, the same two commands are `claude plugin marketplace add Ariz
 | `phoenix-evals` skill | Building and running evaluators. |
 | `phoenix-tracing` skill | Instrumenting apps with OpenInference. |
 
-These are the same skills described under [Skills](#skills), so you don't need `skills add` for them in Claude Code. The plugin does not install the [CLI](#cli) — add that separately.
+These are the same skills described under [Skills](#skills), so you don't need `skills add` for them in Claude Code. Two things the plugin does **not** include: the [`px` CLI](#cli), which the `phoenix-cli` skill needs on your `PATH`, and the [Phoenix Docs MCP](#phoenix-docs-mcp-documentation-access) — add either separately.
 
 ### Change the Endpoint
 
@@ -122,11 +125,15 @@ This setting configures the MCP server only. The `px` CLI that the `phoenix-cli`
 
 ### Authentication
 
-The plugin's MCP server signs in with OAuth in the browser and has no slot for an API key. For headless use, register a server with a bearer header instead of relying on the plugin's:
+When your Phoenix has auth enabled, the plugin's MCP server signs in with OAuth in the browser the first time you use it; the plugin has no slot for an API key. When Phoenix runs without auth, no login happens.
+
+For a headless environment where no browser can open — CI, a remote machine — don't use the plugin's server. Register one that sends your API key as a bearer token instead:
 
 ```bash
 px setup mcp --agent claude --header 'Authorization: Bearer ${PHOENIX_API_KEY}'
 ```
+
+Both register a server named `phoenix`, so pick one: uninstall or disable the plugin before running `px setup mcp`. The skills can still be installed with [`skills add`](#skills).
 
 ### Update, Remove, or Develop Locally
 
@@ -140,6 +147,8 @@ To work on the plugin itself, add the marketplace from a checkout with `/plugin 
 ## Codex
 
 The same repository is a [Codex plugin marketplace](https://developers.openai.com/plugins/build/plugins#add-a-marketplace-from-the-cli). The `arize-phoenix` plugin registers the Phoenix MCP server in Codex. It does not ship skills — add those with [`skills add`](#skills), passing `-a codex`.
+
+**Prerequisites:** Phoenix 19.0.0 or later, and Node.js — the plugin starts its MCP bridge with `npx`. The `codex plugin` commands below run in your shell.
 
 ### Install the Plugin
 
@@ -166,14 +175,14 @@ The same repository is a [Codex plugin marketplace](https://developers.openai.co
     export PHOENIX_API_KEY=your-api-key                   # only if auth is enabled
     ```
 
-    Leave `PHOENIX_ENDPOINT` unset for a local Phoenix; it defaults to `http://localhost:6006`. Codex forwards to a plugin only the variables it declares, and this plugin declares exactly these two — so variables set anywhere other than Codex's own environment are not seen.
+    Leave `PHOENIX_ENDPOINT` unset for a local Phoenix; it defaults to `http://localhost:6006`. The variables must be set in the environment you start `codex` from, and Codex forwards to the plugin only these two, which are the ones it declares.
   </Step>
   <Step title="Verify">
     ```bash
     codex mcp list
     ```
 
-    The `phoenix` server appears as enabled. On first use it opens a browser window to sign in with your Phoenix account, unless `PHOENIX_API_KEY` is set.
+    The `phoenix` server appears as enabled. Then launch `codex` and run `/mcp` to confirm it connects. If your Phoenix has auth enabled and `PHOENIX_API_KEY` is not set, a browser window opens on first use to sign in with your Phoenix account; with the key set, or with auth disabled, no login happens.
   </Step>
 </Steps>
 
@@ -185,8 +194,6 @@ Codex plugin MCP entries cannot contain environment variables in the URL, so ins
 | -------- | ------ |
 | `PHOENIX_ENDPOINT` | [Your Phoenix endpoint](#find-your-phoenix-endpoint). The launcher strips a trailing slash and appends `/mcp`, and leaves a value that already ends in `/mcp` alone, so `https://phoenix.example.com`, `https://phoenix.example.com/`, and `https://phoenix.example.com/mcp` all connect to the same server. Defaults to `http://localhost:6006`. |
 | `PHOENIX_API_KEY` | Optional. When set, requests carry it as a bearer token and no browser login is needed. The launcher passes `mcp-remote` an unexpanded `${PHOENIX_API_KEY}` reference that it resolves from its own environment, so the key never appears in process arguments. |
-
-Requires Node.js, and Phoenix 19.0.0 or later, which serves `/mcp`.
 
 ### Enable, Disable, or Remove
 
@@ -343,7 +350,7 @@ Reference docs: [Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code
 
 For direct operations against your Phoenix instance (traces, sessions, prompts, datasets, experiments, and more), use the dedicated setup guides:
 
-- [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) (beta) — built into the Phoenix server, no install. The primary way to connect going forward.
+- [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) (beta) — built into the Phoenix server, no install. The primary way to connect going forward. In [Claude Code](#claude-code) and [Codex](#codex), the Phoenix plugin registers this server for you.
 - [Phoenix MCP Server](/docs/phoenix/integrations/phoenix-mcp-server) — the `@arizeai/phoenix-mcp` npm package, in maintenance mode; for Phoenix versions without `/mcp`.
 
 <Info>

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -25,13 +25,20 @@ Most users should set up all three:
   </Card>
 </CardGroup>
 
-<Tip>
-Using Claude Code? The [Phoenix plugin](#claude-code) installs the MCP server and the skills together, so the only piece left to add yourself is the CLI.
-</Tip>
+For agents with a plugin system, the Phoenix repository is also a plugin marketplace, so one install replaces the MCP setup below — and, for Claude Code, the skills setup too. The generic [CLI](#cli), [MCP](#mcp), and [Skills](#skills) sections cover every other agent and manual setup.
+
+<CardGroup cols={2}>
+  <Card title="Claude Code" icon="terminal" href="#claude-code">
+    Plugin registers the Phoenix MCP server and the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills.
+  </Card>
+  <Card title="Codex" icon="terminal" href="#codex">
+    Plugin registers the Phoenix MCP server; add skills with `skills add`.
+  </Card>
+</CardGroup>
 
 ## Claude Code
 
-The Phoenix repository doubles as a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins). The `arize-phoenix` plugin registers the Phoenix MCP server and the Phoenix skills in one install, and because the marketplace is versioned in the repository, Claude Code updates both as new versions land.
+The Phoenix repository is a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins). The `arize-phoenix` plugin registers the Phoenix MCP server and the Phoenix skills in one install, and because the marketplace is versioned in the repository, Claude Code updates both as new versions land.
 
 ### Install the Plugin
 
@@ -111,6 +118,74 @@ claude plugin uninstall arize-phoenix@arize-phoenix  # remove the plugin
 ```
 
 To work on the plugin itself, add the marketplace from a checkout with `/plugin marketplace add ./` at the repository root — note the `./`, since a bare `.` is rejected — and check your changes with `claude plugin validate plugins/claude/arize-phoenix`. The catalog is [`.claude-plugin/marketplace.json`](https://github.com/Arize-ai/phoenix/blob/main/.claude-plugin/marketplace.json) and the plugin lives in [`plugins/claude/arize-phoenix`](https://github.com/Arize-ai/phoenix/tree/main/plugins/claude/arize-phoenix).
+
+## Codex
+
+The same repository is a [Codex plugin marketplace](https://developers.openai.com/plugins/build/plugins#add-a-marketplace-from-the-cli). The `arize-phoenix` plugin registers the Phoenix MCP server in Codex. It does not ship skills — add those with [`skills add`](#skills), passing `-a codex`.
+
+### Install the Plugin
+
+<Steps>
+  <Step title="Add the marketplace">
+    ```bash
+    codex plugin marketplace add Arize-ai/phoenix
+    ```
+
+    Codex clones the repository and reads the catalog from `.agents/plugins/marketplace.json`. The source can be `owner/repo` shorthand, `owner/repo@ref`, an HTTPS or SSH Git URL, or a local path; pass `--ref` to pin a Git ref.
+  </Step>
+  <Step title="Install the plugin">
+    ```bash
+    codex plugin add arize-phoenix@arize-phoenix
+    ```
+
+    Codex caches the plugin under `~/.codex/plugins/cache/arize-phoenix/arize-phoenix/<version>` and enables it in `~/.codex/config.toml`. You can also browse and install from the `/plugins` browser inside Codex.
+  </Step>
+  <Step title="Export your Phoenix environment">
+    In the shell you launch Codex from, export the same variables the `px` CLI reads:
+
+    ```bash
+    export PHOENIX_ENDPOINT=https://phoenix.example.com   # defaults to http://localhost:6006
+    export PHOENIX_API_KEY=your-api-key                   # only if auth is enabled
+    ```
+
+    Codex forwards to a plugin only the variables it declares, and this plugin declares exactly these two.
+  </Step>
+  <Step title="Verify">
+    ```bash
+    codex mcp list
+    ```
+
+    The `phoenix` server appears as enabled. On first use it opens a browser window to sign in with your Phoenix account, unless `PHOENIX_API_KEY` is set.
+  </Step>
+</Steps>
+
+### How It Connects
+
+Codex plugin MCP entries cannot contain environment variables in the URL, so instead of pointing at `<endpoint>/mcp` directly, the plugin registers a small stdio launcher, [`scripts/phoenix-mcp`](https://github.com/Arize-ai/phoenix/blob/main/plugins/codex/arize-phoenix/scripts/phoenix-mcp). The launcher reads your environment and bridges to the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) at `<PHOENIX_ENDPOINT>/mcp` with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) via `npx`.
+
+| Variable | Effect |
+| -------- | ------ |
+| `PHOENIX_ENDPOINT` | Base URL of your Phoenix instance, with or without a trailing slash. Defaults to `http://localhost:6006`. |
+| `PHOENIX_API_KEY` | Optional. When set, requests carry it as a bearer token and no browser login is needed. The launcher passes `mcp-remote` an unexpanded `${PHOENIX_API_KEY}` reference that it resolves from its own environment, so the key never appears in process arguments. |
+
+Requires Node.js, and Phoenix 19.0.0 or later, which serves `/mcp`.
+
+### Enable, Disable, or Remove
+
+Installing writes an entry to `~/.codex/config.toml`. Set `enabled = false` to turn the plugin off without uninstalling it:
+
+```toml
+[plugins."arize-phoenix@arize-phoenix"]
+enabled = true
+```
+
+```bash
+codex plugin marketplace upgrade arize-phoenix   # refresh the catalog snapshot
+codex plugin remove arize-phoenix@arize-phoenix  # uninstall and clear the cache
+codex plugin marketplace remove arize-phoenix    # drop the marketplace
+```
+
+To work on the plugin itself, add the marketplace from a checkout with `codex plugin marketplace add .` at the repository root. The catalog is [`.agents/plugins/marketplace.json`](https://github.com/Arize-ai/phoenix/blob/main/.agents/plugins/marketplace.json) and the plugin lives in [`plugins/codex/arize-phoenix`](https://github.com/Arize-ai/phoenix/tree/main/plugins/codex/arize-phoenix).
 
 ## Shared Environment Configuration
 

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -39,8 +39,8 @@ Every setup on this page needs the **endpoint** of your Phoenix instance: the ba
 
 | Deployment | Endpoint | MCP server URL the tools derive from it |
 | ---------- | -------- | --------------------------------------- |
-| Local (`phoenix serve` or Docker) | `http://localhost:6006` | `http://localhost:6006/mcp` |
-| Self-hosted | `https://phoenix.example.com` (your deployment's hostname) | `https://phoenix.example.com/mcp` |
+| Local Phoenix (`phoenix serve`) | `http://localhost:6006` | `http://localhost:6006/mcp` |
+| Deployed Phoenix | `https://phoenix.example.com` (your deployment's hostname) | `https://phoenix.example.com/mcp` |
 
 Enter the endpoint column, never the `/mcp` column — the plugins and the `px` CLI append `/mcp` themselves. A local Phoenix works with the defaults everywhere below; the API key is only required when auth is enabled.
 

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -25,6 +25,62 @@ Most users should set up all three:
   </Card>
 </CardGroup>
 
+## Claude Code Plugin
+
+The Phoenix repository doubles as a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins), so Claude Code users can get the MCP server and the skills below in one install instead of wiring each up by hand. Because the marketplace lives in the repository, Claude Code can update the plugin as new versions land.
+
+Add the marketplace, then install the plugin:
+
+```bash
+/plugin marketplace add Arize-ai/phoenix
+/plugin install arize-phoenix@arize-phoenix
+```
+
+The `owner/repo` shorthand and the full `https://github.com/Arize-ai/phoenix` URL both work. Outside a session, the same steps are `claude plugin marketplace add Arize-ai/phoenix` and `claude plugin install arize-phoenix@arize-phoenix`, which installs to user scope unless you pass `--scope project` or `--scope local`.
+
+### What the Plugin Installs
+
+| Component | What it is |
+| --------- | ---------- |
+| `phoenix` MCP server | Streamable HTTP to `<your-endpoint>/mcp` — the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) built into Phoenix 19.0.0 and later. |
+| `phoenix-cli`, `phoenix-evals`, `phoenix-tracing` skills | The same [skills](#skills) published in this repository, bundled with the plugin. |
+
+### Configure Your Phoenix Endpoint
+
+The plugin has one setting, **Phoenix endpoint** — the base URL of your Phoenix instance with no trailing slash, for example `https://phoenix.example.com`. Claude Code prompts for it when you enable the plugin and appends `/mcp`. Leave the default, `http://localhost:6006`, for a local Phoenix.
+
+To set it at install time instead:
+
+```bash
+claude plugin install arize-phoenix@arize-phoenix --config endpoint=https://phoenix.example.com
+```
+
+To change it later, run `/plugin configure` inside Claude Code, or edit `pluginConfigs` in your user settings (`~/.claude/settings.json`):
+
+```json
+{
+  "pluginConfigs": {
+    "arize-phoenix@arize-phoenix": {
+      "options": { "endpoint": "https://phoenix.example.com" }
+    }
+  }
+}
+```
+
+Then run `/mcp` inside Claude Code, select **phoenix**, and complete the browser login to confirm the server is connected.
+
+<Note>
+This setting configures the MCP server only. The `px` CLI that the `phoenix-cli` skill drives reads `PHOENIX_ENDPOINT` and `PHOENIX_API_KEY` from your shell, so export those as well — see [Shared Environment Configuration](#shared-environment-configuration).
+</Note>
+
+The MCP server signs in with OAuth and has no slot for an API key. For headless use, register the server yourself instead:
+
+```bash
+px setup mcp --agent claude --header 'Authorization: Bearer ${PHOENIX_API_KEY}'
+```
+
+To work on the plugin, add the marketplace from a checkout with `/plugin marketplace add .` at the repository root. The catalog is [`.claude-plugin/marketplace.json`](https://github.com/Arize-ai/phoenix/blob/main/.claude-plugin/marketplace.json) and the plugin itself lives in [`plugins/claude/arize-phoenix`](https://github.com/Arize-ai/phoenix/tree/main/plugins/claude/arize-phoenix).
+
 ## Shared Environment Configuration
 
 Set environment variables to connect to your Phoenix instance:
@@ -178,7 +234,7 @@ Install Phoenix skills using [skills add](https://github.com/vercel-labs/skills)
 npx skills add Arize-ai/phoenix
 ```
 
-This installs skills into the project's agent directory (for example, `.claude/skills/`, `.cursor/skills/`, or `.github/skills/`).
+This installs skills into the project's agent directory (for example, `.claude/skills/`, `.cursor/skills/`, or `.github/skills/`). In Claude Code, the [Phoenix plugin](#claude-code-plugin) already ships the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills, so installing it covers those.
 
 ### Available Skills
 

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -42,7 +42,7 @@ Every setup on this page needs the **endpoint** of your Phoenix instance: the ba
 
 | Deployment | Endpoint | MCP server URL the tools derive from it |
 | ---------- | -------- | --------------------------------------- |
-| Local (`phoenix serve`, Docker, notebook) | `http://localhost:6006` | `http://localhost:6006/mcp` |
+| Local (`phoenix serve` or Docker) | `http://localhost:6006` | `http://localhost:6006/mcp` |
 | Self-hosted | `https://phoenix.example.com` (your deployment's hostname) | `https://phoenix.example.com/mcp` |
 
 Enter the endpoint column, never the `/mcp` column — the plugins and the `px` CLI append `/mcp` themselves. A local Phoenix works with the defaults everywhere below; the API key is only required when auth is enabled.

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -25,13 +25,17 @@ Phoenix connects to a coding agent through three pieces. Most setups use all thr
   </Card>
 </CardGroup>
 
-How you install them depends on your agent. The Phoenix repository is also a plugin marketplace for agents that have one, and the plugin replaces the manual MCP setup:
+How you install them depends on your agent. For agents that have a plugin system, the Phoenix repository is also a plugin marketplace, and the plugin is the fastest way to set up the MCP server (and, for Claude Code, the skills):
 
 - **Claude Code** — install the [Phoenix plugin](#claude-code). It registers the Phoenix MCP server and the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills, so the only piece left to add is the [CLI](#cli).
 - **Codex** — install the [Phoenix plugin](#codex). It registers the Phoenix MCP server; add the [CLI](#cli) and [skills](#skills) yourself.
 - **Every other agent** (Cursor, VS Code, Windsurf, and more) — follow the [CLI](#cli), [MCP](#mcp), and [Skills](#skills) sections below.
 
 Both plugins connect to the MCP endpoint built into the Phoenix server, which requires **Phoenix 19.0.0 or later**. Neither includes the [Phoenix Docs MCP](#phoenix-docs-mcp-documentation-access) for documentation lookup — add that separately if you want it.
+
+<Note>
+**The plugins are optional.** You don't have to add a marketplace to use Phoenix from Claude Code or Codex. If you'd rather not, or want only some of the pieces, install them individually: the [CLI](#cli), [MCP](#mcp), and [Skills](#skills) sections below work for Claude Code and Codex exactly as they do for every other agent. The plugin just bundles the MCP and skills steps into one install that stays up to date.
+</Note>
 
 ### Find Your Phoenix Endpoint
 
@@ -47,6 +51,8 @@ Enter the endpoint column, never the `/mcp` column — the plugins and the `px` 
 ## Claude Code
 
 The Phoenix repository is a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins). The `arize-phoenix` plugin registers the Phoenix MCP server and the Phoenix skills in one install, and because the marketplace is versioned in the repository, Claude Code updates both as new versions land.
+
+Using the plugin is optional. To set things up piece by piece instead — or to skip the marketplace entirely — register the MCP server by hand with `claude mcp add` as shown on the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) page, and add skills with [`skills add`](#skills). The result is the same; the plugin only saves the steps and keeps them updated.
 
 **Prerequisites:** Phoenix 19.0.0 or later, and a current Claude Code — if `/plugin` is not recognized, update Claude Code first. Steps 1, 2, and 4 are slash commands typed inside a Claude Code session; the shell equivalents follow the steps.
 
@@ -147,6 +153,8 @@ To work on the plugin itself, add the marketplace from a checkout with `/plugin 
 ## Codex
 
 The same repository is a [Codex plugin marketplace](https://developers.openai.com/plugins/build/plugins#add-a-marketplace-from-the-cli). The `arize-phoenix` plugin registers the Phoenix MCP server in Codex. It does not ship skills — add those with [`skills add`](#skills), passing `-a codex`.
+
+Using the plugin is optional. To skip the marketplace, add the MCP server to `~/.codex/config.toml` by hand as shown on the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) page, and install the [CLI](#cli) and [skills](#skills) individually.
 
 **Prerequisites:** Phoenix 19.0.0 or later, and Node.js — the plugin starts its MCP bridge with `npx`. The `codex plugin` commands below run in your shell.
 

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -36,6 +36,17 @@ For agents with a plugin system, the Phoenix repository is also a plugin marketp
   </Card>
 </CardGroup>
 
+### Find Your Phoenix Endpoint
+
+Every setup on this page needs the **endpoint** of your Phoenix instance: the base URL you open Phoenix at in the browser, with no trailing slash and no path such as `/mcp` or `/v1`. Go to the **Settings** page in your Phoenix instance to find your endpoint and, if auth is enabled, to create an **API key**.
+
+| Deployment | Endpoint | MCP server URL the tools derive from it |
+| ---------- | -------- | --------------------------------------- |
+| Local (`phoenix serve`, Docker, notebook) | `http://localhost:6006` | `http://localhost:6006/mcp` |
+| Self-hosted | `https://phoenix.example.com` (your deployment's hostname) | `https://phoenix.example.com/mcp` |
+
+Enter the endpoint column, never the `/mcp` column — the plugins and the `px` CLI append `/mcp` themselves. A local Phoenix works with the defaults everywhere below; the API key is only required when auth is enabled.
+
 ## Claude Code
 
 The Phoenix repository is a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins). The `arize-phoenix` plugin registers the Phoenix MCP server and the Phoenix skills in one install, and because the marketplace is versioned in the repository, Claude Code updates both as new versions land.
@@ -58,7 +69,14 @@ The Phoenix repository is a [Claude Code plugin marketplace](https://code.claude
     Claude Code asks for a scope: **user** for all your projects, **project** to share it with collaborators through `.claude/settings.json`, or **local** for this repository only.
   </Step>
   <Step title="Set your Phoenix endpoint">
-    Claude Code prompts for the **Phoenix endpoint** as it enables the plugin. Enter your Phoenix base URL with no trailing slash — for example `https://phoenix.example.com` — or keep the default `http://localhost:6006` for a local Phoenix. The plugin appends `/mcp`.
+    Claude Code prompts for one setting, **Phoenix endpoint**, as it enables the plugin. Enter [your Phoenix endpoint](#find-your-phoenix-endpoint) — the base URL only, with no trailing slash — or keep the default `http://localhost:6006` for a local Phoenix. The plugin appends `/mcp` itself:
+
+    | You enter | The plugin connects to |
+    | --------- | ---------------------- |
+    | `http://localhost:6006` (default) | `http://localhost:6006/mcp` |
+    | `https://phoenix.example.com` | `https://phoenix.example.com/mcp` |
+
+    A trailing slash or a pasted `/mcp` produces a wrong URL (`…//mcp` or `…/mcp/mcp`), so trim those off. This setting is stored in your user settings and applies to every project; see [Change the Endpoint](#change-the-endpoint) to update it later.
   </Step>
   <Step title="Verify">
     Run `/mcp`, select **phoenix**, and complete the browser login. `claude plugin details arize-phoenix@arize-phoenix` lists everything the plugin registered and what it adds to your context window.
@@ -140,15 +158,15 @@ The same repository is a [Codex plugin marketplace](https://developers.openai.co
 
     Codex caches the plugin under `~/.codex/plugins/cache/arize-phoenix/arize-phoenix/<version>` and enables it in `~/.codex/config.toml`. You can also browse and install from the `/plugins` browser inside Codex.
   </Step>
-  <Step title="Export your Phoenix environment">
-    In the shell you launch Codex from, export the same variables the `px` CLI reads:
+  <Step title="Export your Phoenix endpoint">
+    The Codex plugin has no settings dialog; it reads [your Phoenix endpoint](#find-your-phoenix-endpoint) from `PHOENIX_ENDPOINT` — the same variable the `px` CLI reads. Export it, and your API key if auth is enabled, in the shell you launch Codex from:
 
     ```bash
-    export PHOENIX_ENDPOINT=https://phoenix.example.com   # defaults to http://localhost:6006
+    export PHOENIX_ENDPOINT=https://phoenix.example.com   # base URL only; the plugin appends /mcp
     export PHOENIX_API_KEY=your-api-key                   # only if auth is enabled
     ```
 
-    Codex forwards to a plugin only the variables it declares, and this plugin declares exactly these two.
+    Leave `PHOENIX_ENDPOINT` unset for a local Phoenix; it defaults to `http://localhost:6006`. Codex forwards to a plugin only the variables it declares, and this plugin declares exactly these two — so variables set anywhere other than Codex's own environment are not seen.
   </Step>
   <Step title="Verify">
     ```bash
@@ -165,7 +183,7 @@ Codex plugin MCP entries cannot contain environment variables in the URL, so ins
 
 | Variable | Effect |
 | -------- | ------ |
-| `PHOENIX_ENDPOINT` | Base URL of your Phoenix instance, with or without a trailing slash. Defaults to `http://localhost:6006`. |
+| `PHOENIX_ENDPOINT` | [Your Phoenix endpoint](#find-your-phoenix-endpoint). The launcher strips a trailing slash and appends `/mcp`, and leaves a value that already ends in `/mcp` alone, so `https://phoenix.example.com`, `https://phoenix.example.com/`, and `https://phoenix.example.com/mcp` all connect to the same server. Defaults to `http://localhost:6006`. |
 | `PHOENIX_API_KEY` | Optional. When set, requests carry it as a bearer token and no browser login is needed. The launcher passes `mcp-remote` an unexpanded `${PHOENIX_API_KEY}` reference that it resolves from its own environment, so the key never appears in process arguments. |
 
 Requires Node.js, and Phoenix 19.0.0 or later, which serves `/mcp`.
@@ -189,7 +207,7 @@ To work on the plugin itself, add the marketplace from a checkout with `codex pl
 
 ## Shared Environment Configuration
 
-Set environment variables to connect to your Phoenix instance:
+Set environment variables to connect to your Phoenix instance. `PHOENIX_ENDPOINT` is [your Phoenix endpoint](#find-your-phoenix-endpoint) — the base URL, with no path:
 
 ```bash
 export PHOENIX_ENDPOINT=http://localhost:6006    # Your Phoenix endpoint

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -25,37 +25,61 @@ Most users should set up all three:
   </Card>
 </CardGroup>
 
-## Claude Code Plugin
+<Tip>
+Using Claude Code? The [Phoenix plugin](#claude-code) installs the MCP server and the skills together, so the only piece left to add yourself is the CLI.
+</Tip>
 
-The Phoenix repository doubles as a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins), so Claude Code users can get the MCP server and the skills below in one install instead of wiring each up by hand. Because the marketplace lives in the repository, Claude Code can update the plugin as new versions land.
+## Claude Code
 
-Add the marketplace, then install the plugin:
+The Phoenix repository doubles as a [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins). The `arize-phoenix` plugin registers the Phoenix MCP server and the Phoenix skills in one install, and because the marketplace is versioned in the repository, Claude Code updates both as new versions land.
 
-```bash
-/plugin marketplace add Arize-ai/phoenix
-/plugin install arize-phoenix@arize-phoenix
-```
+### Install the Plugin
 
-The `owner/repo` shorthand and the full `https://github.com/Arize-ai/phoenix` URL both work. Outside a session, the same steps are `claude plugin marketplace add Arize-ai/phoenix` and `claude plugin install arize-phoenix@arize-phoenix`, which installs to user scope unless you pass `--scope project` or `--scope local`.
+<Steps>
+  <Step title="Add the marketplace">
+    ```bash
+    /plugin marketplace add Arize-ai/phoenix
+    ```
 
-### What the Plugin Installs
+    The `owner/repo` shorthand and the full `https://github.com/Arize-ai/phoenix` URL both work. Adding a marketplace registers the catalog; it installs nothing on its own.
+  </Step>
+  <Step title="Install the plugin">
+    ```bash
+    /plugin install arize-phoenix@arize-phoenix
+    ```
+
+    Claude Code asks for a scope: **user** for all your projects, **project** to share it with collaborators through `.claude/settings.json`, or **local** for this repository only.
+  </Step>
+  <Step title="Set your Phoenix endpoint">
+    Claude Code prompts for the **Phoenix endpoint** as it enables the plugin. Enter your Phoenix base URL with no trailing slash — for example `https://phoenix.example.com` — or keep the default `http://localhost:6006` for a local Phoenix. The plugin appends `/mcp`.
+  </Step>
+  <Step title="Verify">
+    Run `/mcp`, select **phoenix**, and complete the browser login. `claude plugin details arize-phoenix@arize-phoenix` lists everything the plugin registered and what it adds to your context window.
+  </Step>
+</Steps>
+
+Outside a session, the same two commands are `claude plugin marketplace add Arize-ai/phoenix` and `claude plugin install arize-phoenix@arize-phoenix`, which install to user scope unless you pass `--scope project` or `--scope local`.
+
+### What the Plugin Registers
 
 | Component | What it is |
 | --------- | ---------- |
 | `phoenix` MCP server | Streamable HTTP to `<your-endpoint>/mcp` — the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) built into Phoenix 19.0.0 and later. |
-| `phoenix-cli`, `phoenix-evals`, `phoenix-tracing` skills | The same [skills](#skills) published in this repository, bundled with the plugin. |
+| `phoenix-cli` skill | Fetching traces, inspecting datasets and experiments, and querying GraphQL with the `px` CLI. |
+| `phoenix-evals` skill | Building and running evaluators. |
+| `phoenix-tracing` skill | Instrumenting apps with OpenInference. |
 
-### Configure Your Phoenix Endpoint
+These are the same skills described under [Skills](#skills), so you don't need `skills add` for them in Claude Code. The plugin does not install the [CLI](#cli) — add that separately.
 
-The plugin has one setting, **Phoenix endpoint** — the base URL of your Phoenix instance with no trailing slash, for example `https://phoenix.example.com`. Claude Code prompts for it when you enable the plugin and appends `/mcp`. Leave the default, `http://localhost:6006`, for a local Phoenix.
+### Change the Endpoint
 
-To set it at install time instead:
+To set the endpoint non-interactively at install time:
 
 ```bash
 claude plugin install arize-phoenix@arize-phoenix --config endpoint=https://phoenix.example.com
 ```
 
-To change it later, run `/plugin configure` inside Claude Code, or edit `pluginConfigs` in your user settings (`~/.claude/settings.json`):
+To change it afterward, run `/plugin configure` inside Claude Code, or edit `pluginConfigs` in your user settings (`~/.claude/settings.json`):
 
 ```json
 {
@@ -67,19 +91,26 @@ To change it later, run `/plugin configure` inside Claude Code, or edit `pluginC
 }
 ```
 
-Then run `/mcp` inside Claude Code, select **phoenix**, and complete the browser login to confirm the server is connected.
-
 <Note>
 This setting configures the MCP server only. The `px` CLI that the `phoenix-cli` skill drives reads `PHOENIX_ENDPOINT` and `PHOENIX_API_KEY` from your shell, so export those as well — see [Shared Environment Configuration](#shared-environment-configuration).
 </Note>
 
-The MCP server signs in with OAuth and has no slot for an API key. For headless use, register the server yourself instead:
+### Authentication
+
+The plugin's MCP server signs in with OAuth in the browser and has no slot for an API key. For headless use, register a server with a bearer header instead of relying on the plugin's:
 
 ```bash
 px setup mcp --agent claude --header 'Authorization: Bearer ${PHOENIX_API_KEY}'
 ```
 
-To work on the plugin, add the marketplace from a checkout with `/plugin marketplace add .` at the repository root. The catalog is [`.claude-plugin/marketplace.json`](https://github.com/Arize-ai/phoenix/blob/main/.claude-plugin/marketplace.json) and the plugin itself lives in [`plugins/claude/arize-phoenix`](https://github.com/Arize-ai/phoenix/tree/main/plugins/claude/arize-phoenix).
+### Update, Remove, or Develop Locally
+
+```bash
+claude plugin update arize-phoenix@arize-phoenix     # pull the latest version
+claude plugin uninstall arize-phoenix@arize-phoenix  # remove the plugin
+```
+
+To work on the plugin itself, add the marketplace from a checkout with `/plugin marketplace add ./` at the repository root — note the `./`, since a bare `.` is rejected — and check your changes with `claude plugin validate plugins/claude/arize-phoenix`. The catalog is [`.claude-plugin/marketplace.json`](https://github.com/Arize-ai/phoenix/blob/main/.claude-plugin/marketplace.json) and the plugin lives in [`plugins/claude/arize-phoenix`](https://github.com/Arize-ai/phoenix/tree/main/plugins/claude/arize-phoenix).
 
 ## Shared Environment Configuration
 
@@ -234,7 +265,7 @@ Install Phoenix skills using [skills add](https://github.com/vercel-labs/skills)
 npx skills add Arize-ai/phoenix
 ```
 
-This installs skills into the project's agent directory (for example, `.claude/skills/`, `.cursor/skills/`, or `.github/skills/`). In Claude Code, the [Phoenix plugin](#claude-code-plugin) already ships the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills, so installing it covers those.
+This installs skills into the project's agent directory (for example, `.claude/skills/`, `.cursor/skills/`, or `.github/skills/`). In Claude Code, the [Phoenix plugin](#claude-code) already registers the `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` skills, so installing it covers those.
 
 ### Available Skills
 

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -53,7 +53,7 @@ A client that follows the MCP authorization spec finds all of this on its own: t
         claude mcp add --transport http phoenix http://localhost:6006/mcp
         ```
 
-        Or install the [Phoenix plugin](/docs/phoenix/integrations/developer-tools/coding-agents#claude-code-plugin), which registers this server and the Phoenix skills together.
+        Or install the [Phoenix plugin](/docs/phoenix/integrations/developer-tools/coding-agents#claude-code), which registers this server and the Phoenix skills together.
       </Step>
       <Step title="Log in">
         Run `/mcp` inside Claude Code, select **phoenix**, and complete the browser login.

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -152,6 +152,8 @@ A client that follows the MCP authorization spec finds all of this on its own: t
     ```
 
     Launch `codex` and run `/mcp` to verify the server is connected.
+
+    Or install the [Phoenix plugin for Codex](/docs/phoenix/integrations/developer-tools/coding-agents#codex), which registers this server from a marketplace and supports browser login as well as an API key.
   </Accordion>
 
   <Accordion title="Gemini CLI">

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -52,6 +52,8 @@ A client that follows the MCP authorization spec finds all of this on its own: t
         ```bash
         claude mcp add --transport http phoenix http://localhost:6006/mcp
         ```
+
+        Or install the [Phoenix plugin](/docs/phoenix/integrations/developer-tools/coding-agents#claude-code-plugin), which registers this server and the Phoenix skills together.
       </Step>
       <Step title="Log in">
         Run `/mcp` inside Claude Code, select **phoenix**, and complete the browser login.

--- a/plugins/claude/arize-phoenix/README.md
+++ b/plugins/claude/arize-phoenix/README.md
@@ -44,4 +44,6 @@ claude plugin install arize-phoenix@arize-phoenix
 
 Run `/mcp` inside Claude Code to confirm the `phoenix` server is connected and complete the login.
 
-For local development, add the marketplace from a checkout instead: `claude plugin marketplace add .` from the repository root.
+For local development, add the marketplace from a checkout instead: `claude plugin marketplace add ./` from the repository root. The trailing slash matters — a bare `.` is rejected as an invalid source.
+
+Check changes with `claude plugin validate plugins/claude/arize-phoenix`. It warns that the three `skills/` entries are symlinks it did not follow; that warning is expected, since `validate` reads components without following symlinks while a session loading the plugin does follow them. `claude plugin details arize-phoenix@arize-phoenix` on an installed copy confirms the resolved inventory — three skills and one MCP server.


### PR DESCRIPTION
Documents the plugin marketplaces that landed in ff2abd8 — until now they were only described in the plugin READMEs, so nothing on the docs site told users they existed.

Reorganizes the Coding Agents page (`docs/phoenix/integrations/developer-tools/coding-agents.mdx`) **by agent**. Under Recommended Setup, a per-agent decision list says what to do for Claude Code (plugin, then add the CLI), Codex (plugin, then add CLI and skills), and every other agent (the generic CLI / MCP / Skills sections), followed by a callout making clear the **plugins are optional** — the MCP server, CLI, and skills can each be installed individually for Claude Code and Codex exactly as for any other agent. Then a `## Claude Code` and a `## Codex` section, each opening with the manual alternative and a Prerequisites line.

**Find Your Phoenix Endpoint** — a shared block up top that defines the endpoint (the base URL you open Phoenix at, no trailing slash, no path), says where to find it (the Settings page) and the API key, and maps Local Phoenix / Deployed Phoenix values to the `/mcp` URL the tools derive from them. Both agent sections link to it, with a worked you-enter → plugin-connects-to table for Claude Code and a note on the launcher's trailing-slash and `/mcp` handling for Codex.

**Claude Code** (`.claude-plugin/marketplace.json` → `plugins/claude/arize-phoenix`)
- `/plugin marketplace add Arize-ai/phoenix` → `/plugin install arize-phoenix@arize-phoenix` as a 4-step in-session walkthrough (scope choice, endpoint prompt, `/mcp` verify with and without auth), plus the `claude plugin …` shell forms, `--scope`, and when they take effect
- what it registers: the `phoenix` streamable-HTTP MCP server at `<endpoint>/mcp` **and** the `phoenix-cli` / `phoenix-evals` / `phoenix-tracing` skills symlinked from `.agents/skills/`; explicitly not the CLI or the Docs MCP
- the single `userConfig` option (**Phoenix endpoint**) via prompt, `--config endpoint=…`, `/plugin configure`, or `pluginConfigs`; OAuth when auth is on, no login when it's off; the headless `px setup mcp --header` path, noting it registers a server with the same name so it's instead of the plugin, not alongside it; update/uninstall/local development

**Codex** (`.agents/plugins/marketplace.json` → `plugins/codex/arize-phoenix`)
- `codex plugin marketplace add Arize-ai/phoenix` → `codex plugin add arize-phoenix@arize-phoenix`, export `PHOENIX_ENDPOINT` / `PHOENIX_API_KEY`, verify with `codex mcp list` and `/mcp`
- how it connects: the `scripts/phoenix-mcp` stdio launcher bridging to `<PHOENIX_ENDPOINT>/mcp` with `mcp-remote`, the two forwarded variables, bearer vs. browser login; Node.js + Phoenix ≥ 19.0.0 as prerequisites
- enable/disable via `~/.codex/config.toml`, `marketplace upgrade`, `remove`; skills are not part of this plugin, so it points to `skills add -a codex`

**Verified, not just transcribed.** Both plugins were installed in a container and inspected:
- Claude Code 2.1.268 — `claude plugin details` reports **Skills (3) phoenix-cli, phoenix-evals, phoenix-tracing** + **MCP servers (1) phoenix**, confirming the skill symlinks are followed at load; `pluginConfigs` key form and `--config` checked against the written settings file. Marketplace add works from both `./` and the GitHub shorthand.
- codex-cli 0.154.0 — marketplace add from `.` and from `Arize-ai/phoenix`, `plugin add`, `codex mcp list` showing `phoenix` enabled with `PHOENIX_ENDPOINT` and `PHOENIX_API_KEY` forwarded, `plugin remove`, `marketplace remove`.
- `px setup mcp` server name (`phoenix`) checked in `js/packages/phoenix-cli/src/setup/mcp/agents.ts`; the `--header` flag in `src/commands/setupMcp.ts`.

One bug found by testing and fixed in the Claude Code plugin README: `claude plugin marketplace add .` is rejected as an invalid source; it must be `./`. The README also now explains the expected `claude plugin validate` symlink warning.

Command names, source formats, `--scope`/`--config`/`--ref`, `/plugin configure`, `pluginConfigs`, and `.codex/config.toml` come from the [Claude Code plugin docs](https://code.claude.com/docs/en/discover-plugins) ([reference](https://code.claude.com/docs/en/plugins-reference)) and the [OpenAI plugin docs](https://developers.openai.com/plugins/build/plugins#add-a-marketplace-from-the-cli).

Also cross-links both sections from the Claude Code and Codex accordions in `remote-mcp.mdx`, and from the Remote MCP bullet in the MCP section. Docs only — no nav change, since these are sections on an existing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QApPkwMwVjoEfFuc7MJMfn
