### PR TITLE
fix(ui): show pointer cursor on list box items

### DIFF
--- a/js/app/src/components/core/listbox/ListBox.tsx
+++ b/js/app/src/components/core/listbox/ListBox.tsx
@@ -31,7 +31,7 @@ const listBoxCSS = css`
     padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
     border-radius: var(--global-rounding-small);
     outline: none;
-    cursor: default;
+    cursor: pointer;
     color: var(--global-text-color-900);
     font-size: var(--global-font-size-s);
     line-height: var(--global-line-height-s);
@@ -43,6 +43,10 @@ const listBoxCSS = css`
     &[data-focus-visible] {
       outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
       outline-offset: -2px;
+    }
+
+    &[data-disabled] {
+      cursor: default;
     }
 
     &[data-selected] {

--- a/js/app/src/components/core/listbox/__tests__/ListBox.test.tsx
+++ b/js/app/src/components/core/listbox/__tests__/ListBox.test.tsx
@@ -1,0 +1,46 @@
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+
+import { ListBox, ListBoxItem } from "..";
+
+describe("ListBox", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows the pointer cursor only for interactive items", () => {
+    act(() => {
+      root.render(
+        <ListBox aria-label="Animals" selectionMode="single">
+          <ListBoxItem id="cat">Cat</ListBoxItem>
+          <ListBoxItem id="dog" isDisabled>
+            Dog
+          </ListBoxItem>
+        </ListBox>
+      );
+    });
+
+    const enabledItem = container.querySelector<HTMLElement>(
+      '.react-aria-ListBoxItem[data-key="cat"]'
+    );
+    const disabledItem = container.querySelector<HTMLElement>(
+      '.react-aria-ListBoxItem[data-key="dog"]'
+    );
+
+    expect(enabledItem).not.toBeNull();
+    expect(disabledItem).not.toBeNull();
+    expect(getComputedStyle(enabledItem!).cursor).toBe("pointer");
+    expect(getComputedStyle(disabledItem!).cursor).toBe("default");
+  });
+});


### PR DESCRIPTION
- use the pointer cursor for enabled shared ListBox items
- retain the default cursor for disabled ListBox items
- add regression coverage for both cursor states

This was fixed based on the evaluator gallery but was broken elsewhere and will apply generally.