### PR TITLE
fix(pxi-evals): account for experiment read prerequisites

### DIFF
--- a/evals/pxi/datasets/experiment_observations.yaml
+++ b/evals/pxi/datasets/experiment_observations.yaml
@@ -317,7 +317,12 @@ examples:
       ui_operations:
         forbidden: [experiment.patch, playground.experiment.setRecording]
       budgets:
-        max_tool_calls: 3
+        # No primed catalog here. Allow experiments methodology + backend
+        # discovery + schema/reference + the deferred read. GraphQL uses
+        # load_skill(experiments), load_skill(phoenix-graphql), its reference,
+        # then bash; MCP uses load_skill(experiments), search, get_schema, execute.
+        # Redundant discovery and failed reference loads still exceed this budget.
+        max_tool_calls: 4
     metadata:
       category: negative_read_only
       difficulty: moderate
@@ -341,7 +346,12 @@ examples:
       ui_operations:
         forbidden: [experiment.patch]
       budgets:
-        max_tool_calls: 3
+        # No primed catalog here. Allow experiments methodology + backend
+        # discovery + schema/reference + the deferred read. GraphQL uses
+        # load_skill(experiments), load_skill(phoenix-graphql), its reference,
+        # then bash; MCP uses load_skill(experiments), search, get_schema, execute.
+        # Redundant discovery and failed reference loads still exceed this budget.
+        max_tool_calls: 4
     metadata:
       category: negative_compare_only
       difficulty: moderate


### PR DESCRIPTION
The two unprimed observation reads cannot fit the current backend prerequisites into three calls. Allow four: experiments methodology, backend discovery, schema/reference, then the deferred read. Primed write examples keep their two-call budget.

In regression run 34660270988, the comparison retry used `load_skill(experiments)`, `load_skill(phoenix-graphql)`, `load_skill_reference`, and `bash`. It now passes the budget. The initial seven-call comparison and both five-call read-results attempts still fail. The latter tried a nonexistent reference on the experiments skill and need a separate agent fix.

Validation: replayed all four observation examples and both retries; 26 dataset unit tests passed. Pass-rate thresholds, retry policy, and write prohibitions are unchanged. This does not establish query correctness or completed workflows at the deferred-action boundary.

Related: #15869. Depends on #16132.
