### PR TITLE
fix(pxi-evals): use valid span IDs in filter fixtures

### DIFF
--- a/evals/pxi/datasets/set_spans_filter.yaml
+++ b/evals/pxi/datasets/set_spans_filter.yaml
@@ -554,7 +554,7 @@ examples:
     input:
       messages:
         - role: user
-          content: Filter the spans table to span 7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b.
+          content: Filter the spans table to span 7a3f9c2e1b8d4e5f.
         - role: assistant
           tool_calls:
             - id: search-ops
@@ -569,7 +569,7 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_id == '7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b'
+          condition: span_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: medium
@@ -579,7 +579,7 @@ examples:
     input:
       messages:
         - role: user
-          content: Show me direct children of span 7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b.
+          content: Show me direct children of span 7a3f9c2e1b8d4e5f.
         - role: assistant
           tool_calls:
             - id: search-ops
@@ -594,7 +594,7 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: parent_id == '7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b'
+          condition: parent_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: high

--- a/tests/unit/pxi/evals/test_datasets.py
+++ b/tests/unit/pxi/evals/test_datasets.py
@@ -7,6 +7,7 @@ Run directly:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -358,3 +359,16 @@ examples:
                 assert description.get("non_empty") is True, (
                     f"{example['id']} must reject an empty playground.prompt.save description"
                 )
+
+
+@pytest.mark.parametrize("example_id", ["span-by-id", "children-of-parent"])
+def test_span_id_fixtures_use_matching_otel_span_ids(example_id: str) -> None:
+    example = next(e for e in load_dataset("set_spans_filter").examples if e["id"] == example_id)
+    query = example["input"]["messages"][0]["content"]
+    condition = example["expected"]["ui_operation_args"]["spansFilter.set"]["condition"]
+    input_ids = re.findall(r"\b[0-9a-f]{16,32}\b", query)
+    expected_ids = re.findall(r"\b[0-9a-f]{16,32}\b", condition)
+    assert input_ids == expected_ids
+    assert len(input_ids) == 1
+    assert re.fullmatch(r"[0-9a-f]{16}", input_ids[0])
+    assert int(input_ids[0], 16) != 0


### PR DESCRIPTION
Replace the trace-shaped 32-character IDs in `span-by-id` and `children-of-parent` with valid nonzero 16-character OpenTelemetry span IDs. Update each user request and expected filter together, so asking for clarification or choosing `trace_id` no longer stems from malformed input.

Validation: the two new fixture tests failed on the original IDs and pass after correction; all 28 dataset tests pass. Focused Ruff and whitespace checks pass. The tests verify ID width, nonzero value, and input/expectation agreement.

Related: #15869. Depends on #16133. No production code, gate thresholds, or example splits change.
