### PR TITLE
fix(pxi-evals): accept equivalent in-app link formatting

### DIFF
--- a/evals/pxi/evaluators/links.py
+++ b/evals/pxi/evaluators/links.py
@@ -6,7 +6,8 @@ from urllib.parse import urlparse
 
 from phoenix.evals import create_evaluator
 
-_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s]+)\)")
+_LINK_PADDING = r"[ \t]*(?:\r?\n[ \t]*)?"
+_MARKDOWN_LINK_RE = re.compile(rf"\[[^\]]+\]\({_LINK_PADDING}([^)\s]+){_LINK_PADDING}\)")
 _BARE_URL_RE = re.compile(r"https?://[^\s)]+")
 _LOCAL_APP_HOSTS = {"localhost", "127.0.0.1", "::1"}
 

--- a/evals/pxi/evaluators/links.py
+++ b/evals/pxi/evaluators/links.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from phoenix.evals import create_evaluator
 
@@ -55,13 +55,33 @@ def _bare_urls(text: str, markdown_href_spans: list[tuple[int, int]]) -> list[st
     return urls
 
 
+def _path_segments(path: str) -> tuple[str, ...]:
+    # Decode within segments so an encoded slash cannot change route boundaries.
+    return tuple(unquote(segment) for segment in path.split("/"))
+
+
+def _same_in_app_href(observed: str, expected: str) -> bool:
+    if not _is_root_relative_app_href(observed):
+        return False
+    actual, wanted = urlparse(observed), urlparse(expected)
+    return (
+        _path_segments(actual.path) == _path_segments(wanted.path)
+        and actual.params == wanted.params
+        and actual.query == wanted.query
+        and actual.fragment == wanted.fragment
+    )
+
+
 def _absolute_app_link_reason(href: str, required_paths: list[str]) -> str | None:
     parsed = urlparse(href)
     if parsed.scheme not in {"http", "https"}:
         return None
     if parsed.hostname not in _LOCAL_APP_HOSTS:
         return None
-    if parsed.path in required_paths:
+    if any(
+        _path_segments(parsed.path) == _path_segments(urlparse(path).path)
+        for path in required_paths
+    ):
         return "absolute app link"
     return None
 
@@ -159,7 +179,9 @@ def evaluate_in_app_links(output: Any, expected: Any) -> dict[str, Any]:
 
     hrefs, href_spans = _markdown_href_spans(text)
     bare_urls = _bare_urls(text, href_spans)
-    missing = [path for path in required if path not in hrefs]
+    missing = [
+        path for path in required if not any(_same_in_app_href(href, path) for href in hrefs)
+    ]
     invalid_in_app = _invalid_in_app_hrefs(hrefs, required)
     metadata = {
         "required_in_app": required,

--- a/tests/unit/pxi/evals/test_link_whitespace.py
+++ b/tests/unit/pxi/evals/test_link_whitespace.py
@@ -1,0 +1,25 @@
+"""Regression coverage for CommonMark whitespace around link destinations."""
+
+import pytest
+
+from evals.pxi.evaluators.links import evaluate_in_app_links
+
+
+@pytest.mark.parametrize("padding", [" ", "\t", "\n", " \n\t"])
+def test_destination_padding(padding: str) -> None:
+    result = evaluate_in_app_links(
+        {"assistant_text": f"[Trace]({padding}/redirects/traces/abc{padding})"},
+        {"links": {"required_in_app": ["/redirects/traces/abc"]}},
+    )
+    assert result["score"] == 1
+
+
+@pytest.mark.parametrize(
+    "destination", ["/wrong", "/redirects/traces/a bc", "\n\n/redirects/traces/abc"]
+)
+def test_invalid_destination_does_not_pass(destination: str) -> None:
+    result = evaluate_in_app_links(
+        {"assistant_text": f"[Trace]( {destination} )"},
+        {"links": {"required_in_app": ["/redirects/traces/abc"]}},
+    )
+    assert result["score"] == 0

--- a/tests/unit/pxi/evals/test_link_whitespace.py
+++ b/tests/unit/pxi/evals/test_link_whitespace.py
@@ -23,3 +23,22 @@ def test_invalid_destination_does_not_pass(destination: str) -> None:
         {"links": {"required_in_app": ["/redirects/traces/abc"]}},
     )
     assert result["score"] == 0
+
+
+@pytest.mark.parametrize(
+    "href, score",
+    [
+        ("/projects/UHJvamVjdDo0Nw%3D%3D/traces/abc", 1),
+        ("/projects/UHJvamVjdDo0Nw==/traces/abc", 1),
+        ("/projects/UHJvamVjdDo0Nw%253D%253D/traces/abc", 0),
+        ("/projects/UHJvamVjdDo0Nw%3D%3D%2Ftraces/abc", 0),
+        ("https://localhost/projects/UHJvamVjdDo0Nw%3D%3D/traces/abc", 0),
+        ("/projects/UHJvamVjdDo0Nw%3D%3D/traces/wrong", 0),
+    ],
+)
+def test_encoded_route_parameters(href: str, score: int) -> None:
+    result = evaluate_in_app_links(
+        {"assistant_text": f"[Trace]({href})"},
+        {"links": {"required_in_app": ["/projects/UHJvamVjdDo0Nw==/traces/abc"]}},
+    )
+    assert result["score"] == score


### PR DESCRIPTION
Recorded trace-detail answers use valid forms the scorer rejects: whitespace around a Markdown destination and percent-encoded `=` characters in a Relay resource ID. Accept destination padding and compare decoded path segments while preserving path boundaries, query strings, and fragments. Keep root-relative and bare-URL checks.

Validation: five focused cases reproduced the defects before their fixes. All 95 link/evaluator tests pass, including rejection of wrong IDs, double encoding, encoded route separators, localhost URLs, and whitespace inside destinations. Both historical whitespace outputs and both fresh encoded-ID outputs now pass replay. Targeted Ruff and mypy pass. Syntax reference: https://spec.commonmark.org/0.31.2/#links.

Related: #15869. Depends on #16136. No model, prompt, threshold, or fixture changes.
