### PR TITLE
feat(dsl): expose per-span cost scalars in trace and session filters

### DIFF
--- a/internal_docs/specs/session-filter-dsl.md
+++ b/internal_docs/specs/session-filter-dsl.md
@@ -183,11 +183,23 @@ Six callables accept a comprehension: `any`, `all` (quantifiers) and `len`, `max
 
 | Iterable | Element fields |
 | --- | --- |
-| `spans` | `name`, `span_kind`, `status_code`, `latency_ms`, `llm_token_count_prompt`, `llm_token_count_completion`, `llm_token_count_total` |
+| `spans` | `name`, `span_kind`, `status_code`, `latency_ms`, `llm_token_count_prompt`, `llm_token_count_completion`, `llm_token_count_total`, `total_cost`, `prompt_cost`, `completion_cost` |
 | `traces` | `start_time`, `end_time`, `latency_ms`, and a nested `spans` iterable |
 | `session_annotations` | `name`, `label`, `score` |
 | `span_annotations` | `name`, `label`, `score` (every span's annotations, flattened to session scope) |
 | `span_cost_details` | `token_type`, `is_prompt`, `cost`, `tokens`, `cost_per_token` |
+
+`span.total_cost`, `span.prompt_cost`, and `span.completion_cost` are that span's own cost
+scalars, read from its `span_costs` row:
+
+```
+any(span.total_cost > 0.1 for span in spans)
+```
+
+A span with no cost row, or with the column recorded as null, reads `0` rather than dropping
+out of the comprehension. Each name is correlated to its own element, so a predicate naming
+two of them requires one span to satisfy both. The session-level `total_cost`, `prompt_cost`,
+and `completion_cost` are unchanged and still describe totals across the whole session.
 
 Design notes, each a deliberate choice:
 

--- a/internal_docs/specs/trace-filter-dsl.md
+++ b/internal_docs/specs/trace-filter-dsl.md
@@ -75,6 +75,24 @@ The cumulative fields on a span are ingestion-time subtree rollups:
 "Below" follows stored parent edges within the same trace. It does not infer ancestry across
 traces when OpenTelemetry span IDs collide or an orphan points at a span stored elsewhere.
 
+`span.total_cost`, `span.prompt_cost`, and `span.completion_cost` are that span's own cost
+scalars, read from its `span_costs` row:
+
+```
+any(span.total_cost > 0.1 for span in spans)
+sum(span.total_cost for span in spans) > 1.0
+```
+
+A span with no cost row, or with the column recorded as null, reads `0` rather than dropping
+out of the comprehension, so `all(span.total_cost > 0 for span in spans)` is false for a trace
+that holds an uncosted span. Each name is correlated to its own element, so
+`any(span.prompt_cost == 0.75 and span.total_cost == 0.1 for span in spans)` requires one span
+to satisfy both, and is not answered by two different spans.
+
+The trace-level `total_cost`, `prompt_cost`, and `completion_cost` are unchanged and still
+describe totals across the whole trace. A trace whose spans cost 1.00 and 0.10 has
+`total_cost > 1.05`, while `any(span.total_cost > 1.05 for span in spans)` is false.
+
 ## Parent and Nested Relationships
 
 `span.parent_span` traverses to the direct stored parent in the same trace. It is missing for

--- a/js/app/src/pages/project/sessionFilterDSL.ts
+++ b/js/app/src/pages/project/sessionFilterDSL.ts
@@ -105,6 +105,10 @@ export const sessionFilterSnippets: DSLFilterSnippet[] = [
     snippet: "total_cost > ${1}",
   },
   {
+    label: "any single span cost more than",
+    snippet: "any(span.total_cost > ${0.1} for span in spans)",
+  },
+  {
     label: "filter by tool usage",
     snippet: "tool_span_count > 0",
   },

--- a/js/app/src/pages/project/traceFilterDSL.ts
+++ b/js/app/src/pages/project/traceFilterDSL.ts
@@ -103,6 +103,10 @@ export const traceFilterSnippets: DSLFilterSnippet[] = [
     snippet: "total_cost > ${1}",
   },
   {
+    label: "any single span cost more than",
+    snippet: "any(span.total_cost > ${0.1} for span in spans)",
+  },
+  {
     label: "filter by tool usage",
     snippet: "tool_span_count > 0",
   },

--- a/src/phoenix/trace/dsl/session_filter.py
+++ b/src/phoenix/trace/dsl/session_filter.py
@@ -133,6 +133,9 @@ class _ElementField(typing.NamedTuple):
 
     attribute: str
     kind: typing.Literal["string", "float", "datetime", "boolean"]
+    # True when the value lives on the element span's `span_costs` row rather than on the
+    # span itself, and must therefore be reached by correlation instead of attribute access.
+    from_span_cost: bool = False
 
 
 class _NestedIterable(typing.NamedTuple):
@@ -169,6 +172,11 @@ _SPAN_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
         "llm_token_count_prompt": _ElementField("llm_token_count_prompt", "float"),
         "llm_token_count_completion": _ElementField("llm_token_count_completion", "float"),
         "llm_token_count_total": _ElementField("llm_token_count_total", "float"),
+        # Reached through the element span's cost row. The session-level names of the same
+        # spelling remain totals across the whole session.
+        "total_cost": _ElementField("total_cost", "float", from_span_cost=True),
+        "prompt_cost": _ElementField("prompt_cost", "float", from_span_cost=True),
+        "completion_cost": _ElementField("completion_cost", "float", from_span_cost=True),
     }
 )
 _TRACE_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
@@ -244,9 +252,40 @@ _ITERABLE_SPECS: typing.Mapping[str, _IterableSpec] = MappingProxyType(
 )
 
 
+def _span_cost_scalar(element: typing.Any, member: str) -> typing.Any:
+    """Return one cost scalar of the element span as a correlated subquery.
+
+    Adding `span_costs` to the iterable's joins would not work: those are rendered as inner
+    joins, so a span with no cost row would drop out of the comprehension entirely, and an
+    outer join there would still tie the element's multiplicity to the cost table. Correlating
+    a scalar subquery to the element instead leaves the element set untouched and survives the
+    caller's own joins, since the alias is private to this expression.
+
+    An absent cost row and a recorded-but-null column are the same answer to the user's
+    question, so both coalesce to 0 — matching the top-level cost names.
+    """
+    span_cost = aliased(models.SpanCost)
+    # Assumes at most one cost row per span, as the top-level cost names do; enforcing that
+    # is tracked separately.
+    #
+    # The coalesce wraps the subquery rather than the column: a span with no cost row yields
+    # no rows at all, and a scalar subquery over an empty result is NULL, which a coalesce
+    # placed inside it would never see. Wrapping it turns both an absent row and a
+    # recorded-but-null column into 0.
+    return func.coalesce(
+        select(getattr(span_cost, member))
+        .where(span_cost.span_rowid == element.id)
+        .scalar_subquery(),
+        0,
+    )
+
+
 def _element_column(source: typing.Any, name: str, spec: _IterableSpec) -> typing.Any:
     """What a loop variable's field compiles to on ``source`` — the element model or an alias."""
-    return getattr(source, spec.fields[name].attribute)
+    field = spec.fields[name]
+    if field.from_span_cost:
+        return _span_cost_scalar(source, field.attribute)
+    return getattr(source, field.attribute)
 
 
 def _element_bindings(spec: _IterableSpec) -> _FilterBindings:

--- a/src/phoenix/trace/dsl/trace_filter.py
+++ b/src/phoenix/trace/dsl/trace_filter.py
@@ -90,6 +90,9 @@ _TRACE_DATETIME_NAMES: NameMap = MappingProxyType(
 class _ElementField(typing.NamedTuple):
     attribute: str
     kind: typing.Literal["string", "float", "datetime", "boolean"]
+    # True when the value lives on the element span's `span_costs` row rather than on the
+    # span itself, and must therefore be reached by correlation instead of attribute access.
+    from_span_cost: bool = False
 
 
 class _NestedIterable(typing.NamedTuple):
@@ -147,6 +150,11 @@ _SPAN_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
         "llm_token_count_prompt": _ElementField("llm_token_count_prompt", "float"),
         "llm_token_count_completion": _ElementField("llm_token_count_completion", "float"),
         "llm_token_count_total": _ElementField("llm_token_count_total", "float"),
+        # Reached through the element span's cost row. The trace-level names of the same
+        # spelling remain totals across the whole trace.
+        "total_cost": _ElementField("total_cost", "float", from_span_cost=True),
+        "prompt_cost": _ElementField("prompt_cost", "float", from_span_cost=True),
+        "completion_cost": _ElementField("completion_cost", "float", from_span_cost=True),
     }
 )
 _ANNOTATION_ELEMENT_FIELDS: typing.Mapping[str, _ElementField] = MappingProxyType(
@@ -220,8 +228,39 @@ _ITERABLE_SPECS: typing.Mapping[str, _IterableSpec] = MappingProxyType(
 )
 
 
+def _span_cost_scalar(element: typing.Any, member: str) -> typing.Any:
+    """Return one cost scalar of the element span as a correlated subquery.
+
+    Adding `span_costs` to the iterable's joins would not work: those are rendered as inner
+    joins, so a span with no cost row would drop out of the comprehension entirely, and an
+    outer join there would still tie the element's multiplicity to the cost table. Correlating
+    a scalar subquery to the element instead leaves the element set untouched and survives the
+    caller's own joins, since the alias is private to this expression.
+
+    An absent cost row and a recorded-but-null column are the same answer to the user's
+    question, so both coalesce to 0 — matching the top-level cost names.
+    """
+    span_cost = aliased(models.SpanCost)
+    # Assumes at most one cost row per span, as the top-level cost names do; enforcing that
+    # is tracked separately.
+    #
+    # The coalesce wraps the subquery rather than the column: a span with no cost row yields
+    # no rows at all, and a scalar subquery over an empty result is NULL, which a coalesce
+    # placed inside it would never see. Wrapping it turns both an absent row and a
+    # recorded-but-null column into 0.
+    return func.coalesce(
+        select(getattr(span_cost, member))
+        .where(span_cost.span_rowid == element.id)
+        .scalar_subquery(),
+        0,
+    )
+
+
 def _element_column(source: typing.Any, name: str, spec: _IterableSpec) -> typing.Any:
-    column = getattr(source, spec.fields[name].attribute)
+    field = spec.fields[name]
+    if field.from_span_cost:
+        return _span_cost_scalar(source, field.attribute)
+    column = getattr(source, field.attribute)
     return func.upper(column) if name in spec.uppercase_fields else column
 
 

--- a/tests/unit/trace/dsl/test_trace_filter_span_cost.py
+++ b/tests/unit/trace/dsl/test_trace_filter_span_cost.py
@@ -1,0 +1,184 @@
+"""Span-element cost scalars inside trace and session filter comprehensions.
+
+`total_cost`, `prompt_cost` and `completion_cost` name the *element* span's cost row here.
+The trace- and session-level names of the same spelling keep meaning totals across the whole
+trace or session, and the tests below pin both readings against the same data.
+"""
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import insert, select
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+from phoenix.trace.dsl.session_filter import SessionFilter
+from phoenix.trace.dsl.trace_filter import TraceFilter
+
+_TS = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+
+# Two traces whose spans differ in cost, so a predicate that leaks across elements or across
+# traces produces a different answer than one that is correctly correlated.
+#   trace-a: expensive 1.00 (prompt 0.75 / completion 0.25), cheap 0.10 (0.06 / 0.04)
+#   trace-b: middling  0.50 (prompt 0.50 / completion 0.00), uncosted (no span_costs row)
+_TRACES: dict[str, list[tuple[str, tuple[float, float, float] | None]]] = {
+    "trace-a": [("expensive", (1.0, 0.75, 0.25)), ("cheap", (0.1, 0.06, 0.04))],
+    "trace-b": [("middling", (0.5, 0.5, 0.0)), ("uncosted", None)],
+}
+
+
+@pytest.fixture
+async def cost_traces(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name="element-cost").returning(models.Project.id)
+        )
+        for trace_id, spans in _TRACES.items():
+            trace_rowid = await session.scalar(
+                insert(models.Trace)
+                .values(
+                    trace_id=trace_id,
+                    project_rowid=project_rowid,
+                    start_time=_TS,
+                    end_time=_TS + timedelta(seconds=60),
+                )
+                .returning(models.Trace.id)
+            )
+            for span_id, costs in spans:
+                span_rowid = await session.scalar(
+                    insert(models.Span)
+                    .values(
+                        trace_rowid=trace_rowid,
+                        span_id=span_id,
+                        parent_id=None,
+                        name=span_id,
+                        span_kind="LLM",
+                        start_time=_TS,
+                        end_time=_TS + timedelta(seconds=1),
+                        attributes={},
+                        events=[],
+                        status_code="OK",
+                        status_message="",
+                        cumulative_error_count=0,
+                        cumulative_llm_token_count_prompt=0,
+                        cumulative_llm_token_count_completion=0,
+                    )
+                    .returning(models.Span.id)
+                )
+                if costs is None:
+                    continue
+                total, prompt, completion = costs
+                await session.execute(
+                    insert(models.SpanCost).values(
+                        span_rowid=span_rowid,
+                        trace_rowid=trace_rowid,
+                        span_start_time=_TS,
+                        total_cost=total,
+                        prompt_cost=prompt,
+                        completion_cost=completion,
+                        total_tokens=100.0,
+                        prompt_tokens=75.0,
+                        completion_tokens=25.0,
+                    )
+                )
+
+
+async def _traces(db: DbSessionFactory, condition: str, lowering: Any) -> list[str]:
+    async with db() as session:
+        stmt = TraceFilter(condition)(select(models.Trace.trace_id), lowering=lowering)
+        return sorted(await session.scalars(stmt))
+
+
+@pytest.mark.parametrize("lowering", ["scan", "probe"])
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        pytest.param(
+            "any(span.total_cost > 0.5 for span in spans)", ["trace-a"], id="any-total-cost"
+        ),
+        pytest.param(
+            "any(span.prompt_cost > 0.6 for span in spans)", ["trace-a"], id="any-prompt-cost"
+        ),
+        pytest.param(
+            "any(span.completion_cost > 0.1 for span in spans)",
+            ["trace-a"],
+            id="any-completion-cost",
+        ),
+        pytest.param(
+            "all(span.total_cost > 0.05 for span in spans)", ["trace-a"], id="all-total-cost"
+        ),
+        pytest.param(
+            "sum(span.total_cost for span in spans) > 1.0", ["trace-a"], id="sum-total-cost"
+        ),
+        pytest.param(
+            "max(span.total_cost for span in spans) == 0.5", ["trace-b"], id="max-total-cost"
+        ),
+    ],
+)
+async def test_element_cost_filters_traces(
+    db: DbSessionFactory,
+    cost_traces: None,
+    condition: str,
+    expected: list[str],
+    lowering: Any,
+) -> None:
+    assert await _traces(db, condition, lowering) == expected
+
+
+@pytest.mark.parametrize("lowering", ["scan", "probe"])
+async def test_element_cost_cannot_match_another_spans_cost(
+    db: DbSessionFactory, cost_traces: None, lowering: Any
+) -> None:
+    """The scalar is correlated to its own element, not to any span in the trace.
+
+    `trace-a` holds a span costing 1.00 and one costing 0.10. No single span has a prompt
+    cost of 0.75 together with a total cost of 0.10, so a predicate demanding both on the
+    *same* element must reject the trace; an uncorrelated lowering would accept it.
+    """
+    both_on_one_span = "any(span.prompt_cost == 0.75 and span.total_cost == 0.1 for span in spans)"
+    assert await _traces(db, both_on_one_span, lowering) == []
+
+    # The same two values, each satisfied by a different span, still matches.
+    split_across_spans = (
+        "any(span.prompt_cost == 0.75 for span in spans)"
+        " and any(span.total_cost == 0.1 for span in spans)"
+    )
+    assert await _traces(db, split_across_spans, lowering) == ["trace-a"]
+
+
+@pytest.mark.parametrize("lowering", ["scan", "probe"])
+async def test_span_without_a_cost_row_reads_zero(
+    db: DbSessionFactory, cost_traces: None, lowering: Any
+) -> None:
+    """A missing `span_costs` row coalesces to 0 rather than dropping the span.
+
+    `trace-b` holds one uncosted span. It must still be visible to the comprehension, so
+    `all(... > 0)` fails for that trace while `any(... == 0)` finds it.
+    """
+    assert await _traces(db, "any(span.total_cost == 0 for span in spans)", lowering) == ["trace-b"]
+    assert await _traces(db, "all(span.total_cost > 0 for span in spans)", lowering) == ["trace-a"]
+
+
+@pytest.mark.parametrize("lowering", ["scan", "probe"])
+async def test_trace_level_cost_names_still_mean_trace_totals(
+    db: DbSessionFactory, cost_traces: None, lowering: Any
+) -> None:
+    """Element names must not change what the bare trace-level names mean.
+
+    `trace-a` totals 1.10 across its two spans while its largest single span is 1.00, so a
+    threshold between the two separates the readings.
+    """
+    assert await _traces(db, "total_cost > 1.05", lowering) == ["trace-a"]
+    assert await _traces(db, "any(span.total_cost > 1.05 for span in spans)", lowering) == []
+
+
+async def test_session_filter_exposes_element_cost(db: DbSessionFactory) -> None:
+    """The session vocabulary gains the same three names."""
+    for condition in (
+        "any(span.total_cost > 0.5 for span in spans)",
+        "any(span.prompt_cost > 0 for span in spans)",
+        "all(span.completion_cost >= 0 for span in spans)",
+        "sum(span.total_cost for span in spans) > 1",
+    ):
+        SessionFilter(condition)


### PR DESCRIPTION
resolves #16049

Exposes `total_cost`, `prompt_cost` and `completion_cost` on span elements inside trace and session filter comprehensions:

```python
any(span.total_cost > 0.1 for span in spans)
sum(span.total_cost for span in spans) > 1.0
```

The trace- and session-level names of the same spelling are untouched and still describe totals across the whole trace or session. There is a test pinning that distinction: a trace whose spans cost 1.00 and 0.10 satisfies `total_cost > 1.05`, while `any(span.total_cost > 1.05 for span in spans)` is false.

## Lowering

`_IterableSpec.joins` is the obvious hook for reaching `span_costs` from a span element, but `apply_joins` renders those with `.join()`. An inner join would drop every span with no cost row out of the comprehension rather than reading it as `0`, so `any(span.total_cost > 0.1 for span in spans)` would quietly stop seeing uncosted spans. An outer join there would keep the rows but tie the element's multiplicity to the cost table, which is what #15754 is separately about.

So each scalar resolves through a subquery correlated to the element:

```python
span_cost = aliased(models.SpanCost)
func.coalesce(
    select(getattr(span_cost, member))
    .where(span_cost.span_rowid == element.id)
    .scalar_subquery(),
    0,
)
```

The alias is private to the expression, so a caller's own joins are unaffected, and the element set is untouched.

**The coalesce wraps the subquery, not the column.** This is the one subtlety worth review: a span with no cost row yields *no rows at all*, and a scalar subquery over an empty result is `NULL` — a coalesce placed inside it never sees that case. I had it inside at first; `test_span_without_a_cost_row_reads_zero` caught it, because uncosted spans were reading `NULL` and silently failing every comparison.

Like `_join_span_cost`, this assumes at most one cost row per span rather than aggregating, so `span.total_cost` inside a trace filter means what `total_cost` means in a span filter.

`_ElementField` gains a `from_span_cost` flag in both `trace_filter.py` and `session_filter.py`, since each keeps its own span-element vocabulary.

## Tests

`tests/unit/trace/dsl/test_trace_filter_span_cost.py`, 19 cases, parametrized over both lowerings (`scan`, `probe`) and both backends. Two traces whose spans differ in cost, one of them uncosted, so a leak across elements or traces produces a different answer than correct correlation.

- **Element correlation** — the check this issue asks for. `trace-a` holds a span at 1.00 and one at 0.10, so `any(span.prompt_cost == 0.75 and span.total_cost == 0.1 for span in spans)` must be **false**: no single span satisfies both. Splitting the same two values across two `any(...)` calls still matches, which is what separates a correlated lowering from an uncorrelated one.
- **Missing cost** — an uncosted span reads `0` and stays visible, so `any(span.total_cost == 0 ...)` finds its trace and `all(span.total_cost > 0 ...)` excludes it.
- **Existing top-level aggregates** — unchanged, per the threshold case above.
- **Session vocabulary** — the same three names compile there.

## Verification

```
tests/unit/trace/dsl/            954 passed          (--db sqlite)
tests/unit/trace/dsl/            952 passed, 2 xfailed  (--db postgresql)
```

The two xfails are pre-existing and marked "FIX THIS: this test does not currently pass for postgres" in `test_query.py`; they are unrelated to this change and fail the same way on `main`.

`ruff check`, `ruff format --check` and `mypy` clean on the changed modules.

## Docs

`internal_docs/specs/trace-filter-dsl.md` and `session-filter-dsl.md` document the three names, the coalesce-to-zero rule, the correlation guarantee, and that the trace/session-level names keep their meaning. `traceFilterDSL.ts` and `sessionFilterDSL.ts` each gain one snippet so the capability is discoverable next to the existing trace-level cost filter.

## Out of scope

Enforcing one cost row per span (#15754) and shared compiler standardization, as the issue notes.

This change was developed with AI assistance.
