### PR TITLE
fix(ingest): stop per-key merge from interleaving dual-emitted gen_ai messages

### DIFF
--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -79,7 +79,24 @@ def decode_otlp_span(otlp_span: otlp.Span) -> Span:
     # Synthesize OpenInference attrs from any OTel gen_ai.* semconv attributes.
     # ``setdefault`` means existing OI attributes win — relevant for spans that
     # were dual-emitted by an instrumentation that already set OI keys directly.
+    #
+    # The message namespaces (``llm.input_messages.*``, ``llm.output_messages.*``)
+    # are positional, not scalar, so a per-key ``setdefault`` is unsafe there: if
+    # the client's mapping is already present but incomplete -- e.g. it dropped
+    # a message the synthesized mapping has -- gap-filling per key mixes two
+    # mappings with different index bases into messages that never existed
+    # (a system prompt spliced in under a client-authored ``role: user``, and a
+    # user message duplicated). The client's mapping, even incomplete, is at
+    # least internally consistent, so treat each namespace atomically: skip all
+    # synthesized keys under it once the client has written anything there.
+    occupied_message_namespaces = tuple(
+        f"{prefix}."
+        for prefix in (SpanAttributes.LLM_INPUT_MESSAGES, SpanAttributes.LLM_OUTPUT_MESSAGES)
+        if any(key.startswith(f"{prefix}.") for key in raw_attributes)
+    )
     for key, value in get_openinference_attributes(raw_attributes).items():
+        if key.startswith(occupied_message_namespaces):
+            continue
         raw_attributes.setdefault(key, value)
     attributes = unflatten(load_json_strings(coerce_otlp_span_attributes(raw_attributes.items())))
     span_kind = SpanKind(get_attribute_value(attributes, OPENINFERENCE_SPAN_KIND))

--- a/tests/unit/trace/test_otel.py
+++ b/tests/unit/trace/test_otel.py
@@ -567,6 +567,64 @@ def test_decode_otlp_span_existing_oi_attrs_win_over_gen_ai() -> None:
     assert decoded.attributes["llm"]["model_name"] == "gpt-4-from-oi"
 
 
+def test_decode_otlp_span_does_not_interleave_gen_ai_messages_into_partial_oi_mapping() -> None:
+    """A dual-emitted span (e.g. an instrumentation that converts most gen_ai.*
+    attrs to OpenInference client-side but misses ``gen_ai.system_instructions``)
+    must not have its partial OI message mapping gap-filled per key from the
+    synthesized one. The two mappings disagree on message indexing -- the
+    synthesized mapping puts the system prompt at index 0 and shifts the real
+    user turn to index 1, while the client's mapping has only the user turn, at
+    index 0 -- so a per-key ``setdefault`` merge interleaves them: the system
+    prompt lands under the client's ``role: user`` at index 0, and the user
+    message is duplicated at index 1.
+
+    The client's mapping, even incomplete, is internally consistent, so it must
+    win in its entirety rather than being merged with the synthesized one.
+    """
+    system_instructions = json.dumps([{"type": "text", "content": "You are a helpful assistant."}])
+    input_messages = json.dumps(
+        [{"role": "user", "parts": [{"type": "text", "content": "only root spans"}]}]
+    )
+    otlp_span = otlp.Span(
+        name="chat",
+        trace_id=token_bytes(16),
+        span_id=token_bytes(8),
+        attributes=[
+            KeyValue(
+                key="gen_ai.system_instructions",
+                value=AnyValue(string_value=system_instructions),
+            ),
+            KeyValue(key="gen_ai.input.messages", value=AnyValue(string_value=input_messages)),
+            # The client already converted its own input message to OpenInference,
+            # but -- like `@arizeai/openinference-genai` 0.2.0 -- dropped the
+            # system instructions, so only index 0 (the user turn) is present.
+            KeyValue(
+                key="llm.input_messages.0.message.role",
+                value=AnyValue(string_value="user"),
+            ),
+            KeyValue(
+                key="llm.input_messages.0.message.contents.0.message_content.text",
+                value=AnyValue(string_value="only root spans"),
+            ),
+        ],
+    )
+
+    decoded = decode_otlp_span(otlp_span)
+
+    input_messages_attr = decoded.attributes["llm"]["input_messages"]
+    assert len(input_messages_attr) == 1, (
+        "the synthesized system message must not be merged in alongside the "
+        f"client's mapping: {input_messages_attr}"
+    )
+    message = input_messages_attr[0]["message"]
+    assert message["role"] == "user"
+    assert message["contents"][0]["message_content"]["text"] == "only root spans"
+    # The synthesized per-key fallback (`.content`) must not appear -- that is
+    # the shape the old per-key `setdefault` merge filled in from the
+    # synthesized mapping once the client's own index 0 didn't set it.
+    assert "content" not in message
+
+
 @pytest.fixture
 def span() -> Span:
     trace_id = "f096b681-b8d4-44eb-bc4a-1db0b5a8d556"


### PR DESCRIPTION
Fixes #14961.

`decode_otlp_span` synthesizes OpenInference attributes from OTel `gen_ai.*` semconv and merges them into the span with a **per-flattened-key `setdefault`**:

```python
for key, value in get_openinference_attributes(raw_attributes).items():
    raw_attributes.setdefault(key, value)
```

That's safe for scalar attributes, but the indexed message namespaces (`llm.input_messages.*`, `llm.output_messages.*`) are positional. When a client already wrote a *partial* OpenInference mapping of the same data — a dual-emitted span, e.g. an instrumentation that converts most `gen_ai.*` attributes client-side but misses `gen_ai.system_instructions` — the two mappings can disagree on message indexing, and the per-key merge interleaves them into messages that never existed: the system prompt lands under the client's `role: user`, and the user message is duplicated at the next index.

Concretely, from the linked issue: the client wrote only
```
llm.input_messages.0.message.role = user
llm.input_messages.0.message.contents.0.message_content.text = only root spans
```
while the synthesized mapping (system prompt shifting the real turn to index 1) supplied
```
llm.input_messages.0.message.role = system
llm.input_messages.0.message.content = <system prompt>
llm.input_messages.1.message.role = user
llm.input_messages.1.message.content = only root spans
```
The per-key merge stored the interleave — `role: user` at index 0 (client wins) next to `content: <system prompt>` (server fills the "gap"), plus a duplicate user message at index 1.

## Fix

Treat each message namespace atomically: if the incoming span already has any key under `llm.input_messages.` (respectively `llm.output_messages.`), skip all synthesized keys for that namespace instead of gap-filling per key. The client's mapping, even incomplete, is at least internally consistent — mixing it with a different index base never is.

## Testing

Added `test_decode_otlp_span_does_not_interleave_gen_ai_messages_into_partial_oi_mapping`, reproducing the issue's exact scenario (system instructions + input message via `gen_ai.*`, partial OI mapping missing the system prompt via `llm.input_messages.*`) and asserting the client's mapping wins in its entirety — one message, not the interleaved/duplicated result.

Verified against the full `tests/unit/trace/test_otel.py` suite (33 passed, 0 failed). `ruff` and `mypy` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
