### PR TITLE
fix(cost-tracking): preserve leading groups and escaped dollar in regex specificity scorer

### DIFF
--- a/src/phoenix/server/cost_tracking/regex_specificity.py
+++ b/src/phoenix/server/cost_tracking/regex_specificity.py
@@ -121,7 +121,7 @@ def score(regex: Union[str, re.Pattern[str]]) -> int:
 
     # Score anchors - most significant factor
     has_start_anchor = _has_start_anchor(pattern)
-    has_end_anchor = pattern.endswith("$")
+    has_end_anchor = _has_end_anchor(pattern)
 
     if has_start_anchor and has_end_anchor:
         score_value += FULL_ANCHOR
@@ -138,6 +138,22 @@ def score(regex: Union[str, re.Pattern[str]]) -> int:
     return max(score_value, 1)
 
 
+def _is_inline_flag(s: str) -> bool:
+    return bool(s) and all(c in "aiLmsux" for c in s)
+
+
+def _get_inline_flag_end(pattern: str, start: int) -> int:
+    if not pattern.startswith("(?", start):
+        return -1
+    close = pattern.find(")", start)
+    if close == -1:
+        return -1
+    inner = pattern[start + 2 : close]
+    if _is_inline_flag(inner):
+        return close + 1
+    return -1
+
+
 def _has_start_anchor(pattern: str) -> bool:
     """
     Check if pattern has a start anchor (after all leading inline flags).
@@ -145,13 +161,28 @@ def _has_start_anchor(pattern: str) -> bool:
     """
     i = 0
     # Skip all leading inline flags
-    while pattern.startswith("(?", i):
-        close = pattern.find(")", i)
-        if close == -1:
+    while True:
+        end = _get_inline_flag_end(pattern, i)
+        if end == -1:
             break
-        i = close + 1
+        i = end
     # After all flags, check for ^
     return i < len(pattern) and pattern[i] == "^"
+
+
+def _has_end_anchor(pattern: str) -> bool:
+    """
+    Check if pattern ends with an unescaped end anchor ($).
+    """
+    if not pattern.endswith("$"):
+        return False
+    # Count preceding backslashes
+    backslashes = 0
+    j = len(pattern) - 2
+    while j >= 0 and pattern[j] == "\\":
+        backslashes += 1
+        j -= 1
+    return backslashes % 2 == 0
 
 
 def _strip_anchors(pattern: str) -> str:
@@ -161,17 +192,17 @@ def _strip_anchors(pattern: str) -> str:
     """
     i = 0
     # Remove all leading inline flags
-    while pattern.startswith("(?", i):
-        close = pattern.find(")", i)
-        if close == -1:
+    while True:
+        end = _get_inline_flag_end(pattern, i)
+        if end == -1:
             break
-        i = close + 1
+        i = end
     # Remove start anchor
     if i < len(pattern) and pattern[i] == "^":
         i += 1
     content = pattern[i:]
     # Remove end anchor
-    if content.endswith("$"):
+    if _has_end_anchor(content):
         content = content[:-1]
     return content
 
@@ -213,6 +244,16 @@ def _score_content(content: str) -> int:
             quantifier_score, new_pos = _score_quantifier(content, i)
             score_value += quantifier_score
             i = new_pos
+        elif content.startswith("(?<=", i) or content.startswith("(?<!", i):
+            # Lookbehind assertions: metacharacters, score 0
+            i += 4
+        elif (
+            content.startswith("(?:", i)
+            or content.startswith("(?=", i)
+            or content.startswith("(?!", i)
+        ):
+            # Non-capturing groups and lookahead assertions: metacharacters, score 0
+            i += 3
         else:
             # Handle single characters
             score_value += _score_char(char)

--- a/tests/unit/server/cost_tracking/test_regex_specificity.py
+++ b/tests/unit/server/cost_tracking/test_regex_specificity.py
@@ -26,6 +26,8 @@ from phoenix.server.cost_tracking.regex_specificity import (
         pytest.param("(?i)abc^", False, id="anchor not at start"),
         pytest.param("(?i)^", True, id="just anchor with flags"),
         pytest.param("(?i)", False, id="just flags"),
+        pytest.param("(?:gpt-4)", False, id="non-capturing group is not an inline flag"),
+        pytest.param("(?!gpt-3)gpt-4", False, id="negative lookahead is not an inline flag"),
     ],
 )
 def test_has_start_anchor(pattern: str, expected: bool) -> None:
@@ -43,6 +45,11 @@ def test_has_start_anchor(pattern: str, expected: bool) -> None:
         pytest.param("(?i)abc", "abc", id="inline flag only"),
         pytest.param("(?i)(?m)^abc$", "abc", id="multiple flags + anchors"),
         pytest.param("(?i)^(?m)abc$", "(?m)abc", id="flag-anchor-flag"),
+        pytest.param("(?:gpt-4)", "(?:gpt-4)", id="non-capturing group content preserved"),
+        pytest.param(
+            "(?:gpt-4|gpt-4o)$", "(?:gpt-4|gpt-4o)", id="non-capturing group with end anchor"
+        ),
+        pytest.param("gpt\\$", "gpt\\$", id="escaped dollar not stripped"),
     ],
 )
 def test_strip_anchors(pattern: str, expected: str) -> None:
@@ -266,6 +273,9 @@ def test_find_bracket_end(pattern: str, start: int, expected: int) -> None:
         pytest.param("[-a]", 508, id="dash at start of class"),
         pytest.param("[a-z-]", 512, id="dash at end of range"),
         pytest.param("[-a-z]", 512, id="dash at start of range"),
+        pytest.param("(?:gpt-4)", 5018, id="non-capturing group content scored"),
+        pytest.param("gpt\\$", 3960, id="escaped dollar scored as literal not anchor"),
+        pytest.param("^(?:gpt)-4o-mini$", 21034, id="non-capturing group with anchor"),
     ],
 )
 def test_score(pattern: str, expected: int) -> None:


### PR DESCRIPTION
## Problem
When a pattern begins with a non-capturing group (e.g. `(?:gpt-4)`) or a lookaround assertion (e.g. `(?!=...)`), `regex_specificity` treats it as an inline flag group and discards the entire group before scoring the content. As a result, patterns like `(?:gpt-4)` receive a score of 18 instead of 5010, causing models with grouped patterns in `CostModelLookup` to lose priority ties to less specific patterns.

Additionally, literal escaped dollar signs (e.g. `gpt\$`) are treated as end anchors because `has_end_anchor` and `_strip_anchors` only check `endswith("$")`. This inflates the score with an anchor bonus and leaves a dangling backslash in the content. Furthermore, inline non-capturing groups like `^(?:gpt)-4o-mini$` had `?:` scored as an optional quantifier plus a literal colon (+900 points).

## Root Cause
1. `_has_start_anchor` and `_strip_anchors` looped over any `(?...` prefix and jumped to the closing parenthesis, mistaking all groups starting with `(?` for inline flags.
2. End anchor detection did not inspect whether the trailing `$` was preceded by an odd number of escaping backslashes.
3. `_score_content` character iteration did not recognize non-capturing group `(?:` or lookaround `(?=`, `(?!`, `(?<=`, `(?<!` syntax prefixes as metacharacters, misclassifying them as optional quantifiers and literals.

## Fix
1. Added `_is_inline_flag` and `_get_inline_flag_end` helpers to only skip genuine inline flag groups whose contents are purely flag letters (`[aiLmsux]+`).
2. Added `_has_end_anchor` helper that counts preceding backslashes to ensure trailing `$` is unescaped.
3. Updated `_score_content` to recognize non-capturing group and lookaround prefixes as zero-score metacharacters without misclassifying their components.

Fixes #16096

## Testing
- Added unit tests in `tests/unit/server/cost_tracking/test_regex_specificity.py` covering non-capturing groups and negative lookaheads in `test_has_start_anchor`, `test_strip_anchors`, and `test_score`.
- Validated with `pytest tests/unit/server/cost_tracking/test_regex_specificity.py` (242 passed).
- Verified all related cost tracking suites pass (`test_cost_model_lookup.py`, `test_cost_details_calculator.py`, `test_helpers.py`).