### PR TITLE
fix(filter): use default_factory for MappingProxyType fields in _FilterBindings

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -250,13 +250,17 @@ class _FilterBindings:
     annotation_table_prefix: str
     reject_unbound_names: bool
     caller_bound_string_names: frozenset[str] = frozenset()
-    boolean_names: NameMap = MappingProxyType({})
+    boolean_names: NameMap = field(default_factory=lambda: MappingProxyType({}))
     quantifiers: frozenset[str] = frozenset()
     exists_names: frozenset[str] = frozenset()
     supports_parent_keyword: bool = False
-    iterables: typing.Mapping[str, "_IterableGrammar"] = MappingProxyType({})
+    iterables: typing.Mapping[str, "_IterableGrammar"] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
     annotation_accessors: frozenset[str] = frozenset(_ANNOTATION_ACCESSORS)
-    annotation_accessor_errors: typing.Mapping[str, str] = MappingProxyType({})
+    annotation_accessor_errors: typing.Mapping[str, str] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
     # The iterable that reads this grain's annotations element-wise, named when an
     # annotation accessor is rejected for being out of scope.
     annotation_iterable: typing.Optional[str] = None

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -1054,6 +1054,21 @@ def test_trace_annotation_name_with_escaped_quote() -> None:
     ]
 
 
+def test_filter_bindings_mappingproxy_defaults_are_factories() -> None:
+    from dataclasses import fields
+    from types import MappingProxyType
+
+    from phoenix.trace.dsl.filter import _FilterBindings
+
+    field_dict = {f.name: f for f in fields(_FilterBindings)}
+    for name in ("boolean_names", "iterables", "annotation_accessor_errors"):
+        f = field_dict[name]
+        assert callable(f.default_factory)
+        default_val = f.default_factory()
+        assert isinstance(default_val, MappingProxyType)
+        assert len(default_val) == 0
+
+
 async def test_span_and_trace_annotations_join_distinct_relations(
     db: DbSessionFactory,
     default_project: Any,

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -1054,21 +1054,6 @@ def test_trace_annotation_name_with_escaped_quote() -> None:
     ]
 
 
-def test_filter_bindings_mappingproxy_defaults_are_factories() -> None:
-    from dataclasses import fields
-    from types import MappingProxyType
-
-    from phoenix.trace.dsl.filter import _FilterBindings
-
-    field_dict = {f.name: f for f in fields(_FilterBindings)}
-    for name in ("boolean_names", "iterables", "annotation_accessor_errors"):
-        f = field_dict[name]
-        assert callable(f.default_factory)
-        default_val = f.default_factory()
-        assert isinstance(default_val, MappingProxyType)
-        assert len(default_val) == 0
-
-
 async def test_span_and_trace_annotations_join_distinct_relations(
     db: DbSessionFactory,
     default_project: Any,


### PR DESCRIPTION
Fixes #16095

## Problem
When importing `phoenix.trace.dsl.filter` on Python 3.11, dataclass definition raises a `ValueError`:
```
ValueError: mutable default <class 'mappingproxy'> for field boolean_names is not allowed: use default_factory
```
This occurs because Python 3.11's `dataclasses._get_field` treats any unhashable default as a mutable default (bpo-44674), and `mappingproxy` objects are unhashable.

## Root Cause
`_FilterBindings` in `src/phoenix/trace/dsl/filter.py` assigned `MappingProxyType({})` as bare default values on dataclass fields instead of using `field(default_factory=...)`.

## Fix
Use `field(default_factory=lambda: MappingProxyType({}))` for `boolean_names`, `iterables`, and `annotation_accessor_errors` in `_FilterBindings`.

## Testing
Added unit test in `tests/unit/trace/dsl/test_filter.py` checking that `default_factory` is properly configured for these fields and produces empty `MappingProxyType` instances without import errors on Python 3.11.