### PR TITLE
fix(db): enforce a unique constraint on span_costs.span_rowid

### DIFF
--- a/src/phoenix/db/ddl/postgresql_schema.sql
+++ b/src/phoenix/db/ddl/postgresql_schema.sql
@@ -327,6 +327,8 @@ CREATE TABLE public.span_costs (
     completion_cost DOUBLE PRECISION,
     completion_tokens DOUBLE PRECISION,
     CONSTRAINT pk_span_costs PRIMARY KEY (id),
+    CONSTRAINT uq_span_costs_span_rowid
+        UNIQUE (span_rowid),
     CONSTRAINT fk_span_costs_model_id_generative_models
         FOREIGN KEY (model_id)
         REFERENCES public.generative_models (id)
@@ -343,8 +345,6 @@ CREATE TABLE public.span_costs (
 
 CREATE INDEX ix_span_costs_model_id_span_start_time ON public.span_costs
     USING btree (model_id, span_start_time);
-CREATE INDEX ix_span_costs_span_rowid ON public.span_costs
-    USING btree (span_rowid);
 CREATE INDEX ix_span_costs_span_start_time ON public.span_costs
     USING btree (span_start_time);
 CREATE INDEX ix_span_costs_trace_rowid ON public.span_costs

--- a/src/phoenix/db/ddl/sqlite_schema.sql
+++ b/src/phoenix/db/ddl/sqlite_schema.sql
@@ -309,6 +309,7 @@ CREATE TABLE span_costs (
     completion_cost FLOAT,
     completion_tokens FLOAT,
     CONSTRAINT pk_span_costs PRIMARY KEY (id),
+    CONSTRAINT uq_span_costs_span_rowid UNIQUE (span_rowid),
     CONSTRAINT fk_span_costs_model_id_generative_models
         FOREIGN KEY (model_id)
         REFERENCES generative_models (id)
@@ -325,7 +326,6 @@ CREATE TABLE span_costs (
 
 CREATE INDEX ix_span_costs_model_id_span_start_time ON span_costs
     (model_id, span_start_time);
-CREATE INDEX ix_span_costs_span_rowid ON span_costs (span_rowid);
 CREATE INDEX ix_span_costs_span_start_time ON span_costs (span_start_time);
 CREATE INDEX ix_span_costs_trace_rowid ON span_costs (trace_rowid);
 

--- a/src/phoenix/db/migrations/versions/08a89b1ca1f6_unique_constraint_on_span_costs_span_.py
+++ b/src/phoenix/db/migrations/versions/08a89b1ca1f6_unique_constraint_on_span_costs_span_.py
@@ -1,0 +1,79 @@
+"""unique constraint on span_costs.span_rowid
+
+Revision ID: 08a89b1ca1f6
+Revises: 4aad9107d196
+Create Date: 2026-09-11 00:00:00.000000
+
+`Span.span_cost` is modeled and consumed as a one-to-one relationship, but
+`span_costs.span_rowid` has only a regular index, not a unique constraint --
+nothing at the database level stops a second cost row for the same span, and
+current writers only avoid that by convention (computing cost once, after a
+successful unique span insertion). If duplicates ever land -- a retry, a
+future writer, a direct write -- joins against `span_costs` can return a
+span multiple times and inflate cost/token aggregates.
+
+Resolves any existing duplicates before adding the constraint: for each
+`span_rowid` with more than one cost row, keeps the row with the greatest
+`id` (the most recently written one) and deletes the rest, along with their
+`span_cost_details`, so no orphans are left behind. This should be a no-op on
+every database that doesn't already have duplicates -- which is expected to
+be all of them, since nothing has shipped that could create one -- but the
+issue this closes is precisely that nothing enforces it.
+
+The dedup step is irreversible: `downgrade()` restores the index and drops
+the constraint, but does not resurrect deleted rows.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "08a89b1ca1f6"
+down_revision: Union[str, None] = "4aad9107d196"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_CHUNK_SIZE = 500  # bound the size of any single IN-list
+
+
+def _dedup_span_costs() -> None:
+    connection = op.get_bind()
+    span_costs = sa.table(
+        "span_costs",
+        sa.column("id", sa.Integer),
+        sa.column("span_rowid", sa.Integer),
+    )
+    span_cost_details = sa.table(
+        "span_cost_details",
+        sa.column("id", sa.Integer),
+        sa.column("span_cost_id", sa.Integer),
+    )
+    # The row to keep for each span_rowid: the one with the greatest id.
+    keep_ids = sa.select(sa.func.max(span_costs.c.id)).group_by(span_costs.c.span_rowid)
+    duplicate_ids = [
+        row[0]
+        for row in connection.execute(
+            sa.select(span_costs.c.id).where(span_costs.c.id.notin_(keep_ids))
+        )
+    ]
+    for i in range(0, len(duplicate_ids), _CHUNK_SIZE):
+        chunk = duplicate_ids[i : i + _CHUNK_SIZE]
+        connection.execute(
+            span_cost_details.delete().where(span_cost_details.c.span_cost_id.in_(chunk))
+        )
+        connection.execute(span_costs.delete().where(span_costs.c.id.in_(chunk)))
+
+
+def upgrade() -> None:
+    _dedup_span_costs()
+    with op.batch_alter_table("span_costs") as batch_op:
+        batch_op.drop_index("ix_span_costs_span_rowid")
+        batch_op.create_unique_constraint("uq_span_costs_span_rowid", ["span_rowid"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("span_costs") as batch_op:
+        batch_op.drop_constraint("uq_span_costs_span_rowid", type_="unique")
+        batch_op.create_index("ix_span_costs_span_rowid", ["span_rowid"])

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2866,7 +2866,6 @@ class SpanCost(HasId):
     span_rowid: Mapped[int] = mapped_column(
         ForeignKey("spans.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     trace_rowid: Mapped[int] = mapped_column(
         ForeignKey("traces.id", ondelete="CASCADE"),
@@ -2951,6 +2950,11 @@ class SpanCost(HasId):
     )
 
     __table_args__ = (
+        # `Span.span_cost` is a scalar relationship: the application never
+        # expects more than one cost row per span. The unique constraint
+        # doubles as the lookup index `index=True` used to provide, so there
+        # is no separate non-unique index on `span_rowid` to maintain.
+        UniqueConstraint("span_rowid"),
         Index(
             "ix_span_costs_model_id_span_start_time",
             "model_id",

--- a/src/phoenix/server/daemons/span_cost_calculator.py
+++ b/src/phoenix/server/daemons/span_cost_calculator.py
@@ -6,6 +6,7 @@ from collections import deque
 from datetime import datetime
 from typing import Any, Mapping, NamedTuple, Optional
 
+from sqlalchemy.exc import IntegrityError
 from typing_extensions import TypeAlias
 
 from phoenix.db import models
@@ -68,6 +69,21 @@ class SpanCostCalculator(DaemonTask):
         try:
             async with self._db() as session:
                 session.add_all(costs)
+        except IntegrityError:
+            # `span_costs.span_rowid` is unique, so this batch has a span that
+            # already has a cost row -- a re-queued item after a prior partial
+            # failure, or another writer racing to insert the same span. A
+            # single conflict must not also drop every other span's
+            # legitimate cost in the same batch, so retry one row at a time
+            # and skip (not fail) just the conflicting ones.
+            for cost in costs:
+                try:
+                    async with self._db() as session:
+                        session.add(cost)
+                except IntegrityError:
+                    logger.debug(f"Span {cost.span_rowid} already has a cost row; skipping")
+                except Exception as e:
+                    logger.exception(f"Failed to insert cost for span {cost.span_rowid}: {e}")
         except Exception as e:
             logger.exception(f"Failed to insert costs: {e}")
 

--- a/tests/integration/db_migrations/test_data_migration_08a89b1ca1f6_unique_constraint_on_span_costs.py
+++ b/tests/integration/db_migrations/test_data_migration_08a89b1ca1f6_unique_constraint_on_span_costs.py
@@ -1,0 +1,181 @@
+from datetime import datetime, timezone
+from typing import Literal
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from . import _down, _run_async, _up, _version_num
+
+_PREVIOUS_REVISION = "4aad9107d196"
+_THIS_REVISION = "08a89b1ca1f6"
+
+
+async def test_span_costs_unique_constraint_migration(
+    _engine: AsyncEngine,
+    _alembic_config: Config,
+    _db_backend: Literal["sqlite", "postgresql"],
+    _schema: str,
+) -> None:
+    # no migrations applied yet
+    with pytest.raises(BaseException, match="alembic_version"):
+        await _version_num(_engine, _schema)
+
+    # apply migrations up to right before this one
+    await _up(_engine, _alembic_config, _PREVIOUS_REVISION, _schema)
+
+    now = datetime.now(timezone.utc)
+
+    def _seed(conn: Connection) -> tuple[int, int, list[int]]:
+        """One span with three pre-existing span_costs rows (a state the
+        model layer could never itself produce, but the migration must be
+        able to clean up regardless), each with its own detail row.
+        Returns (span_rowid, trace_rowid, [span_cost_id, ...] oldest to newest)."""
+        project_id = conn.execute(
+            text(
+                "INSERT INTO projects (name, description) VALUES (:name, :description) RETURNING id"
+            ),
+            {"name": "project-name", "description": None},
+        ).scalar()
+
+        trace_rowid = conn.execute(
+            text(
+                "INSERT INTO traces (project_rowid, trace_id, start_time, end_time) "
+                "VALUES (:project_id, :trace_id, :now, :now) RETURNING id"
+            ),
+            {"project_id": project_id, "trace_id": "trace1", "now": now},
+        ).scalar()
+        assert isinstance(trace_rowid, int)
+
+        span_rowid = conn.execute(
+            text(
+                """
+                INSERT INTO spans (
+                    trace_rowid, span_id, parent_id, name, span_kind, start_time, end_time,
+                    attributes, events, status_code, status_message,
+                    cumulative_error_count, cumulative_llm_token_count_prompt,
+                    cumulative_llm_token_count_completion, llm_token_count_prompt,
+                    llm_token_count_completion
+                )
+                VALUES (
+                    :trace_rowid, :span_id, :parent_id, :name, :span_kind, :start_time, :end_time,
+                    :attributes, :events, :status_code, :status_message,
+                    :cumulative_error_count, :cumulative_llm_token_count_prompt,
+                    :cumulative_llm_token_count_completion, :llm_token_count_prompt,
+                    :llm_token_count_completion
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "trace_rowid": trace_rowid,
+                "span_id": "span1",
+                "parent_id": None,
+                "name": "span-name",
+                "span_kind": "LLM",
+                "start_time": now,
+                "end_time": now,
+                "attributes": "{}",
+                "events": "[]",
+                "status_code": "OK",
+                "status_message": "",
+                "cumulative_error_count": 0,
+                "cumulative_llm_token_count_prompt": 0,
+                "cumulative_llm_token_count_completion": 0,
+                "llm_token_count_prompt": None,
+                "llm_token_count_completion": None,
+            },
+        ).scalar()
+        assert isinstance(span_rowid, int)
+
+        span_cost_ids: list[int] = []
+        for _ in range(3):
+            span_cost_id = conn.execute(
+                text(
+                    "INSERT INTO span_costs (span_rowid, trace_rowid, span_start_time) "
+                    "VALUES (:span_rowid, :trace_rowid, :now) RETURNING id"
+                ),
+                {"span_rowid": span_rowid, "trace_rowid": trace_rowid, "now": now},
+            ).scalar()
+            assert isinstance(span_cost_id, int)
+            span_cost_ids.append(span_cost_id)
+            conn.execute(
+                text(
+                    "INSERT INTO span_cost_details (span_cost_id, token_type, is_prompt) "
+                    "VALUES (:span_cost_id, 'input', true)"
+                ),
+                {"span_cost_id": span_cost_id},
+            )
+        conn.commit()
+        return span_rowid, trace_rowid, span_cost_ids
+
+    span_rowid, trace_rowid, span_cost_ids = await _run_async(_engine, _seed)
+    kept_id = max(span_cost_ids)
+    deleted_ids = [i for i in span_cost_ids if i != kept_id]
+
+    # apply this migration
+    await _up(_engine, _alembic_config, _THIS_REVISION, _schema)
+
+    def _assert_deduped(conn: Connection) -> None:
+        remaining = (
+            conn.execute(
+                text("SELECT id FROM span_costs WHERE span_rowid = :span_rowid"),
+                {"span_rowid": span_rowid},
+            )
+            .scalars()
+            .all()
+        )
+        assert list(remaining) == [kept_id], "exactly the highest-id row must survive dedup"
+        orphaned_details = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM span_cost_details WHERE span_cost_id IN "
+                + "("
+                + ", ".join(str(i) for i in deleted_ids)
+                + ")"
+            )
+        ).scalar()
+        assert orphaned_details == 0, "no span_cost_details may survive their deleted parent"
+        remaining_details = conn.execute(
+            text("SELECT COUNT(*) FROM span_cost_details WHERE span_cost_id = :id"),
+            {"id": kept_id},
+        ).scalar()
+        assert remaining_details == 1, "the kept row's own detail must be untouched"
+
+    await _run_async(_engine, _assert_deduped)
+
+    def _assert_constraint_present(conn: Connection) -> None:
+        inspector = sa.inspect(conn)
+        unique_columns = {
+            tuple(uq["column_names"])
+            for uq in inspector.get_unique_constraints("span_costs", schema=_schema or None)
+        }
+        assert ("span_rowid",) in unique_columns, (
+            f"expected a unique constraint on span_rowid, found {unique_columns}"
+        )
+        index_names = {
+            ix["name"] for ix in inspector.get_indexes("span_costs", schema=_schema or None)
+        }
+        assert "ix_span_costs_span_rowid" not in index_names, (
+            "the old non-unique index should have been replaced by the constraint"
+        )
+
+    await _run_async(_engine, _assert_constraint_present)
+
+    # downgrade drops the constraint again (the dedup itself is not reversed)
+    await _down(_engine, _alembic_config, _PREVIOUS_REVISION, _schema)
+
+    def _assert_constraint_removed(conn: Connection) -> None:
+        inspector = sa.inspect(conn)
+        unique_columns = {
+            tuple(uq["column_names"])
+            for uq in inspector.get_unique_constraints("span_costs", schema=_schema or None)
+        }
+        assert ("span_rowid",) not in unique_columns
+        index_names = {
+            ix["name"] for ix in inspector.get_indexes("span_costs", schema=_schema or None)
+        }
+        assert "ix_span_costs_span_rowid" in index_names, "the original index must be restored"
+
+    await _run_async(_engine, _assert_constraint_removed)

--- a/tests/unit/server/daemons/test_span_cost_calculator.py
+++ b/tests/unit/server/daemons/test_span_cost_calculator.py
@@ -1,0 +1,118 @@
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from phoenix.db import models
+from phoenix.server.daemons.span_cost_calculator import (
+    SpanCostCalculator,
+    SpanCostCalculatorQueueItem,
+)
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _conflict() -> IntegrityError:
+    return IntegrityError(
+        "INSERT", {}, Exception("UNIQUE constraint failed: span_costs.span_rowid")
+    )
+
+
+class _FakeSession:
+    """Records every `SpanCost` added to it. `add_all` and `add` raise the
+    session factory's configured exception (if any) instead of touching a
+    real database, so the retry logic under test is exercised in isolation."""
+
+    def __init__(self, added: list[models.SpanCost], fail_span_rowids: frozenset[int]) -> None:
+        self._added = added
+        self._fail_span_rowids = fail_span_rowids
+
+    def add_all(self, costs: list[models.SpanCost]) -> None:
+        if any(c.span_rowid in self._fail_span_rowids for c in costs):
+            raise _conflict()
+        self._added.extend(costs)
+
+    def add(self, cost: models.SpanCost) -> None:
+        if cost.span_rowid in self._fail_span_rowids:
+            raise _conflict()
+        self._added.append(cost)
+
+
+def _make_db(
+    added: list[models.SpanCost], fail_span_rowids: frozenset[int]
+) -> Callable[[], AbstractAsyncContextManager[_FakeSession]]:
+    @asynccontextmanager
+    async def db() -> AsyncIterator[_FakeSession]:
+        yield _FakeSession(added, fail_span_rowids)
+
+    return db
+
+
+def _item(span_rowid: int) -> SpanCostCalculatorQueueItem:
+    return SpanCostCalculatorQueueItem(
+        span_rowid=span_rowid,
+        trace_rowid=1,
+        attributes={"llm": {"token_count": {"prompt": 1}}},
+        span_start_time=_NOW,
+    )
+
+
+@pytest.mark.parametrize("conflicting_span_rowid", [1, 2])
+async def test_insert_costs_skips_only_the_conflicting_row(conflicting_span_rowid: int) -> None:
+    """`span_costs.span_rowid` is unique. A batch containing a span that
+    already has a cost row -- a re-queued item after a prior partial
+    failure, or another writer racing to insert the same span -- must not
+    also drop every other span's legitimate cost in the same batch: only
+    the conflicting row is skipped (regardless of its position in the
+    batch), and everything else is still committed.
+    """
+    added: list[models.SpanCost] = []
+    calculator = SpanCostCalculator(
+        db=_make_db(added, frozenset({conflicting_span_rowid})),  # type: ignore[arg-type]
+        model_store=AsyncMock(),
+    )
+    calculator.put_nowait(_item(1))
+    calculator.put_nowait(_item(2))
+    calculator.calculate_cost = lambda start_time, attributes: models.SpanCost(  # type: ignore[method-assign]
+        span_start_time=start_time
+    )
+
+    # Must not raise: the conflict is caught and only that row is skipped.
+    await calculator._insert_costs(2)
+
+    assert sorted(c.span_rowid for c in added) == sorted({1, 2} - {conflicting_span_rowid})
+
+
+async def test_insert_costs_swallows_non_conflict_errors_per_item() -> None:
+    """A non-conflict error on the per-item retry (e.g. a transient
+    connection failure) must not abort the retry of the remaining items in
+    the batch -- it is logged and the loop continues."""
+    added: list[models.SpanCost] = []
+
+    class _FlakySession(_FakeSession):
+        def add(self, cost: models.SpanCost) -> None:
+            if cost.span_rowid == 1:
+                raise RuntimeError("transient failure")
+            super().add(cost)
+
+    @asynccontextmanager
+    async def db() -> AsyncIterator[_FlakySession]:
+        # span 1 alone is enough to force the batch add_all to fail and fall
+        # into the per-item retry; span 2 must not also be in this set, or
+        # its retry would hit the same simulated conflict instead of the
+        # override below succeeding via super().add().
+        yield _FlakySession(added, frozenset({1}))
+
+    calculator = SpanCostCalculator(db=db, model_store=AsyncMock())  # type: ignore[arg-type]
+    calculator.put_nowait(_item(1))
+    calculator.put_nowait(_item(2))
+    calculator.calculate_cost = lambda start_time, attributes: models.SpanCost(  # type: ignore[method-assign]
+        span_start_time=start_time
+    )
+
+    await calculator._insert_costs(2)
+
+    assert sorted(c.span_rowid for c in added) == [2]


### PR DESCRIPTION
Fixes #15754.

`Span.span_cost` is modeled and consumed as a one-to-one relationship, but the database never enforced it: `span_costs.span_rowid` had only a regular index. Duplicate cost rows for one span — from a retry, a future writer, or a direct write — can make joins against `span_costs` return a span multiple times and inflate cost/token aggregates. Current writers only avoid this by convention (computing cost once, after a successful unique span insertion).

## Changes

- **`models.py`**: replaces the non-unique index with `UniqueConstraint("span_rowid")`, which doubles as the lookup index the old one provided — no separate index to maintain.
- **New migration `08a89b1ca1f6`**: resolves any existing duplicates before adding the constraint — keeps the highest-id row per `span_rowid`, deletes the rest along with their `span_cost_details` so none are orphaned (FK cascade is not relied on here, since `PRAGMA foreign_keys` is off during SQLite migrations per this repo's own migration-test conftest), then swaps the index for the constraint via `batch_alter_table` for SQLite compatibility. This should be a no-op on every database that doesn't already have duplicates — expected to be all of them — but the issue this closes is precisely that nothing enforces it. `downgrade()` restores the index but does not resurrect deleted rows; documented as irreversible in the migration docstring.
- **`span_cost_calculator.py`**: the sole writer of `span_costs` batches up to 1000 rows into one `add_all`. A single conflict (a re-queued item after a partial failure, or a racing writer) would otherwise fail the whole batch and silently drop every other span's legitimate cost in it. Now retries one row at a time on `IntegrityError` and skips only the conflicting one — addressing the issue's "Ensure independent or retrying cost writers handle conflicts intentionally" point.
- Regenerates both checked-in DDL files:
  - `sqlite_schema.sql`: regenerated with the project's own `scripts/ddl/generate_ddl_sqlite.py`, which self-validates by replaying the schema into a fresh in-memory database.
  - `postgresql_schema.sql`: **hand-edited** in the same shape (matching the file's existing `UniqueConstraint`-column convention, e.g. `uq_projects_name`) and validated with `pglast.parse_sql()` for syntactic correctness. Neither Docker nor a local Postgres toolchain was available in this environment to run `make schema-ddl`'s Postgres step, which spins up `testing.postgresql`. **Flagging this explicitly for a maintainer or CI to double-check** — the diff is a two-line addition/removal mirroring the SQLite change exactly, but it wasn't produced by the canonical generator.

## Testing

- New migration test (`tests/integration/db_migrations`) seeds three duplicate `span_costs` rows against the pre-migration schema, applies the migration, and asserts via schema introspection that dedup kept the highest-id row, left no orphaned `span_cost_details`, and that the constraint (up) / plain index (down) is present as expected. Also ran the full `test_up_and_down_migrations` chain (1 passed) to confirm this migration composes cleanly with all others.
- New unit tests for the writer's retry logic against a mocked session. (A live-DB version of this test tripped an aiosqlite/sqlean quirk in this dev environment where a caught `IntegrityError` still resurfaces at connection teardown — worth knowing about if it comes up elsewhere, but orthogonal to this fix. The mocked version verifies the same control flow deterministically and is arguably the better unit test anyway.)
- Full `tests/unit/trace/dsl/test_filter_span_cost.py`, `tests/unit/db/test_trace_aggregates.py`, `tests/unit/server/api/types/test_Project.py`, `tests/unit/server/api/types/test_Span.py`, and `tests/unit/test_tracers.py` (261 passed) to confirm the model change is compatible with existing cost-related code.
- `ruff` and `mypy` clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
