### PR TITLE
fix(evals): repair fixtures for pxi regression evals

### DIFF
--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -715,3 +715,17 @@ coding agent) consume it:
    ```bash
    gh run download <run-id> -n pxi-eval-reports-<run-id>
    ```
+
+### Static filter predicate comparisons
+
+`condition: {filter_equals: "span_kind in ['LLM', 'TOOL']"}` compares a decoded
+`ui.spansFilter.set` condition with a Python DSL AST. It accepts quote and whitespace
+changes, reordered AND/OR clauses, and equivalent literal membership lists. It rejects
+missing or additional predicates and preserves the difference between AND and OR.
+
+This matcher supports a single unconditional operation with a string literal or
+`const` string binding, including shorthand properties, comments, static templates,
+and a UIResult return guard after the call. Dynamic expressions, conditional calls,
+and multiple filter calls fail closed. Scripts are never executed. Other matchers
+retain their existing substring semantics; this is not a complete JavaScript or
+semantic filter evaluator.

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -176,6 +176,14 @@ not-applicable, sampling, and checkpoint behavior relevant to the evaluator.
 
 ## Run Locally
 
+The harness builds the production read-only MCP catalog, including PXI skills,
+and the server-side bash tool. Skills, references, and catalog discovery execute
+normally. Calls to `bash` and MCP `execute` are deferred, just like browser
+actions: these examples score the next requested action without executing it
+against application data. The harness does not start a Phoenix database or
+sandbox worker. Missing backend tools or a missing skill catalog fail before the
+model request and are reported as task errors rather than behavioral misses.
+
 There are two ways to run the evals:
 
 - The **pytest suite** (`pytest evals/pxi -c evals/pxi/pytest.ini`) is what CI

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -604,7 +604,16 @@ content matters. Use `absent: true` when omission itself is the behavior under
 test.
 
 For efficiency-focused examples, add `expected.budgets.max_tool_calls` and
-enable the `tool_call_count_within_limit` evaluator. Bash-first examples can
+enable the `tool_call_count_within_limit` evaluator. When a read-only example
+must allow different setup paths, use `expected.budgets.max_repeated_tool_calls`
+instead. A repeat has the same tool name and JSON arguments as an earlier call
+in the scored output; object-key order and call IDs do not matter. Every call
+after the first matching one counts toward the limit. Distinct skills and
+corrected arguments are not repeats. Both limits apply if both are supplied.
+
+Use a zero-repeat budget only when another identical request would add no new
+information. It is not a replacement for latency or total-cost measurements,
+and it does not detect unnecessary calls with different arguments. Bash-first examples can
 use `bash_command_substrings_match` to check command intent without requiring
 exact shell syntax.
 

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -506,81 +506,75 @@ list through to the Phoenix client upload payload.
 
 ## Inputs
 
-Every example declares `input.messages` as a single ordered conversation
-prefix. The trailing entry decides which step of the agent loop the harness
-scores:
-
-- **Last entry is `role: user`.** That turn becomes the user prompt; everything
-  before it is replayed as message history. The default case -- "user asks,
-  what does the agent do?"
-- **Last entry is `role: tool`.** The harness runs the agent with `user_prompt
-  = None` and the full list as message history, so the agent picks up
-  mid-loop from a primed tool return. Lets a dataset isolate one step of
-  behavior ("given the bash output below, what does the agent emit next?")
-  without a synthetic user follow-up.
-- **Last entry is `role: assistant`.** Rejected -- nothing remains to score.
-
-Examples may also include `input.contexts`, which uses the same camelCase
-shape as the browser agent API (`app`, `project`, `graphql`, etc.) so
-server-side evals can exercise realistic page state without launching
-Playwright.
-
-A plain example -- user asks, agent decides:
+New fixtures should use the public `PhoenixUIMessage` transcript returned by
+`GET /v1/agent_sessions/{session_id}/messages`. This is a stored conversation
+artifact. The chat POST now sends a new message or tool outputs into a server-owned
+session, so a fixture is not a literal POST request body.
 
 ```yaml
 input:
-  contexts:
-    - type: project
-      projectNodeId: UHJvamVjdDoxMg==
-      spanFilter: "status_code == 'ERROR'"
   messages:
-    - role: user
-      content: Keep the error filter, but only show root spans.
+    - id: user-1
+      role: user
+      parts:
+        - type: text
+          text: Keep the error filter, but only show root spans.
+      metadata:
+        phoenix:
+          type: user
+          currentDateTime: "2026-04-03T12:00:00-07:00"
+          timeZone: America/Los_Angeles
+          editPermission: manual
+          uiContexts:
+            project:
+              type: project
+              projectNodeId: UHJvamVjdDoxMg==
+              spanFilter: "status_code == 'ERROR'"
 ```
 
-A primed-tool-history example -- the agent has already issued a `bash` call
-to inspect recent traces, and the harness scores whatever action it emits
-next (typically a `set_spans_filter` call referencing the dates that came
-back in the tool return):
+Completed tool calls and their outputs live together in an assistant part:
 
 ```yaml
-input:
-  contexts:
-    - type: project
-      projectNodeId: UHJvamVjdDoxMg==
-      spanFilter: "span_kind == 'LLM'"
-  messages:
-    - role: user
-      content: Show me only the latest traces in this project.
-    - role: assistant
-      tool_calls:
-        - id: t1
-          name: bash
-          args:
-            command: "phoenix-gql --query '...recent spans by startTime desc...'"
-    - role: tool
-      tool_call_id: t1
-      name: bash
-      content: |
-        {"data":{"node":{"spans":{"edges":[
-          {"node":{"startTime":"2026-04-03T18:42:11Z"}},
-          {"node":{"startTime":"2026-04-03T18:41:58Z"}}
-        ]}}}}
+- id: assistant-1
+  role: assistant
+  parts:
+    - type: tool-search_browser_actions
+      toolCallId: search-1
+      state: output-available
+      input: {query: filter the spans table}
+      output: "<the public browser operation catalog>"
 ```
 
-Schema notes:
+The transcript must end with a user message or a completed tool output. Pending
+calls and approvals are rejected. Use synthetic identifiers and results; do not
+commit private production conversations. Keep each user turn's UI state and
+browser clock in its metadata. The production adapter renders changed state at
+the corresponding turn and preserves structured tool results.
 
-- An assistant turn may carry `content`, `tool_calls`, or both. Real PXI
-  traces show no assistant text between tool calls, so primed-tool examples
-  should omit narration unless you're deliberately testing narration
-  behavior.
-- Each tool call needs a local string `id` (any value; not interpreted by
-  the agent) plus `name` and `args`. Every assistant `tool_calls` entry
-  MUST be followed later by a `role: tool` entry whose `tool_call_id` and
-  `name` match. `tool_call_id` values must be unique across the whole list.
-- Primed messages are fed to the model verbatim via pydantic_ai's message
-  types; the model cannot distinguish a primed tool call from one that
-  was actually executed.
+Existing datasets may retain the compact `role/content/tool_calls` notation.
+The fixture compiler pairs each tool return with its call, validates the result
+as `PhoenixUIMessage`, then uses the same transcript adapter as production.
+Tool `content` may be an object. In particular, `bash` returns `command`,
+`stdout`, `stderr`, `exitCode`, timing, byte counts, and truncation flags. Raw
+GraphQL JSON belongs inside `stdout`, not at the top level of the tool result.
+
+For compact fixtures, `input.contexts` uses the public context union and describes
+the active user turn. Omitted contexts mean no page context. There is no implicit
+project. Do not combine top-level contexts with per-turn stored UI state.
+
+Prefer assertions about public UI operation arguments, resulting filter
+predicates, links, and artifacts. Avoid asserting a particular discovery order
+unless that order is the behavior under test. A catalog excerpt still isolates a
+single step; it does not exercise discovery against the full browser catalog.
+These offline evals stop at deferred actions and cannot prove that a script ran,
+a database query succeeded, or a UI mutation produced the intended state. Browser
+E2E tests cover those outcomes. Script argument extraction and tool-call budgets
+remain implementation-dependent checks and should be used sparingly.
+
+`test_agent_task_inputs.py` validates every fixture through the current public
+message models and production adapter. It also checks primed bash results against
+the shipped result schema. That catches wire-format drift before spending tokens
+on live evals.
 
 ## Matcher Vocabulary
 

--- a/evals/pxi/datasets/experiment_observations.yaml
+++ b/evals/pxi/datasets/experiment_observations.yaml
@@ -210,13 +210,24 @@ examples:
             - id: r1
               name: bash
               args:
+                summary: Read the requested Phoenix data.
                 command: >-
-                  px-graphql 'query { node(id: "RXhwZXJpbWVudDoxMA==") { ... on Experiment { metadata averageRunLatencyMs } } }'
+                  phoenix-gql 'query { node(id: "RXhwZXJpbWVudDoxMA==") { ... on Experiment { metadata averageRunLatencyMs } } }'
         - role: tool
           tool_call_id: r1
           name: bash
-          content: >-
-            {"data":{"node":{"metadata":{},"averageRunLatencyMs":2840}}}
+          content:
+            command: 'phoenix-gql ''query { node(id: "RXhwZXJpbWVudDoxMA==") { ... on Experiment { metadata averageRunLatencyMs } } }'''
+            stdout: '{"data":{"node":{"metadata":{},"averageRunLatencyMs":2840}}}'
+            stderr: ''
+            exitCode: 0
+            durationMs: 1
+            startedAt: '2026-04-03T19:00:00Z'
+            completedAt: '2026-04-03T19:00:00.001Z'
+            stdoutBytes: 60
+            stderrBytes: 0
+            stdoutTruncated: false
+            stderrTruncated: false
         - role: user
           content: >-
             Quality held up but it's noticeably slower on the long inputs — add
@@ -263,14 +274,25 @@ examples:
             - id: r1
               name: bash
               args:
+                summary: Read the requested Phoenix data.
                 command: >-
-                  px-graphql 'query { node(id: "RXhwZXJpbWVudDoyMA==") { ... on Experiment { metadata } } }'
+                  phoenix-gql 'query { node(id: "RXhwZXJpbWVudDoyMA==") { ... on Experiment { metadata } } }'
         - role: tool
           tool_call_id: r1
           name: bash
-          content: >-
-            {"data":{"node":{"metadata":{"hypothesis":"tighter system prompt
-            reduces hedging","changed_variable":"system_prompt","baseline_experiment_id":"RXhwZXJpbWVudDox"}}}}
+          content:
+            command: 'phoenix-gql ''query { node(id: "RXhwZXJpbWVudDoyMA==") { ... on Experiment { metadata } } }'''
+            stdout: |-
+              {"data":{"node":{"metadata":{"hypothesis":"tighter system prompt reduces hedging","changed_variable":"system_prompt","baseline_experiment_id":"RXhwZXJpbWVudDox"}}}}
+            stderr: ''
+            exitCode: 0
+            durationMs: 1
+            startedAt: '2026-04-03T19:00:00Z'
+            completedAt: '2026-04-03T19:00:00.001Z'
+            stdoutBytes: 164
+            stderrBytes: 0
+            stdoutTruncated: false
+            stderrTruncated: false
         - role: user
           content: >-
             The hedging is mostly gone but it now refuses two of the edge cases.

--- a/evals/pxi/datasets/experiment_observations.yaml
+++ b/evals/pxi/datasets/experiment_observations.yaml
@@ -339,12 +339,10 @@ examples:
       ui_operations:
         forbidden: [experiment.patch, playground.experiment.setRecording]
       budgets:
-        # No primed catalog here. Allow experiments methodology + backend
-        # discovery + schema/reference + the deferred read. GraphQL uses
-        # load_skill(experiments), load_skill(phoenix-graphql), its reference,
-        # then bash; MCP uses load_skill(experiments), search, get_schema, execute.
-        # Redundant discovery and failed reference loads still exceed this budget.
-        max_tool_calls: 4
+        # Reading must not write metadata. Distinct skill/reference/discovery
+        # steps vary by backend and page context, so do not require a fixed
+        # setup path. Repeating an identical request still fails this example.
+        max_repeated_tool_calls: 0
     metadata:
       category: negative_read_only
       difficulty: moderate
@@ -368,12 +366,10 @@ examples:
       ui_operations:
         forbidden: [experiment.patch]
       budgets:
-        # No primed catalog here. Allow experiments methodology + backend
-        # discovery + schema/reference + the deferred read. GraphQL uses
-        # load_skill(experiments), load_skill(phoenix-graphql), its reference,
-        # then bash; MCP uses load_skill(experiments), search, get_schema, execute.
-        # Redundant discovery and failed reference loads still exceed this budget.
-        max_tool_calls: 4
+        # Reading must not write metadata. Distinct skill/reference/discovery
+        # steps vary by backend and page context, so do not require a fixed
+        # setup path. Repeating an identical request still fails this example.
+        max_repeated_tool_calls: 0
     metadata:
       category: negative_compare_only
       difficulty: moderate

--- a/evals/pxi/datasets/experiment_observations.yaml
+++ b/evals/pxi/datasets/experiment_observations.yaml
@@ -317,7 +317,12 @@ examples:
       ui_operations:
         forbidden: [experiment.patch, playground.experiment.setRecording]
       budgets:
-        max_tool_calls: 3
+        # No primed catalog here. Allow experiments methodology + backend
+        # discovery + schema/reference + the deferred read. GraphQL uses
+        # load_skill(experiments), load_skill(phoenix-graphql), its reference,
+        # then bash; MCP uses load_skill(experiments), search, get_schema, execute.
+        # Redundant discovery and failed reference loads still exceed this budget.
+        max_tool_calls: 4
     metadata:
       category: negative_read_only
       difficulty: moderate
@@ -341,7 +346,12 @@ examples:
       ui_operations:
         forbidden: [experiment.patch]
       budgets:
-        max_tool_calls: 3
+        # No primed catalog here. Allow experiments methodology + backend
+        # discovery + schema/reference + the deferred read. GraphQL uses
+        # load_skill(experiments), load_skill(phoenix-graphql), its reference,
+        # then bash; MCP uses load_skill(experiments), search, get_schema, execute.
+        # Redundant discovery and failed reference loads still exceed this budget.
+        max_tool_calls: 4
     metadata:
       category: negative_compare_only
       difficulty: moderate

--- a/evals/pxi/datasets/experiments_skill_trigger.yaml
+++ b/evals/pxi/datasets/experiments_skill_trigger.yaml
@@ -283,12 +283,12 @@ examples:
   # tool-agnostic. Variants cover both summary-level and per-run reads.
 
   - id: footprint-three-axis-read
-    # quarantined regression -> dev (2026-08-25): since the browser-action
-    # meta-tools landed, the agent loads the right skills but then drifts to
-    # an execute_browser_action script (which cannot read GraphQL) and gives
-    # up, instead of running the bash phoenix-gql read the skill prescribes.
-    # Reproduced in CI runs 32749407419 + 32865446008 and locally. Real
-    # agent deficiency to investigate, not flake.
+    # Quarantined regression -> dev (2026-08-25). The original failures ran
+    # without bash after the session-persistence migration; attributing them
+    # to production-agent behavior was unsupported. The harness now exposes
+    # both bash and MCP reads. Keep dev-only until the three-axis contract
+    # is verified across supported reads; these bash substrings alone cannot
+    # assess MCP reads or query execution beyond the deferred-action boundary.
     splits: [dev]
     input:
       contexts:
@@ -411,22 +411,23 @@ examples:
         - role: user
           content: What's the average relevance score on my last experiment?
     expected:
-      forbidden_tool_call_args:
+      tools:
+        required: [load_skill]
+      tool_call_args:
         load_skill:
           skill_name: experiments
     metadata:
-      negative: true
-      category: negative_closed_form_read
+      category: experiment_result_read
       difficulty: tricky
-      polarity: negative
+      polarity: positive
       annotation:
         agreement: medium
         n_opinions: 3
         notes: >-
-          Single closed-form statistic answerable with a direct phoenix-gql
-          read; does not need the experiments authoring/iteration methodology.
-          Medium because it mentions an experiment, which sits near the trigger
-          boundary.
+          Reading an experiment score triggers the shipped experiments skill,
+          even for one aggregate. Keep the historical example ID for continuity.
+          DATASET_CONTEXT_INSTRUCTIONS requires the methodology before reading
+          experiment results; this case previously contradicted that policy.
 
   - id: negative-tell-me-about-dataset
     splits: [regression]

--- a/evals/pxi/datasets/in_app_links.yaml
+++ b/evals/pxi/datasets/in_app_links.yaml
@@ -213,12 +213,12 @@ examples:
               name: bash
               args:
                 summary: Read the requested Phoenix data.
-                command: phoenix-gql query.graphql --data-only
+                command: phoenix-gql query.graphql
         - role: tool
           tool_call_id: bash_call
           name: bash
           content:
-            command: phoenix-gql query.graphql --data-only
+            command: phoenix-gql query.graphql
             stdout: |
               {"data":{"node":{"name":"pxi_dev","id":"UHJvamVjdDo0Nw==","spans":{"edges":[{"node":{"name":"pxiAgent Turn","cumulativeTokenCountTotal":617245,"trace":{"id":"VHJhY2U6NDQy","traceId":"66a8042a448b757ed73e3ab80dd83db1"}}}]}}}}
             stderr: ''

--- a/evals/pxi/datasets/in_app_links.yaml
+++ b/evals/pxi/datasets/in_app_links.yaml
@@ -212,12 +212,24 @@ examples:
             - id: bash_call
               name: bash
               args:
+                summary: Read the requested Phoenix data.
                 command: phoenix-gql query.graphql --data-only
         - role: tool
           tool_call_id: bash_call
           name: bash
-          content: |
-            {"data":{"node":{"name":"pxi_dev","id":"UHJvamVjdDo0Nw==","spans":{"edges":[{"node":{"name":"pxiAgent Turn","cumulativeTokenCountTotal":617245,"trace":{"id":"VHJhY2U6NDQy","traceId":"66a8042a448b757ed73e3ab80dd83db1"}}}]}}}}
+          content:
+            command: phoenix-gql query.graphql --data-only
+            stdout: |
+              {"data":{"node":{"name":"pxi_dev","id":"UHJvamVjdDo0Nw==","spans":{"edges":[{"node":{"name":"pxiAgent Turn","cumulativeTokenCountTotal":617245,"trace":{"id":"VHJhY2U6NDQy","traceId":"66a8042a448b757ed73e3ab80dd83db1"}}}]}}}}
+            stderr: ''
+            exitCode: 0
+            durationMs: 1
+            startedAt: '2026-04-03T19:00:00Z'
+            completedAt: '2026-04-03T19:00:00.001Z'
+            stdoutBytes: 225
+            stderrBytes: 0
+            stdoutTruncated: false
+            stderrTruncated: false
     expected:
       tools:
         required: []

--- a/evals/pxi/datasets/set_spans_filter.yaml
+++ b/evals/pxi/datasets/set_spans_filter.yaml
@@ -15,6 +15,10 @@ examples:
   - id: llm-spans
     splits: [regression]
     input:
+      contexts: &project_context
+        - type: project
+          projectNodeId: UHJvamVjdDoxMg==
+          spanFilter: ""
       messages:
         - role: user
           content: Show me only LLM spans.
@@ -98,6 +102,7 @@ examples:
   - id: tool-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter the table to tool spans.
@@ -124,6 +129,7 @@ examples:
   - id: error-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans that errored.
@@ -154,6 +160,7 @@ examples:
     # plausible inverted-threshold failure mode (``latency_ms < 5000``).
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show slow spans taking at least five seconds.
@@ -183,6 +190,7 @@ examples:
     # can emit clauses in either order. Both clauses must appear.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show slow LLM calls taking at least five seconds.
@@ -209,6 +217,7 @@ examples:
   - id: trace-id
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to trace id 8f3c2d1e0a9b4c5d6e7f8091a2b3c4d5.
@@ -235,6 +244,7 @@ examples:
   - id: span-name
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans named retrieve_documents.
@@ -265,6 +275,7 @@ examples:
     # pins the DSL's ``in input.value`` form while allowing quote/spacing drift.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans where the input mentions refund policy.
@@ -292,6 +303,7 @@ examples:
   - id: annotation-label
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans marked hallucinated by the Hallucination annotation.
@@ -318,6 +330,7 @@ examples:
   - id: reset-filter
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Clear the span filter and return to the default root spans view.
@@ -344,6 +357,7 @@ examples:
   - id: chain-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to the chain spans.
@@ -373,6 +387,7 @@ examples:
     # root predicate on its own. Accept either via variants.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me top-level agent traces only.
@@ -400,6 +415,7 @@ examples:
   - id: embedding-spans-lowercase
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: just embeddings pls
@@ -426,6 +442,7 @@ examples:
   - id: status-ok-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show only successful spans.
@@ -452,6 +469,7 @@ examples:
   - id: status-unset-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: show me spans that have no status set
@@ -478,6 +496,7 @@ examples:
   - id: high-prompt-tokens
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: find LLM calls that used more than 10k prompt tokens
@@ -505,6 +524,7 @@ examples:
   - id: cumulative-tokens-roots
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show traces that burned over 50k tokens in total.
@@ -535,6 +555,7 @@ examples:
     # exact string. Literal expectation pins the canonical form.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to spans that started at or after 2025-01-15T00:00:00Z.
@@ -564,6 +585,7 @@ examples:
   - id: span-by-id
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter the spans table to span 7a3f9c2e1b8d4e5f.
@@ -590,6 +612,7 @@ examples:
   - id: children-of-parent
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me direct children of span 7a3f9c2e1b8d4e5f.
@@ -616,6 +639,7 @@ examples:
   - id: annotation-score
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans where the Helpfulness annotation scored above 0.8.
@@ -643,6 +667,7 @@ examples:
   - id: output-substring
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans whose response mentions error code 502.
@@ -669,6 +694,7 @@ examples:
   - id: metadata-access
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to spans tagged with environment 'prod' in metadata.
@@ -695,6 +721,7 @@ examples:
   - id: agent-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me agent spans.
@@ -721,6 +748,7 @@ examples:
   - id: retriever-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to retriever spans only.
@@ -747,6 +775,7 @@ examples:
   - id: not-llm-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me everything that's not an LLM call.
@@ -775,6 +804,7 @@ examples:
     # are free. ``not_contains`` rules out the inverted ``latency_ms >`` form.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to spans under 100ms latency.
@@ -804,6 +834,7 @@ examples:
     # Historical substring matching accepted an impossible AND of both kinds.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me LLM or tool calls.
@@ -830,6 +861,7 @@ examples:
   - id: high-completion-tokens
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Find LLM calls that produced more than 2000 completion tokens.
@@ -857,6 +889,7 @@ examples:
   - id: ended-before-timestamp
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans that ended before 2025-01-15T12:00:00Z.
@@ -883,6 +916,7 @@ examples:
   - id: status-message-substring
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter to spans whose status message mentions 'timeout'.
@@ -909,6 +943,7 @@ examples:
   - id: attribute-path-access
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show spans where attribute 'user.id' equals 'alice'.
@@ -935,6 +970,7 @@ examples:
   - id: three-clause-conjunction
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show errored LLM calls slower than 3 seconds.
@@ -965,6 +1001,7 @@ examples:
     # downward-bounded latency clause counts.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: show me fast spans
@@ -992,6 +1029,7 @@ examples:
   - id: ambiguous-tools-or-retrievers
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: show me tool or retriever spans only
@@ -1020,6 +1058,7 @@ examples:
   - id: ambiguous-not-tool-spans
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: show me everything except tool calls
@@ -1048,6 +1087,7 @@ examples:
   - id: negative-greeting
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: hey, what's up?
@@ -1062,6 +1102,7 @@ examples:
   - id: negative-capabilities-question
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: what can you do?
@@ -1076,6 +1117,7 @@ examples:
   - id: negative-thanks
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: thanks!
@@ -1093,6 +1135,7 @@ examples:
     # expected to stage timeRange.set and must not touch the spans filter.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me only the last hour.
@@ -1117,6 +1160,7 @@ examples:
   - id: negative-clone-prompt-intent
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Clone the current prompt please.
@@ -1131,6 +1175,7 @@ examples:
   - id: negative-how-to-question
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: How do I create a new dataset?
@@ -1145,6 +1190,7 @@ examples:
   - id: negative-summarize-ask
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Summarize what we see in the spans table right now.
@@ -1159,6 +1205,7 @@ examples:
   - id: negative-diagnosis-question
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Is there a problem with my project?
@@ -1173,6 +1220,7 @@ examples:
   - id: negative-definitional-question
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Explain what span kinds mean.
@@ -1187,6 +1235,7 @@ examples:
   - id: negative-debug-advice
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: I think my agent is too slow, what should I do?
@@ -1201,6 +1250,7 @@ examples:
   - id: negative-average-latency
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: what's the average latency?
@@ -1215,6 +1265,7 @@ examples:
   - id: negative-delete-trace
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: delete this trace
@@ -1237,8 +1288,6 @@ examples:
         - type: app
           currentDateTime: "2026-05-18T14:43:38-07:00"
           timeZone: America/Los_Angeles
-        - type: graphql
-          mutationsEnabled: false
         - type: project
           projectNodeId: UHJvamVjdDoxMg==
           spanFilter: "span_kind == 'LLM'"
@@ -1259,6 +1308,7 @@ examples:
             - id: t1
               name: bash
               args:
+                summary: Read the requested Phoenix data.
                 command: >-
                   phoenix-gql '{ node(id: "UHJvamVjdDoxMg==") { ... on Project
                   { spans(first: 5, rootSpansOnly: true, sort: {col: startTime,
@@ -1266,14 +1316,26 @@ examples:
         - role: tool
           tool_call_id: t1
           name: bash
-          content: |
-            {"data":{"node":{"spans":{"edges":[
-              {"node":{"startTime":"2026-04-03T18:42:11Z"}},
-              {"node":{"startTime":"2026-04-03T18:41:58Z"}},
-              {"node":{"startTime":"2026-04-03T17:55:02Z"}},
-              {"node":{"startTime":"2026-04-03T17:12:30Z"}},
-              {"node":{"startTime":"2026-04-03T16:48:14Z"}}
-            ]}}}}
+          content:
+            command: |-
+              phoenix-gql '{ node(id: "UHJvamVjdDoxMg==") { ... on Project { spans(first: 5, rootSpansOnly: true, sort: {col: startTime, dir: desc}) { edges { node { startTime } } } } } }'
+            stdout: |
+              {"data":{"node":{"spans":{"edges":[
+                {"node":{"startTime":"2026-04-03T18:42:11Z"}},
+                {"node":{"startTime":"2026-04-03T18:41:58Z"}},
+                {"node":{"startTime":"2026-04-03T17:55:02Z"}},
+                {"node":{"startTime":"2026-04-03T17:12:30Z"}},
+                {"node":{"startTime":"2026-04-03T16:48:14Z"}}
+              ]}}}}
+            stderr: ''
+            exitCode: 0
+            durationMs: 1
+            startedAt: '2026-04-03T19:00:00Z'
+            completedAt: '2026-04-03T19:00:00.001Z'
+            stdoutBytes: 286
+            stderrBytes: 0
+            stdoutTruncated: false
+            stderrTruncated: false
     expected:
       tools:
         forbidden: [bash, ask_user, query_docs_filesystem_phoenix, search_phoenix]
@@ -1300,8 +1362,6 @@ examples:
         - type: app
           currentDateTime: "2026-05-18T15:02:00-07:00"
           timeZone: America/Los_Angeles
-        - type: graphql
-          mutationsEnabled: false
         - type: project
           projectNodeId: UHJvamVjdDoxMg==
           spanFilter: ""
@@ -1322,6 +1382,7 @@ examples:
             - id: t1
               name: bash
               args:
+                summary: Read the requested Phoenix data.
                 command: >-
                   phoenix-gql '{ node(id: "UHJvamVjdDoxMg==") { ... on Project {
                   p50: spanLatencyMsQuantile(probability: 0.5, filterCondition:
@@ -1333,13 +1394,25 @@ examples:
         - role: tool
           tool_call_id: t1
           name: bash
-          content: |
-            {"data":{"node":{
-              "p50": 312,
-              "p90": 1840,
-              "p95": 3210,
-              "p99": 8420
-            }}}
+          content:
+            command: |-
+              phoenix-gql '{ node(id: "UHJvamVjdDoxMg==") { ... on Project { p50: spanLatencyMsQuantile(probability: 0.5, filterCondition: "span_kind == ''LLM''") p90: spanLatencyMsQuantile(probability: 0.9, filterCondition: "span_kind == ''LLM''") p95: spanLatencyMsQuantile(probability: 0.95, filterCondition: "span_kind == ''LLM''") p99: spanLatencyMsQuantile(probability: 0.99, filterCondition: "span_kind == ''LLM''") } } }'
+            stdout: |
+              {"data":{"node":{
+                "p50": 312,
+                "p90": 1840,
+                "p95": 3210,
+                "p99": 8420
+              }}}
+            stderr: ''
+            exitCode: 0
+            durationMs: 1
+            startedAt: '2026-04-03T19:00:00Z'
+            completedAt: '2026-04-03T19:00:00.001Z'
+            stdoutBytes: 80
+            stderrBytes: 0
+            stdoutTruncated: false
+            stderrTruncated: false
     expected:
       tools:
         forbidden: [ask_user, query_docs_filesystem_phoenix, search_phoenix]
@@ -1362,8 +1435,6 @@ examples:
         - type: app
           currentDateTime: "2026-05-18T14:45:12-07:00"
           timeZone: America/Los_Angeles
-        - type: graphql
-          mutationsEnabled: false
         - type: project
           projectNodeId: UHJvamVjdDoxMg==
           spanFilter: "status_code == 'ERROR'"

--- a/evals/pxi/datasets/set_spans_filter.yaml
+++ b/evals/pxi/datasets/set_spans_filter.yaml
@@ -89,7 +89,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'LLM'
+          condition:
+            filter_equals: span_kind == 'LLM'
     metadata:
       annotation:
         agreement: high
@@ -114,7 +115,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'TOOL'
+          condition:
+            filter_equals: span_kind == 'TOOL'
     metadata:
       annotation:
         agreement: high
@@ -139,7 +141,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: status_code == 'ERROR'
+          condition:
+            filter_equals: status_code == 'ERROR'
     metadata:
       annotation:
         agreement: high
@@ -223,7 +226,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: trace_id == '8f3c2d1e0a9b4c5d6e7f8091a2b3c4d5'
+          condition:
+            filter_equals: trace_id == '8f3c2d1e0a9b4c5d6e7f8091a2b3c4d5'
     metadata:
       annotation:
         agreement: high
@@ -248,7 +252,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: name == 'retrieve_documents'
+          condition:
+            filter_equals: name == 'retrieve_documents'
     metadata:
       annotation:
         agreement: high
@@ -304,7 +309,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: annotations['Hallucination'].label == 'hallucinated'
+          condition:
+            filter_equals: annotations['Hallucination'].label == 'hallucinated'
     metadata:
       annotation:
         agreement: high
@@ -329,7 +335,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: parent_id is None
+          condition:
+            filter_equals: parent_id is None
     metadata:
       annotation:
         agreement: high
@@ -354,7 +361,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'CHAIN'
+          condition:
+            filter_equals: span_kind == 'CHAIN'
     metadata:
       annotation:
         agreement: high
@@ -409,7 +417,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'EMBEDDING'
+          condition:
+            filter_equals: span_kind == 'EMBEDDING'
     metadata:
       annotation:
         agreement: high
@@ -434,7 +443,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: status_code == 'OK'
+          condition:
+            filter_equals: status_code == 'OK'
     metadata:
       annotation:
         agreement: high
@@ -459,7 +469,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: status_code == 'UNSET'
+          condition:
+            filter_equals: status_code == 'UNSET'
     metadata:
       annotation:
         agreement: high
@@ -511,10 +522,10 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition:
-            contains_all:
-              ["cumulative_token_count.total", "50000", "parent_id is None"]
-            not_contains: ["cumulative_token_count.total < ", "cumulative_token_count.total <= "]
+          - condition:
+              filter_equals: parent_id is None and cumulative_token_count.total > 50000
+          - condition:
+              filter_equals: parent_id is None and cumulative_token_count.total >= 50000
     metadata:
       annotation:
         agreement: high
@@ -541,7 +552,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: start_time >= '2025-01-15T00:00:00Z'
+          condition:
+            filter_equals: start_time >= '2025-01-15T00:00:00Z'
     metadata:
       annotation:
         agreement: medium
@@ -569,7 +581,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_id == '7a3f9c2e1b8d4e5f'
+          condition:
+            filter_equals: span_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: medium
@@ -594,7 +607,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: parent_id == '7a3f9c2e1b8d4e5f'
+          condition:
+            filter_equals: parent_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: high
@@ -672,7 +686,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: metadata['environment'] == 'prod'
+          condition:
+            filter_equals: metadata['environment'] == 'prod'
     metadata:
       annotation:
         agreement: medium
@@ -697,7 +712,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'AGENT'
+          condition:
+            filter_equals: span_kind == 'AGENT'
     metadata:
       annotation:
         agreement: high
@@ -722,7 +738,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind == 'RETRIEVER'
+          condition:
+            filter_equals: span_kind == 'RETRIEVER'
     metadata:
       annotation:
         agreement: high
@@ -747,7 +764,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind != 'LLM'
+          condition:
+            filter_equals: span_kind != 'LLM'
     metadata:
       annotation:
         agreement: medium
@@ -782,9 +800,8 @@ examples:
         agreement: high
         n_opinions: 3
   - id: llm-or-tool-spans
-    # OR semantics: ``contains_all`` of just the literal values matches both
-    # ``span_kind == 'LLM' or span_kind == 'TOOL'`` and the equivalent
-    # ``span_kind in ('LLM', 'TOOL')`` form the parser accepts.
+    # Compare the full predicate, accepting both membership and OR clauses.
+    # Historical substring matching accepted an impossible AND of both kinds.
     splits: [regression]
     input:
       messages:
@@ -805,8 +822,7 @@ examples:
       ui_operation_args:
         spansFilter.set:
           condition:
-            contains_all: ["LLM", "TOOL"]
-            not_contains: ["!=", "not_in", "not in"]
+            filter_equals: span_kind in ['LLM', 'TOOL']
     metadata:
       annotation:
         agreement: high
@@ -858,7 +874,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: end_time < '2025-01-15T12:00:00Z'
+          condition:
+            filter_equals: end_time < '2025-01-15T12:00:00Z'
     metadata:
       annotation:
         agreement: high
@@ -909,7 +926,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: attributes['user.id'] == 'alice'
+          condition:
+            filter_equals: attributes['user.id'] == 'alice'
     metadata:
       annotation:
         agreement: high
@@ -992,8 +1010,7 @@ examples:
       ui_operation_args:
         spansFilter.set:
           condition:
-            contains_all: ["TOOL", "RETRIEVER"]
-            not_contains: ["!=", "not_in", "not in"]
+            filter_equals: span_kind in ['TOOL', 'RETRIEVER']
     metadata:
       annotation:
         agreement: medium
@@ -1020,7 +1037,8 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_kind != 'TOOL'
+          condition:
+            filter_equals: span_kind != 'TOOL'
     metadata:
       annotation:
         agreement: high

--- a/evals/pxi/datasets/set_spans_filter.yaml
+++ b/evals/pxi/datasets/set_spans_filter.yaml
@@ -554,7 +554,7 @@ examples:
     input:
       messages:
         - role: user
-          content: Filter the spans table to span 7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b.
+          content: Filter the spans table to span 7a3f9c2e1b8d4e5f.
         - role: assistant
           tool_calls:
             - id: search-ops
@@ -569,7 +569,7 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: span_id == '7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b'
+          condition: span_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: medium
@@ -579,7 +579,7 @@ examples:
     input:
       messages:
         - role: user
-          content: Show me direct children of span 7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b.
+          content: Show me direct children of span 7a3f9c2e1b8d4e5f.
         - role: assistant
           tool_calls:
             - id: search-ops
@@ -594,7 +594,7 @@ examples:
         required: [spansFilter.set]
       ui_operation_args:
         spansFilter.set:
-          condition: parent_id == '7a3f9c2e1b8d4e5f6a7b8c9d0e1f2a3b'
+          condition: parent_id == '7a3f9c2e1b8d4e5f'
     metadata:
       annotation:
         agreement: high

--- a/evals/pxi/datasets/set_time_range.yaml
+++ b/evals/pxi/datasets/set_time_range.yaml
@@ -14,6 +14,10 @@ examples:
   - id: preset-15m
     splits: [regression]
     input:
+      contexts: &project_context
+        - type: project
+          projectNodeId: UHJvamVjdDoxMg==
+          spanFilter: ""
       messages:
         - role: user
           content: Show me just the last 15 minutes.
@@ -93,6 +97,7 @@ examples:
   - id: preset-1h
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Filter this view to the last hour.
@@ -115,6 +120,7 @@ examples:
   - id: preset-12h
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: past 12 hrs only
@@ -137,6 +143,7 @@ examples:
   - id: preset-1d
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: I want the last 24 hours of traces.
@@ -159,6 +166,7 @@ examples:
   - id: preset-7d
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Can you set the range to the past week?
@@ -181,6 +189,7 @@ examples:
   - id: preset-30d
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: zoom out to the last month
@@ -203,6 +212,7 @@ examples:
   - id: custom-explicit-utc-range
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Set the range from 2025-01-01T00:00:00Z to 2025-01-31T23:59:59Z.
@@ -227,6 +237,7 @@ examples:
   - id: custom-explicit-offset-range
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show traces between 2025-03-10T08:30:00-07:00 and 2025-03-10T11:00:00-07:00.
@@ -254,6 +265,7 @@ examples:
     # unconstrained via subset semantics.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Everything until 2025-04-01T00:00:00Z.
@@ -277,6 +289,7 @@ examples:
   - id: custom-open-end
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show traces since 2025-04-01T09:00:00Z.
@@ -309,6 +322,7 @@ examples:
     # belong in the regression gate.
     splits: [dev]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: I need traces from January 15, 2025.
@@ -337,6 +351,7 @@ examples:
     # Accept either via variants.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: just show today
@@ -361,6 +376,7 @@ examples:
     # "Recent" has no canonical window; accept any short preset.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: focus on recent traces
@@ -387,6 +403,7 @@ examples:
     # global time range. The primed catalog carries both operations.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Show me only LLM spans.
@@ -408,6 +425,7 @@ examples:
   - id: negative-latency-filter
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: only spans that took more than five seconds
@@ -431,6 +449,7 @@ examples:
     # fresh turn; whatever the agent does, it must not touch the time range.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Clone the current prompt so I can compare a shorter version.
@@ -442,6 +461,7 @@ examples:
   - id: negative-read-current-prompt
     splits: [dev]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: What's in prompt A right now?
@@ -454,6 +474,7 @@ examples:
     # Asks for analysis of span latency, not the time range selector.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: Which span took the longest time to complete?
@@ -467,6 +488,7 @@ examples:
     # changed.
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: What does the time range selector do?
@@ -478,6 +500,7 @@ examples:
   - id: negative-greeting
     splits: [dev]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: hey, what can you help me with?
@@ -489,6 +512,7 @@ examples:
   - id: negative-thanks
     splits: [regression]
     input:
+      contexts: *project_context
       messages:
         - role: user
           content: thanks!
@@ -511,8 +535,6 @@ examples:
         - type: app
           currentDateTime: "2026-05-18T14:30:00-07:00"
           timeZone: America/Los_Angeles
-        - type: graphql
-          mutationsEnabled: false
         - type: project
           projectNodeId: UHJvamVjdDoxMg==
           spanFilter: parent_id is None
@@ -557,8 +579,6 @@ examples:
         - type: app
           currentDateTime: "2026-05-18T14:44:02-07:00"
           timeZone: America/Los_Angeles
-        - type: graphql
-          mutationsEnabled: false
         - type: project
           projectNodeId: UHJvamVjdDoxMg==
           spanFilter: parent_id is None
@@ -570,6 +590,7 @@ examples:
             - id: t1
               name: bash
               args:
+                summary: Read the requested Phoenix data.
                 command: >-
                   phoenix-gql '{ node(id: "UHJvamVjdDoxMg==") { ... on Project
                   { spans(first: 5, rootSpansOnly: true, sort: {col: startTime,
@@ -577,14 +598,26 @@ examples:
         - role: tool
           tool_call_id: t1
           name: bash
-          content: |
-            {"data":{"node":{"spans":{"edges":[
-              {"node":{"startTime":"2026-04-03T18:42:11Z"}},
-              {"node":{"startTime":"2026-04-03T18:41:58Z"}},
-              {"node":{"startTime":"2026-04-03T17:55:02Z"}},
-              {"node":{"startTime":"2026-04-03T17:12:30Z"}},
-              {"node":{"startTime":"2026-04-03T16:48:14Z"}}
-            ]}}}}
+          content:
+            command: |-
+              phoenix-gql '{ node(id: "UHJvamVjdDoxMg==") { ... on Project { spans(first: 5, rootSpansOnly: true, sort: {col: startTime, dir: desc}) { edges { node { startTime } } } } } }'
+            stdout: |
+              {"data":{"node":{"spans":{"edges":[
+                {"node":{"startTime":"2026-04-03T18:42:11Z"}},
+                {"node":{"startTime":"2026-04-03T18:41:58Z"}},
+                {"node":{"startTime":"2026-04-03T17:55:02Z"}},
+                {"node":{"startTime":"2026-04-03T17:12:30Z"}},
+                {"node":{"startTime":"2026-04-03T16:48:14Z"}}
+              ]}}}}
+            stderr: ''
+            exitCode: 0
+            durationMs: 1
+            startedAt: '2026-04-03T19:00:00Z'
+            completedAt: '2026-04-03T19:00:00.001Z'
+            stdoutBytes: 286
+            stderrBytes: 0
+            stdoutTruncated: false
+            stderrTruncated: false
         - role: user
           content: Set the time filter to that day so the table shows only those traces.
         - role: assistant

--- a/evals/pxi/evaluators/filters.py
+++ b/evals/pxi/evaluators/filters.py
@@ -1,0 +1,142 @@
+"""Decode static filter scripts and compare predicate structure without executing code."""
+
+from __future__ import annotations
+
+import ast
+import re
+
+_STRING = r"""(?:"(?:[^"\\\r\n]|\\.)*"|'(?:[^'\\\r\n]|\\.)*'|`(?:[^`\\]|\\.)*`)"""
+_IDENTIFIER = r"[A-Za-z_$][\w$]*"
+_COMMENT_OR_STRING = re.compile(rf"({_STRING})|//[^\n]*|/\*[\s\S]*?\*/")
+_BINDING = re.compile(rf"\s*const\s+({_IDENTIFIER})\s*=\s*({_STRING})\s*;")
+_CALL = re.compile(
+    rf"\s*(?:const\s+(?P<result>{_IDENTIFIER})\s*=\s*|return\s+)?"
+    rf"(?:await\s+)?ui\.spansFilter\.set\s*\(\s*\{{\s*"
+    rf"(?:condition|\"condition\"|'condition')\s*(?::\s*(?P<value>{_STRING}|{_IDENTIFIER}))?"
+    rf"\s*,?\s*\}}\s*\)\s*;?\s*(?P<tail>[\s\S]*)"
+)
+
+
+def _decode_string(source: str) -> str:
+    if source.startswith("`") and "${" in source:
+        raise ValueError("Interpolated templates are not static")
+    escapes = {"n": "\n", "r": "\r", "t": "\t", "b": "\b", "f": "\f", "v": "\v"}
+
+    def decode(match: re.Match[str]) -> str:
+        escape = match.group(1)
+        if escape.startswith(("u", "x")):
+            return chr(int(escape[1:], 16))
+        if escape in escapes:
+            return escapes[escape]
+        if escape in "\\/'\"`":
+            return escape
+        raise ValueError("Unsupported JavaScript escape")
+
+    return re.sub(r"\\(u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])", decode, source[1:-1])
+
+
+def static_filter_condition(script: str) -> str | None:
+    """Read a literal or const-bound condition from one straight-line filter call.
+
+    Comments, quote styles, const string bindings, and a UIResult return guard
+    after the call are supported. Conditional calls, interpolation, reassignment,
+    and multiple calls fail closed. This deliberately
+    does not implement a JavaScript runtime or infer values from source substrings.
+    """
+    if len(script) > 32_768:
+        return None
+    source = _COMMENT_OR_STRING.sub(lambda match: match.group(1) or " ", script)
+    bindings: dict[str, str] = {}
+    try:
+        while match := _BINDING.match(source):
+            name, value = match.groups()
+            if name in bindings or name == "ui":
+                return None
+            bindings[name] = _decode_string(value)
+            source = source[match.end() :]
+        call = _CALL.fullmatch(source)
+        if call is None:
+            return None
+        result = call["result"]
+        if result in bindings or result == "ui":
+            return None
+        tail = call["tail"].strip()
+        if tail:
+            if result is None:
+                return None
+            result_name = re.escape(result)
+            # A common wrapper returns a failed UIResult, otherwise the condition.
+            # Both branches follow the unconditional operation; neither adds calls.
+            return_value = rf"(?:{result_name}|\{{\s*condition\s*:\s*{_STRING}\s*,?\s*\}})"
+            tail_pattern = (
+                rf"(?:if\s*\(\s*!{result_name}\.ok\s*\)\s*return\s+{result_name}\s*;\s*)?"
+                rf"return\s+{return_value}\s*;?"
+            )
+            if re.fullmatch(tail_pattern, tail) is None:
+                return None
+        if call["value"] is None and re.search(r"[\"']condition[\"']", source):
+            return None
+        value = call["value"] or "condition"
+        return _decode_string(value) if value[0] in "'\"`" else bindings.get(value)
+    except ValueError:
+        return None
+
+
+class _CanonicalPredicate(ast.NodeTransformer):
+    def visit_Compare(self, node: ast.Compare) -> ast.AST:
+        visited = self.generic_visit(node)
+        assert isinstance(visited, ast.Compare)
+        node = visited
+        if (
+            len(node.ops) == 1
+            and isinstance(node.ops[0], ast.In)
+            and isinstance(node.comparators[0], (ast.List, ast.Tuple, ast.Set))
+            and node.comparators[0].elts
+            and all(isinstance(item, ast.Constant) for item in node.comparators[0].elts)
+        ):
+            expanded = self.visit(
+                ast.BoolOp(
+                    op=ast.Or(),
+                    values=[
+                        ast.Compare(left=node.left, ops=[ast.Eq()], comparators=[item])
+                        for item in node.comparators[0].elts
+                    ],
+                )
+            )
+            assert isinstance(expanded, ast.AST)
+            return expanded
+        return node
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> ast.AST:
+        values: list[ast.expr] = []
+        for value in node.values:
+            value = self.visit(value)
+            if isinstance(value, ast.BoolOp) and type(value.op) is type(node.op):
+                values.extend(value.values)
+            else:
+                values.append(value)
+        unique = {ast.dump(value): value for value in values}
+        ordered = [unique[key] for key in sorted(unique)]
+        return ordered[0] if len(ordered) == 1 else ast.BoolOp(op=node.op, values=ordered)
+
+
+def _predicate_key(condition: str) -> str:
+    if len(condition) > 16_384:
+        raise ValueError("Filter exceeds parser limit")
+    if not condition.strip():
+        return ""
+    tree = ast.parse(condition.strip(), mode="eval")
+    if sum(1 for _ in ast.walk(tree)) > 512:
+        raise ValueError("Filter exceeds AST limit")
+    return ast.dump(_CanonicalPredicate().visit(tree), include_attributes=False)
+
+
+def filter_matches(script: str, expected: str) -> bool:
+    """Compare decoded DSL ASTs, allowing clause order and literal membership lists."""
+    condition = static_filter_condition(script)
+    if condition is None:
+        return False
+    try:
+        return _predicate_key(condition) == _predicate_key(expected)
+    except (SyntaxError, ValueError, RecursionError):
+        return False

--- a/evals/pxi/evaluators/links.py
+++ b/evals/pxi/evaluators/links.py
@@ -6,7 +6,8 @@ from urllib.parse import urlparse
 
 from phoenix.evals import create_evaluator
 
-_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s]+)\)")
+_LINK_PADDING = r"[ \t]*(?:\r?\n[ \t]*)?"
+_MARKDOWN_LINK_RE = re.compile(rf"\[[^\]]+\]\({_LINK_PADDING}([^)\s]+){_LINK_PADDING}\)")
 _BARE_URL_RE = re.compile(r"https?://[^\s)]+")
 _LOCAL_APP_HOSTS = {"localhost", "127.0.0.1", "::1"}
 

--- a/evals/pxi/evaluators/links.py
+++ b/evals/pxi/evaluators/links.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from phoenix.evals import create_evaluator
 
@@ -55,13 +55,33 @@ def _bare_urls(text: str, markdown_href_spans: list[tuple[int, int]]) -> list[st
     return urls
 
 
+def _path_segments(path: str) -> tuple[str, ...]:
+    # Decode within segments so an encoded slash cannot change route boundaries.
+    return tuple(unquote(segment) for segment in path.split("/"))
+
+
+def _same_in_app_href(observed: str, expected: str) -> bool:
+    if not _is_root_relative_app_href(observed):
+        return False
+    actual, wanted = urlparse(observed), urlparse(expected)
+    return (
+        _path_segments(actual.path) == _path_segments(wanted.path)
+        and actual.params == wanted.params
+        and actual.query == wanted.query
+        and actual.fragment == wanted.fragment
+    )
+
+
 def _absolute_app_link_reason(href: str, required_paths: list[str]) -> str | None:
     parsed = urlparse(href)
     if parsed.scheme not in {"http", "https"}:
         return None
     if parsed.hostname not in _LOCAL_APP_HOSTS:
         return None
-    if parsed.path in required_paths:
+    if any(
+        _path_segments(parsed.path) == _path_segments(urlparse(path).path)
+        for path in required_paths
+    ):
         return "absolute app link"
     return None
 
@@ -159,7 +179,9 @@ def evaluate_in_app_links(output: Any, expected: Any) -> dict[str, Any]:
 
     hrefs, href_spans = _markdown_href_spans(text)
     bare_urls = _bare_urls(text, href_spans)
-    missing = [path for path in required if path not in hrefs]
+    missing = [
+        path for path in required if not any(_same_in_app_href(href, path) for href in hrefs)
+    ]
     invalid_in_app = _invalid_in_app_hrefs(hrefs, required)
     metadata = {
         "required_in_app": required,

--- a/evals/pxi/evaluators/tools.py
+++ b/evals/pxi/evaluators/tools.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from phoenix.evals import create_evaluator
 
+from evals.pxi.evaluators.filters import filter_matches
+
 
 def _as_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
@@ -410,6 +412,8 @@ def bash_command_substrings_match(output: Any, expected: Any) -> dict[str, Any]:
 #   passing an empty value are semantically equivalent, e.g. ``tags`` (the save
 #   tool treats an omitted ``tags`` and ``tags: []`` identically), so the agent
 #   may legitimately produce either form.
+# - ``filter_equals: <DSL>`` -- UI condition only: decode a static spansFilter.set
+#   script and compare predicate ASTs, allowing clause order and membership lists.
 # - ``has_keys: [<key>, ...]`` -- observed must be a dict containing every
 #   listed key (presence only -- values are not checked, and nesting below the
 #   top level is not inspected). For object-valued args where the agent fills
@@ -419,6 +423,7 @@ def bash_command_substrings_match(output: Any, expected: Any) -> dict[str, Any]:
 _MATCHER_KEYS: frozenset[str] = frozenset(
     {
         "equals",
+        "filter_equals",
         "contains_all",
         "contains_any",
         "not_contains",
@@ -452,6 +457,9 @@ def _string_list_or_none(value: Any) -> list[str] | None:
 
 def _matcher_value_error(matcher: dict[str, Any]) -> str | None:
     """Validate a matcher dict; return an error string if malformed."""
+    if "filter_equals" in matcher:
+        if not isinstance(matcher["filter_equals"], str) or len(matcher) != 1:
+            return "matcher 'filter_equals' must be a string and used alone"
     if "any" in matcher and matcher["any"] is not True:
         return "matcher 'any' must be true"
     if "non_empty" in matcher and matcher["non_empty"] is not True:
@@ -479,6 +487,8 @@ def _matcher_passes(observed: Any, matcher: dict[str, Any]) -> bool:
     ``observed`` is the literal value pulled from the call's args, or the
     ``_MISSING`` sentinel if the key wasn't present at all.
     """
+    if "filter_equals" in matcher:
+        return False  # Only supported for static spansFilter.set UI scripts.
     if "any" in matcher:
         if observed is _MISSING:
             return False
@@ -625,6 +635,8 @@ def _source_pair_passes(source: str, key: str, expected_value: Any, script: str 
     (``{ key }``) the value is a hoisted variable whose text lives elsewhere
     in the script, so value checks fall back to the whole ``script``.
     """
+    if isinstance(expected_value, dict) and "filter_equals" in expected_value:
+        return key == "condition" and filter_matches(script, expected_value["filter_equals"])
     has_key = _source_has_key(source, key)
     # Where the value's text lives: the argument source for longhand, the
     # whole script for shorthand (hoisted `const key = ...`).

--- a/evals/pxi/evaluators/tools.py
+++ b/evals/pxi/evaluators/tools.py
@@ -256,29 +256,47 @@ def evaluate_tools_called(output: Any, expected: Any) -> dict[str, Any]:
 
 
 def evaluate_tool_call_count(output: Any, expected: Any) -> dict[str, Any]:
-    """Evaluate the number of tool calls against ``expected.budgets.max_tool_calls``.
+    """Apply optional limits to total calls or repeated name/argument pairs.
 
-    Missing budget expectations pass so the evaluator can be enabled for a
-    whole dataset while only scoring examples that opt into a budget.
+    Repeat limits suit next-action, read-only examples where distinct setup
+    steps are valid but repeating the same request supplies no new information.
+    They do not measure overall efficiency or successful tool execution.
     """
-    max_tool_calls = _expected_budgets(expected).get("max_tool_calls")
-    if max_tool_calls is None:
-        return _success()
-    if not isinstance(max_tool_calls, int) or max_tool_calls < 0:
+    budgets = _expected_budgets(expected)
+    max_tool_calls = budgets.get("max_tool_calls")
+    max_repeated = budgets.get("max_repeated_tool_calls")
+    for key, value in (
+        ("max_tool_calls", max_tool_calls),
+        ("max_repeated_tool_calls", max_repeated),
+    ):
+        if value is not None and (type(value) is not int or value < 0):
+            return _failure(
+                f"Expected budgets.{key} must be a non-negative integer",
+                metadata={key: value},
+            )
+    calls = [call for call in tool_calls_from_output(output) if _tool_name(call) is not None]
+    observed_names = [_tool_name(call) for call in calls]
+    if max_tool_calls is not None and len(calls) > max_tool_calls:
         return _failure(
-            "Expected budgets.max_tool_calls must be a non-negative integer",
-            metadata={"max_tool_calls": max_tool_calls},
+            f"Expected at most {max_tool_calls} tool calls, observed {len(calls)}",
+            metadata={"observed_tools": observed_names, "max_tool_calls": max_tool_calls},
         )
-
-    observed_names = [
-        name for call in tool_calls_from_output(output) if (name := _tool_name(call)) is not None
-    ]
-    if len(observed_names) <= max_tool_calls:
-        return _success()
-    return _failure(
-        f"Expected at most {max_tool_calls} tool calls, observed {len(observed_names)}",
-        metadata={"observed_tools": observed_names, "max_tool_calls": max_tool_calls},
-    )
+    if max_repeated is not None:
+        seen: set[tuple[str, str]] = set()
+        repeated: list[str] = []
+        for call in calls:
+            name = _tool_name(call)
+            assert name is not None
+            call_key = (name, json.dumps(_tool_args(call), sort_keys=True))
+            if call_key in seen:
+                repeated.append(name)
+            seen.add(call_key)
+        if len(repeated) > max_repeated:
+            return _failure(
+                f"Expected at most {max_repeated} repeated tool calls, observed {len(repeated)}",
+                metadata={"repeated_tools": repeated, "max_repeated_tool_calls": max_repeated},
+            )
+    return _success()
 
 
 @create_evaluator(name="correct_tools_called", kind="code")

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -3,23 +3,13 @@ from __future__ import annotations
 import json
 import os
 import sys
-from dataclasses import replace
-from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
 from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry.sdk.trace import TracerProvider
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.mcp import MCPToolset
-from pydantic_ai.messages import (
-    ModelMessage,
-    ModelRequest,
-    ModelResponse,
-    TextPart,
-    ToolCallPart,
-    ToolReturnPart,
-    UserPromptPart,
-)
+from pydantic_ai.messages import ModelMessage
 from pydantic_ai.models import Model as PydanticAIModel
 
 from evals.pxi.harness.backend import (
@@ -28,12 +18,13 @@ from evals.pxi.harness.backend import (
     eval_phoenix_mcp_server,
     unavailable_graphql_context,
 )
+from evals.pxi.harness.transcript import fixture_messages
 from phoenix.config import (
     get_env_allow_external_resources,
     get_env_collector_endpoint,
     get_env_disable_agent_assistant,
 )
-from phoenix.db.types.data_stream_protocol.ui_state_types import ProjectUIContext
+from phoenix.db.types.data_stream_protocol.phoenix_types import PhoenixUIMessage
 from phoenix.server.agents.agent_factory import build_agent
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.agents.context import (
@@ -50,12 +41,19 @@ from phoenix.server.agents.model_factory import (
 from phoenix.server.agents.prompts import UI_STATE_TEMPLATE
 from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
-from phoenix.server.api.routers.agents import _get_ui_contexts, _render_ui_state
+from phoenix.server.api.routers.agents import (
+    _get_ui_contexts,
+    _get_user_message_metadata,
+    _prepend_ui_state_block,
+    _prepend_ui_state_blocks_from_metadata,
+    _render_ui_state,
+    _resolve_browser_clock,
+    _to_pydantic_ai_messages,
+)
 
 DEFAULT_ASSISTANT_PROVIDER = "OPENAI"
 DEFAULT_ASSISTANT_MODEL = "gpt-5.4"
 DEFAULT_ASSISTANT_OPENAI_API_TYPE = "responses"
-DEFAULT_PROJECT_NODE_ID = "UHJvamVjdDox"
 ENV_ASSISTANT_PROVIDER = "PHOENIX_AGENTS_ASSISTANT_PROVIDER"
 ENV_ASSISTANT_MODEL = "PHOENIX_AGENTS_ASSISTANT_MODEL"
 ENV_ASSISTANT_OPENAI_API_TYPE = "PHOENIX_AGENTS_ASSISTANT_OPENAI_API_TYPE"
@@ -215,29 +213,41 @@ def build_shared_docs_mcp_server() -> MCPToolset[Any] | None:
     return MintlifyDocsMCPServer()
 
 
-def _default_contexts() -> ResolvedContexts:
-    contexts = ResolvedContexts(
-        project=ProjectUIContext(
-            type="project",
-            project_node_id=DEFAULT_PROJECT_NODE_ID,
-            span_filter="",
-        )
-    )
+def _build_contexts(input: dict[str, Any]) -> ResolvedContexts:
+    raw_contexts = input.get("contexts", [])
+    if not isinstance(raw_contexts, list):
+        raise ValueError("PXI eval input.contexts must be a list when provided")
+    messages = fixture_messages(input["messages"]) if "messages" in input else []
+    if "contexts" not in input:
+        for message in reversed(messages):
+            metadata = _get_user_message_metadata(message)
+            if metadata is not None and metadata.ui_contexts is not None:
+                raw_contexts = list(
+                    metadata.ui_contexts.model_dump(exclude_none=True, by_alias=True).values()
+                )
+                break
+    contexts = resolve_contexts([ChatContext.model_validate(context) for context in raw_contexts])
+    if (clock := _resolve_browser_clock(messages)) is not None:
+        contexts.app = clock
     return contexts
 
 
-def _build_contexts(input: dict[str, Any]) -> ResolvedContexts:
-    raw_contexts = input.get("contexts")
-    if raw_contexts is None:
-        return _default_contexts()
-    if not isinstance(raw_contexts, list):
-        raise ValueError("PXI eval input.contexts must be a list when provided")
-    return resolve_contexts([ChatContext.model_validate(context) for context in raw_contexts])
-
-
 def _build_dependencies(input: dict[str, Any]) -> AgentDependencies:
-    contexts = _build_contexts(input)
-    return AgentDependencies(contexts=contexts)
+    messages = fixture_messages(input["messages"]) if "messages" in input else []
+    edit_permission = input.get("editPermission")
+    if edit_permission is None:
+        for message in reversed(messages):
+            if (metadata := _get_user_message_metadata(message)) is not None:
+                edit_permission = metadata.edit_permission
+                break
+    if edit_permission is None:
+        edit_permission = "manual"
+    if edit_permission not in ("manual", "bypass"):
+        raise ValueError("PXI eval input.editPermission must be manual or bypass")
+    return AgentDependencies(
+        contexts=_build_contexts(input),
+        edit_permission=cast(Literal["manual", "bypass"], edit_permission),
+    )
 
 
 def _ui_state_block(deps: AgentDependencies) -> str:
@@ -246,242 +256,39 @@ def _ui_state_block(deps: AgentDependencies) -> str:
     )
 
 
-def _attach_ui_state(
-    block: str,
-    *,
-    user_prompt: str | None,
-    message_history: list[ModelMessage] | None,
-) -> tuple[str | None, list[ModelMessage] | None]:
-    """Prepend the state block to the run's earliest user turn."""
-    for message_index, message in enumerate(message_history or ()):
-        if not isinstance(message, ModelRequest):
+def _prepare_transcript(input: dict[str, Any]) -> list[PhoenixUIMessage]:
+    messages = fixture_messages(input.get("messages"))
+    rendered = _prepend_ui_state_blocks_from_metadata(messages)
+    # Legacy shorthand has no persisted metadata. Its top-level contexts describe
+    # the active turn, including a continuation after a primed tool result.
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if message.role != "user":
             continue
-        for part_index, part in enumerate(message.parts):
-            if not (isinstance(part, UserPromptPart) and isinstance(part.content, str)):
-                continue
-            parts = list(message.parts)
-            parts[part_index] = replace(part, content=f"{block}\n\n{part.content}")
-            assert message_history is not None
-            message_history[message_index] = replace(message, parts=parts)
-            return user_prompt, message_history
-    if user_prompt is not None:
-        return f"{block}\n\n{user_prompt}", message_history
-    return user_prompt, message_history
+        metadata = _get_user_message_metadata(message)
+        if metadata is None or metadata.ui_contexts is None:
+            rendered[index] = _prepend_ui_state_block(
+                rendered[index], _ui_state_block(_build_dependencies(input))
+            )
+        elif "contexts" in input or "editPermission" in input:
+            raise ValueError(
+                "Use per-turn metadata for public transcripts; do not also supply "
+                "top-level contexts or editPermission"
+            )
+        break
+    return rendered
 
 
 def _build_run_inputs(
     input: dict[str, Any],
-) -> tuple[str | None, list[ModelMessage] | None]:
-    """Translate ``input.messages`` into ``(user_prompt, message_history)``.
+) -> tuple[None, list[ModelMessage]]:
+    """Replay a public session transcript through the production chat adapter.
 
-    Datasets describe an example as a single ``messages`` list -- the full
-    conversation prefix the agent should enter the run with. The trailing
-    entry drives which step of the agent loop is being scored:
-
-    - **Last entry is ``role: user``.** That user turn is the new user prompt
-      for this run; everything before it is replayed as ``message_history``.
-    - **Last entry is ``role: tool``.** The harness invokes ``agent.run``
-      with ``user_prompt=None`` and the full ``messages`` list as
-      ``message_history``, so the agent picks up mid-loop from the primed
-      tool return. The action it emits next is what gets scored.
-    - **Last entry is ``role: assistant``.** Rejected: nothing remains for
-      the agent to do.
+    The transcript includes the latest user message or completed tool output.
+    Returning no separate prompt lets Phoenix's adapter preserve message parts,
+    structured outputs and per-turn state exactly as it does for stored sessions.
     """
-    raw_messages = input.get("messages")
-    if not isinstance(raw_messages, list) or not raw_messages:
-        raise ValueError("PXI eval input.messages must be a non-empty list")
-    if not isinstance(raw_messages[-1], dict):
-        raise ValueError("PXI eval input.messages[-1] must be an object")
-    last_role = raw_messages[-1].get("role")
-    if last_role == "user":
-        content = raw_messages[-1].get("content")
-        if not isinstance(content, str) or not content:
-            raise ValueError(
-                "PXI eval input.messages: final user turn must have non-empty string content"
-            )
-        prefix_messages = (
-            _materialize_messages(raw_messages[:-1]) if len(raw_messages) > 1 else None
-        )
-        return content, prefix_messages
-    if last_role == "tool":
-        return None, _materialize_messages(raw_messages)
-    raise ValueError(
-        "PXI eval input.messages must end with a user turn (new prompt) or a tool "
-        f"return (mid-loop continuation); got role={last_role!r}"
-    )
-
-
-def _materialize_messages(raw_messages: list[Any]) -> list[ModelMessage]:
-    """Translate raw message dicts into pydantic_ai ``ModelMessage`` objects.
-
-    Supports four entry shapes so an example can simulate a multi-turn session
-    in which the agent has already executed tools, without the harness having
-    to actually run those tools:
-
-    1. ``{role: user, content: <str>}`` -- a user turn.
-    2. ``{role: assistant, content: <str>}`` -- an assistant text turn.
-    3. ``{role: assistant, tool_calls: [{id, name, args}, ...], content?: <str>}``
-       -- an assistant turn that issued one or more tool calls (with optional
-       accompanying text). ``id`` is a local string used to pair with the
-       matching ``tool`` return below; it is passed through to pydantic_ai
-       verbatim as the ``tool_call_id``.
-    4. ``{role: tool, tool_call_id: <id>, name: <tool>, content: <str>}`` -- a
-       tool return that the model previously observed. ``tool_call_id`` MUST
-       reference an ``id`` declared on an earlier assistant ``tool_calls``
-       entry in the same history; ``name`` MUST match.
-
-    Primed tool calls + returns are exactly the same message shape pydantic_ai
-    builds for genuinely-executed tools, so the model cannot tell the
-    difference. This lets datasets isolate one step of agent behavior (e.g.
-    "given a primed catalog and a known latest-trace date, did the
-    ui.spansFilter.set invocation get the right condition?") from the
-    upstream discovery steps that would normally precede it.
-    """
-    if not isinstance(raw_messages, list):
-        raise ValueError("PXI eval input.messages must be a list")
-
-    messages: list[ModelMessage] = []
-    # Tracks (tool_call_id -> tool_name) declared by prior assistant tool_calls
-    # entries that have not yet been paired with a tool return.
-    pending_tool_calls: dict[str, str] = {}
-    # Tracks every tool_call_id ever declared (pending or already consumed) so a
-    # later assistant turn can't reuse the same id even after it was returned.
-    seen_tool_call_ids: set[str] = set()
-
-    for index, item in enumerate(raw_messages):
-        if not isinstance(item, dict):
-            raise ValueError(f"PXI eval input.messages[{index}] must be an object")
-        role = item.get("role")
-        if role == "user":
-            messages.append(_build_user_turn(item, index))
-        elif role in {"assistant", "ai"}:
-            messages.append(
-                _build_assistant_turn(item, index, pending_tool_calls, seen_tool_call_ids)
-            )
-        elif role == "tool":
-            messages.append(_build_tool_return_turn(item, index, pending_tool_calls))
-        else:
-            raise ValueError(
-                f"PXI eval input.messages[{index}].role must be user, assistant, or tool"
-            )
-
-    if pending_tool_calls:
-        raise ValueError(
-            "PXI eval input.messages primed tool calls without matching tool returns: "
-            f"{sorted(pending_tool_calls)}"
-        )
-    return messages
-
-
-def _build_user_turn(item: dict[str, Any], index: int) -> ModelMessage:
-    content = item.get("content")
-    if not isinstance(content, str):
-        raise ValueError(
-            f"PXI eval input.messages[{index}].content must be a string for user turns"
-        )
-    return ModelRequest(parts=[UserPromptPart(content=content)])
-
-
-def _build_assistant_turn(
-    item: dict[str, Any],
-    index: int,
-    pending_tool_calls: dict[str, str],
-    seen_tool_call_ids: set[str],
-) -> ModelMessage:
-    content = item.get("content")
-    raw_tool_calls = item.get("tool_calls")
-    if content is None and raw_tool_calls is None:
-        raise ValueError(
-            f"PXI eval input.messages[{index}] assistant turn must have content or tool_calls"
-        )
-    if content is not None and not isinstance(content, str):
-        raise ValueError(f"PXI eval input.messages[{index}].content must be a string when provided")
-
-    parts: list[Any] = []
-    if isinstance(content, str):
-        parts.append(TextPart(content=content))
-
-    if raw_tool_calls is not None:
-        if not isinstance(raw_tool_calls, list) or not raw_tool_calls:
-            raise ValueError(
-                f"PXI eval input.messages[{index}].tool_calls must be a non-empty list of objects"
-            )
-        for call_index, call in enumerate(raw_tool_calls):
-            if not isinstance(call, dict):
-                raise ValueError(
-                    f"PXI eval input.messages[{index}].tool_calls[{call_index}] must be an object"
-                )
-            tool_call_id = call.get("id")
-            tool_name = call.get("name")
-            args = call.get("args", {})
-            if not isinstance(tool_call_id, str) or not tool_call_id:
-                raise ValueError(
-                    f"PXI eval input.messages[{index}].tool_calls[{call_index}].id "
-                    "must be a non-empty string"
-                )
-            if not isinstance(tool_name, str) or not tool_name:
-                raise ValueError(
-                    f"PXI eval input.messages[{index}].tool_calls[{call_index}].name "
-                    "must be a non-empty string"
-                )
-            if not isinstance(args, (dict, str)):
-                raise ValueError(
-                    f"PXI eval input.messages[{index}].tool_calls[{call_index}].args "
-                    "must be an object or a JSON string"
-                )
-            if tool_call_id in seen_tool_call_ids:
-                raise ValueError(
-                    f"PXI eval input.messages[{index}].tool_calls[{call_index}].id "
-                    f"{tool_call_id!r} was already used earlier in the history"
-                )
-            seen_tool_call_ids.add(tool_call_id)
-            pending_tool_calls[tool_call_id] = tool_name
-            parts.append(ToolCallPart(tool_name=tool_name, args=args, tool_call_id=tool_call_id))
-
-    return ModelResponse(parts=parts)
-
-
-def _build_tool_return_turn(
-    item: dict[str, Any],
-    index: int,
-    pending_tool_calls: dict[str, str],
-) -> ModelMessage:
-    tool_call_id = item.get("tool_call_id")
-    tool_name = item.get("name")
-    content = item.get("content")
-    if not isinstance(tool_call_id, str) or not tool_call_id:
-        raise ValueError(
-            f"PXI eval input.messages[{index}].tool_call_id must be a non-empty string"
-        )
-    if not isinstance(tool_name, str) or not tool_name:
-        raise ValueError(
-            f"PXI eval input.messages[{index}].name must be a non-empty string for tool turns"
-        )
-    if not isinstance(content, str):
-        raise ValueError(
-            f"PXI eval input.messages[{index}].content must be a string for tool turns"
-        )
-    expected_name = pending_tool_calls.pop(tool_call_id, None)
-    if expected_name is None:
-        raise ValueError(
-            f"PXI eval input.messages[{index}] tool return references unknown "
-            f"tool_call_id {tool_call_id!r}; declare it on a prior assistant tool_calls entry"
-        )
-    if expected_name != tool_name:
-        raise ValueError(
-            f"PXI eval input.messages[{index}] tool return name {tool_name!r} "
-            f"does not match prior tool call name {expected_name!r} for id {tool_call_id!r}"
-        )
-    return ModelRequest(
-        parts=[
-            ToolReturnPart(
-                tool_name=tool_name,
-                content=content,
-                tool_call_id=tool_call_id,
-                timestamp=datetime.now(timezone.utc),
-            )
-        ]
-    )
+    return None, _to_pydantic_ai_messages(_prepare_transcript(input))
 
 
 def _serialize_new_messages(result: AgentRunResult[AgentOutput]) -> list[dict[str, Any]]:
@@ -568,11 +375,11 @@ async def run_pxi_example(
 ) -> dict[str, Any]:
     """Run a single PXI agent turn imperatively.
 
-    ``input`` is an example input dict. ``input["messages"]`` is the full
-    conversation prefix; the last entry decides whether the harness invokes
-    the agent with a fresh user prompt or as a mid-loop continuation off a
-    primed tool return (see :func:`_build_run_inputs`). Optional ``contexts``
-    inject realistic Phoenix page state without launching a browser.
+    ``input["messages"]`` is a public session transcript or compact fixture
+    notation compiled to one. The last entry supplies a new user message or a
+    completed tool output. The production adapter prepares the model history.
+    Optional ``contexts`` supplies the active turn's page state for compact
+    fixtures; public transcripts carry it in each user message's metadata.
     Failures anywhere in setup or in ``agent.run`` are caught and returned
     with ``error`` set, so the failure report can still resolve a stable
     example ID for the row.
@@ -590,11 +397,6 @@ async def run_pxi_example(
     try:
         user_prompt, message_history = _build_run_inputs(input)
         deps = _build_dependencies(input)
-        user_prompt, message_history = _attach_ui_state(
-            _ui_state_block(deps),
-            user_prompt=user_prompt,
-            message_history=message_history,
-        )
         model = await _build_model()
         tracer_provider = _get_tracer_provider()
         if tracer_provider is not None:

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -611,7 +611,7 @@ async def run_pxi_example(
             headless=False,
             model=model,
             docs_mcp_server=docs_mcp_server,
-            phoenix_mcp_server=eval_phoenix_mcp_server(_OFFLINE_DB),
+            phoenix_mcp_server=eval_phoenix_mcp_server(),
             schema=eval_graphql_schema(),
             build_graphql_context=unavailable_graphql_context,
             tracer_provider=tracer_provider,

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -22,6 +22,12 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import Model as PydanticAIModel
 
+from evals.pxi.harness.backend import (
+    EvalBackendCapability,
+    eval_graphql_schema,
+    eval_phoenix_mcp_server,
+    unavailable_graphql_context,
+)
 from phoenix.config import (
     get_env_allow_external_resources,
     get_env_collector_endpoint,
@@ -605,6 +611,9 @@ async def run_pxi_example(
             headless=False,
             model=model,
             docs_mcp_server=docs_mcp_server,
+            phoenix_mcp_server=eval_phoenix_mcp_server(_OFFLINE_DB),
+            schema=eval_graphql_schema(),
+            build_graphql_context=unavailable_graphql_context,
             tracer_provider=tracer_provider,
             read_only=True,
         )
@@ -612,6 +621,7 @@ async def run_pxi_example(
             user_prompt,
             deps=deps,
             message_history=message_history,
+            capabilities=[EvalBackendCapability()],
         )
         output = agent_task_output(result)
     except Exception as exc:

--- a/evals/pxi/harness/backend.py
+++ b/evals/pxi/harness/backend.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from functools import lru_cache
 from typing import Any
 
@@ -14,6 +16,7 @@ from pydantic_ai.exceptions import CallDeferred
 from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.models import ModelRequestContext
 from pydantic_ai.tools import ToolDefinition
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.server.agents.types import AgentDependencies
 from phoenix.server.api.context import Context
@@ -34,8 +37,14 @@ def unavailable_graphql_context() -> Context:
     raise RuntimeError("PXI eval backend calls must be deferred; no application data is provided.")
 
 
+@asynccontextmanager
+async def _unavailable_db_session() -> AsyncIterator[AsyncSession]:
+    raise RuntimeError("PXI eval backend calls must be deferred; no application data is provided.")
+    yield
+
+
 @lru_cache(maxsize=1)
-def eval_phoenix_mcp_server(db: DbSessionFactory) -> FastMCP:
+def eval_phoenix_mcp_server() -> FastMCP:
     """Share the production read-only catalog and skill server within a worker.
 
     Routes supply schemas only. No app lifespan, database, or sandbox worker
@@ -49,7 +58,7 @@ def eval_phoenix_mcp_server(db: DbSessionFactory) -> FastMCP:
         code_mode=True,
         monty_consumer="agent",
         read_only=True,
-        db=db,
+        db=DbSessionFactory(db=_unavailable_db_session, dialect="sqlite"),
         skills_roots=PXI_SKILLS_ROOTS,
     )
     return server

--- a/evals/pxi/harness/backend.py
+++ b/evals/pxi/harness/backend.py
@@ -1,0 +1,92 @@
+"""Production backend tool definitions for next-action PXI evaluations."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import strawberry
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.exceptions import CallDeferred
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.models import ModelRequestContext
+from pydantic_ai.tools import ToolDefinition
+
+from phoenix.server.agents.types import AgentDependencies
+from phoenix.server.api.context import Context
+from phoenix.server.api.routers.v1 import create_v1_router
+from phoenix.server.api.schema import build_graphql_schema
+from phoenix.server.mcp.skills import PXI_SKILLS_ROOTS, SKILL_TOOL_NAMES
+from phoenix.server.mcp_server import build_phoenix_mcp_server
+from phoenix.server.monty_runtime import MontyRuntime
+from phoenix.server.types import DbSessionFactory
+
+
+@lru_cache(maxsize=1)
+def eval_graphql_schema() -> strawberry.Schema:
+    return build_graphql_schema()
+
+
+def unavailable_graphql_context() -> Context:
+    raise RuntimeError("PXI eval backend calls must be deferred; no application data is provided.")
+
+
+@lru_cache(maxsize=1)
+def eval_phoenix_mcp_server(db: DbSessionFactory) -> FastMCP:
+    """Share the production read-only catalog and skill server within a worker.
+
+    Routes supply schemas only. No app lifespan, database, or sandbox worker
+    starts: ``EvalBackendCapability`` defers data execution before dispatch.
+    """
+    app = FastAPI()
+    app.include_router(create_v1_router(authentication_enabled=False))
+    server, _ = build_phoenix_mcp_server(
+        app,
+        monty_runtime=MontyRuntime(),
+        code_mode=True,
+        monty_consumer="agent",
+        read_only=True,
+        db=db,
+        skills_roots=PXI_SKILLS_ROOTS,
+    )
+    return server
+
+
+class EvalBackendCapability(AbstractCapability[AgentDependencies]):
+    """Load skills and discover tools, then record backend execution intent.
+
+    Like browser actions, backend requests end the evaluated turn without
+    reading or writing real data. This preserves the suite's next-action
+    contract after bash and skills moved to server-side capabilities.
+    """
+
+    async def before_model_request(
+        self,
+        ctx: RunContext[AgentDependencies],
+        request_context: ModelRequestContext,
+    ) -> ModelRequestContext:
+        parameters = request_context.model_request_parameters
+        tools = {tool.name for tool in parameters.function_tools}
+        missing = (set(SKILL_TOOL_NAMES) | {"bash", "execute"}) - tools
+        if missing:
+            raise RuntimeError(f"PXI eval backend tools are missing: {', '.join(sorted(missing))}")
+        if not any(
+            "<available_skills>" in part.content for part in parameters.instruction_parts or ()
+        ):
+            raise RuntimeError("PXI eval skill catalog is missing")
+        return request_context
+
+    async def before_tool_execute(
+        self,
+        ctx: RunContext[AgentDependencies],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        if tool_def.name in {"bash", "execute"}:
+            raise CallDeferred()
+        return args

--- a/evals/pxi/harness/transcript.py
+++ b/evals/pxi/harness/transcript.py
@@ -1,0 +1,113 @@
+"""Fixture authoring helpers at Phoenix's public session-transcript boundary."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from phoenix.db.types.data_stream_protocol.phoenix_types import PhoenixUIMessage
+from phoenix.db.types.data_stream_protocol.request_types import TextUIPart
+
+
+def fixture_messages(raw: Any) -> list[PhoenixUIMessage]:
+    """Accept public UI messages or compile the existing compact YAML notation.
+
+    Tool results belong to assistant message parts in a stored Phoenix session.
+    The shorthand's separate tool rows only pair outputs with their calls; they
+    are not a second transcript format passed directly to the model provider.
+    """
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("PXI eval input.messages must be a non-empty list")
+    if not all(isinstance(message, dict) for message in raw):
+        raise ValueError("PXI eval input.messages entries must be objects")
+    if any("parts" in message for message in raw):
+        messages = [PhoenixUIMessage.model_validate(message) for message in raw]
+    else:
+        messages = _from_shorthand(raw)
+    last = messages[-1]
+    if last.role == "user":
+        if not any(isinstance(part, TextUIPart) and part.text.strip() for part in last.parts):
+            raise ValueError("PXI eval final user message must contain non-empty text")
+    elif last.role == "assistant":
+        if not any(
+            getattr(part, "state", None) in ("output-available", "output-error")
+            for part in last.parts
+        ):
+            raise ValueError("PXI eval messages must end with a user turn or a tool return")
+    else:
+        raise ValueError("PXI eval messages must end with a user turn or a tool return")
+    # A primed prefix must be resumable. Pending calls/approvals need a browser
+    # callback and are not completed evidence from which this offline run starts.
+    seen: set[str] = set()
+    for message in messages:
+        for part in message.parts:
+            call_id = getattr(part, "tool_call_id", None)
+            if call_id is None:
+                continue
+            if call_id in seen:
+                raise ValueError(f"Duplicate tool call id: {call_id}")
+            seen.add(call_id)
+            if getattr(part, "state", None) not in ("output-available", "output-error"):
+                raise ValueError(f"Tool call {call_id} has no completed output")
+    return messages
+
+
+def _from_shorthand(raw: list[dict[str, Any]]) -> list[PhoenixUIMessage]:
+    messages: list[dict[str, Any]] = []
+    pending: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        role = item.get("role")
+        if role == "tool":
+            call_id = item.get("tool_call_id")
+            if not isinstance(call_id, str):
+                raise ValueError("Tool returns require a string tool_call_id")
+            part = pending.pop(call_id, None)
+            if part is None:
+                raise ValueError(f"Unknown tool_call_id: {call_id}")
+            if part["type"] != f"tool-{item.get('name')}":
+                raise ValueError(f"Tool return name does not match call {call_id}")
+            if "content" not in item:
+                raise ValueError(f"Tool return {call_id} must have content")
+            part.update(state="output-available", output=item["content"])
+            continue
+        if pending:
+            raise ValueError("Complete pending tool outputs before the next message")
+        if role not in ("user", "assistant"):
+            raise ValueError("Fixture role must be user, assistant, or tool")
+        parts: list[dict[str, Any]] = []
+        if "content" in item:
+            if not isinstance(item["content"], str):
+                raise ValueError("User and assistant content must be a string")
+            parts.append({"type": "text", "text": item["content"]})
+        calls = item.get("tool_calls", [])
+        if not isinstance(calls, list) or (calls and role != "assistant"):
+            raise ValueError("Only assistant messages may contain a list of tool calls")
+        for call in calls:
+            if not isinstance(call, dict):
+                raise ValueError("Tool calls must be objects")
+            call_id, name = call.get("id"), call.get("name")
+            if not isinstance(call_id, str) or not call_id or not isinstance(name, str) or not name:
+                raise ValueError("Tool calls require non-empty id and name")
+            if call_id in seen:
+                raise ValueError(f"Duplicate tool call id: {call_id}")
+            seen.add(call_id)
+            args = call.get("args", {})
+            if isinstance(args, str):
+                args = json.loads(args)
+            if not isinstance(args, dict):
+                raise ValueError("Tool call args must be an object")
+            part = {
+                "type": f"tool-{name}",
+                "toolCallId": call_id,
+                "state": "input-available",
+                "input": args,
+            }
+            pending[call_id] = part
+            parts.append(part)
+        if not parts:
+            raise ValueError("User and assistant messages require text or tool calls")
+        messages.append({"id": f"fixture-{index}", "role": role, "parts": parts})
+    if pending:
+        raise ValueError(f"Primed calls without matching tool returns: {sorted(pending)}")
+    return [PhoenixUIMessage.model_validate(message) for message in messages]

--- a/tests/unit/pxi/evals/test_agent_backend.py
+++ b/tests/unit/pxi/evals/test_agent_backend.py
@@ -182,3 +182,31 @@ async def test_shared_mcp_server_supports_concurrent_examples(
         )
     )
     assert all(output.get("assistant_text") == "Loaded." for output in outputs), outputs
+
+
+async def test_primed_tool_inputs_match_current_agent_schemas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pathlib import Path
+
+    import jsonschema
+    import yaml
+
+    from evals.pxi.harness.transcript import fixture_messages
+
+    def respond(messages: Any, info: AgentInfo) -> ModelResponse:
+        definitions = {tool.name: tool for tool in info.function_tools}
+        datasets = Path(__file__).parents[4] / "evals" / "pxi" / "datasets"
+        for path in sorted(datasets.glob("*.yaml")):
+            for example in yaml.safe_load(path.read_text())["examples"]:
+                for message in fixture_messages(example["input"]["messages"]):
+                    for part in message.model_dump(by_alias=True)["parts"]:
+                        if not part["type"].startswith("tool-"):
+                            continue
+                        name = part["type"].removeprefix("tool-")
+                        assert name in definitions, (path.name, example["id"], name)
+                        jsonschema.validate(part["input"], definitions[name].parameters_json_schema)
+        return ModelResponse(parts=[TextPart(content="Fixture inputs match tool schemas.")])
+
+    output = await _run(monkeypatch, respond)
+    assert not output.get("error"), output

--- a/tests/unit/pxi/evals/test_agent_backend.py
+++ b/tests/unit/pxi/evals/test_agent_backend.py
@@ -1,0 +1,184 @@
+"""Exercise backend capabilities through the same entry point as live evals."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from evals.pxi.evaluators.tools import evaluate_tools_called, tool_calls_from_output
+from evals.pxi.harness import agent_task
+from phoenix.server.agents.agent_factory import build_agent as real_build_agent
+from phoenix.server.mcp.skills import PXI_SKILLS_ROOTS, load_skills
+
+
+@pytest.fixture(autouse=True)
+def no_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(agent_task, "_get_tracer_provider", lambda: None)
+
+
+async def _run(monkeypatch: pytest.MonkeyPatch, respond: Any) -> dict[str, Any]:
+    async def build_model() -> FunctionModel:
+        return FunctionModel(respond)
+
+    monkeypatch.setattr(agent_task, "_build_model", build_model)
+    return await agent_task.run_pxi_example(
+        {"messages": [{"role": "user", "content": "Inspect this experiment."}]},
+        stable_example_id="backend-contract",
+    )
+
+
+async def test_skills_and_references_execute_with_production_definitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses: Iterator[ToolCallPart | TextPart] = iter(
+        [
+            ToolCallPart(
+                tool_name="load_skill",
+                args={"skill_name": "phoenix-graphql"},
+                tool_call_id="skill",
+            ),
+            ToolCallPart(
+                tool_name="load_skill_reference",
+                args={
+                    "skill_name": "phoenix-graphql",
+                    "reference_name": "references/experiments.md",
+                },
+                tool_call_id="reference",
+            ),
+            TextPart(content="Loaded the experiment reference."),
+        ]
+    )
+
+    def respond(messages: Any, info: AgentInfo) -> ModelResponse:
+        definitions = {tool.name: tool for tool in info.function_tools}
+        assert {"bash", "execute", "search", "load_skill", "load_skill_reference"} <= (
+            definitions.keys()
+        )
+        assert info.instructions is not None
+        skills = load_skills(PXI_SKILLS_ROOTS)
+        for skill in skills:
+            assert f"<name>{skill.name}</name>" in info.instructions
+        assert set(
+            definitions["load_skill"].parameters_json_schema["properties"]["skill_name"]["enum"]
+        ) == {skill.name for skill in skills}
+        return ModelResponse(parts=[next(responses)])
+
+    output = await _run(monkeypatch, respond)
+    assert not output.get("error"), output
+    assert output["assistant_text"] == "Loaded the experiment reference."
+    assert (
+        evaluate_tools_called(
+            output, {"tools": {"required": ["load_skill", "load_skill_reference"]}}
+        )["score"]
+        == 1.0
+    )
+    returns = [
+        part
+        for message in output["messages"]
+        for part in message["parts"]
+        if part["part_kind"] == "tool-return"
+    ]
+    assert len(returns) == 2
+    assert all("isError" not in str(part["content"]) for part in returns)
+    assert "ExperimentRun" in str(returns[1]["content"])
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args"),
+    [
+        (
+            "bash",
+            {
+                "summary": "Read experiments",
+                "command": "phoenix-gql '{ datasets { edges { node { id } } } }'",
+            },
+        ),
+        ("execute", {"code": "return await call_tool('listProjects', {})"}),
+    ],
+)
+async def test_backend_execution_is_deferred_without_accessing_data(
+    monkeypatch: pytest.MonkeyPatch, tool_name: str, args: dict[str, Any]
+) -> None:
+    def respond(messages: Any, info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name=tool_name, args=args, tool_call_id="backend")]
+        )
+
+    output = await _run(monkeypatch, respond)
+    assert not output.get("error"), output
+    assert output["raw_output_type"] == "DeferredToolRequests"
+    assert [call["tool_name"] for call in tool_calls_from_output(output)] == [tool_name]
+    assert not any(
+        part["part_kind"] == "tool-return"
+        for message in output["messages"]
+        for part in message["parts"]
+    )
+
+
+async def test_catalog_discovery_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    def respond(messages: Any, info: AgentInfo) -> ModelResponse:
+        returns = [
+            part
+            for message in messages
+            for part in message.parts
+            if isinstance(part, ToolReturnPart)
+        ]
+        if returns:
+            assert "project" in str(returns[-1].content).lower()
+            return ModelResponse(parts=[TextPart(content="Found project tools.")])
+        return ModelResponse(
+            parts=[
+                ToolCallPart(tool_name="search", args={"query": "projects"}, tool_call_id="search")
+            ]
+        )
+
+    output = await _run(monkeypatch, respond)
+    assert not output.get("error"), output
+    assert output["assistant_text"] == "Found project tools."
+
+
+@pytest.mark.parametrize("dependency", ["phoenix_mcp_server", "schema"])
+async def test_missing_backend_fails_before_model_request(
+    monkeypatch: pytest.MonkeyPatch, dependency: str
+) -> None:
+    def build_agent(**kwargs: Any) -> Any:
+        kwargs.pop(dependency)
+        return real_build_agent(**kwargs)
+
+    monkeypatch.setattr(agent_task, "build_agent", build_agent)
+
+    def respond(messages: Any, info: AgentInfo) -> ModelResponse:
+        pytest.fail("A misconfigured harness must not call the model")
+
+    output = await _run(monkeypatch, respond)
+    assert "PXI eval backend tools are missing" in output["error"]
+    assert output["messages"] == []
+    assert output["stable_example_id"] == "backend-contract"
+
+
+async def test_shared_mcp_server_supports_concurrent_examples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def respond(messages: Any, info: AgentInfo) -> ModelResponse:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[TextPart(content="Loaded.")])
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="load_skill", args={"skill_name": "experiments"})]
+        )
+
+    async def build_model() -> FunctionModel:
+        return FunctionModel(respond)
+
+    monkeypatch.setattr(agent_task, "_build_model", build_model)
+    outputs = await asyncio.gather(
+        *(
+            agent_task.run_pxi_example({"messages": [{"role": "user", "content": "hello"}]})
+            for _ in range(3)
+        )
+    )
+    assert all(output.get("assistant_text") == "Loaded." for output in outputs), outputs

--- a/tests/unit/pxi/evals/test_agent_task_inputs.py
+++ b/tests/unit/pxi/evals/test_agent_task_inputs.py
@@ -1,336 +1,161 @@
+"""Check fixture inputs against Phoenix's public transcript and tool contracts."""
+
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import pytest
-from pydantic_ai.messages import (
-    ModelRequest,
-    ModelResponse,
-    TextPart,
-    ToolCallPart,
-    ToolReturnPart,
-    UserPromptPart,
-)
+import yaml
+from pydantic import TypeAdapter
+from pydantic_ai.messages import ToolReturnPart, UserPromptPart
 
 from evals.pxi.harness.agent_task import (
-    _attach_ui_state,
     _build_contexts,
     _build_dependencies,
     _build_run_inputs,
-    _materialize_messages,
-    _ui_state_block,
+    _prepare_transcript,
 )
+from evals.pxi.harness.transcript import fixture_messages
+from phoenix.server.agents.capabilities.tools.internal.bash import BashToolResult
+
+_DATASETS = Path(__file__).parents[4] / "evals" / "pxi" / "datasets"
 
 
-class TestBuildContexts:
-    def test_uses_default_project_context_when_contexts_omitted(self) -> None:
-        contexts = _build_contexts({"messages": [{"role": "user", "content": "x"}]})
-        assert contexts.project is not None
-        assert contexts.project.project_node_id == "UHJvamVjdDox"
-        assert contexts.project.span_filter == ""
-
-    def test_parses_browser_context_shape(self) -> None:
-        contexts = _build_contexts(
-            {
-                "contexts": [
-                    {
-                        "type": "app",
-                        "currentDateTime": "2026-05-18T14:30:00-07:00",
-                        "timeZone": "America/Los_Angeles",
-                    },
-                    {"type": "graphql", "mutationsEnabled": False},
-                    {
-                        "type": "project",
-                        "projectNodeId": "UHJvamVjdDoxMg==",
-                        "spanFilter": "span_kind == 'LLM' and parent_span is None",
-                    },
-                ]
+def _user(id: str, text: str, project: str) -> dict[str, Any]:
+    return {
+        "id": id,
+        "role": "user",
+        "parts": [{"type": "text", "text": text}],
+        "metadata": {
+            "phoenix": {
+                "type": "user",
+                "currentDateTime": "2026-04-03T12:00:00-07:00",
+                "timeZone": "America/Los_Angeles",
+                "editPermission": "manual",
+                "uiContexts": {"project": {"type": "project", "projectNodeId": project}},
             }
-        )
-        assert contexts.app is not None
-        assert contexts.app.current_date_time == "2026-05-18T14:30:00-07:00"
-        assert contexts.app.time_zone == "America/Los_Angeles"
-        assert contexts.graphql is not None
-        assert contexts.graphql.mutations_enabled is False
-        assert contexts.project is not None
-        assert contexts.project.project_node_id == "UHJvamVjdDoxMg=="
-        assert contexts.project.span_filter == "span_kind == 'LLM' and parent_span is None"
-
-    def test_rejects_non_list_contexts(self) -> None:
-        with pytest.raises(ValueError, match="input.contexts must be a list"):
-            _build_contexts({"contexts": {"type": "project"}})
+        },
+    }
 
 
-class TestBuildRunInputs:
-    def test_user_only_messages_becomes_user_prompt_with_no_history(self) -> None:
-        user_prompt, history = _build_run_inputs(
-            {"messages": [{"role": "user", "content": "Show me the latest traces."}]}
-        )
-        assert user_prompt == "Show me the latest traces."
-        assert history is None
-
-    def test_user_terminated_history_pops_last_as_user_prompt(self) -> None:
-        user_prompt, history = _build_run_inputs(
-            {
-                "messages": [
-                    {"role": "user", "content": "Show me the latest traces."},
-                    {"role": "assistant", "content": "They were on April 3."},
-                    {"role": "user", "content": "Filter to that day."},
-                ]
-            }
-        )
-        assert user_prompt == "Filter to that day."
-        assert history is not None
-        assert len(history) == 2
-        first, second = history
-        assert isinstance(first, ModelRequest)
-        assert isinstance(first.parts[0], UserPromptPart)
-        assert first.parts[0].content == "Show me the latest traces."
-        assert isinstance(second, ModelResponse)
-        assert isinstance(second.parts[0], TextPart)
-        assert second.parts[0].content == "They were on April 3."
-
-    def test_tool_terminated_history_is_mid_loop_continuation(self) -> None:
-        user_prompt, history = _build_run_inputs(
-            {
-                "messages": [
-                    {"role": "user", "content": "When were the latest traces?"},
-                    {
-                        "role": "assistant",
-                        "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": "ls"}}],
-                    },
-                    {
-                        "role": "tool",
-                        "tool_call_id": "t1",
-                        "name": "bash",
-                        "content": "a.json\nb.json",
-                    },
-                ]
-            }
-        )
-        # Mid-loop continuation: user_prompt is None, full history is replayed.
-        assert user_prompt is None
-        assert history is not None
-        assert len(history) == 3
-        last = history[-1]
-        assert isinstance(last, ModelRequest)
-        return_part = last.parts[0]
-        assert isinstance(return_part, ToolReturnPart)
-        assert return_part.tool_call_id == "t1"
-        assert return_part.content == "a.json\nb.json"
-
-    def test_rejects_assistant_terminated_messages(self) -> None:
-        with pytest.raises(ValueError, match="user turn .* or a tool return"):
-            _build_run_inputs(
-                {
-                    "messages": [
-                        {"role": "user", "content": "hi"},
-                        {"role": "assistant", "content": "hello"},
-                    ]
-                }
-            )
-
-    def test_rejects_empty_messages(self) -> None:
-        with pytest.raises(ValueError, match="must be a non-empty list"):
-            _build_run_inputs({"messages": []})
-
-    def test_rejects_final_user_turn_with_empty_content(self) -> None:
-        with pytest.raises(ValueError, match="non-empty string content"):
-            _build_run_inputs({"messages": [{"role": "user", "content": ""}]})
+def test_omitted_contexts_do_not_invent_a_project() -> None:
+    assert _build_contexts({"messages": [{"role": "user", "content": "hello"}]}).project is None
 
 
-class TestMaterializeMessages:
-    def test_builds_primed_bash_tool_call_and_return(self) -> None:
-        history = _materialize_messages(
-            [
-                {"role": "user", "content": "When were the latest traces?"},
-                {
-                    "role": "assistant",
-                    "tool_calls": [
-                        {"id": "t1", "name": "bash", "args": {"command": "ls /phoenix"}}
-                    ],
-                },
-                {
-                    "role": "tool",
-                    "tool_call_id": "t1",
-                    "name": "bash",
-                    "content": "agent-start.md\npage-context.json\n",
-                },
-            ]
-        )
-        assert len(history) == 3
-        user_turn, assistant_call_turn, tool_turn = history
-        assert isinstance(user_turn, ModelRequest)
-        assert isinstance(user_turn.parts[0], UserPromptPart)
-        assert isinstance(assistant_call_turn, ModelResponse)
-        call_part = assistant_call_turn.parts[0]
-        assert isinstance(call_part, ToolCallPart)
-        assert call_part.tool_name == "bash"
-        assert call_part.tool_call_id == "t1"
-        assert call_part.args == {"command": "ls /phoenix"}
-        assert isinstance(tool_turn, ModelRequest)
-        return_part = tool_turn.parts[0]
-        assert isinstance(return_part, ToolReturnPart)
-        assert return_part.tool_call_id == "t1"
-
-    def test_assistant_turn_may_include_text_and_tool_calls(self) -> None:
-        history = _materialize_messages(
-            [
-                {
-                    "role": "assistant",
-                    "content": "Let me check the recent traces.",
-                    "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": "ls"}}],
-                },
-                {
-                    "role": "tool",
-                    "tool_call_id": "t1",
-                    "name": "bash",
-                    "content": "a.json",
-                },
-            ]
-        )
-        assistant_turn = history[0]
-        assert isinstance(assistant_turn, ModelResponse)
-        kinds = [type(part).__name__ for part in assistant_turn.parts]
-        assert kinds == ["TextPart", "ToolCallPart"]
-
-    def test_rejects_tool_return_with_unknown_tool_call_id(self) -> None:
-        with pytest.raises(ValueError, match="unknown tool_call_id"):
-            _materialize_messages(
-                [{"role": "tool", "tool_call_id": "ghost", "name": "bash", "content": "x"}]
-            )
-
-    def test_rejects_tool_return_name_mismatch(self) -> None:
-        with pytest.raises(ValueError, match="does not match prior tool call name"):
-            _materialize_messages(
-                [
-                    {
-                        "role": "assistant",
-                        "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": "ls"}}],
-                    },
-                    {
-                        "role": "tool",
-                        "tool_call_id": "t1",
-                        "name": "search_phoenix",
-                        "content": "x",
-                    },
-                ]
-            )
-
-    def test_rejects_assistant_tool_call_without_matching_return(self) -> None:
-        with pytest.raises(ValueError, match="without matching tool returns"):
-            _materialize_messages(
-                [
-                    {
-                        "role": "assistant",
-                        "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": "ls"}}],
-                    }
-                ]
-            )
-
-    def test_rejects_duplicate_tool_call_ids(self) -> None:
-        with pytest.raises(ValueError, match="was already used earlier"):
-            _materialize_messages(
-                [
-                    {
-                        "role": "assistant",
-                        "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": "ls"}}],
-                    },
-                    {
-                        "role": "tool",
-                        "tool_call_id": "t1",
-                        "name": "bash",
-                        "content": "out",
-                    },
-                    {
-                        "role": "assistant",
-                        "tool_calls": [{"id": "t1", "name": "bash", "args": {"command": "pwd"}}],
-                    },
-                ]
-            )
-
-    def test_rejects_assistant_turn_with_neither_content_nor_tool_calls(self) -> None:
-        with pytest.raises(ValueError, match="must have content or tool_calls"):
-            _materialize_messages([{"role": "assistant"}])
-
-    def test_rejects_unknown_roles(self) -> None:
-        with pytest.raises(ValueError, match="role must be user, assistant, or tool"):
-            _materialize_messages([{"role": "system", "content": "x"}])
-
-
-class TestUIStateAttachment:
-    """The harness renders the state block the chat route would otherwise have
-    put on the user's turn."""
-
-    def test_block_reflects_the_example_contexts(self) -> None:
-        deps = _build_dependencies(
-            {
-                "contexts": [
-                    {"type": "project", "projectNodeId": "UHJvamVjdDoxMg=="},
-                    {"type": "dataset", "datasetNodeId": "RGF0YXNldDox"},
-                ],
-                "messages": [{"role": "user", "content": "x"}],
-            }
-        )
-
-        block = _ui_state_block(deps)
-
-        assert '"projectNodeId": "UHJvamVjdDoxMg=="' in block
-        assert '"datasetNodeId": "RGF0YXNldDox"' in block
-        assert "<edit_permission>manual</edit_permission>" in block
-
-    def test_prepends_to_the_new_user_prompt_when_there_is_no_history(self) -> None:
-        user_prompt, history = _attach_ui_state(
-            "<phoenix_ui_state/>", user_prompt="hello", message_history=None
-        )
-
-        assert user_prompt == "<phoenix_ui_state/>\n\nhello"
-        assert history is None
-
-    def test_prepends_to_the_earliest_user_turn_of_a_replayed_history(self) -> None:
-        history = _materialize_messages(
-            [
-                {"role": "user", "content": "first"},
-                {"role": "assistant", "content": "ok"},
-            ]
-        )
-
-        user_prompt, updated = _attach_ui_state(
-            "<phoenix_ui_state/>", user_prompt="second", message_history=history
-        )
-
-        assert user_prompt == "second"
-        assert updated is not None
-        first_request = updated[0]
-        assert isinstance(first_request, ModelRequest)
-        [part] = [p for p in first_request.parts if isinstance(p, UserPromptPart)]
-        assert part.content == "<phoenix_ui_state/>\n\nfirst"
-
-    def test_mid_loop_continuation_still_carries_the_block(self) -> None:
-        """A tool-return continuation has no new user prompt, so the block has
-        to land on the replayed user turn."""
-        _, history = _build_run_inputs(
-            {
-                "messages": [
-                    {"role": "user", "content": "find errors"},
-                    {
-                        "role": "assistant",
-                        "tool_calls": [{"id": "c1", "name": "bash", "args": {"command": "x"}}],
-                    },
-                    {"role": "tool", "tool_call_id": "c1", "name": "bash", "content": "{}"},
-                ]
-            }
-        )
-
-        user_prompt, updated = _attach_ui_state(
-            "<phoenix_ui_state/>", user_prompt=None, message_history=history
-        )
-
-        assert user_prompt is None
-        assert updated is not None
-        [part] = [
-            p
-            for message in updated
-            if isinstance(message, ModelRequest)
-            for p in message.parts
-            if isinstance(p, UserPromptPart)
+def test_per_turn_metadata_preserves_navigation_and_browser_clock() -> None:
+    first, second = "UHJvamVjdDox", "UHJvamVjdDoy"
+    inp = {
+        "messages": [
+            _user("u1", "Show this project", first),
+            {"id": "a1", "role": "assistant", "parts": [{"type": "text", "text": "OK"}]},
+            _user("u2", "Now show this project", second),
         ]
-        assert part.content == "<phoenix_ui_state/>\n\nfind errors"
+    }
+    deps = _build_dependencies(inp)
+    assert deps.contexts.project is not None
+    assert deps.contexts.project.project_node_id == second
+    assert deps.contexts.app is not None
+    assert deps.contexts.app.time_zone == "America/Los_Angeles"
+    _, history = _build_run_inputs(inp)
+    users = [p.content for m in history for p in m.parts if isinstance(p, UserPromptPart)]
+    assert first in str(users[0]) and second not in str(users[0])
+    assert second in str(users[1]) and first not in str(users[1])
+    assert inp["messages"][0]["parts"][0]["text"] == "Show this project"
+
+
+def test_same_state_is_not_repeated_on_each_user_message() -> None:
+    inp = {
+        "messages": [_user("u1", "first", "UHJvamVjdDox"), _user("u2", "second", "UHJvamVjdDox")]
+    }
+    messages = _prepare_transcript(inp)
+    assert "phoenix_ui_state" in messages[0].model_dump_json()
+    assert "phoenix_ui_state" not in messages[1].model_dump_json()
+
+
+def test_legacy_context_applies_to_active_turn_not_first_turn() -> None:
+    inp = {
+        "contexts": [{"type": "project", "projectNodeId": "UHJvamVjdDoy"}],
+        "messages": [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "OK"},
+            {"role": "user", "content": "second"},
+        ],
+    }
+    messages = _prepare_transcript(inp)
+    assert "phoenix_ui_state" not in messages[0].model_dump_json()
+    assert "UHJvamVjdDoy" in messages[2].model_dump_json()
+
+
+@pytest.mark.parametrize("dynamic", [False, True])
+def test_public_tool_output_keeps_structured_result(dynamic: bool) -> None:
+    part = {
+        "type": "dynamic-tool" if dynamic else "tool-bash",
+        "toolCallId": "c1",
+        "state": "output-available",
+        "input": {"command": "pwd"},
+        "output": {"stdout": "/workspace", "stderr": "", "exitCode": 0},
+    }
+    if dynamic:
+        part["toolName"] = "bash"
+    inp = {
+        "messages": [
+            _user("u1", "where am I", "UHJvamVjdDox"),
+            {"id": "a1", "role": "assistant", "parts": [part]},
+        ]
+    }
+    prompt, history = _build_run_inputs(inp)
+    assert prompt is None
+    outputs = [p for m in history for p in m.parts if isinstance(p, ToolReturnPart)]
+    assert len(outputs) == 1
+    assert outputs[0].content == part["output"]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        [],
+        [{"role": "user", "content": ""}],
+        [{"role": "assistant", "content": "done"}],
+        [{"role": "tool", "tool_call_id": "unknown", "name": "bash", "content": "x"}],
+        [{"role": "assistant", "tool_calls": [{"id": "t1", "name": "bash", "args": {}}]}],
+        [{"role": "user", "content": "hello", "tool_calls": [{"id": "t1", "name": "bash"}]}],
+    ],
+)
+def test_rejects_unresumable_or_invalid_prefixes(raw: Any) -> None:
+    with pytest.raises(ValueError):
+        fixture_messages(raw)
+
+
+def test_rejects_conflicting_context_sources() -> None:
+    with pytest.raises(ValueError, match="per-turn metadata"):
+        _prepare_transcript({"contexts": [], "messages": [_user("u", "x", "UHJvamVjdDox")]})
+
+
+def test_shorthand_pairs_parallel_outputs_and_rejects_duplicate_ids() -> None:
+    calls = [{"id": "c1", "name": "first", "args": {}}, {"id": "c2", "name": "second", "args": {}}]
+    raw = [
+        {"role": "assistant", "tool_calls": calls},
+        {"role": "tool", "tool_call_id": "c2", "name": "second", "content": "two"},
+        {"role": "tool", "tool_call_id": "c1", "name": "first", "content": "one"},
+    ]
+    result = fixture_messages(raw)[0].model_dump(by_alias=True)
+    assert [part["output"] for part in result["parts"]] == ["one", "two"]
+    raw.append({"role": "assistant", "tool_calls": [calls[0]]})
+    with pytest.raises(ValueError, match="Duplicate"):
+        fixture_messages(raw)
+
+
+@pytest.mark.parametrize("path", sorted(_DATASETS.glob("*.yaml")), ids=lambda p: p.stem)
+def test_all_fixtures_use_current_transcript_and_bash_result_contracts(path: Path) -> None:
+    for example in yaml.safe_load(path.read_text())["examples"]:
+        inp = example["input"]
+        # Public message validation and the same conversion production uses.
+        _, history = _build_run_inputs(inp)
+        assert history, example["id"]
+        for message in history:
+            for part in message.parts:
+                if isinstance(part, ToolReturnPart) and part.tool_name == "bash":
+                    output = TypeAdapter(BashToolResult).validate_python(part.content)
+                    assert output["stdoutBytes"] == len(output["stdout"].encode())
+                    assert output["stderrBytes"] == len(output["stderr"].encode())

--- a/tests/unit/pxi/evals/test_agent_task_inputs.py
+++ b/tests/unit/pxi/evals/test_agent_task_inputs.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
+from graphql import build_schema, parse, validate
 from pydantic import TypeAdapter
 from pydantic_ai.messages import ToolReturnPart, UserPromptPart
 
@@ -16,6 +18,7 @@ from evals.pxi.harness.agent_task import (
     _build_run_inputs,
     _prepare_transcript,
 )
+from evals.pxi.harness.backend import eval_graphql_schema
 from evals.pxi.harness.transcript import fixture_messages
 from phoenix.server.agents.capabilities.tools.internal.bash import BashToolResult
 
@@ -153,9 +156,20 @@ def test_all_fixtures_use_current_transcript_and_bash_result_contracts(path: Pat
         # Public message validation and the same conversion production uses.
         _, history = _build_run_inputs(inp)
         assert history, example["id"]
+        commands = {
+            part["toolCallId"]: part["input"].get("command")
+            for message in fixture_messages(inp["messages"])
+            for part in message.model_dump(by_alias=True)["parts"]
+            if part["type"] == "tool-bash"
+        }
         for message in history:
             for part in message.parts:
                 if isinstance(part, ToolReturnPart) and part.tool_name == "bash":
                     output = TypeAdapter(BashToolResult).validate_python(part.content)
+                    assert output["command"] == commands[part.tool_call_id]
+                    argv = shlex.split(output["command"])
+                    if argv[0] == "phoenix-gql" and argv[1].startswith(("{", "query ")):
+                        schema = build_schema(eval_graphql_schema().as_str())
+                        assert not validate(schema, parse(argv[1])), example["id"]
                     assert output["stdoutBytes"] == len(output["stdout"].encode())
                     assert output["stderrBytes"] == len(output["stderr"].encode())

--- a/tests/unit/pxi/evals/test_call_budgets.py
+++ b/tests/unit/pxi/evals/test_call_budgets.py
@@ -1,0 +1,118 @@
+"""Keep setup choices out of read-only fixtures' repetition checks."""
+
+from typing import Any
+
+import pytest
+
+from evals.pxi.evaluators.tools import evaluate_tool_call_count, evaluate_tools_called
+
+
+def _calls(*calls: tuple[str, Any]) -> dict[str, Any]:
+    return {
+        "messages": [
+            {
+                "parts": [
+                    {
+                        "part_kind": "tool-call",
+                        "tool_name": name,
+                        "args": args,
+                        "tool_call_id": str(i),
+                    }
+                    for i, (name, args) in enumerate(calls)
+                ]
+            }
+        ]
+    }
+
+
+def test_distinct_prerequisites_do_not_consume_repeat_budget() -> None:
+    output = _calls(
+        ("load_skill", {"skill_name": "experiments"}),
+        ("load_skill", {"skill_name": "playground"}),
+        ("load_skill", {"skill_name": "phoenix-graphql"}),
+        (
+            "load_skill_reference",
+            {"skill_name": "phoenix-graphql", "reference_name": "references/experiments.md"},
+        ),
+        ("bash", {"summary": "Read results", "command": "phoenix-gql query.graphql"}),
+    )
+    assert (
+        evaluate_tool_call_count(output, {"budgets": {"max_repeated_tool_calls": 0}})["score"] == 1
+    )
+    assert evaluate_tool_call_count(output, {"budgets": {"max_tool_calls": 4}})["score"] == 0
+
+
+def test_identical_calls_are_repeats_despite_ids_and_argument_serialization() -> None:
+    output = _calls(
+        (
+            "load_skill_reference",
+            {"skill_name": "phoenix-graphql", "reference_name": "references/experiments.md"},
+        ),
+        ("search", {"query": "results"}),
+        (
+            "load_skill_reference",
+            '{"reference_name":"references/experiments.md","skill_name":"phoenix-graphql"}',
+        ),
+    )
+    result = evaluate_tool_call_count(output, {"budgets": {"max_repeated_tool_calls": 0}})
+    assert result["score"] == 0
+    assert result["metadata"]["repeated_tools"] == ["load_skill_reference"]
+
+
+def test_repeat_allowance_counts_each_extra_call() -> None:
+    output = _calls(*[("search", {"query": "results"})] * 3)
+    assert (
+        evaluate_tool_call_count(output, {"budgets": {"max_repeated_tool_calls": 1}})["score"] == 0
+    )
+    assert (
+        evaluate_tool_call_count(output, {"budgets": {"max_repeated_tool_calls": 2}})["score"] == 1
+    )
+
+
+def test_recovery_with_corrected_arguments_is_not_a_repeat() -> None:
+    output = _calls(
+        (
+            "load_skill_reference",
+            {"skill_name": "experiments", "reference_name": "references/experiments.md"},
+        ),
+        (
+            "load_skill_reference",
+            {"skill_name": "phoenix-graphql", "reference_name": "references/experiments.md"},
+        ),
+    )
+    assert (
+        evaluate_tool_call_count(output, {"budgets": {"max_repeated_tool_calls": 0}})["score"] == 1
+    )
+
+
+def test_total_limit_still_applies_when_both_limits_are_present() -> None:
+    output = _calls(("search", {"query": "results"}), ("bash", {"command": "pwd"}))
+    assert (
+        evaluate_tool_call_count(
+            output, {"budgets": {"max_tool_calls": 1, "max_repeated_tool_calls": 0}}
+        )["score"]
+        == 0
+    )
+
+
+@pytest.mark.parametrize("value", [-1, "1", True])
+def test_invalid_repeat_limit_fails(value: Any) -> None:
+    assert (
+        evaluate_tool_call_count(_calls(), {"budgets": {"max_repeated_tool_calls": value}})["score"]
+        == 0
+    )
+
+
+def test_forbidden_writes_still_fail_without_repeated_calls() -> None:
+    output = _calls(
+        (
+            "execute_browser_action",
+            {"script": "await ui.experiment.patch({experimentId: 'e1', metadata: {}});"},
+        )
+    )
+    expected = {
+        "ui_operations": {"forbidden": ["experiment.patch"]},
+        "budgets": {"max_repeated_tool_calls": 0},
+    }
+    assert evaluate_tool_call_count(output, expected)["score"] == 1
+    assert evaluate_tools_called(output, expected)["score"] == 0

--- a/tests/unit/pxi/evals/test_datasets.py
+++ b/tests/unit/pxi/evals/test_datasets.py
@@ -7,6 +7,7 @@ Run directly:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -358,3 +359,16 @@ examples:
                 assert description.get("non_empty") is True, (
                     f"{example['id']} must reject an empty playground.prompt.save description"
                 )
+
+
+@pytest.mark.parametrize("example_id", ["span-by-id", "children-of-parent"])
+def test_span_id_fixtures_use_matching_otel_span_ids(example_id: str) -> None:
+    example = next(e for e in load_dataset("set_spans_filter").examples if e["id"] == example_id)
+    query = example["input"]["messages"][0]["content"]
+    condition = example["expected"]["ui_operation_args"]["spansFilter.set"]["condition"]
+    input_ids = re.findall(r"\b[0-9a-f]{16,32}\b", query)
+    expected_ids = re.findall(r"\b[0-9a-f]{16,32}\b", condition)
+    assert input_ids == expected_ids
+    assert len(input_ids) == 1
+    assert re.fullmatch(r"[0-9a-f]{16}", input_ids[0])
+    assert int(input_ids[0], 16) != 0

--- a/tests/unit/pxi/evals/test_datasets.py
+++ b/tests/unit/pxi/evals/test_datasets.py
@@ -365,7 +365,9 @@ examples:
 def test_span_id_fixtures_use_matching_otel_span_ids(example_id: str) -> None:
     example = next(e for e in load_dataset("set_spans_filter").examples if e["id"] == example_id)
     query = example["input"]["messages"][0]["content"]
-    condition = example["expected"]["ui_operation_args"]["spansFilter.set"]["condition"]
+    condition = example["expected"]["ui_operation_args"]["spansFilter.set"]["condition"][
+        "filter_equals"
+    ]
     input_ids = re.findall(r"\b[0-9a-f]{16,32}\b", query)
     expected_ids = re.findall(r"\b[0-9a-f]{16,32}\b", condition)
     assert input_ids == expected_ids

--- a/tests/unit/pxi/evals/test_filter_scoring.py
+++ b/tests/unit/pxi/evals/test_filter_scoring.py
@@ -1,0 +1,119 @@
+"""Filter assertions compare decoded predicates, including their boolean structure."""
+
+import json
+
+import pytest
+
+from evals.pxi.evaluators.tools import evaluate_tool_call_args
+from evals.pxi.harness.datasets import load_dataset
+
+
+def _score(example_id: str, script: str) -> float:
+    example = next(e for e in load_dataset("set_spans_filter").examples if e["id"] == example_id)
+    output = {
+        "messages": [
+            {
+                "parts": [
+                    {
+                        "part_kind": "tool-call",
+                        "tool_name": "execute_browser_action",
+                        "args": {"script": script},
+                    }
+                ]
+            }
+        ]
+    }
+    return evaluate_tool_call_args(output, example["expected"])["score"]
+
+
+def _script(condition: str) -> str:
+    return f"return await ui.spansFilter.set({{condition: {json.dumps(condition)}}});"
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "metadata['environment'] == 'prod'",
+        'metadata["environment"] == "prod"',
+    ],
+)
+def test_equivalent_quotes(condition: str) -> None:
+    assert _score("metadata-access", _script(condition)) == 1
+
+
+@pytest.mark.parametrize(
+    "condition, score",
+    [
+        ("span_kind == 'LLM' or span_kind == 'TOOL'", 1),
+        ("span_kind == 'TOOL' or span_kind == 'LLM'", 1),
+        ("span_kind in ('LLM', 'TOOL')", 1),
+        ("span_kind in ['TOOL', 'LLM']", 1),
+        ("span_kind == 'LLM' and span_kind == 'TOOL'", 0),
+        ("span_kind == 'LLM'", 0),
+        ("span_kind in ['LLM', 'TOOL', 'CHAIN']", 0),
+        ("span_kind == 'LLM' or name == 'TOOL'", 0),
+    ],
+)
+def test_or_semantics(condition: str, score: int) -> None:
+    assert _score("llm-or-tool-spans", _script(condition)) == score
+
+
+@pytest.mark.parametrize(
+    "condition, score",
+    [
+        ("parent_id is None and cumulative_token_count.total > 50000", 1),
+        ("cumulative_token_count.total > 50000 and parent_id is None", 1),
+        ("cumulative_token_count.total > 50000", 0),
+        ("parent_id is None or cumulative_token_count.total > 50000", 0),
+    ],
+)
+def test_root_scope(condition: str, score: int) -> None:
+    assert _score("cumulative-tokens-roots", _script(condition)) == score
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        """const condition = "metadata['environment'] == 'prod'"; return await ui.spansFilter.set({condition});""",
+        """// prepare the filter
+    const filter = `metadata["environment"] == "prod"`;
+    const result = await ui.spansFilter.set({ condition: filter }); return result;""",
+        r"""return await ui.spansFilter.set({condition: 'metadata[\'environment\'] == \'prod\''});""",
+        r"""return await ui.spansFilter.set({condition: "metadata['environment'] == '\u0070rod'"});""",
+    ],
+)
+def test_static_script_forms(script: str) -> None:
+    assert _score("metadata-access", script) == 1
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        """// ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"});""",
+        """return "ui.spansFilter.set({condition: metadata['environment'] == 'prod'})";""",
+        """if (false) { return await ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"}); }""",
+        """const condition = "metadata['environment'] == 'prod'"; condition = ""; return await ui.spansFilter.set({condition});""",
+        """const condition = "metadata['environment'] == 'prod'"; return await ui.spansFilter.set({condition: ""});""",
+        """return await ui.spansFilter.set({condition: `${condition}`});""",
+        """const condition = "metadata['environment'] == 'prod'"; return await ui.spansFilter.set({'condition'});""",
+        """const ui = "fake"; return await ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"});""",
+        """return await ui.spansFilter.set({condition: "metadata['environment'] == 'prod'"}); ui.spansFilter.set({condition: ''});""",
+    ],
+)
+def test_unresolved_or_misleading_source_fails_closed(script: str) -> None:
+    assert _score("metadata-access", script) == 0
+
+
+def test_invalid_filter_syntax_fails() -> None:
+    assert _score("metadata-access", _script("metadata['environment'] == 'prod' ???")) == 0
+
+
+def test_result_guard_after_unconditional_call() -> None:
+    script = """const result = await ui.spansFilter.set({condition: "status_code == 'UNSET'"});
+    if (!result.ok) return result;
+    return {condition: "status_code == 'UNSET'"};"""
+    assert _score("status-unset-spans", script) == 1
+
+
+def test_unrequested_root_scope_fails() -> None:
+    assert _score("chain-spans", _script("parent_id is None and span_kind == 'CHAIN'")) == 0

--- a/tests/unit/pxi/evals/test_filter_scoring.py
+++ b/tests/unit/pxi/evals/test_filter_scoring.py
@@ -23,7 +23,7 @@ def _score(example_id: str, script: str) -> float:
             }
         ]
     }
-    return evaluate_tool_call_args(output, example["expected"])["score"]
+    return float(evaluate_tool_call_args(output, example["expected"])["score"])
 
 
 def _script(condition: str) -> str:

--- a/tests/unit/pxi/evals/test_link_whitespace.py
+++ b/tests/unit/pxi/evals/test_link_whitespace.py
@@ -1,0 +1,25 @@
+"""Regression coverage for CommonMark whitespace around link destinations."""
+
+import pytest
+
+from evals.pxi.evaluators.links import evaluate_in_app_links
+
+
+@pytest.mark.parametrize("padding", [" ", "\t", "\n", " \n\t"])
+def test_destination_padding(padding: str) -> None:
+    result = evaluate_in_app_links(
+        {"assistant_text": f"[Trace]({padding}/redirects/traces/abc{padding})"},
+        {"links": {"required_in_app": ["/redirects/traces/abc"]}},
+    )
+    assert result["score"] == 1
+
+
+@pytest.mark.parametrize(
+    "destination", ["/wrong", "/redirects/traces/a bc", "\n\n/redirects/traces/abc"]
+)
+def test_invalid_destination_does_not_pass(destination: str) -> None:
+    result = evaluate_in_app_links(
+        {"assistant_text": f"[Trace]( {destination} )"},
+        {"links": {"required_in_app": ["/redirects/traces/abc"]}},
+    )
+    assert result["score"] == 0

--- a/tests/unit/pxi/evals/test_link_whitespace.py
+++ b/tests/unit/pxi/evals/test_link_whitespace.py
@@ -23,3 +23,22 @@ def test_invalid_destination_does_not_pass(destination: str) -> None:
         {"links": {"required_in_app": ["/redirects/traces/abc"]}},
     )
     assert result["score"] == 0
+
+
+@pytest.mark.parametrize(
+    "href, score",
+    [
+        ("/projects/UHJvamVjdDo0Nw%3D%3D/traces/abc", 1),
+        ("/projects/UHJvamVjdDo0Nw==/traces/abc", 1),
+        ("/projects/UHJvamVjdDo0Nw%253D%253D/traces/abc", 0),
+        ("/projects/UHJvamVjdDo0Nw%3D%3D%2Ftraces/abc", 0),
+        ("https://localhost/projects/UHJvamVjdDo0Nw%3D%3D/traces/abc", 0),
+        ("/projects/UHJvamVjdDo0Nw%3D%3D/traces/wrong", 0),
+    ],
+)
+def test_encoded_route_parameters(href: str, score: int) -> None:
+    result = evaluate_in_app_links(
+        {"assistant_text": f"[Trace]({href})"},
+        {"links": {"required_in_app": ["/projects/UHJvamVjdDo0Nw==/traces/abc"]}},
+    )
+    assert result["score"] == score


### PR DESCRIPTION
The PXI regression harness was missing backend tools and skills available to the production agent. Some fixtures also used outdated inputs, and some assertions rejected equivalent results. These problems caused eval failures that did not reflect agent regressions.

This PR repairs the harness, fixtures, and scoring:

- Give the eval agent the production MCP tool definitions, skills, and GraphQL schema. Skill discovery runs normally; browser and backend actions remain deferred for inspection.
- Validate fixture history as public Phoenix session messages and convert it through the production chat adapter. Preserve each turn's navigation context and browser time, and require fixtures to supply any project context they need.
- Correct recorded bash inputs and results, span IDs, and experiment-skill expectations. Accept equivalent filter expressions and link destinations.
- Replace total-call limits in two read-only examples with a check for repeated calls with identical arguments. This allows distinct setup calls and corrected requests while still rejecting repeated work and forbidden writes.

Fixture shapes were checked against the current API and a sample of traces from phoenix-devs. Contract tests cover all 175 fixtures and their recorded tool inputs. Production prompts and skills are unchanged.

Validation: 388 eval unit tests, Mypy, and Ruff pass. The 155-example live run and [regression CI](https://github.com/Arize-ai/phoenix/actions/runs/34667644790) pass the existing gate with two tolerated misses, three cases recovered on retry, and no unassessed examples. Gate thresholds and retry limits are unchanged.

These evals check the agent's next action. They do not execute deferred actions or verify the resulting UI or database state. Some fixtures still depend on tool discovery details; the README documents those limits and recommends assertions based on public API arguments and artifacts.
