### PR TITLE
fix(pxi): ask before changing out-of-range repetition requests

### DIFF
--- a/src/phoenix/server/agents/prompts/static/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml
+++ b/src/phoenix/server/agents/prompts/static/context/PLAYGROUND_CONTEXT_INSTRUCTIONS.xml
@@ -7,6 +7,9 @@
     - Each entry in `instances` is one mounted prompt instance and its current model selection. `model.provider` and `model.modelName` identify the model; `model.type` is `custom` when it comes from a custom provider, which adds `customProviderId` and `customProviderName`. An instance with no `model` key has no model selected yet. `experimentId` is the experiment produced by that instance's last dataset-backed run, when it has produced one.
     - `evaluators` lists the dataset evaluators already on the loaded dataset. An empty `evaluators` array means the dataset has none yet.
   </state_semantics>
+  <repetition_limits>
+    Repetitions must be between 1 and 30. If the user requests a count outside this range, explain the limit and ask for a valid count before changing repetitions or starting a run. Do not silently clamp to 30, choose a replacement count, or split the request into multiple runs.
+  </repetition_limits>
   <guidance>
     The operations below are called from `execute_browser_action` scripts as `await ui.<operation>(input)`; confirm input shapes with `search_browser_actions` before first use, and combine related steps into one small script when that keeps approvals and errors legible.
     Call `ui.playground.prompt.read` before proposing edits to an existing prompt instance, `ui.playground.instance.add` when the user wants a fresh comparison instance that starts from the default prompt messages, `ui.playground.instance.clone` when the user wants a comparison variant that starts from existing prompt content, `ui.playground.instance.remove` when the user asks to delete a specific prompt instance, and `ui.playground.prompt.edit` to show the user an approval diff before changing prompt messages.


### PR DESCRIPTION
When asked to run 50 times, PXI silently substituted the maximum of 30 on both recorded attempts and started a run on the retry. Clarify the playground instructions: explain the 1–30 range and ask for a valid count before changing repetitions or running. Do not clamp the count or split it into multiple runs.

Validation: both failures were reproduced in the full regression run and its gate-selected retry. After this change, all 18 evaluator checks across six live repetition examples pass. The 50-run case explains the limit and offers 30 without invoking tools; valid-count and ordinary-run cases retain their expected actions. The final focused unit suite passes 400 tests, and the previously failing SQLite MCP test passes locally.

Related: #15869. Depends on #16139. Existing example coverage and thresholds are unchanged.

Final whole-stack regression CI: [run 34662856834](https://github.com/Arize-ai/phoenix/actions/runs/34662856834) passes all 155 examples after one CHAIN-filter retry, with zero confirmed misses and zero unassessed examples. All gating cells pass at 1.0 without changing thresholds or retry policy.
