### PR TITLE
fix(pxi-evals): compare decoded filter predicates

### DIFF
--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -715,3 +715,17 @@ coding agent) consume it:
    ```bash
    gh run download <run-id> -n pxi-eval-reports-<run-id>
    ```
+
+### Static filter predicate comparisons
+
+`condition: {filter_equals: "span_kind in ['LLM', 'TOOL']"}` compares a decoded
+`ui.spansFilter.set` condition with a Python DSL AST. It accepts quote and whitespace
+changes, reordered AND/OR clauses, and equivalent literal membership lists. It rejects
+missing or additional predicates and preserves the difference between AND and OR.
+
+This matcher supports a single unconditional operation with a string literal or
+`const` string binding, including shorthand properties, comments, static templates,
+and a UIResult return guard after the call. Dynamic expressions, conditional calls,
+and multiple filter calls fail closed. Scripts are never executed. Other matchers
+retain their existing substring semantics; this is not a complete JavaScript or
+semantic filter evaluator.

--- a/evals/pxi/datasets/set_spans_filter.yaml
+++ b/evals/pxi/datasets/set_spans_filter.yaml
@@ -89,7 +89,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'LLM'
+          condition:
+            filter_equals: span_kind == 'LLM'
     metadata:
       annotation:
         agreement: high
@@ -114,7 +115,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'TOOL'
+          condition:
+            filter_equals: span_kind == 'TOOL'
     metadata:
       annotation:
         agreement: high
@@ -139,7 +141,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: status_code == 'ERROR'
+          condition:
+            filter_equals: status_code == 'ERROR'
     metadata:
       annotation:
         agreement: high
@@ -223,7 +226,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: trace_id == '8f3c2d1e0a9b4c5d6e7f8091a2b3c4d5'
+          condition:
+            filter_equals: trace_id == '8f3c2d1e0a9b4c5d6e7f8091a2b3c4d5'
     metadata:
       annotation:
         agreement: high
@@ -248,7 +252,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: name == 'retrieve_documents'
+          condition:
+            filter_equals: name == 'retrieve_documents'
     metadata:
       annotation:
         agreement: high
@@ -304,7 +309,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: annotations['Hallucination'].label == 'hallucinated'
+          condition:
+            filter_equals: annotations['Hallucination'].label == 'hallucinated'
     metadata:
       annotation:
         agreement: high
@@ -329,7 +335,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: parent_id is None
+          condition:
+            filter_equals: parent_id is None
     metadata:
       annotation:
         agreement: high
@@ -354,7 +361,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'CHAIN'
+          condition:
+            filter_equals: span_kind == 'CHAIN'
     metadata:
       annotation:
         agreement: high
@@ -409,7 +417,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'EMBEDDING'
+          condition:
+            filter_equals: span_kind == 'EMBEDDING'
     metadata:
       annotation:
         agreement: high
@@ -434,7 +443,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: status_code == 'OK'
+          condition:
+            filter_equals: status_code == 'OK'
     metadata:
       annotation:
         agreement: high
@@ -459,7 +469,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: status_code == 'UNSET'
+          condition:
+            filter_equals: status_code == 'UNSET'
     metadata:
       annotation:
         agreement: high
@@ -511,10 +522,10 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition:
-            contains_all:
-              ["cumulative_token_count.total", "50000", "parent_id is None"]
-            not_contains: ["cumulative_token_count.total < ", "cumulative_token_count.total <= "]
+          - condition:
+              filter_equals: parent_id is None and cumulative_token_count.total > 50000
+          - condition:
+              filter_equals: parent_id is None and cumulative_token_count.total >= 50000
     metadata:
       annotation:
         agreement: high
@@ -541,7 +552,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: start_time >= '2025-01-15T00:00:00Z'
+          condition:
+            filter_equals: start_time >= '2025-01-15T00:00:00Z'
     metadata:
       annotation:
         agreement: medium
@@ -569,7 +581,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_id == '7a3f9c2e1b8d4e5f'
+          condition:
+            filter_equals: span_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: medium
@@ -594,7 +607,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: parent_id == '7a3f9c2e1b8d4e5f'
+          condition:
+            filter_equals: parent_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: high
@@ -672,7 +686,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: metadata['environment'] == 'prod'
+          condition:
+            filter_equals: metadata['environment'] == 'prod'
     metadata:
       annotation:
         agreement: medium
@@ -697,7 +712,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'AGENT'
+          condition:
+            filter_equals: span_kind == 'AGENT'
     metadata:
       annotation:
         agreement: high
@@ -722,7 +738,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'RETRIEVER'
+          condition:
+            filter_equals: span_kind == 'RETRIEVER'
     metadata:
       annotation:
         agreement: high
@@ -747,7 +764,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind != 'LLM'
+          condition:
+            filter_equals: span_kind != 'LLM'
     metadata:
       annotation:
         agreement: medium
@@ -782,9 +800,8 @@ examples:
         agreement: high
         n_opinions: 3
   - id: llm-or-tool-spans
-    # OR semantics: ``contains_all`` of just the literal values matches both
-    # ``span_kind == 'LLM' or span_kind == 'TOOL'`` and the equivalent
-    # ``span_kind in ('LLM', 'TOOL')`` form the parser accepts.
+    # Compare the full predicate, accepting both membership and OR clauses.
+    # Historical substring matching accepted an impossible AND of both kinds.
     splits: [regression]
     input:
       messages:
@@ -805,8 +822,7 @@ examples:
       ui_operation_args:
         spansFilter.set:
           condition:
-            contains_all: ["LLM", "TOOL"]
-            not_contains: ["!=", "not_in", "not in"]
+            filter_equals: span_kind in ['LLM', 'TOOL']
     metadata:
       annotation:
         agreement: high
@@ -858,7 +874,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: end_time < '2025-01-15T12:00:00Z'
+          condition:
+            filter_equals: end_time < '2025-01-15T12:00:00Z'
     metadata:
       annotation:
         agreement: high
@@ -909,7 +926,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: attributes['user.id'] == 'alice'
+          condition:
+            filter_equals: attributes['user.id'] == 'alice'
     metadata:
       annotation:
         agreement: high
@@ -992,8 +1010,7 @@ examples:
       ui_operation_args:
         spansFilter.set:
           condition:
-            contains_all: ["TOOL", "RETRIEVER"]
-            not_contains: ["!=", "not_in", "not in"]
+            filter_equals: span_kind in ['TOOL', 'RETRIEVER']
     metadata:
       annotation:
         agreement: medium
@@ -1020,7 +1037,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind != 'TOOL'
+          condition:
+            filter_equals: span_kind != 'TOOL'
     metadata:
       annotation:
         agreement: high

--- a/evals/pxi/evaluators/filters.py
+++ b/evals/pxi/evaluators/filters.py
@@ -1,0 +1,142 @@
+"""Decode static filter scripts and compare predicate structure without executing code."""
+
+from __future__ import annotations
+
+import ast
+import re
+
+_STRING = r"""(?:"(?:[^"\\\r\n]|\\.)*"|'(?:[^'\\\r\n]|\\.)*'|`(?:[^`\\]|\\.)*`)"""
+_IDENTIFIER = r"[A-Za-z_$][\w$]*"
+_COMMENT_OR_STRING = re.compile(rf"({_STRING})|//[^\n]*|/\*[\s\S]*?\*/")
+_BINDING = re.compile(rf"\s*const\s+({_IDENTIFIER})\s*=\s*({_STRING})\s*;")
+_CALL = re.compile(
+    rf"\s*(?:const\s+(?P<result>{_IDENTIFIER})\s*=\s*|return\s+)?"
+    rf"(?:await\s+)?ui\.spansFilter\.set\s*\(\s*\{{\s*"
+    rf"(?:condition|\"condition\"|'condition')\s*(?::\s*(?P<value>{_STRING}|{_IDENTIFIER}))?"
+    rf"\s*,?\s*\}}\s*\)\s*;?\s*(?P<tail>[\s\S]*)"
+)
+
+
+def _decode_string(source: str) -> str:
+    if source.startswith("`") and "${" in source:
+        raise ValueError("Interpolated templates are not static")
+    escapes = {"n": "\n", "r": "\r", "t": "\t", "b": "\b", "f": "\f", "v": "\v"}
+
+    def decode(match: re.Match[str]) -> str:
+        escape = match.group(1)
+        if escape.startswith(("u", "x")):
+            return chr(int(escape[1:], 16))
+        if escape in escapes:
+            return escapes[escape]
+        if escape in "\\/'\"`":
+            return escape
+        raise ValueError("Unsupported JavaScript escape")
+
+    return re.sub(r"\\(u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])", decode, source[1:-1])
+
+
+def static_filter_condition(script: str) -> str | None:
+    """Read a literal or const-bound condition from one straight-line filter call.
+
+    Comments, quote styles, const string bindings, and a UIResult return guard
+    after the call are supported. Conditional calls, interpolation, reassignment,
+    and multiple calls fail closed. This deliberately
+    does not implement a JavaScript runtime or infer values from source substrings.
+    """
+    if len(script) > 32_768:
+        return None
+    source = _COMMENT_OR_STRING.sub(lambda match: match.group(1) or " ", script)
+    bindings: dict[str, str] = {}
+    try:
+        while match := _BINDING.match(source):
+            name, value = match.groups()
+            if name in bindings or name == "ui":
+                return None
+            bindings[name] = _decode_string(value)
+            source = source[match.end() :]
+        call = _CALL.fullmatch(source)
+        if call is None:
+            return None
+        result = call["result"]
+        if result in bindings or result == "ui":
+            return None
+        tail = call["tail"].strip()
+        if tail:
+            if result is None:
+                return None
+            result_name = re.escape(result)
+            # A common wrapper returns a failed UIResult, otherwise the condition.
+            # Both branches follow the unconditional operation; neither adds calls.
+            return_value = rf"(?:{result_name}|\{{\s*condition\s*:\s*{_STRING}\s*,?\s*\}})"
+            tail_pattern = (
+                rf"(?:if\s*\(\s*!{result_name}\.ok\s*\)\s*return\s+{result_name}\s*;\s*)?"
+                rf"return\s+{return_value}\s*;?"
+            )
+            if re.fullmatch(tail_pattern, tail) is None:
+                return None
+        if call["value"] is None and re.search(r"[\"']condition[\"']", source):
+            return None
+        value = call["value"] or "condition"
+        return _decode_string(value) if value[0] in "'\"`" else bindings.get(value)
+    except ValueError:
+        return None
+
+
+class _CanonicalPredicate(ast.NodeTransformer):
+    def visit_Compare(self, node: ast.Compare) -> ast.AST:
+        visited = self.generic_visit(node)
+        assert isinstance(visited, ast.Compare)
+        node = visited
+        if (
+            len(node.ops) == 1
+            and isinstance(node.ops[0], ast.In)
+            and isinstance(node.comparators[0], (ast.List, ast.Tuple, ast.Set))
+            and node.comparators[0].elts
+            and all(isinstance(item, ast.Constant) for item in node.comparators[0].elts)
+        ):
+            expanded = self.visit(
+                ast.BoolOp(
+                    op=ast.Or(),
+                    values=[
+                        ast.Compare(left=node.left, ops=[ast.Eq()], comparators=[item])
+                        for item in node.comparators[0].elts
+                    ],
+                )
+            )
+            assert isinstance(expanded, ast.AST)
+            return expanded
+        return node
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> ast.AST:
+        values: list[ast.expr] = []
+        for value in node.values:
+            value = self.visit(value)
+            if isinstance(value, ast.BoolOp) and type(value.op) is type(node.op):
+                values.extend(value.values)
+            else:
+                values.append(value)
+        unique = {ast.dump(value): value for value in values}
+        ordered = [unique[key] for key in sorted(unique)]
+        return ordered[0] if len(ordered) == 1 else ast.BoolOp(op=node.op, values=ordered)
+
+
+def _predicate_key(condition: str) -> str:
+    if len(condition) > 16_384:
+        raise ValueError("Filter exceeds parser limit")
+    if not condition.strip():
+        return ""
+    tree = ast.parse(condition.strip(), mode="eval")
+    if sum(1 for _ in ast.walk(tree)) > 512:
+        raise ValueError("Filter exceeds AST limit")
+    return ast.dump(_CanonicalPredicate().visit(tree), include_attributes=False)
+
+
+def filter_matches(script: str, expected: str) -> bool:
+    """Compare decoded DSL ASTs, allowing clause order and literal membership lists."""
+    condition = static_filter_condition(script)
+    if condition is None:
+        return False
+    try:
+        return _predicate_key(condition) == _predicate_key(expected)
+    except (SyntaxError, ValueError, RecursionError):
+        return False

--- a/evals/pxi/evaluators/tools.py
+++ b/evals/pxi/evaluators/tools.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from phoenix.evals import create_evaluator
 
+from evals.pxi.evaluators.filters import filter_matches
+
 
 def _as_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
@@ -410,6 +412,8 @@ def bash_command_substrings_match(output: Any, expected: Any) -> dict[str, Any]:
 #   passing an empty value are semantically equivalent, e.g. ``tags`` (the save
 #   tool treats an omitted ``tags`` and ``tags: []`` identically), so the agent
 #   may legitimately produce either form.
+# - ``filter_equals: <DSL>`` -- UI condition only: decode a static spansFilter.set
+#   script and compare predicate ASTs, allowing clause order and membership lists.
 # - ``has_keys: [<key>, ...]`` -- observed must be a dict containing every
 #   listed key (presence only -- values are not checked, and nesting below the
 #   top level is not inspected). For object-valued args where the agent fills
@@ -419,6 +423,7 @@ def bash_command_substrings_match(output: Any, expected: Any) -> dict[str, Any]:
 _MATCHER_KEYS: frozenset[str] = frozenset(
     {
         "equals",
+        "filter_equals",
         "contains_all",
         "contains_any",
         "not_contains",
@@ -452,6 +457,9 @@ def _string_list_or_none(value: Any) -> list[str] | None:
 
 def _matcher_value_error(matcher: dict[str, Any]) -> str | None:
     """Validate a matcher dict; return an error string if malformed."""
+    if "filter_equals" in matcher:
+        if not isinstance(matcher["filter_equals"], str) or len(matcher) != 1:
+            return "matcher 'filter_equals' must be a string and used alone"
     if "any" in matcher and matcher["any"] is not True:
         return "matcher 'any' must be true"
     if "non_empty" in matcher and matcher["non_empty"] is not True:
@@ -479,6 +487,8 @@ def _matcher_passes(observed: Any, matcher: dict[str, Any]) -> bool:
     ``observed`` is the literal value pulled from the call's args, or the
     ``_MISSING`` sentinel if the key wasn't present at all.
     """
+    if "filter_equals" in matcher:
+        return False  # Only supported for static spansFilter.set UI scripts.
     if "any" in matcher:
         if observed is _MISSING:
             return False
@@ -625,6 +635,8 @@ def _source_pair_passes(source: str, key: str, expected_value: Any, script: str 
     (``{ key }``) the value is a hoisted variable whose text lives elsewhere
     in the script, so value checks fall back to the whole ``script``.
     """
+    if isinstance(expected_value, dict) and "filter_equals" in expected_value:
+        return key == "condition" and filter_matches(script, expected_value["filter_equals"])
     has_key = _source_has_key(source, key)
     # Where the value's text lives: the argument source for longhand, the
     # whole script for shorthand (hoisted `const key = ...`).

--- a/tests/unit/pxi/evals/test_datasets.py
+++ b/tests/unit/pxi/evals/test_datasets.py
@@ -365,7 +365,9 @@ examples:
 def test_span_id_fixtures_use_matching_otel_span_ids(example_id: str) -> None:
     example = next(e for e in load_dataset("set_spans_filter").examples if e["id"] == example_id)
     query = example["input"]["messages"][0]["content"]
-    condition = example["expected"]["ui_operation_args"]["spansFilter.set"]["condition"]
+    condition = example["expected"]["ui_operation_args"]["spansFilter.set"]["condition"][
+        "filter_equals"
+    ]
     input_ids = re.findall(r"\b[0-9a-f]{16,32}\b", query)
     expected_ids = re.findall(r"\b[0-9a-f]{16,32}\b", condition)
     assert input_ids == expected_ids

--- a/tests/unit/pxi/evals/test_filter_scoring.py
+++ b/tests/unit/pxi/evals/test_filter_scoring.py
@@ -1,0 +1,119 @@
+"""Filter assertions compare decoded predicates, including their boolean structure."""
+
+import json
+
+import pytest
+
+from evals.pxi.evaluators.tools import evaluate_tool_call_args
+from evals.pxi.harness.datasets import load_dataset
+
+
+def _score(example_id: str, script: str) -> float:
+    example = next(e for e in load_dataset("set_spans_filter").examples if e["id"] == example_id)
+    output = {
+        "messages": [
+            {
+                "parts": [
+                    {
+                        "part_kind": "tool-call",
+                        "tool_name": "execute_browser_action",
+                        "args": {"script": script},
+                    }
+                ]
+            }
+        ]
+    }
+    return evaluate_tool_call_args(output, example["expected"])["score"]
+
+
+def _script(condition: str) -> str:
+    return f"return await ui.spansFilter.set({{condition: {json.dumps(condition)}}});"
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "metadata['environment'] == 'prod'",
+        'metadata["environment"] == "prod"',
+    ],
+)
+def test_equivalent_quotes(condition: str) -> None:
+    assert _score("metadata-access", _script(condition)) == 1
+
+
+@pytest.mark.parametrize(
+    "condition, score",
+    [
+        ("span_kind == 'LLM' or span_kind == 'TOOL'", 1),
+        ("span_kind == 'TOOL' or span_kind == 'LLM'", 1),
+        ("span_kind in ('LLM', 'TOOL')", 1),
+        ("span_kind in ['TOOL', 'LLM']", 1),
+        ("span_kind == 'LLM' and span_kind == 'TOOL'", 0),
+        ("span_kind == 'LLM'", 0),
+        ("span_kind in ['LLM', 'TOOL', 'CHAIN']", 0),
+        ("span_kind == 'LLM' or name == 'TOOL'", 0),
+    ],
+)
+def test_or_semantics(condition: str, score: int) -> None:
+    assert _score("llm-or-tool-spans", _script(condition)) == score
+
+
+@pytest.mark.parametrize(
+    "condition, score",
+    [
+        ("parent_id is None and cumulative_token_count.total > 50000", 1),
+        ("cumulative_token_count.total > 50000 and parent_id is None", 1),
+        ("cumulative_token_count.total > 50000", 0),
+        ("parent_id is None or cumulative_token_count.total > 50000", 0),
+    ],
+)
+def test_root_scope(condition: str, score: int) -> None:
+    assert _score("cumulative-tokens-roots", _script(condition)) == score
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        """const condition = "metadata['environment'] == 'prod'"; return await ui.spansFilter.set({condition});""",
+        """// prepare the filter
+    const filter = `metadata["environment"] == "prod"`;
+    const result = await ui.spansFilter.set({ condition: filter }); return result;""",
+        r"""return await ui.spansFilter.set({condition: 'metadata[\'environment\'] == \'prod\''});""",
+        r"""return await ui.spansFilter.set({condition: "metadata['environment'] == '\u0070rod'"});""",
+    ],
+)
+def test_static_script_forms(script: str) -> None:
+    assert _score("metadata-access", script) == 1
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        """// ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"});""",
+        """return "ui.spansFilter.set({condition: metadata['environment'] == 'prod'})";""",
+        """if (false) { return await ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"}); }""",
+        """const condition = "metadata['environment'] == 'prod'"; condition = ""; return await ui.spansFilter.set({condition});""",
+        """const condition = "metadata['environment'] == 'prod'"; return await ui.spansFilter.set({condition: ""});""",
+        """return await ui.spansFilter.set({condition: `${condition}`});""",
+        """const condition = "metadata['environment'] == 'prod'"; return await ui.spansFilter.set({'condition'});""",
+        """const ui = "fake"; return await ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"});""",
+        """return await ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"}); ui.spansFilter.set({condition: ''});""",
+    ],
+)
+def test_unresolved_or_misleading_source_fails_closed(script: str) -> None:
+    assert _score("metadata-access", script) == 0
+
+
+def test_invalid_filter_syntax_fails() -> None:
+    assert _score("metadata-access", _script("metadata['environment'] == 'prod' ???")) == 0
+
+
+def test_result_guard_after_unconditional_call() -> None:
+    script = """const result = await ui.spansFilter.set({condition: "status_code == 'UNSET'"});
+    if (!result.ok) return result;
+    return {condition: "status_code == 'UNSET'"};"""
+    assert _score("status-unset-spans", script) == 1
+
+
+def test_unrequested_root_scope_fails() -> None:
+    assert _score("chain-spans", _script("parent_id is None and span_kind == 'CHAIN'")) == 0

--- a/tests/unit/pxi/evals/test_filter_scoring.py
+++ b/tests/unit/pxi/evals/test_filter_scoring.py
@@ -23,7 +23,7 @@ def _score(example_id: str, script: str) -> float:
             }
         ]
     }
-    return evaluate_tool_call_args(output, example["expected"])["score"]
+    return float(evaluate_tool_call_args(output, example["expected"])["score"])
 
 
 def _script(condition: str) -> str:


### PR DESCRIPTION
Literal source matching rejects equivalent quote spellings and accepts wrong predicates, including `LLM and TOOL` for an OR request and OR in place of required root scoping. Add `filter_equals` to decode a bounded static `spansFilter.set` script and compare DSL ASTs. Migrate exact conditions plus the OR and cumulative-root cases. Clause ordering and equivalent literal membership lists are accepted.

Scripts are never executed. The parser supports literals, const string bindings, comments, static templates, and the recorded UIResult return wrapper. Dynamic expressions, conditional calls, and multiple filter calls fail closed. Other substring matchers retain their existing semantics; this is a bounded scorer repair, not a JavaScript runtime.

Validation: five deterministic failures reproduced before the change; all 30 new scorer cases pass. The focused PXI suite passed 358 tests before the last two wrapper/scope cases were added. Focused Ruff, mypy, and whitespace checks pass. Replaying the 48 recorded filter outputs rejects the known missing-TOOL output and now detects an unrequested root restriction in the CHAIN case. Two old outputs still contain the IDs corrected by the preceding PR; they need fresh runs. The OR retry passes.

Related: #15869. Depends on #16135. No production code, gate thresholds, or splits change.
