### PR TITLE
fix(dsl): three defects in the span-filter DSL found in a security review

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -1296,6 +1296,12 @@ class SpanFilter:
             raise SpanFilterError("filter condition is nested too deeply") from None
         except SyntaxError as error:
             raise SpanFilterError(_format_syntax_error(error)) from error
+        except IndexError as error:
+            # Belt-and-suspenders alongside the line-offset table's own
+            # universal-newline handling: a lineno/col_offset the table
+            # doesn't have an entry for is a malformed-filter condition to
+            # the caller, not a 500.
+            raise SpanFilterError("invalid filter condition") from error
 
     def _initialize(self) -> None:
         object.__setattr__(self, "root_scope", None)
@@ -1644,7 +1650,7 @@ class Projector:
         # confusable-identifier hazard the filter side already rejects.
         _validate_python_surface(root.body, source)
         _validate_projection_expression(root)
-        translated = _ProjectionTranslator(source).visit(root)
+        translated = _ProjectionTranslator().visit(root)
         ast.fix_missing_locations(translated)
         compiled = compile(translated, filename="", mode="eval")
         object.__setattr__(self, "translated", translated)
@@ -2423,7 +2429,28 @@ class _ProjectionTranslator(ast.NodeTransformer):
             )
         )
 
-    def visit_generic(self, node: ast.AST) -> typing.Any:
+    # Node types this translator (and `_FilterTranslator` below) has no
+    # explicit `visit_*` for and relies on the inherited `generic_visit`
+    # traversal to pass through unchanged: leaf values (`_VALID_PROJECTION_NODE_TYPES`
+    # and `_validate_expression`'s allowlist both admit them with no
+    # corresponding `visit_Constant`/`visit_List`/`visit_Tuple`/`visit_Load`
+    # here) and the operator-symbol nodes (`ast.BoolOp.op`, `ast.Compare.ops`,
+    # `ast.BinOp.op`, `ast.UnaryOp.op`) that `visit_BoolOp` etc. read directly
+    # off the node rather than visiting.
+    _PASSTHROUGH_NODE_TYPES: typing.ClassVar[tuple[type, ...]] = (
+        ast.Constant,
+        ast.List,
+        ast.Tuple,
+        ast.Load,
+        ast.boolop,
+        ast.cmpop,
+        ast.operator,
+        ast.unaryop,
+    )
+
+    def generic_visit(self, node: ast.AST) -> typing.Any:
+        if isinstance(node, self._PASSTHROUGH_NODE_TYPES):
+            return super().generic_visit(node)
         raise SyntaxError(f"invalid expression: {ast.unparse(node)}")
 
     def visit_Expression(self, node: ast.Expression) -> typing.Any:
@@ -3817,18 +3844,23 @@ def _apply_eval_aliasing(
 class _AnnotationExpressionAliaser(ast.NodeVisitor):
     def __init__(self, source: str, bindings: _FilterBindings = SPAN_BINDINGS) -> None:
         self._bindings = bindings
-        # Split on "\n" only. `str.splitlines` also breaks on \v, \f, \x1c-\x1e,
-        # \x85, \u2028 and \u2029, while the tokenizer that produced the AST
-        # positions these offsets are matched against counts none of them. One
-        # of those characters inside an earlier string literal would start a
-        # line here that the tokenizer never saw, shifting every later offset
-        # and splicing the alias at the wrong byte.
-        lines = source.split("\n")
+        # Split on the same universal newlines the tokenizer that produced the
+        # AST positions these offsets are matched against uses: "\r\n", "\r"
+        # and "\n", each counted as exactly one line break. `str.splitlines`
+        # breaks on \v, \f, \x1c-\x1e, \x85, \u2028 and \u2029 too, none of
+        # which the tokenizer treats as a line break -- one of those inside an
+        # earlier string literal would start a line here the tokenizer never
+        # saw, shifting every later offset and splicing the alias at the wrong
+        # byte. A lone "\r" is the same hazard from the other direction: the
+        # tokenizer breaks the line there, so the offset table must too.
         self._line_offsets = [0]
-        for line in lines:
-            # +1 for the "\n" that `split` consumed. A trailing "\r" of a CRLF
-            # pair stays in `line`, so its byte is already counted.
-            self._line_offsets.append(self._line_offsets[-1] + len(line.encode()) + 1)
+        pos = 0
+        for match in re.finditer(r"\r\n|\r|\n", source):
+            line = source[pos : match.start()]
+            self._line_offsets.append(
+                self._line_offsets[-1] + len(line.encode()) + len(match.group().encode())
+            )
+            pos = match.end()
         self._relations_by_key: dict[
             tuple[AnnotationRelationKind, AnnotationName], AliasedAnnotationRelation
         ] = {}

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -1246,6 +1246,73 @@ class TestProjectorValidationGap:
         )
 
 
+class TestFilterDslDefects:
+    """
+    Regression pins for three defects reported in a security review of
+    ``phoenix/trace/dsl/filter.py`` (the review's conclusion was that the
+    sandbox around ``eval()`` is sound; these are ordinary bugs found along
+    the way, none exploitable).
+    """
+
+    def test_lone_cr_in_condition_does_not_raise_index_error(self) -> None:
+        # A bare "\r" (no matching "\n") is a line terminator to the
+        # tokenizer that produced the AST's lineno/col_offset, but was not to
+        # `_AnnotationExpressionAliaser`'s old `source.split("\n")` line-offset
+        # table. Two lone CRs put a node on a line beyond the table's range
+        # and raised an unhandled IndexError -- a 500 instead of a validation
+        # error. This condition previously reproduced that crash.
+        condition = "(1 > 0\ror 1 > 0\ror evals['x'].score > 1)"
+        # Must not raise IndexError; a malformed-filter SpanFilterError would
+        # also be an acceptable outcome, but the condition here is valid.
+        span_filter = SpanFilter(condition)
+        assert span_filter.condition
+
+    def test_lone_cr_aliases_at_the_correct_byte_offset(self) -> None:
+        # Beyond not crashing, the alias must land in the right place. A
+        # single lone "\r" desyncs the old table without going out of range,
+        # producing a confusing SyntaxError instead of a correct splice.
+        # Wrapped in parens, as a lone "\r" is a line break to the parser: an
+        # un-parenthesized boolean expression split across it is a
+        # SyntaxError unrelated to the bug under test.
+        condition = "(evals['x'].score > 1\rand True)"
+        aliased_source, relations = _apply_eval_aliasing(condition)
+        assert len(relations) == 1
+        # The unaliased `evals[...]` reference must not survive translation --
+        # if it did, `_validate_expression` would reject it downstream, but
+        # this checks the aliasing step directly rather than only its net
+        # effect.
+        assert "evals[" not in aliased_source
+        assert relations[0].attribute_alias("score") in aliased_source
+        # And the rest of the expression, on the far side of the lone CR,
+        # must be untouched.
+        assert aliased_source.endswith("\rand True)")
+
+    def test_single_character_projection_name_is_not_treated_as_reserved(self) -> None:
+        # `Projector` passed its own source string where `_ProjectionTranslator`
+        # expects an iterable of reserved keywords. `frozenset(chain("n", ...))`
+        # turned the string into a set of its individual characters, so a
+        # single-character projection name like "n" was (mis)treated as a
+        # reserved binding and emitted as a bare global reference -- which
+        # raised NameError inside eval() rather than resolving to
+        # `attributes['n']` like any other unbound name.
+        projector = Projector("n")
+        translated = unparse(projector.translated)
+        assert translated == "attributes[['n']]"
+
+    def test_translator_rejects_unknown_node_types(self) -> None:
+        # `_ProjectionTranslator.visit_generic` was never called: the
+        # `ast.NodeVisitor`/`NodeTransformer` hook is named `generic_visit`,
+        # so this "reject unknown node type" backstop was dead code -- any
+        # node type without an explicit `visit_*` method passed through
+        # unchanged into `compile()` instead of being rejected. `ast.Starred`
+        # is one such type; it is already rejected upstream by the structural
+        # allowlist, so this exercises the translator's own backstop by
+        # invoking it directly on a tree the allowlist never sees.
+        root = ast.parse("[*a]", mode="eval")
+        with pytest.raises(SyntaxError, match="invalid expression"):
+            phoenix.trace.dsl.filter._ProjectionTranslator().visit(root)
+
+
 _PARENT_PREDICATE_TS = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
 
 


### PR DESCRIPTION
Fixes #15420.

The issue reports three low-severity, non-exploitable defects in `phoenix/trace/dsl/filter.py` found during a security review of the `eval()` sandbox that backs the span-filter DSL (the review's conclusion, laid out in the issue, is that the sandbox itself is sound — these are ordinary bugs found along the way). Fixing all three, as offered in the issue.

## 1. A lone `\r` desyncs the line-offset table → unhandled `IndexError`

`_AnnotationExpressionAliaser`'s line-offset table was built from `source.split("\n")`, but the tokenizer that produced the AST's `lineno`/`col_offset` treats a bare `\r` as a line break too. Two lone CRs put a node beyond the table's range and raised an unhandled `IndexError` (a 500, not a validation error); even a single lone CR desynced the splice enough to alias at the wrong byte.

Fixed by building the offset table from the same universal newlines (`\r\n`, `\r`, `\n`) the tokenizer uses, and adding `IndexError` to `SpanFilter`'s guarded exceptions as defense in depth.

## 2. `Projector` passes the source string where an iterable of keywords is expected

```python
translated = _ProjectionTranslator(source).visit(root)
```

`_ProjectionTranslator.__init__`'s first parameter is `reserved_keywords: Iterable[str]`, so passing the source *string* turned it into a set of its individual characters via `frozenset(chain(reserved_keywords, ...))`. Any single-character projection name (`{"select": {"col": "n"}}`) was then (mis)treated as reserved and emitted as a bare global reference, raising `NameError` inside `eval()` instead of resolving to `attributes['n']`.

Fixed by dropping the argument.

## 3. The "reject unknown node type" guard was dead code

```python
def visit_generic(self, node: ast.AST) -> typing.Any:
    raise SyntaxError(f"invalid expression: {ast.unparse(node)}")
```

The `NodeVisitor`/`NodeTransformer` hook is `generic_visit`, not `visit_generic`, so this backstop never ran — unknown node types passed silently through to `compile()`. No exploit results today because the structural allow-lists upstream (`_VALID_PROJECTION_NODE_TYPES`, `_validate_expression`'s node-type allowlist) are already strict, but it's presumably meant to be the backstop for exactly that assumption.

**This one needed more than the one-line rename the issue suggests.** A blind rename breaks legitimate expressions: `_ProjectionTranslator` has no explicit `visit_Constant`/`visit_List`/`visit_Tuple`/`visit_Load`, relying entirely on the inherited `generic_visit` traversal to pass those through unchanged — both allowlists admit them for exactly that reason. An unconditional `raise` in `generic_visit` rejects every constant and list/tuple literal a projection or filter is built from (caught by running the existing suite before pushing — several `TestProjectorValidationGap` tests failed immediately). The fix scopes the guard to the node types the translator has no explicit handler for and genuinely relies on passthrough for: `Constant`, `List`, `Tuple`, `Load`, and the four operator-symbol base classes (`boolop`, `cmpop`, `operator`, `unaryop`) that `visit_BoolOp`/`visit_Compare`/`visit_BinOp`/`visit_UnaryOp` read directly off the node rather than visiting.

## Testing

Four new regression tests in `tests/unit/trace/dsl/test_filter.py`, covering all three defects plus the corrected passthrough scoping. Verified against the full `tests/unit/trace/` suite (1276 passed, 0 failed) to catch any regression from narrowing the `generic_visit` guard. `ruff` and `mypy` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
