### PR TITLE
fix(agent): scroll the chat transcript on vertical trackpad intent

### DIFF
--- a/js/app/src/components/agent/ToolPartPierreViews.tsx
+++ b/js/app/src/components/agent/ToolPartPierreViews.tsx
@@ -45,6 +45,11 @@ const toolPartPierreViewCSS = css`
 
 const PIERRE_THEME = { light: "pierre-light", dark: "pierre-dark" } as const;
 
+// Wrap long lines in the narrow chat panel: a horizontally scrolling block
+// captures diagonal trackpad gestures and stops the transcript from scrolling
+// down to the approval buttons.
+const PIERRE_OVERFLOW = "wrap";
+
 /**
  * A syntax-highlighted read-only file body (language inferred from
  * `fileName`) for tool part content such as the `execute_browser_action` script argument.
@@ -63,6 +68,7 @@ export function ToolPartFileView({
         file={{ name: fileName, contents }}
         options={{
           disableFileHeader: true,
+          overflow: PIERRE_OVERFLOW,
           theme: PIERRE_THEME,
           themeType: theme,
           unsafeCSS: PIERRE_TOOL_PART_UNSAFE_CSS,
@@ -99,6 +105,7 @@ export function ToolPartDiffView({
         options={{
           diffStyle: "unified",
           disableFileHeader: true,
+          overflow: PIERRE_OVERFLOW,
           theme: PIERRE_THEME,
           themeType: theme,
           unsafeCSS: PIERRE_TOOL_PART_UNSAFE_CSS,

--- a/js/app/src/components/agent/__tests__/useChatFollowScroll.test.tsx
+++ b/js/app/src/components/agent/__tests__/useChatFollowScroll.test.tsx
@@ -89,6 +89,118 @@ function createScroller(scrollHeight = 1000) {
 }
 
 describe("useChatFollowScroll", () => {
+  it("moves past a stalled native scroll position over plain text in both directions", () => {
+    const follow = renderFollowScroll();
+    const scroller = createScroller(2000);
+    follow.scrollRef(scroller.el);
+    scroller.userScrollTo(223);
+    const paragraph = document.createElement("p");
+    scroller.el.append(paragraph);
+
+    for (const deltaY of [300, 300, -200]) {
+      const before = scroller.el.scrollTop;
+      const gesture = new WheelEvent("wheel", {
+        deltaY,
+        bubbles: true,
+        cancelable: true,
+      });
+      paragraph.dispatchEvent(gesture);
+      expect(gesture.defaultPrevented).toBe(true);
+      expect(scroller.el.scrollTop).toBe(before + deltaY);
+    }
+    scroller.growContent(100);
+    scroller.fireResize();
+    expect(scroller.el.scrollTop).toBe(623);
+  });
+
+  it("preserves pinch zoom and already handled wheel events", () => {
+    const follow = renderFollowScroll();
+    const scroller = createScroller();
+    follow.scrollRef(scroller.el);
+    scroller.userScrollTo(200);
+    const zoom = new WheelEvent("wheel", {
+      deltaY: 100,
+      ctrlKey: true,
+      cancelable: true,
+    });
+    scroller.el.dispatchEvent(zoom);
+    expect(zoom.defaultPrevented).toBe(false);
+    expect(scroller.el.scrollTop).toBe(200);
+
+    const handled = new WheelEvent("wheel", {
+      deltaY: 100,
+      cancelable: true,
+    });
+    handled.preventDefault();
+    scroller.el.dispatchEvent(handled);
+    expect(scroller.el.scrollTop).toBe(200);
+  });
+
+  it("scrolls the transcript for vertical trackpad intent over a wide table", () => {
+    const follow = renderFollowScroll();
+    const scroller = createScroller(2000);
+    follow.scrollRef(scroller.el);
+    scroller.userScrollTo(200);
+    const table = document.createElement("div");
+    table.style.overflowX = "auto";
+    table.style.overflowY = "auto";
+    Object.defineProperties(table, {
+      clientWidth: { value: 400 },
+      scrollWidth: { value: 600 },
+      clientHeight: { value: 100 },
+      scrollHeight: { value: 100 },
+    });
+    scroller.el.append(table);
+    const gesture = new WheelEvent("wheel", {
+      deltaX: 8,
+      deltaY: 300,
+      bubbles: true,
+      cancelable: true,
+    });
+    table.dispatchEvent(gesture);
+    expect(gesture.defaultPrevented).toBe(true);
+    expect(scroller.el.scrollTop).toBe(500);
+
+    const sideways = new WheelEvent("wheel", {
+      deltaX: 300,
+      deltaY: 8,
+      bubbles: true,
+      cancelable: true,
+    });
+    table.dispatchEvent(sideways);
+    expect(sideways.defaultPrevented).toBe(false);
+    expect(scroller.el.scrollTop).toBe(500);
+  });
+
+  it("preserves native scrolling for a vertically scrollable viewer around wide content", () => {
+    const follow = renderFollowScroll();
+    const scroller = createScroller(2000);
+    follow.scrollRef(scroller.el);
+    scroller.userScrollTo(200);
+    const viewer = document.createElement("div");
+    viewer.style.overflowY = "auto";
+    Object.defineProperties(viewer, {
+      clientHeight: { value: 100 },
+      scrollHeight: { value: 500 },
+    });
+    const wideContent = document.createElement("div");
+    wideContent.style.overflowX = "auto";
+    Object.defineProperties(wideContent, {
+      clientWidth: { value: 400 },
+      scrollWidth: { value: 600 },
+    });
+    viewer.append(wideContent);
+    scroller.el.append(viewer);
+    const gesture = new WheelEvent("wheel", {
+      deltaX: 8,
+      deltaY: 300,
+      bubbles: true,
+      cancelable: true,
+    });
+    wideContent.dispatchEvent(gesture);
+    expect(gesture.defaultPrevented).toBe(false);
+    expect(scroller.el.scrollTop).toBe(200);
+  });
   it("pins to the bottom on content resize while following", () => {
     const follow = renderFollowScroll();
     const scroller = createScroller();

--- a/js/app/src/components/agent/useChatFollowScroll.ts
+++ b/js/app/src/components/agent/useChatFollowScroll.ts
@@ -114,6 +114,28 @@ export function useChatFollowScroll(): {
     if (event.deltaY < 0) {
       modeRef.current = "free";
     }
+    const scroller = scrollElementRef.current;
+    if (
+      !scroller ||
+      !event.cancelable ||
+      event.defaultPrevented ||
+      event.ctrlKey ||
+      Math.abs(event.deltaY) <= Math.abs(event.deltaX) ||
+      hasNestedVerticalScroller({ event, scroller })
+    ) {
+      return;
+    }
+    // Native trackpad scrolling can stall even over plain transcript text.
+    // Apply vertical intent directly; leave horizontal gestures, pinch zoom,
+    // and nested vertical viewers to the browser.
+    const scale =
+      event.deltaMode === 2
+        ? scroller.clientHeight
+        : event.deltaMode === 1
+          ? 16
+          : 1;
+    event.preventDefault();
+    scroller.scrollTop += event.deltaY * scale;
   }, []);
 
   const getResizeObserver = useCallback(() => {
@@ -134,14 +156,17 @@ export function useChatFollowScroll(): {
       const previous = scrollElementRef.current;
       if (previous) {
         previous.removeEventListener("scroll", handleScroll);
-        previous.removeEventListener("wheel", handleWheel);
+        previous.removeEventListener("wheel", handleWheel, true);
         resizeObserverRef.current?.unobserve(previous);
       }
       scrollElementRef.current = element;
       lastScrollTopRef.current = element?.scrollTop ?? null;
       if (element) {
         element.addEventListener("scroll", handleScroll, { passive: true });
-        element.addEventListener("wheel", handleWheel, { passive: true });
+        element.addEventListener("wheel", handleWheel, {
+          passive: false,
+          capture: true,
+        });
         // Observing the scroller itself keeps the pin correct when the
         // viewport (panel) is resized while following.
         getResizeObserver().observe(element);
@@ -175,4 +200,24 @@ export function useChatFollowScroll(): {
   }, []);
 
   return { scrollRef, contentRef, scrollToBottom, stopScroll };
+}
+
+function hasNestedVerticalScroller({
+  event,
+  scroller,
+}: {
+  event: WheelEvent;
+  scroller: HTMLElement;
+}): boolean {
+  // composedPath also includes code viewers inside shadow roots.
+  for (const target of event.composedPath()) {
+    if (target === scroller) break;
+    if (!(target instanceof HTMLElement)) continue;
+    const style = getComputedStyle(target);
+    const canScrollY =
+      /^(auto|scroll)$/.test(style.overflowY) &&
+      target.scrollHeight > target.clientHeight + 1;
+    if (canScrollY) return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

Split out of `cephalization/project-evaluators-playground` (it landed there in 424641eae5) because it changes chat-panel behavior unrelated to the evaluator playground.

- `useChatFollowScroll` handles `wheel` in the capture phase as a non-passive listener. When a vertical trackpad gesture would otherwise stall (over plain transcript text, or over a wide table whose horizontal overflow captures the diagonal gesture), it applies the vertical delta to the transcript and prevents the default. Pinch zoom, already-handled events, horizontal gestures, and gestures over a nested vertical scroller are left to the browser.
- Pierre file and diff viewers in tool parts wrap long lines instead of scrolling horizontally, so a code block no longer captures diagonal gestures and blocks scrolling down to the approval buttons.

## Testing

- `useChatFollowScroll.test.tsx` gains four cases: a stalled native scroll over plain text in both directions, pinch zoom and handled events preserved, vertical intent over a wide table, and native scrolling preserved for a vertically scrollable viewer around wide content.
- Typecheck, oxlint and vitest pass with these files on the source branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
