### PR TITLE
fix(pxi): clarify skill selection and reference ownership

### DIFF
--- a/src/phoenix/server/agents/prompts/static/context/DATASET_CONTEXT_INSTRUCTIONS.xml
+++ b/src/phoenix/server/agents/prompts/static/context/DATASET_CONTEXT_INSTRUCTIONS.xml
@@ -2,6 +2,7 @@
   <description>This guidance applies when the user is viewing a dataset in the UI or working in a flow bound to one, i.e., when `ui_contexts` has a `dataset` entry. The user may ask you to author an evaluator, sample examples, or otherwise reason about the dataset. `datasetNodeId` scopes queries and links; `datasetVersionNodeId`, when present, is the active version.</description>
   <experiments_methodology>
     Running a prompt over this dataset is implicitly an experiment. Before designing a dataset run or its evaluators — and before reading or comparing experiment results — `load_skill` the `experiments` skill for the iteration methodology if it is not already loaded.
+    A mounted dataset alone does not imply a planned experiment. For standalone evaluator logic or rubric authoring, load `evaluators` directly. Load `experiments` first only when the conversation connects that evaluator to a planned or existing experiment, or asks to run, read, or compare experiment results.
   </experiments_methodology>
   <code_evaluator_authoring>
     <case condition="a codeEvaluator entry is present in ui_contexts">

--- a/src/phoenix/server/mcp/skills/__init__.py
+++ b/src/phoenix/server/mcp/skills/__init__.py
@@ -203,7 +203,13 @@ def register_skill_tools(mcp: FastMCP, skills: Sequence[Skill]) -> None:
     async def load_skill(
         skill_name: Annotated[str, Field(description="Exact name of the skill to load.")],
     ) -> str:
-        return _skill(skill_name).text
+        skill = _skill(skill_name)
+        references = ", ".join(reference.name for reference in skill.references) or "none"
+        return (
+            f"{skill.text}\n\nReferences for {skill.name}: {references}.\n"
+            "Only request references listed for this skill. References from another skill "
+            "require that skill's name, even when the filename matches this skill's topic."
+        )
 
     async def load_skill_reference(
         skill_name: Annotated[str, Field(description="Skill the reference belongs to.")],

--- a/tests/unit/server/mcp/test_skills.py
+++ b/tests/unit/server/mcp/test_skills.py
@@ -70,11 +70,25 @@ class TestAdvertisedInstructions:
 
 
 class TestTools:
-    async def test_load_skill_returns_the_file_verbatim(self) -> None:
+    async def test_load_skill_preserves_the_file_before_the_reference_inventory(self) -> None:
         async with Client(_server(PXI_SKILLS_ROOT)) as client:
             loaded = await _text(client, "load_skill", skill_name="phoenix-graphql")
 
-        assert loaded == (_GRAPHQL_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert loaded.startswith((_GRAPHQL_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8"))
+
+    @pytest.mark.parametrize("skill_name", ["experiments", "phoenix-graphql"])
+    async def test_load_skill_lists_only_its_own_references(self, skill_name: str) -> None:
+        skill = next(skill for skill in load_skills(PXI_SKILLS_ROOTS) if skill.name == skill_name)
+        async with Client(_server(*PXI_SKILLS_ROOTS)) as client:
+            loaded = await _text(client, "load_skill", skill_name=skill_name)
+        inventory = loaded.removeprefix(skill.text)
+        assert f"References for {skill_name}:" in inventory
+        if skill.references:
+            for reference in skill.references:
+                assert reference.name in inventory
+        else:
+            assert "none" in inventory
+            assert "references/experiments.md" not in inventory
 
     async def test_load_skill_reference_returns_the_file(self) -> None:
         async with Client(_server(PXI_SKILLS_ROOT)) as client:


### PR DESCRIPTION
Experiment-result reads repeatedly request `references/experiments.md` from the methodology-only `experiments` skill, although that file belongs to `phoenix-graphql`. Append an inventory derived from each loaded skill's actual references, explicitly showing `none` when appropriate. Preserve the skill file text and keep reference validation unchanged.

Also clarify that a mounted dataset alone does not imply a planned experiment. Standalone evaluator logic/rubric authoring should load `evaluators` directly; experiment-backed authoring still loads `experiments` first.

Validation: 400 focused unit tests pass across the final stack, including MCP reference inventory and real eval-entry-point coverage. Targeted mypy and Ruff pass. In a fresh 155-example regression run, the read-results case used the correct GraphQL reference and four total calls; standalone judge authoring loaded only `evaluators`. The full run plus seven retries passed the existing gate thresholds with no unassessed examples. Remaining link-scoring and repetition misses have separate repairs in this stack.

Related: #15869. Depends on #16138. No eval expectations or thresholds change in this layer.
