### PR TITLE
refactor(dsl): share element field declarations across filter grains

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -190,14 +190,25 @@ _SPAN_COST_SCALARS: typing.Mapping[str, "FilterValueType"] = MappingProxyType(
     }
 )
 _SPAN_COST_DETAILS = "cost_details"
+ElementKind: TypeAlias = typing.Literal["string", "float", "datetime", "boolean"]
+
+
+class ElementField(typing.NamedTuple):
+    """One field a loop variable exposes: the element-model attribute and how it is typed."""
+
+    attribute: str
+    kind: ElementKind
+
+
 # Detail fields remain nullable; a missing element value fails every comparison.
-_COST_DETAIL_FIELDS: typing.Mapping[str, str] = MappingProxyType(
+# Shared by the span, trace, and session grains so the vocabulary has one source of truth.
+COST_DETAIL_ELEMENT_FIELDS: typing.Mapping[str, ElementField] = MappingProxyType(
     {
-        "token_type": "string",
-        "is_prompt": "boolean",
-        "cost": "float",
-        "tokens": "float",
-        "cost_per_token": "float",
+        "token_type": ElementField("token_type", "string"),
+        "is_prompt": ElementField("is_prompt", "boolean"),
+        "cost": ElementField("cost", "float"),
+        "tokens": ElementField("tokens", "float"),
+        "cost_per_token": ElementField("cost_per_token", "float"),
     }
 )
 
@@ -328,19 +339,19 @@ class ElementFieldReference(typing.NamedTuple):
     scope_depth: int
     source_iterable: str
     path: tuple[str, ...]
-    kind: typing.Literal["string", "float", "datetime", "boolean"]
+    kind: ElementKind
     uppercase: bool
 
 
 def _cost_detail_bindings() -> _FilterBindings:
     """Return the closed, strictly typed language for cost-detail elements."""
 
-    def columns(kind: str) -> NameMap:
+    def columns(kind: ElementKind) -> NameMap:
         return MappingProxyType(
             {
-                name: getattr(models.SpanCostDetail, name)
-                for name, field_kind in _COST_DETAIL_FIELDS.items()
-                if field_kind == kind
+                name: getattr(models.SpanCostDetail, element_field.attribute)
+                for name, element_field in COST_DETAIL_ELEMENT_FIELDS.items()
+                if element_field.kind == kind
             }
         )
 

--- a/src/phoenix/trace/dsl/session_filter.py
+++ b/src/phoenix/trace/dsl/session_filter.py
@@ -38,9 +38,11 @@ from phoenix.db.session_aggregates import (
 )
 from phoenix.trace.dsl.filter import (
     COMPREHENSION_NAMES,
+    COST_DETAIL_ELEMENT_FIELDS,
     QUANTIFIER_NAMES,
     AliasedAnnotationRelation,
     ComprehensionSpec,
+    ElementField,
     NameMap,
     _compile_condition,
     _eval_globals,
@@ -128,13 +130,6 @@ _SESSION_DATETIME_NAMES: NameMap = MappingProxyType(
 )
 
 
-class _ElementField(typing.NamedTuple):
-    """One field a loop variable exposes: the element-model attribute and how it is typed."""
-
-    attribute: str
-    kind: typing.Literal["string", "float", "datetime", "boolean"]
-
-
 class _NestedIterable(typing.NamedTuple):
     """An iterable reached from an element of another one, e.g. ``trace.spans`` for a trace."""
 
@@ -150,7 +145,7 @@ class _IterableSpec(typing.NamedTuple):
     """
 
     model: typing.Any
-    fields: typing.Mapping[str, _ElementField]
+    fields: typing.Mapping[str, ElementField]
     joins: tuple[typing.Any, ...]
     session_key: typing.Callable[[typing.Any], typing.Any]
     project_key: typing.Optional[typing.Callable[[typing.Any], typing.Any]] = None
@@ -160,39 +155,30 @@ class _IterableSpec(typing.NamedTuple):
 
 # Leaf per-span token counts, never the cumulative_* rollups: summing cumulative counts over a
 # session multi-counts tokens through wrapping agent/tool spans (#12768).
-_SPAN_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
+_SPAN_ELEMENT_FIELDS: typing.Mapping[str, ElementField] = MappingProxyType(
     {
-        "name": _ElementField("name", "string"),
-        "span_kind": _ElementField("span_kind", "string"),
-        "status_code": _ElementField("status_code", "string"),
-        "latency_ms": _ElementField("latency_ms", "float"),
-        "llm_token_count_prompt": _ElementField("llm_token_count_prompt", "float"),
-        "llm_token_count_completion": _ElementField("llm_token_count_completion", "float"),
-        "llm_token_count_total": _ElementField("llm_token_count_total", "float"),
+        "name": ElementField("name", "string"),
+        "span_kind": ElementField("span_kind", "string"),
+        "status_code": ElementField("status_code", "string"),
+        "latency_ms": ElementField("latency_ms", "float"),
+        "llm_token_count_prompt": ElementField("llm_token_count_prompt", "float"),
+        "llm_token_count_completion": ElementField("llm_token_count_completion", "float"),
+        "llm_token_count_total": ElementField("llm_token_count_total", "float"),
     }
 )
-_TRACE_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
+_TRACE_ELEMENT_FIELDS: typing.Mapping[str, ElementField] = MappingProxyType(
     {
-        "start_time": _ElementField("start_time", "datetime"),
-        "end_time": _ElementField("end_time", "datetime"),
-        "latency_ms": _ElementField("latency_ms", "float"),
+        "start_time": ElementField("start_time", "datetime"),
+        "end_time": ElementField("end_time", "datetime"),
+        "latency_ms": ElementField("latency_ms", "float"),
     }
 )
-_ANNOTATION_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
+_ANNOTATION_ELEMENT_FIELDS: typing.Mapping[str, ElementField] = MappingProxyType(
     {
-        "name": _ElementField("name", "string"),
-        "label": _ElementField("label", "string"),
-        "score": _ElementField("score", "float"),
-        "identifier": _ElementField("identifier", "string"),
-    }
-)
-_COST_DETAIL_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
-    {
-        "token_type": _ElementField("token_type", "string"),
-        "is_prompt": _ElementField("is_prompt", "boolean"),
-        "cost": _ElementField("cost", "float"),
-        "tokens": _ElementField("tokens", "float"),
-        "cost_per_token": _ElementField("cost_per_token", "float"),
+        "name": ElementField("name", "string"),
+        "label": ElementField("label", "string"),
+        "score": ElementField("score", "float"),
+        "identifier": ElementField("identifier", "string"),
     }
 )
 
@@ -235,7 +221,7 @@ _ITERABLE_SPECS: typing.Mapping[str, _IterableSpec] = MappingProxyType(
         ),
         "span_cost_details": _IterableSpec(
             model=models.SpanCostDetail,
-            fields=_COST_DETAIL_ELEMENT_FIELDS,
+            fields=COST_DETAIL_ELEMENT_FIELDS,
             joins=(models.SpanCost, models.Trace),
             session_key=lambda element: models.Trace.project_session_rowid,
             project_key=lambda element: models.Trace.project_rowid,

--- a/src/phoenix/trace/dsl/trace_filter.py
+++ b/src/phoenix/trace/dsl/trace_filter.py
@@ -29,9 +29,11 @@ from phoenix.db.trace_aggregates import (
 )
 from phoenix.trace.dsl.filter import (
     COMPREHENSION_NAMES,
+    COST_DETAIL_ELEMENT_FIELDS,
     QUANTIFIER_NAMES,
     AliasedAnnotationRelation,
     ComprehensionSpec,
+    ElementField,
     NameMap,
     _compile_condition,
     _eval_globals,
@@ -87,11 +89,6 @@ _TRACE_DATETIME_NAMES: NameMap = MappingProxyType(
 )
 
 
-class _ElementField(typing.NamedTuple):
-    attribute: str
-    kind: typing.Literal["string", "float", "datetime", "boolean"]
-
-
 class _NestedIterable(typing.NamedTuple):
     iterable: str
     correlate: typing.Callable[[typing.Mapping[typing.Any, typing.Any], typing.Any], typing.Any]
@@ -99,7 +96,7 @@ class _NestedIterable(typing.NamedTuple):
 
 class _IterableSpec(typing.NamedTuple):
     model: typing.Any
-    fields: typing.Mapping[str, _ElementField]
+    fields: typing.Mapping[str, ElementField]
     joins: tuple[typing.Any, ...]
     trace_key_model: typing.Any
     uppercase_fields: frozenset[str] = frozenset()
@@ -125,45 +122,36 @@ def _correlate_siblings(
     )
 
 
-_SPAN_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
+_SPAN_ELEMENT_FIELDS: typing.Mapping[str, ElementField] = MappingProxyType(
     {
-        "name": _ElementField("name", "string"),
-        "parent_id": _ElementField("parent_id", "string"),
-        "span_kind": _ElementField("span_kind", "string"),
-        "status_code": _ElementField("status_code", "string"),
-        "start_time": _ElementField("start_time", "datetime"),
-        "end_time": _ElementField("end_time", "datetime"),
-        "latency_ms": _ElementField("latency_ms", "float"),
-        "cumulative_error_count": _ElementField("cumulative_error_count", "float"),
-        "cumulative_llm_token_count_prompt": _ElementField(
+        "name": ElementField("name", "string"),
+        "parent_id": ElementField("parent_id", "string"),
+        "span_kind": ElementField("span_kind", "string"),
+        "status_code": ElementField("status_code", "string"),
+        "start_time": ElementField("start_time", "datetime"),
+        "end_time": ElementField("end_time", "datetime"),
+        "latency_ms": ElementField("latency_ms", "float"),
+        "cumulative_error_count": ElementField("cumulative_error_count", "float"),
+        "cumulative_llm_token_count_prompt": ElementField(
             "cumulative_llm_token_count_prompt", "float"
         ),
-        "cumulative_llm_token_count_completion": _ElementField(
+        "cumulative_llm_token_count_completion": ElementField(
             "cumulative_llm_token_count_completion", "float"
         ),
-        "cumulative_llm_token_count_total": _ElementField(
+        "cumulative_llm_token_count_total": ElementField(
             "cumulative_llm_token_count_total", "float"
         ),
-        "llm_token_count_prompt": _ElementField("llm_token_count_prompt", "float"),
-        "llm_token_count_completion": _ElementField("llm_token_count_completion", "float"),
-        "llm_token_count_total": _ElementField("llm_token_count_total", "float"),
+        "llm_token_count_prompt": ElementField("llm_token_count_prompt", "float"),
+        "llm_token_count_completion": ElementField("llm_token_count_completion", "float"),
+        "llm_token_count_total": ElementField("llm_token_count_total", "float"),
     }
 )
-_ANNOTATION_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
+_ANNOTATION_ELEMENT_FIELDS: typing.Mapping[str, ElementField] = MappingProxyType(
     {
-        "name": _ElementField("name", "string"),
-        "label": _ElementField("label", "string"),
-        "score": _ElementField("score", "float"),
-        "identifier": _ElementField("identifier", "string"),
-    }
-)
-_COST_DETAIL_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
-    {
-        "token_type": _ElementField("token_type", "string"),
-        "is_prompt": _ElementField("is_prompt", "boolean"),
-        "cost": _ElementField("cost", "float"),
-        "tokens": _ElementField("tokens", "float"),
-        "cost_per_token": _ElementField("cost_per_token", "float"),
+        "name": ElementField("name", "string"),
+        "label": ElementField("label", "string"),
+        "score": ElementField("score", "float"),
+        "identifier": ElementField("identifier", "string"),
     }
 )
 
@@ -212,7 +200,7 @@ _ITERABLE_SPECS: typing.Mapping[str, _IterableSpec] = MappingProxyType(
         ),
         "span_cost_details": _IterableSpec(
             model=models.SpanCostDetail,
-            fields=_COST_DETAIL_ELEMENT_FIELDS,
+            fields=COST_DETAIL_ELEMENT_FIELDS,
             joins=(models.SpanCost,),
             trace_key_model=models.SpanCost,
         ),

--- a/tests/unit/trace/dsl/test_filter_span_cost.py
+++ b/tests/unit/trace/dsl/test_filter_span_cost.py
@@ -545,3 +545,18 @@ def test_cost_members_have_one_declared_type_on_both_sides() -> None:
     for member in _SPAN_COST_SCALARS:
         assert _get_named_filter_value_type(member) == "number"
     assert _get_named_filter_value_type("nope") is None
+
+
+def test_cost_detail_fields_share_one_declaration() -> None:
+    from phoenix.trace.dsl import session_filter, trace_filter
+    from phoenix.trace.dsl.filter import COST_DETAIL_ELEMENT_FIELDS, _cost_detail_bindings
+
+    # The trace and session grains expose the same cost-detail vocabulary as the span grain.
+    for grain in (trace_filter, session_filter):
+        assert grain._ITERABLE_SPECS["span_cost_details"].fields is COST_DETAIL_ELEMENT_FIELDS
+    # Every declared field binds to a real column of the element model.
+    for name, element_field in COST_DETAIL_ELEMENT_FIELDS.items():
+        assert hasattr(models.SpanCostDetail, element_field.attribute), name
+    bindings = _cost_detail_bindings()
+    bound = {*bindings.string_names, *bindings.float_names, *bindings.boolean_names}
+    assert bound == set(COST_DETAIL_ELEMENT_FIELDS)


### PR DESCRIPTION
resolves #16050

## Summary

The span, trace, and session filter DSLs each kept their own cost-detail field map, and `trace_filter.py` and `session_filter.py` each declared an identical `_ElementField` record (see the review thread linked from #16050). This PR gives those declarations one home in `filter.py`, which both other grains already import from:

- `ElementKind` (the `"string" | "float" | "datetime" | "boolean"` literal), `ElementField`, and `COST_DETAIL_ELEMENT_FIELDS` are now declared once in `src/phoenix/trace/dsl/filter.py`.
- `trace_filter.py` and `session_filter.py` import them and drop their local copies. Their own span/trace/annotation field maps stay where they are; only the record type and the cost-detail map are shared.
- The span grain's `_cost_detail_bindings()` now derives its typed column bindings from the shared `ElementField` entries instead of a separate `str -> str` map, so field names, model attributes, and kinds have one source of truth for all three grains.
- `ElementFieldReference.kind` reuses `ElementKind`.

Grain-specific vocabulary, joins, lowering, and query behavior are untouched. Runtime-binding consolidation and new element capabilities stay out of scope, as the issue describes.

## Test

- New `test_cost_detail_fields_share_one_declaration` asserts that the trace and session `span_cost_details` iterables use the shared map by identity, that every declared attribute exists on `models.SpanCostDetail`, and that the span grain binds exactly the declared names.
- `tests/unit/trace/dsl` (sqlite): 932 passed, 257 skipped. The four `test_query.py` failures on my machine (`test_select_all`, `test_limit_with_select_statement`, the two `explode_and_concat` typo cases) are pandas `assert_frame_equal` mismatches that fail identically on `main` without this change.
- `ruff check`, `ruff format --check`, and `mypy --strict` on the three modules and the test file are clean.