### PR TITLE
chore(ui): remove phoenix-devs mailto link from error boundary

### DIFF
--- a/js/app/src/pages/ErrorElement.tsx
+++ b/js/app/src/pages/ErrorElement.tsx
@@ -175,19 +175,7 @@ function ErrorContent({ error }: { error: unknown }) {
           gap: var(--global-dimension-size-100);
         `}
       >
-        <span
-          css={css`
-            display: inline-flex;
-            flex-direction: row;
-            align-items: baseline;
-            gap: 0.2em;
-          `}
-        >
-          💙 the
-          <ExternalLink href="mailto:phoenix-devs@arize.com">
-            phoenix team
-          </ExternalLink>
-        </span>
+        <span>💙 the phoenix team</span>
       </p>
       <div
         css={css`


### PR DESCRIPTION
## Summary

Removes the `mailto:phoenix-devs@arize.com` link from the app's error boundary. The "💙 the phoenix team" sign-off remains as plain text; the GitHub "file an issue" link is unchanged.

This was the only occurrence of the email address in the frontend app. Package metadata, Helm chart, and code of conduct references are out of scope and untouched.

## Test plan

- [x] `pnpm run typecheck`, `oxlint`, `oxfmt --check` pass in `js/app`