### PR TITLE
ci: add a Python 3.11 cell to the scheduled all-platforms unit tests

### DIFF
--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -76,6 +76,13 @@ jobs:
           - os: ubuntu-latest
             py: "3.10"
             db: postgresql
+        include:
+          # 3.11 is the only Python whose dataclasses reject unhashable defaults
+          # such as MappingProxyType, so it needs its own import check.
+          - branch: main
+            db: sqlite
+            py: "3.11"
+            os: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Related to #16095 and #16106.

## Problem

Python 3.11 is the only release whose `dataclasses` reject unhashable defaults such as `MappingProxyType`. No CI job that imports the Phoenix server runs on 3.11 (the per-PR unit and integration jobs use 3.10, the all-platforms jobs use 3.10 and 3.14, and the PyPI smoke test uses 3.12), so the import-time failure in #16095 shipped in 19.18.0 and went unnoticed for several releases.

## Change

Add one `include` cell to the all-platforms unit-tests matrix: `main`, sqlite, Python 3.11, ubuntu-latest. Test collection imports the affected modules, so a regression fails the job within seconds.

A single cell is used rather than adding 3.11 to the `py` axis, which would multiply across every database and OS.